### PR TITLE
Add SSH tunnel management for shed port forwarding

### DIFF
--- a/cmd/shed-server/serve.go
+++ b/cmd/shed-server/serve.go
@@ -206,6 +206,11 @@ func (a *dockerSSHAdapter) StartShed(ctx context.Context, name string) error {
 	return err
 }
 
+// GetContainerIP returns the IP address of a container.
+func (a *dockerSSHAdapter) GetContainerIP(ctx context.Context, containerID string) (string, error) {
+	return a.client.GetContainerIP(ctx, containerID)
+}
+
 // ExecInContainer executes a command in a container with the given options.
 func (a *dockerSSHAdapter) ExecInContainer(ctx context.Context, containerID string, opts sshd.ExecOptions) error {
 	dockerClient := a.client.Docker()

--- a/cmd/shed/attach.go
+++ b/cmd/shed/attach.go
@@ -59,9 +59,9 @@ func runAttach(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Verify the shed is running
+	// Ensure the shed is running (auto-start if stopped)
 	client := NewAPIClientFromEntry(entry)
-	if _, err := requireRunningShed(client, name); err != nil {
+	if _, err := ensureRunningShed(client, name); err != nil {
 		return err
 	}
 

--- a/cmd/shed/console.go
+++ b/cmd/shed/console.go
@@ -89,9 +89,9 @@ func sshToShed(name string, command []string) error {
 		return err
 	}
 
-	// Verify the shed is running
+	// Ensure the shed is running (auto-start if stopped)
 	client := NewAPIClientFromEntry(entry)
-	if _, err := requireRunningShed(client, name); err != nil {
+	if _, err := ensureRunningShed(client, name); err != nil {
 		return err
 	}
 

--- a/cmd/shed/main.go
+++ b/cmd/shed/main.go
@@ -114,19 +114,24 @@ func printError(msg string, suggestions ...string) {
 	}
 }
 
-// requireRunningShed gets a shed and verifies it's running.
-// Returns the shed if running, or prints a helpful error and returns an error if not.
-func requireRunningShed(client *APIClient, name string) (*config.Shed, error) {
+// ensureRunningShed gets a shed and starts it if not running.
+// Returns the shed after ensuring it's running.
+func ensureRunningShed(client *APIClient, name string) (*config.Shed, error) {
 	shed, err := client.GetShed(name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get shed status: %w", err)
 	}
 
-	if shed.Status != config.StatusRunning {
-		printError(fmt.Sprintf("shed %q is %s", name, shed.Status),
-			"shed start "+name+"  # Start the shed first")
-		return nil, fmt.Errorf("shed %q is not running", name)
+	if shed.Status == config.StatusRunning {
+		return shed, nil
 	}
 
+	// Auto-start the shed
+	fmt.Printf("Starting shed %s...\n", name)
+	shed, err = client.StartShed(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start shed: %w", err)
+	}
+	printSuccess("Shed %s started", name)
 	return shed, nil
 }

--- a/cmd/shed/shed.go
+++ b/cmd/shed/shed.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/tunnels"
 )
 
 var createCmd = &cobra.Command{
@@ -222,6 +223,9 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Stop any associated tunnels first
+	stopTunnelsForShed(name)
+
 	client := NewAPIClientFromEntry(entry)
 	if err := client.DeleteShed(name, deleteKeep); err != nil {
 		return fmt.Errorf("failed to delete shed: %w", err)
@@ -281,6 +285,9 @@ func runStop(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Stopping shed %s on %s...\n", name, serverName)
 	}
 
+	// Stop any associated tunnels first
+	stopTunnelsForShed(name)
+
 	client := NewAPIClientFromEntry(entry)
 	shed, err := client.StopShed(name)
 	if err != nil {
@@ -297,6 +304,23 @@ func runStop(cmd *cobra.Command, args []string) error {
 
 	printSuccess("Stopped shed %s", name)
 	return nil
+}
+
+// stopTunnelsForShed stops any running tunnels for a shed.
+// Errors are logged but not returned since tunnel cleanup is best-effort.
+func stopTunnelsForShed(name string) {
+	mgr, err := tunnels.NewManager()
+	if err != nil {
+		if verboseFlag {
+			fmt.Fprintf(os.Stderr, "Warning: failed to initialize tunnel manager: %v\n", err)
+		}
+		return
+	}
+	if err := mgr.StopAllTunnelsForShed(name); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to stop tunnel for %s: %v\n", name, err)
+	} else if verboseFlag {
+		fmt.Printf("Stopped tunnel for %s\n", name)
+	}
 }
 
 // findShedServer finds which server hosts a shed.

--- a/cmd/shed/tunnels.go
+++ b/cmd/shed/tunnels.go
@@ -1,0 +1,471 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/charliek/shed/internal/tunnels"
+)
+
+var (
+	tunnelProfiles    []string
+	tunnelPorts       []string
+	tunnelBackground  bool
+	tunnelReplace     bool
+	tunnelStopAll     bool
+	tunnelListVerbose bool
+	tunnelListJSON    bool
+)
+
+var tunnelsCmd = &cobra.Command{
+	Use:   "tunnels",
+	Short: "Manage SSH tunnels to sheds",
+	Long: `Manage SSH port forwarding tunnels to shed containers.
+
+Tunnels allow you to access services running inside sheds from your
+local machine (e.g., web servers, databases, OpenCode).
+
+Configuration is stored in ~/.shed/tunnels.yaml`,
+}
+
+var tunnelsStartCmd = &cobra.Command{
+	Use:   "start <shed>",
+	Short: "Start SSH tunnels to a shed",
+	Long: `Start SSH port forwarding tunnels to a shed.
+
+By default, runs in the foreground (Ctrl+C to stop).
+Use -d/--background to run as a daemon.
+
+Examples:
+  shed tunnels start myproj                    # Start with default profile
+  shed tunnels start myproj -p dev             # Use dev profile
+  shed tunnels start myproj -t 3000            # Forward port 3000
+  shed tunnels start myproj -t 4501:4096       # Forward local 4501 to remote 4096
+  shed tunnels start myproj -p dev -t 5432 -d  # Combine profile + extra port, background`,
+	Args: cobra.ExactArgs(1),
+	RunE: runTunnelsStart,
+}
+
+var tunnelsStopCmd = &cobra.Command{
+	Use:   "stop [shed]",
+	Short: "Stop SSH tunnels",
+	Long: `Stop SSH tunnels for a shed.
+
+Examples:
+  shed tunnels stop myproj    # Stop tunnels for myproj
+  shed tunnels stop --all     # Stop all tunnels`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runTunnelsStop,
+}
+
+var tunnelsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List active tunnels",
+	Long: `List all active SSH tunnels.
+
+Examples:
+  shed tunnels list           # Basic list
+  shed tunnels list -v        # Show port mappings
+  shed tunnels list --json    # JSON output`,
+	Args: cobra.NoArgs,
+	RunE: runTunnelsList,
+}
+
+var tunnelsConfigCmd = &cobra.Command{
+	Use:   "config <shed>",
+	Short: "Preview tunnel configuration",
+	Long: `Preview tunnel configuration without starting.
+
+Shows the ports that would be forwarded and the SSH command
+that would be executed.
+
+Examples:
+  shed tunnels config myproj          # Show default profile
+  shed tunnels config myproj -p dev   # Show dev profile
+  shed tunnels config myproj -t 5432  # Show with extra tunnel`,
+	Args: cobra.ExactArgs(1),
+	RunE: runTunnelsConfig,
+}
+
+func init() {
+	// tunnels start flags
+	tunnelsStartCmd.Flags().StringArrayVarP(&tunnelProfiles, "profile", "p", nil, "Profile to use (repeatable for merging)")
+	tunnelsStartCmd.Flags().StringArrayVarP(&tunnelPorts, "tunnel", "t", nil, "Explicit tunnel - \"3000\" or \"3001:3000\" (repeatable)")
+	tunnelsStartCmd.Flags().BoolVarP(&tunnelBackground, "background", "d", false, "Run as background daemon")
+	tunnelsStartCmd.Flags().BoolVar(&tunnelReplace, "replace", false, "Replace existing tunnel without prompting")
+
+	// tunnels stop flags
+	tunnelsStopCmd.Flags().BoolVar(&tunnelStopAll, "all", false, "Stop all tunnels")
+
+	// tunnels list flags
+	tunnelsListCmd.Flags().BoolVarP(&tunnelListVerbose, "verbose", "v", false, "Show detailed port mappings")
+	tunnelsListCmd.Flags().BoolVar(&tunnelListJSON, "json", false, "Output as JSON")
+
+	// tunnels config flags
+	tunnelsConfigCmd.Flags().StringArrayVarP(&tunnelProfiles, "profile", "p", nil, "Profile to preview")
+	tunnelsConfigCmd.Flags().StringArrayVarP(&tunnelPorts, "tunnel", "t", nil, "Additional tunnels to include")
+
+	// Add subcommands
+	tunnelsCmd.AddCommand(tunnelsStartCmd)
+	tunnelsCmd.AddCommand(tunnelsStopCmd)
+	tunnelsCmd.AddCommand(tunnelsListCmd)
+	tunnelsCmd.AddCommand(tunnelsConfigCmd)
+
+	rootCmd.AddCommand(tunnelsCmd)
+}
+
+// collectPortMappings gathers port mappings from profiles and explicit ports.
+// Returns the port mappings, a profile name string, and any error.
+func collectPortMappings(mgr *tunnels.Manager, shedName string, profiles, ports []string, cmdName string) ([]tunnels.PortMapping, string, error) {
+	var allPorts []tunnels.PortMapping
+
+	// If no profiles specified and no explicit tunnels, use "default" profile
+	effectiveProfiles := profiles
+	if len(profiles) == 0 && len(ports) == 0 {
+		effectiveProfiles = []string{"default"}
+	}
+
+	// Load ports from profiles
+	profileName := ""
+	if len(effectiveProfiles) > 0 {
+		for _, profile := range effectiveProfiles {
+			mappings, err := mgr.Config().GetPortMappings(shedName, profile)
+			if err != nil {
+				// Check if it's just no config for this shed
+				if errors.Is(err, tunnels.ErrNoTunnelConfig) {
+					printError(fmt.Sprintf("No tunnel config for shed %q", shedName),
+						"Add configuration to ~/.shed/tunnels.yaml",
+						fmt.Sprintf("Or use -t flag: shed tunnels %s %s -t 3000", cmdName, shedName))
+					return nil, "", err
+				}
+				return nil, "", err
+			}
+			allPorts = tunnels.MergePortMappings(allPorts, mappings)
+		}
+		profileName = strings.Join(effectiveProfiles, "+")
+	}
+
+	// Add explicit tunnels
+	if len(ports) > 0 {
+		explicitPorts, err := tunnels.ParsePortMappings(ports)
+		if err != nil {
+			return nil, "", fmt.Errorf("invalid tunnel port: %w", err)
+		}
+		allPorts = tunnels.MergePortMappings(allPorts, explicitPorts)
+		if profileName != "" {
+			profileName += "+explicit"
+		} else {
+			profileName = "explicit"
+		}
+	}
+
+	return allPorts, profileName, nil
+}
+
+func runTunnelsStart(cmd *cobra.Command, args []string) error {
+	shedName := args[0]
+
+	// Find the server hosting this shed
+	serverName, entry, err := findShedServer(shedName)
+	if err != nil {
+		return err
+	}
+
+	// Ensure the shed is running (auto-start if stopped)
+	client := NewAPIClientFromEntry(entry)
+	if _, err := ensureRunningShed(client, shedName); err != nil {
+		return err
+	}
+
+	// Create tunnel manager
+	mgr, err := tunnels.NewManager()
+	if err != nil {
+		return fmt.Errorf("failed to initialize tunnel manager: %w", err)
+	}
+
+	// Clean up dead tunnels first
+	if err := mgr.CleanupDeadTunnels(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to clean up dead tunnels: %v\n", err)
+	}
+
+	// Check for existing tunnel
+	if existingEntry, ok := mgr.State().GetTunnel(shedName); ok {
+		// Check if process is still alive
+		alive, err := mgr.CheckHealth(shedName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to check tunnel health: %v\n", err)
+		}
+		if alive {
+			if !tunnelReplace {
+				// Prompt for replacement
+				fmt.Printf("Tunnel already running for %s (profile: %s, PID %d).\n",
+					shedName, existingEntry.Profile, existingEntry.PID)
+
+				// Check if stdin is interactive before prompting
+				if stat, err := os.Stdin.Stat(); err == nil && (stat.Mode()&os.ModeCharDevice) == 0 {
+					return fmt.Errorf("tunnel already running for %s; use --replace in non-interactive mode", shedName)
+				}
+
+				fmt.Print("Replace? [y/N] ")
+
+				reader := bufio.NewReader(os.Stdin)
+				response, _ := reader.ReadString('\n')
+				response = strings.TrimSpace(strings.ToLower(response))
+				if response != "y" && response != "yes" {
+					fmt.Println("Cancelled.")
+					return nil
+				}
+			}
+
+			fmt.Println("Stopping existing tunnel...")
+			if err := mgr.Stop(shedName); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to stop existing tunnel: %v\n", err)
+			}
+		}
+	}
+
+	// Collect port mappings
+	allPorts, profileName, err := collectPortMappings(mgr, shedName, tunnelProfiles, tunnelPorts, "start")
+	if err != nil {
+		return err
+	}
+
+	if len(allPorts) == 0 {
+		return fmt.Errorf("no ports to forward")
+	}
+
+	// Check for port conflicts
+	if err := mgr.CheckPortConflicts(allPorts); err != nil {
+		return err
+	}
+
+	// Show what we're doing
+	if verboseFlag {
+		fmt.Printf("Starting tunnel to %s on %s\n", shedName, serverName)
+		fmt.Println("Port mappings:")
+		for _, pm := range allPorts {
+			fmt.Printf("  localhost:%d -> container:%d\n", pm.Local, pm.Remote)
+		}
+		fmt.Println()
+		fmt.Println("SSH command:")
+		fmt.Printf("  %s\n", strings.Join(mgr.BuildSSHArgs(shedName, entry, allPorts), " "))
+		fmt.Println()
+	}
+
+	if tunnelBackground {
+		// Start as daemon
+		if err := mgr.StartBackground(shedName, serverName, entry, allPorts, profileName); err != nil {
+			return fmt.Errorf("failed to start tunnel: %w", err)
+		}
+		printSuccess("Tunnel started for %s (profile: %s)", shedName, profileName)
+		fmt.Println("Forwarding:")
+		for _, pm := range allPorts {
+			fmt.Printf("  localhost:%d -> %s:%d\n", pm.Local, shedName, pm.Remote)
+		}
+	} else {
+		// Start in foreground
+		fmt.Printf("Starting tunnel to %s (Ctrl+C to stop)...\n", shedName)
+		for _, pm := range allPorts {
+			fmt.Printf("  localhost:%d -> %s:%d\n", pm.Local, shedName, pm.Remote)
+		}
+		fmt.Println()
+
+		// This replaces the current process
+		if err := mgr.StartForeground(shedName, serverName, entry, allPorts, profileName); err != nil {
+			return fmt.Errorf("failed to start tunnel: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func runTunnelsStop(cmd *cobra.Command, args []string) error {
+	mgr, err := tunnels.NewManager()
+	if err != nil {
+		return fmt.Errorf("failed to initialize tunnel manager: %w", err)
+	}
+
+	if tunnelStopAll {
+		allTunnels := mgr.State().GetAllTunnels()
+		if len(allTunnels) == 0 {
+			fmt.Println("No tunnels running.")
+			return nil
+		}
+
+		for shedName := range allTunnels {
+			if err := mgr.Stop(shedName); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to stop tunnel for %s: %v\n", shedName, err)
+			} else {
+				printSuccess("Stopped tunnel for %s", shedName)
+			}
+		}
+		return nil
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("shed name required (or use --all)")
+	}
+
+	shedName := args[0]
+
+	if _, ok := mgr.State().GetTunnel(shedName); !ok {
+		return fmt.Errorf("no tunnel running for shed %q", shedName)
+	}
+
+	if err := mgr.Stop(shedName); err != nil {
+		return fmt.Errorf("failed to stop tunnel: %w", err)
+	}
+
+	printSuccess("Stopped tunnel for %s", shedName)
+	return nil
+}
+
+func runTunnelsList(cmd *cobra.Command, args []string) error {
+	mgr, err := tunnels.NewManager()
+	if err != nil {
+		return fmt.Errorf("failed to initialize tunnel manager: %w", err)
+	}
+
+	// Clean up dead tunnels first
+	if err := mgr.CleanupDeadTunnels(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to clean up dead tunnels: %v\n", err)
+	}
+
+	allTunnels := mgr.State().GetAllTunnels()
+
+	if tunnelListJSON {
+		return outputTunnelsJSON(allTunnels)
+	}
+
+	if len(allTunnels) == 0 {
+		fmt.Println("No tunnels running.")
+		return nil
+	}
+
+	// Sort by shed name
+	names := make([]string, 0, len(allTunnels))
+	for name := range allTunnels {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	if tunnelListVerbose {
+		fmt.Fprintln(w, "SHED\tPROFILE\tPID\tPORTS\tSTARTED\tSERVER")
+		for _, name := range names {
+			entry := allTunnels[name]
+			ports := formatPortMappings(entry.Ports)
+			started := formatRelativeTime(entry.StartedAt)
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\n",
+				name, entry.Profile, entry.PID, ports, started, entry.ServerName)
+		}
+	} else {
+		fmt.Fprintln(w, "SHED\tPROFILE\tPORTS\tSTARTED")
+		for _, name := range names {
+			entry := allTunnels[name]
+			portCount := fmt.Sprintf("%d port(s)", len(entry.Ports))
+			started := formatRelativeTime(entry.StartedAt)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+				name, entry.Profile, portCount, started)
+		}
+	}
+
+	w.Flush()
+	return nil
+}
+
+func runTunnelsConfig(cmd *cobra.Command, args []string) error {
+	shedName := args[0]
+
+	// Find the server hosting this shed
+	serverName, entry, err := findShedServer(shedName)
+	if err != nil {
+		return err
+	}
+
+	mgr, err := tunnels.NewManager()
+	if err != nil {
+		return fmt.Errorf("failed to initialize tunnel manager: %w", err)
+	}
+
+	// Collect port mappings
+	allPorts, profileName, err := collectPortMappings(mgr, shedName, tunnelProfiles, tunnelPorts, "config")
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Tunnel configuration for %s\n", shedName)
+	fmt.Printf("Server: %s\n", serverName)
+	fmt.Printf("Profile: %s\n", profileName)
+	fmt.Println()
+
+	fmt.Println("Port mappings:")
+	for _, pm := range allPorts {
+		fmt.Printf("  localhost:%d -> %s:%d\n", pm.Local, shedName, pm.Remote)
+	}
+	fmt.Println()
+
+	if verboseFlag {
+		fmt.Println("SSH command:")
+		fmt.Printf("  %s\n", strings.Join(mgr.BuildSSHArgs(shedName, entry, allPorts), " "))
+	}
+
+	return nil
+}
+
+func outputTunnelsJSON(entries map[string]tunnels.TunnelEntry) error {
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+func formatPortMappings(ports []tunnels.PortMapping) string {
+	strs := make([]string, len(ports))
+	for i, pm := range ports {
+		if pm.Local == pm.Remote {
+			strs[i] = fmt.Sprintf("%d", pm.Local)
+		} else {
+			strs[i] = fmt.Sprintf("%d:%d", pm.Local, pm.Remote)
+		}
+	}
+	return strings.Join(strs, ",")
+}
+
+func formatRelativeTime(t time.Time) string {
+	d := time.Since(t)
+	if d < time.Minute {
+		return "just now"
+	}
+	if d < time.Hour {
+		mins := int(d.Minutes())
+		if mins == 1 {
+			return "1 min ago"
+		}
+		return fmt.Sprintf("%d mins ago", mins)
+	}
+	if d < 24*time.Hour {
+		hours := int(d.Hours())
+		if hours == 1 {
+			return "1 hour ago"
+		}
+		return fmt.Sprintf("%d hours ago", hours)
+	}
+	days := int(d.Hours() / 24)
+	if days == 1 {
+		return "1 day ago"
+	}
+	return fmt.Sprintf("%d days ago", days)
+}

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -49,6 +49,16 @@ func GetKnownHostsPath() string {
 	return filepath.Join(GetClientConfigDir(), "known_hosts")
 }
 
+// GetTunnelsConfigPath returns the path to the tunnels config file.
+func GetTunnelsConfigPath() string {
+	return filepath.Join(GetClientConfigDir(), "tunnels.yaml")
+}
+
+// GetTunnelStatePath returns the path to the tunnel state file.
+func GetTunnelStatePath() string {
+	return filepath.Join(GetClientConfigDir(), "tunnel-state.json")
+}
+
 // LoadClientConfig loads the client configuration from the default location.
 func LoadClientConfig() (*ClientConfig, error) {
 	return LoadClientConfigFromPath(GetClientConfigPath())

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -94,3 +94,24 @@ func (c *Client) buildEnvList() []string {
 	}
 	return envList
 }
+
+// GetContainerIP returns the IP address of a container.
+func (c *Client) GetContainerIP(ctx context.Context, containerID string) (string, error) {
+	info, err := c.docker.ContainerInspect(ctx, containerID)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect container: %w", err)
+	}
+
+	// Try bridge network first, fall back to first available
+	if network, ok := info.NetworkSettings.Networks["bridge"]; ok && network.IPAddress != "" {
+		return network.IPAddress, nil
+	}
+
+	for _, network := range info.NetworkSettings.Networks {
+		if network.IPAddress != "" {
+			return network.IPAddress, nil
+		}
+	}
+
+	return "", fmt.Errorf("no IP address found for container %s", containerID)
+}

--- a/internal/sshd/server.go
+++ b/internal/sshd/server.go
@@ -7,10 +7,13 @@ import (
 	"crypto/rand"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
+	"time"
 
 	"github.com/gliderlabs/ssh"
 	gossh "golang.org/x/crypto/ssh"
@@ -29,6 +32,9 @@ type DockerClient interface {
 
 	// ExecInContainer executes a command in a container with the given options.
 	ExecInContainer(ctx context.Context, containerID string, opts ExecOptions) error
+
+	// GetContainerIP returns the IP address of a container.
+	GetContainerIP(ctx context.Context, containerID string) (string, error)
 }
 
 // ShedInfo contains information about a shed needed by the SSH server.
@@ -114,6 +120,10 @@ func NewServer(dockerClient DockerClient, hostKeyPath string, port int, termConf
 		},
 		Handler: func(sess ssh.Session) {
 			s.handleSession(sess)
+		},
+		ChannelHandlers: map[string]ssh.ChannelHandler{
+			"session":      ssh.DefaultSessionHandler,
+			"direct-tcpip": s.handleDirectTCPIP,
 		},
 	}
 
@@ -229,4 +239,80 @@ func (s *Server) handlePublicKey(ctx ssh.Context, key ssh.PublicKey) bool {
 	// For MVP, accept all keys.
 	// TODO: Implement proper key verification against stored keys.
 	return true
+}
+
+// localForwardChannelData matches RFC4254 Section 7.2
+type localForwardChannelData struct {
+	DestAddr   string
+	DestPort   uint32
+	OriginAddr string
+	OriginPort uint32
+}
+
+// handleDirectTCPIP handles local port forwarding (-L) by proxying to the container.
+func (s *Server) handleDirectTCPIP(srv *ssh.Server, conn *gossh.ServerConn,
+	newChan gossh.NewChannel, ctx ssh.Context) {
+
+	d := localForwardChannelData{}
+	if err := gossh.Unmarshal(newChan.ExtraData(), &d); err != nil {
+		_ = newChan.Reject(gossh.ConnectionFailed, "error parsing forward data")
+		return
+	}
+
+	user := ctx.User()
+	log.Printf("Port forward: user=%s dest=%s:%d", user, d.DestAddr, d.DestPort)
+
+	// Only allow localhost destinations (security: prevent using shed as proxy)
+	if d.DestAddr != "localhost" && d.DestAddr != "127.0.0.1" && d.DestAddr != "::1" {
+		log.Printf("Port forward denied: non-localhost destination %s for user %s", d.DestAddr, user)
+		_ = newChan.Reject(gossh.Prohibited, "only localhost forwarding allowed")
+		return
+	}
+
+	// Look up container for this shed
+	shed, err := s.docker.GetShed(ctx, user)
+	if err != nil {
+		log.Printf("Port forward: shed not found for user %s: %v", user, err)
+		_ = newChan.Reject(gossh.ConnectionFailed, "shed not found")
+		return
+	}
+
+	// Get container IP to forward to
+	containerIP, err := s.docker.GetContainerIP(ctx, shed.ContainerID)
+	if err != nil {
+		log.Printf("Port forward: cannot get container IP for %s: %v", user, err)
+		_ = newChan.Reject(gossh.ConnectionFailed, "cannot get container IP")
+		return
+	}
+
+	// Connect to container's port
+	dest := net.JoinHostPort(containerIP, strconv.FormatUint(uint64(d.DestPort), 10))
+	dconn, err := net.DialTimeout("tcp", dest, 30*time.Second)
+	if err != nil {
+		log.Printf("Port forward: failed to connect to %s: %v", dest, err)
+		_ = newChan.Reject(gossh.ConnectionFailed, err.Error())
+		return
+	}
+
+	// Accept the SSH channel
+	ch, reqs, err := newChan.Accept()
+	if err != nil {
+		dconn.Close()
+		return
+	}
+	go gossh.DiscardRequests(reqs)
+
+	log.Printf("Port forward established: %s -> %s", user, dest)
+
+	// Bidirectional proxy
+	go func() {
+		defer ch.Close()
+		defer dconn.Close()
+		_, _ = io.Copy(ch, dconn)
+	}()
+	go func() {
+		defer ch.Close()
+		defer dconn.Close()
+		_, _ = io.Copy(dconn, ch)
+	}()
 }

--- a/internal/tunnels/config.go
+++ b/internal/tunnels/config.go
@@ -1,0 +1,202 @@
+// Package tunnels provides SSH port forwarding tunnel management.
+package tunnels
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+// Sentinel errors for tunnel configuration.
+var (
+	// ErrNoTunnelConfig is returned when no tunnel configuration exists for a shed.
+	ErrNoTunnelConfig = errors.New("no tunnel config for shed")
+	// ErrProfileNotFound is returned when a profile is not found for a shed.
+	ErrProfileNotFound = errors.New("profile not found")
+)
+
+// TunnelConfig represents the tunnel configuration file.
+type TunnelConfig struct {
+	SSH   SSHConfig             `yaml:"ssh"`
+	Sheds map[string]ShedConfig `yaml:"sheds"`
+}
+
+// SSHConfig contains SSH connection settings.
+type SSHConfig struct {
+	ServerAliveInterval int `yaml:"server_alive_interval"`
+	ServerAliveCountMax int `yaml:"server_alive_count_max"`
+	ConnectTimeout      int `yaml:"connect_timeout"`
+}
+
+// ShedConfig contains tunnel profiles for a shed.
+type ShedConfig struct {
+	Profiles map[string][]string `yaml:"profiles"`
+}
+
+// Validate checks that SSH configuration values are within acceptable ranges.
+func (c *SSHConfig) Validate() error {
+	if c.ServerAliveInterval < 0 || c.ServerAliveInterval > 3600 {
+		return fmt.Errorf("server_alive_interval must be 0-3600, got %d", c.ServerAliveInterval)
+	}
+	if c.ServerAliveCountMax < 0 || c.ServerAliveCountMax > 100 {
+		return fmt.Errorf("server_alive_count_max must be 0-100, got %d", c.ServerAliveCountMax)
+	}
+	if c.ConnectTimeout < 0 || c.ConnectTimeout > 300 {
+		return fmt.Errorf("connect_timeout must be 0-300, got %d", c.ConnectTimeout)
+	}
+	return nil
+}
+
+// PortMapping represents a local:remote port mapping.
+type PortMapping struct {
+	Local  int `json:"local"`
+	Remote int `json:"remote"`
+}
+
+// LoadTunnelConfig loads the tunnel configuration from disk.
+func LoadTunnelConfig() (*TunnelConfig, error) {
+	return LoadTunnelConfigFromPath(config.GetTunnelsConfigPath())
+}
+
+// LoadTunnelConfigFromPath loads tunnel configuration from a specific path.
+func LoadTunnelConfigFromPath(path string) (*TunnelConfig, error) {
+	cfg := &TunnelConfig{
+		SSH: SSHConfig{
+			ServerAliveInterval: 30,
+			ServerAliveCountMax: 3,
+			ConnectTimeout:      10,
+		},
+		Sheds: make(map[string]ShedConfig),
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+		return nil, fmt.Errorf("failed to read tunnel config: %w", err)
+	}
+
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse tunnel config: %w", err)
+	}
+
+	// Ensure maps are initialized
+	if cfg.Sheds == nil {
+		cfg.Sheds = make(map[string]ShedConfig)
+	}
+
+	// Validate SSH config
+	if err := cfg.SSH.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid tunnel config: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// GetProfiles returns the profile names available for a shed.
+func (c *TunnelConfig) GetProfiles(shedName string) []string {
+	shedCfg, ok := c.Sheds[shedName]
+	if !ok {
+		return nil
+	}
+
+	profiles := make([]string, 0, len(shedCfg.Profiles))
+	for name := range shedCfg.Profiles {
+		profiles = append(profiles, name)
+	}
+	return profiles
+}
+
+// GetPortMappings returns the port mappings for a shed and profile.
+func (c *TunnelConfig) GetPortMappings(shedName, profileName string) ([]PortMapping, error) {
+	shedCfg, ok := c.Sheds[shedName]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrNoTunnelConfig, shedName)
+	}
+
+	portStrs, ok := shedCfg.Profiles[profileName]
+	if !ok {
+		available := c.GetProfiles(shedName)
+		return nil, fmt.Errorf("%w: %q for shed %q. Available: %s",
+			ErrProfileNotFound, profileName, shedName, strings.Join(available, ", "))
+	}
+
+	return ParsePortMappings(portStrs)
+}
+
+// ParsePortMappings parses a list of port mapping strings.
+// Supports formats: "3000" (same port both sides) or "3001:3000" (local:remote).
+func ParsePortMappings(portStrs []string) ([]PortMapping, error) {
+	mappings := make([]PortMapping, 0, len(portStrs))
+
+	for _, s := range portStrs {
+		mapping, err := ParsePortMapping(s)
+		if err != nil {
+			return nil, err
+		}
+		mappings = append(mappings, mapping)
+	}
+
+	return mappings, nil
+}
+
+// ParsePortMapping parses a single port mapping string.
+func ParsePortMapping(s string) (PortMapping, error) {
+	s = strings.TrimSpace(s)
+
+	if strings.Contains(s, ":") {
+		parts := strings.SplitN(s, ":", 2)
+		local, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return PortMapping{}, fmt.Errorf("invalid local port %q: %w", parts[0], err)
+		}
+		remote, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return PortMapping{}, fmt.Errorf("invalid remote port %q: %w", parts[1], err)
+		}
+		if local < 1 || local > 65535 {
+			return PortMapping{}, fmt.Errorf("local port %d out of range (1-65535)", local)
+		}
+		if remote < 1 || remote > 65535 {
+			return PortMapping{}, fmt.Errorf("remote port %d out of range (1-65535)", remote)
+		}
+		return PortMapping{Local: local, Remote: remote}, nil
+	}
+
+	port, err := strconv.Atoi(s)
+	if err != nil {
+		return PortMapping{}, fmt.Errorf("invalid port %q: %w", s, err)
+	}
+	if port < 1 || port > 65535 {
+		return PortMapping{}, fmt.Errorf("port %d out of range (1-65535)", port)
+	}
+	return PortMapping{Local: port, Remote: port}, nil
+}
+
+// MergePortMappings merges multiple port mapping slices, with later entries overriding earlier ones.
+func MergePortMappings(mappingSlices ...[]PortMapping) []PortMapping {
+	seen := make(map[int]PortMapping)
+	order := make([]int, 0)
+
+	for _, mappings := range mappingSlices {
+		for _, m := range mappings {
+			if _, exists := seen[m.Local]; !exists {
+				order = append(order, m.Local)
+			}
+			seen[m.Local] = m
+		}
+	}
+
+	result := make([]PortMapping, 0, len(seen))
+	for _, local := range order {
+		result = append(result, seen[local])
+	}
+	return result
+}

--- a/internal/tunnels/config_test.go
+++ b/internal/tunnels/config_test.go
@@ -1,0 +1,286 @@
+package tunnels
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParsePortMapping(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    PortMapping
+		wantErr bool
+	}{
+		{
+			name:  "single port",
+			input: "3000",
+			want:  PortMapping{Local: 3000, Remote: 3000},
+		},
+		{
+			name:  "local:remote",
+			input: "4501:4096",
+			want:  PortMapping{Local: 4501, Remote: 4096},
+		},
+		{
+			name:  "with whitespace",
+			input: "  8080  ",
+			want:  PortMapping{Local: 8080, Remote: 8080},
+		},
+		{
+			name:    "invalid format",
+			input:   "abc",
+			wantErr: true,
+		},
+		{
+			name:    "port too high",
+			input:   "70000",
+			wantErr: true,
+		},
+		{
+			name:    "port zero",
+			input:   "0",
+			wantErr: true,
+		},
+		{
+			name:    "negative port",
+			input:   "-1",
+			wantErr: true,
+		},
+		{
+			name:    "invalid local port",
+			input:   "abc:3000",
+			wantErr: true,
+		},
+		{
+			name:    "invalid remote port",
+			input:   "3000:abc",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePortMapping(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParsePortMapping() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ParsePortMapping() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePortMappings(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		want    []PortMapping
+		wantErr bool
+	}{
+		{
+			name:  "multiple ports",
+			input: []string{"3000", "4501:4096", "8080"},
+			want: []PortMapping{
+				{Local: 3000, Remote: 3000},
+				{Local: 4501, Remote: 4096},
+				{Local: 8080, Remote: 8080},
+			},
+		},
+		{
+			name:  "empty list",
+			input: []string{},
+			want:  []PortMapping{},
+		},
+		{
+			name:    "one invalid",
+			input:   []string{"3000", "invalid"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePortMappings(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParsePortMappings() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParsePortMappings() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergePortMappings(t *testing.T) {
+	tests := []struct {
+		name  string
+		input [][]PortMapping
+		want  []PortMapping
+	}{
+		{
+			name: "merge two slices",
+			input: [][]PortMapping{
+				{{Local: 3000, Remote: 3000}},
+				{{Local: 4000, Remote: 4000}},
+			},
+			want: []PortMapping{
+				{Local: 3000, Remote: 3000},
+				{Local: 4000, Remote: 4000},
+			},
+		},
+		{
+			name: "override same local port",
+			input: [][]PortMapping{
+				{{Local: 3000, Remote: 3000}},
+				{{Local: 3000, Remote: 4000}}, // Same local, different remote
+			},
+			want: []PortMapping{
+				{Local: 3000, Remote: 4000}, // Later takes precedence
+			},
+		},
+		{
+			name: "preserve order",
+			input: [][]PortMapping{
+				{{Local: 8080, Remote: 8080}, {Local: 3000, Remote: 3000}},
+				{{Local: 4000, Remote: 4000}},
+			},
+			want: []PortMapping{
+				{Local: 8080, Remote: 8080},
+				{Local: 3000, Remote: 3000},
+				{Local: 4000, Remote: 4000},
+			},
+		},
+		{
+			name:  "empty slices",
+			input: [][]PortMapping{},
+			want:  []PortMapping{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MergePortMappings(tt.input...)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MergePortMappings() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadTunnelConfig(t *testing.T) {
+	// Create temp dir
+	tmpDir := t.TempDir()
+
+	t.Run("file not exists returns empty config", func(t *testing.T) {
+		cfg, err := LoadTunnelConfigFromPath(filepath.Join(tmpDir, "nonexistent.yaml"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Sheds == nil {
+			t.Error("Sheds map should be initialized")
+		}
+	})
+
+	t.Run("valid config", func(t *testing.T) {
+		configPath := filepath.Join(tmpDir, "tunnels.yaml")
+		content := `
+ssh:
+  server_alive_interval: 60
+  server_alive_count_max: 5
+  connect_timeout: 15
+
+sheds:
+  myproj:
+    profiles:
+      default:
+        - "4501:4096"
+      dev:
+        - "4501:4096"
+        - "3000"
+        - "8080"
+`
+		if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
+			t.Fatalf("failed to write config: %v", err)
+		}
+
+		cfg, err := LoadTunnelConfigFromPath(configPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if cfg.SSH.ServerAliveInterval != 60 {
+			t.Errorf("ServerAliveInterval = %d, want 60", cfg.SSH.ServerAliveInterval)
+		}
+		if cfg.SSH.ServerAliveCountMax != 5 {
+			t.Errorf("ServerAliveCountMax = %d, want 5", cfg.SSH.ServerAliveCountMax)
+		}
+
+		profiles := cfg.GetProfiles("myproj")
+		if len(profiles) != 2 {
+			t.Errorf("expected 2 profiles, got %d", len(profiles))
+		}
+
+		ports, err := cfg.GetPortMappings("myproj", "dev")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ports) != 3 {
+			t.Errorf("expected 3 ports, got %d", len(ports))
+		}
+	})
+
+	t.Run("invalid YAML", func(t *testing.T) {
+		configPath := filepath.Join(tmpDir, "invalid.yaml")
+		if err := os.WriteFile(configPath, []byte("invalid: yaml: content:"), 0600); err != nil {
+			t.Fatalf("failed to write config: %v", err)
+		}
+
+		_, err := LoadTunnelConfigFromPath(configPath)
+		if err == nil {
+			t.Error("expected error for invalid YAML")
+		}
+	})
+}
+
+func TestGetPortMappings(t *testing.T) {
+	cfg := &TunnelConfig{
+		Sheds: map[string]ShedConfig{
+			"myproj": {
+				Profiles: map[string][]string{
+					"default": {"4501:4096"},
+					"dev":     {"3000", "8080"},
+				},
+			},
+		},
+	}
+
+	t.Run("valid profile", func(t *testing.T) {
+		ports, err := cfg.GetPortMappings("myproj", "dev")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ports) != 2 {
+			t.Errorf("expected 2 ports, got %d", len(ports))
+		}
+	})
+
+	t.Run("unknown shed", func(t *testing.T) {
+		_, err := cfg.GetPortMappings("unknown", "default")
+		if err == nil {
+			t.Error("expected error for unknown shed")
+		}
+	})
+
+	t.Run("unknown profile", func(t *testing.T) {
+		_, err := cfg.GetPortMappings("myproj", "unknown")
+		if err == nil {
+			t.Error("expected error for unknown profile")
+		}
+	})
+}

--- a/internal/tunnels/filelock.go
+++ b/internal/tunnels/filelock.go
@@ -1,0 +1,99 @@
+package tunnels
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// FileLock provides file-based locking using flock.
+type FileLock struct {
+	path string
+	file *os.File
+}
+
+// NewFileLock creates a new file lock for the given path.
+// The lock file will be created at path + ".lock".
+func NewFileLock(path string) *FileLock {
+	return &FileLock{
+		path: path + ".lock",
+	}
+}
+
+// Lock acquires an exclusive lock on the file.
+// It creates the lock file if it doesn't exist.
+func (fl *FileLock) Lock() error {
+	// Ensure directory exists
+	dir := filepath.Dir(fl.path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create lock directory: %w", err)
+	}
+
+	// Open or create the lock file
+	file, err := os.OpenFile(fl.path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to open lock file: %w", err)
+	}
+	fl.file = file
+
+	// Acquire exclusive lock (blocking)
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+		file.Close()
+		fl.file = nil
+		return fmt.Errorf("failed to acquire lock: %w", err)
+	}
+
+	return nil
+}
+
+// TryLock attempts to acquire an exclusive lock without blocking.
+// Returns true if the lock was acquired, false if it's already held.
+func (fl *FileLock) TryLock() (bool, error) {
+	// Ensure directory exists
+	dir := filepath.Dir(fl.path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return false, fmt.Errorf("failed to create lock directory: %w", err)
+	}
+
+	// Open or create the lock file
+	file, err := os.OpenFile(fl.path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return false, fmt.Errorf("failed to open lock file: %w", err)
+	}
+	fl.file = file
+
+	// Try to acquire exclusive lock (non-blocking)
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		file.Close()
+		fl.file = nil
+		if err == syscall.EWOULDBLOCK {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to acquire lock: %w", err)
+	}
+
+	return true, nil
+}
+
+// Unlock releases the lock and closes the lock file.
+func (fl *FileLock) Unlock() error {
+	if fl.file == nil {
+		return nil
+	}
+
+	// Release the lock
+	if err := syscall.Flock(int(fl.file.Fd()), syscall.LOCK_UN); err != nil {
+		fl.file.Close()
+		fl.file = nil
+		return fmt.Errorf("failed to release lock: %w", err)
+	}
+
+	if err := fl.file.Close(); err != nil {
+		fl.file = nil
+		return fmt.Errorf("failed to close lock file: %w", err)
+	}
+
+	fl.file = nil
+	return nil
+}

--- a/internal/tunnels/filelock_test.go
+++ b/internal/tunnels/filelock_test.go
@@ -1,0 +1,148 @@
+package tunnels
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestFileLock_LockUnlock(t *testing.T) {
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, "test.state")
+
+	fl := NewFileLock(lockPath)
+
+	// Lock should succeed
+	if err := fl.Lock(); err != nil {
+		t.Fatalf("Lock() failed: %v", err)
+	}
+
+	// Lock file should exist
+	if _, err := os.Stat(lockPath + ".lock"); os.IsNotExist(err) {
+		t.Error("Lock file was not created")
+	}
+
+	// Unlock should succeed
+	if err := fl.Unlock(); err != nil {
+		t.Fatalf("Unlock() failed: %v", err)
+	}
+}
+
+func TestFileLock_TryLock(t *testing.T) {
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, "test.state")
+
+	fl1 := NewFileLock(lockPath)
+	fl2 := NewFileLock(lockPath)
+
+	// First lock should succeed
+	acquired, err := fl1.TryLock()
+	if err != nil {
+		t.Fatalf("TryLock() failed: %v", err)
+	}
+	if !acquired {
+		t.Error("TryLock() should have acquired the lock")
+	}
+
+	// Second lock should fail (non-blocking)
+	acquired, err = fl2.TryLock()
+	if err != nil {
+		t.Fatalf("TryLock() returned error: %v", err)
+	}
+	if acquired {
+		t.Error("TryLock() should not have acquired the lock while held")
+	}
+
+	// Unlock first lock
+	if err := fl1.Unlock(); err != nil {
+		t.Fatalf("Unlock() failed: %v", err)
+	}
+
+	// Now second lock should succeed
+	acquired, err = fl2.TryLock()
+	if err != nil {
+		t.Fatalf("TryLock() failed: %v", err)
+	}
+	if !acquired {
+		t.Error("TryLock() should have acquired the lock after release")
+	}
+
+	if err := fl2.Unlock(); err != nil {
+		t.Fatalf("Unlock() failed: %v", err)
+	}
+}
+
+func TestFileLock_ConcurrentAccess(t *testing.T) {
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, "test.state")
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	accessOrder := make([]int, 0)
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			fl := NewFileLock(lockPath)
+			if err := fl.Lock(); err != nil {
+				t.Errorf("Lock() failed for goroutine %d: %v", id, err)
+				return
+			}
+
+			// Record access order
+			mu.Lock()
+			accessOrder = append(accessOrder, id)
+			mu.Unlock()
+
+			// Simulate some work
+			time.Sleep(10 * time.Millisecond)
+
+			if err := fl.Unlock(); err != nil {
+				t.Errorf("Unlock() failed for goroutine %d: %v", id, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// All goroutines should have accessed
+	if len(accessOrder) != 5 {
+		t.Errorf("Expected 5 accesses, got %d", len(accessOrder))
+	}
+}
+
+func TestFileLock_UnlockWithoutLock(t *testing.T) {
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, "test.state")
+
+	fl := NewFileLock(lockPath)
+
+	// Unlock without lock should not error
+	if err := fl.Unlock(); err != nil {
+		t.Errorf("Unlock() without lock should not error: %v", err)
+	}
+}
+
+func TestFileLock_CreateDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, "nested", "dir", "test.state")
+
+	fl := NewFileLock(lockPath)
+
+	if err := fl.Lock(); err != nil {
+		t.Fatalf("Lock() failed: %v", err)
+	}
+
+	// Nested directory should exist
+	if _, err := os.Stat(filepath.Dir(lockPath + ".lock")); os.IsNotExist(err) {
+		t.Error("Nested directory was not created")
+	}
+
+	if err := fl.Unlock(); err != nil {
+		t.Fatalf("Unlock() failed: %v", err)
+	}
+}

--- a/internal/tunnels/manager.go
+++ b/internal/tunnels/manager.go
@@ -1,0 +1,281 @@
+package tunnels
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+// Manager handles tunnel lifecycle operations.
+type Manager struct {
+	config *TunnelConfig
+	state  *TunnelState
+}
+
+// NewManager creates a new tunnel manager.
+func NewManager() (*Manager, error) {
+	cfg, err := LoadTunnelConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	state, err := LoadTunnelState()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Manager{
+		config: cfg,
+		state:  state,
+	}, nil
+}
+
+// NewManagerWithConfig creates a manager with a specific config (for testing).
+func NewManagerWithConfig(cfg *TunnelConfig, state *TunnelState) *Manager {
+	return &Manager{
+		config: cfg,
+		state:  state,
+	}
+}
+
+// Config returns the tunnel configuration.
+func (m *Manager) Config() *TunnelConfig {
+	return m.config
+}
+
+// State returns the tunnel state.
+func (m *Manager) State() *TunnelState {
+	return m.state
+}
+
+// BuildSSHArgs constructs the SSH command arguments for port forwarding.
+func (m *Manager) BuildSSHArgs(shedName string, serverEntry *config.ServerEntry, ports []PortMapping) []string {
+	knownHostsPath := config.GetKnownHostsPath()
+
+	args := []string{
+		"ssh",
+		"-N", // No remote command
+		"-T", // No pseudo-terminal
+		"-p", strconv.Itoa(serverEntry.SSHPort),
+		"-o", "UserKnownHostsFile=" + knownHostsPath,
+		"-o", "StrictHostKeyChecking=yes",
+		"-o", fmt.Sprintf("ServerAliveInterval=%d", m.config.SSH.ServerAliveInterval),
+		"-o", fmt.Sprintf("ServerAliveCountMax=%d", m.config.SSH.ServerAliveCountMax),
+		"-o", fmt.Sprintf("ConnectTimeout=%d", m.config.SSH.ConnectTimeout),
+		"-o", "ExitOnForwardFailure=yes",
+	}
+
+	for _, pm := range ports {
+		args = append(args, "-L", fmt.Sprintf("%d:localhost:%d", pm.Local, pm.Remote))
+	}
+
+	args = append(args, shedName+"@"+serverEntry.Host)
+	return args
+}
+
+// StartForeground starts a tunnel in the foreground using syscall.Exec.
+// This replaces the current process.
+func (m *Manager) StartForeground(shedName, serverName string, serverEntry *config.ServerEntry, ports []PortMapping, profile string) error {
+	args := m.BuildSSHArgs(shedName, serverEntry, ports)
+
+	sshPath, err := exec.LookPath("ssh")
+	if err != nil {
+		return fmt.Errorf("ssh not found in PATH: %w", err)
+	}
+
+	// Note: We don't save state for foreground tunnels since the process
+	// replaces the current one and we can't track the PID
+
+	if err := syscall.Exec(sshPath, args, os.Environ()); err != nil {
+		return fmt.Errorf("failed to exec ssh: %w", err)
+	}
+
+	return nil
+}
+
+// StartBackground starts a tunnel as a background daemon.
+func (m *Manager) StartBackground(shedName, serverName string, serverEntry *config.ServerEntry, ports []PortMapping, profile string) error {
+	args := m.BuildSSHArgs(shedName, serverEntry, ports)
+
+	sshPath, err := exec.LookPath("ssh")
+	if err != nil {
+		return fmt.Errorf("ssh not found in PATH: %w", err)
+	}
+
+	cmd := exec.Command(sshPath, args[1:]...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true, // Create new session (detach from terminal)
+	}
+
+	// Open /dev/null for proper process detachment
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", os.DevNull, err)
+	}
+	defer devNull.Close()
+
+	cmd.Stdout = devNull
+	cmd.Stderr = devNull
+	cmd.Stdin = devNull
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start ssh: %w", err)
+	}
+
+	// Save state
+	m.state.SetTunnel(shedName, TunnelEntry{
+		ShedName:   shedName,
+		Profile:    profile,
+		PID:        cmd.Process.Pid,
+		Ports:      ports,
+		StartedAt:  time.Now(),
+		ServerName: serverName,
+	})
+
+	if err := m.state.Save(); err != nil {
+		// Rollback: kill the process and remove from in-memory state
+		_ = m.killProcess(cmd.Process.Pid)
+		m.state.RemoveTunnel(shedName)
+		return fmt.Errorf("failed to save tunnel state: %w", err)
+	}
+
+	return nil
+}
+
+// Stop stops a tunnel for a shed.
+func (m *Manager) Stop(shedName string) error {
+	entry, ok := m.state.GetTunnel(shedName)
+	if !ok {
+		return fmt.Errorf("no tunnel found for shed %q", shedName)
+	}
+
+	// Process might already be dead, just clean up state regardless of error
+	_ = m.killProcess(entry.PID)
+
+	m.state.RemoveTunnel(shedName)
+	return m.state.Save()
+}
+
+// StopAllTunnelsForShed stops all tunnels for a shed (used when shed is stopped/deleted).
+func (m *Manager) StopAllTunnelsForShed(shedName string) error {
+	entry, ok := m.state.GetTunnel(shedName)
+	if !ok {
+		return nil // No tunnel to stop
+	}
+
+	// Process might already be dead, just clean up state regardless of error
+	_ = m.killProcess(entry.PID)
+
+	m.state.RemoveTunnel(shedName)
+	return m.state.Save()
+}
+
+// StopAll stops all tunnels.
+func (m *Manager) StopAll() error {
+	for shedName, entry := range m.state.GetAllTunnels() {
+		// Process might already be dead, continue cleaning up regardless of error
+		_ = m.killProcess(entry.PID)
+		m.state.RemoveTunnel(shedName)
+	}
+	return m.state.Save()
+}
+
+// CheckHealth checks if a tunnel process is still alive.
+func (m *Manager) CheckHealth(shedName string) (bool, error) {
+	entry, ok := m.state.GetTunnel(shedName)
+	if !ok {
+		return false, nil
+	}
+
+	return m.isProcessAlive(entry.PID), nil
+}
+
+// CleanupDeadTunnels removes state entries for dead processes.
+func (m *Manager) CleanupDeadTunnels() error {
+	changed := false
+	for shedName, entry := range m.state.GetAllTunnels() {
+		if !m.isProcessAlive(entry.PID) {
+			m.state.RemoveTunnel(shedName)
+			changed = true
+		}
+	}
+
+	if changed {
+		return m.state.Save()
+	}
+	return nil
+}
+
+// CheckPortConflict checks if a local port is available.
+// Returns a descriptive error if the port is in use.
+func (m *Manager) CheckPortConflict(port int) error {
+	// First check our own state for conflicts
+	if shedName, entry := m.state.FindTunnelUsingPort(port); entry != nil {
+		if m.isProcessAlive(entry.PID) {
+			duration := time.Since(entry.StartedAt)
+			return fmt.Errorf("port %d in use by tunnel %s:%s (started %s ago)",
+				port, shedName, entry.Profile, formatDuration(duration))
+		}
+	}
+
+	// Try to bind to the port to check if it's free
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return fmt.Errorf("port %d is already in use. Check with: lsof -i :%d", port, port)
+	}
+	listener.Close()
+
+	return nil
+}
+
+// CheckPortConflicts checks multiple ports for conflicts.
+func (m *Manager) CheckPortConflicts(ports []PortMapping) error {
+	for _, pm := range ports {
+		if err := m.CheckPortConflict(pm.Local); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// killProcess sends SIGTERM to a process.
+func (m *Manager) killProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+
+	return process.Signal(syscall.SIGTERM)
+}
+
+// isProcessAlive checks if a process is still running.
+func (m *Manager) isProcessAlive(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+
+	// Signal 0 checks if process exists without sending a signal
+	err = process.Signal(syscall.Signal(0))
+	return err == nil
+}
+
+// formatDuration formats a duration in a human-readable way.
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+	return fmt.Sprintf("%dd", int(d.Hours()/24))
+}

--- a/internal/tunnels/manager_test.go
+++ b/internal/tunnels/manager_test.go
@@ -1,0 +1,376 @@
+package tunnels
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+func TestBuildSSHArgs(t *testing.T) {
+	cfg := &TunnelConfig{
+		SSH: SSHConfig{
+			ServerAliveInterval: 30,
+			ServerAliveCountMax: 3,
+			ConnectTimeout:      10,
+		},
+		Sheds: make(map[string]ShedConfig),
+	}
+	state := &TunnelState{
+		Tunnels: make(map[string]TunnelEntry),
+	}
+	mgr := NewManagerWithConfig(cfg, state)
+
+	serverEntry := &config.ServerEntry{
+		Host:    "myserver.local",
+		SSHPort: 2222,
+	}
+
+	tests := []struct {
+		name      string
+		shedName  string
+		ports     []PortMapping
+		wantParts []string // Substrings that must appear in the args
+	}{
+		{
+			name:     "single port",
+			shedName: "myproj",
+			ports:    []PortMapping{{Local: 3000, Remote: 3000}},
+			wantParts: []string{
+				"ssh",
+				"-N",
+				"-T",
+				"-p", "2222",
+				"-o", "StrictHostKeyChecking=yes",
+				"-o", "ServerAliveInterval=30",
+				"-o", "ServerAliveCountMax=3",
+				"-o", "ConnectTimeout=10",
+				"-o", "ExitOnForwardFailure=yes",
+				"-L", "3000:localhost:3000",
+				"myproj@myserver.local",
+			},
+		},
+		{
+			name:     "multiple ports with different local/remote",
+			shedName: "devproj",
+			ports: []PortMapping{
+				{Local: 4501, Remote: 4096},
+				{Local: 8080, Remote: 8080},
+			},
+			wantParts: []string{
+				"ssh",
+				"-L", "4501:localhost:4096",
+				"-L", "8080:localhost:8080",
+				"devproj@myserver.local",
+			},
+		},
+		{
+			name:      "no ports",
+			shedName:  "empty",
+			ports:     []PortMapping{},
+			wantParts: []string{"ssh", "empty@myserver.local"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := mgr.BuildSSHArgs(tt.shedName, serverEntry, tt.ports)
+
+			// Check all expected parts appear in order
+			argStr := ""
+			for _, arg := range args {
+				argStr += arg + " "
+			}
+
+			for _, want := range tt.wantParts {
+				found := false
+				for _, arg := range args {
+					if arg == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("BuildSSHArgs() missing expected arg %q in %v", want, args)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildSSHArgsUsesKnownHostsPath(t *testing.T) {
+	cfg := &TunnelConfig{
+		SSH: SSHConfig{
+			ServerAliveInterval: 30,
+			ServerAliveCountMax: 3,
+			ConnectTimeout:      10,
+		},
+		Sheds: make(map[string]ShedConfig),
+	}
+	state := &TunnelState{
+		Tunnels: make(map[string]TunnelEntry),
+	}
+	mgr := NewManagerWithConfig(cfg, state)
+
+	serverEntry := &config.ServerEntry{
+		Host:    "test.local",
+		SSHPort: 22,
+	}
+
+	args := mgr.BuildSSHArgs("test", serverEntry, []PortMapping{{Local: 3000, Remote: 3000}})
+
+	// Check that UserKnownHostsFile is set
+	foundKnownHosts := false
+	for _, arg := range args {
+		if len(arg) > 18 && arg[:18] == "UserKnownHostsFile" {
+			foundKnownHosts = true
+			break
+		}
+	}
+	if !foundKnownHosts {
+		t.Errorf("BuildSSHArgs() should include UserKnownHostsFile option, got %v", args)
+	}
+}
+
+func TestCheckPortConflict(t *testing.T) {
+	cfg := &TunnelConfig{
+		SSH:   SSHConfig{},
+		Sheds: make(map[string]ShedConfig),
+	}
+
+	t.Run("conflict with existing tunnel from own process", func(t *testing.T) {
+		// Use our own PID which we know is alive
+		ourPID := os.Getpid()
+		state := &TunnelState{
+			Tunnels: map[string]TunnelEntry{
+				"existing": {
+					ShedName:  "existing",
+					Profile:   "default",
+					PID:       ourPID,
+					Ports:     []PortMapping{{Local: 9999, Remote: 9999}},
+					StartedAt: time.Now().Add(-time.Hour),
+				},
+			},
+		}
+		mgr := NewManagerWithConfig(cfg, state)
+
+		err := mgr.CheckPortConflict(9999)
+		if err == nil {
+			t.Error("expected error for port conflict with existing tunnel")
+		}
+	})
+
+	t.Run("no conflict with dead tunnel", func(t *testing.T) {
+		state := &TunnelState{
+			Tunnels: map[string]TunnelEntry{
+				"dead": {
+					ShedName:  "dead",
+					Profile:   "default",
+					PID:       999999999, // Unlikely to be a real process
+					Ports:     []PortMapping{{Local: 19876, Remote: 19876}},
+					StartedAt: time.Now().Add(-time.Hour),
+				},
+			},
+		}
+		mgr := NewManagerWithConfig(cfg, state)
+
+		// Port 19876 shouldn't be in use (high ephemeral port)
+		// This test may fail if port happens to be in use
+		err := mgr.CheckPortConflict(19876)
+		if err != nil {
+			// If port is actually in use by something else, skip
+			t.Skipf("port 19876 appears to be in use: %v", err)
+		}
+	})
+}
+
+func TestCheckPortConflicts(t *testing.T) {
+	cfg := &TunnelConfig{
+		SSH:   SSHConfig{},
+		Sheds: make(map[string]ShedConfig),
+	}
+	// Use our own PID which we know is alive
+	ourPID := os.Getpid()
+	state := &TunnelState{
+		Tunnels: map[string]TunnelEntry{
+			"existing": {
+				ShedName:  "existing",
+				Profile:   "default",
+				PID:       ourPID,
+				Ports:     []PortMapping{{Local: 9998, Remote: 9998}},
+				StartedAt: time.Now().Add(-time.Hour),
+			},
+		},
+	}
+	mgr := NewManagerWithConfig(cfg, state)
+
+	t.Run("conflict in list", func(t *testing.T) {
+		ports := []PortMapping{
+			{Local: 19877, Remote: 19877},
+			{Local: 9998, Remote: 9998}, // Conflicts with existing tunnel
+		}
+		err := mgr.CheckPortConflicts(ports)
+		if err == nil {
+			t.Error("expected error for port conflict")
+		}
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		err := mgr.CheckPortConflicts([]PortMapping{})
+		if err != nil {
+			t.Errorf("unexpected error for empty list: %v", err)
+		}
+	})
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		want     string
+	}{
+		{
+			name:     "seconds",
+			duration: 45 * time.Second,
+			want:     "45s",
+		},
+		{
+			name:     "one second",
+			duration: time.Second,
+			want:     "1s",
+		},
+		{
+			name:     "minutes",
+			duration: 5 * time.Minute,
+			want:     "5m",
+		},
+		{
+			name:     "one minute",
+			duration: time.Minute,
+			want:     "1m",
+		},
+		{
+			name:     "hours",
+			duration: 3 * time.Hour,
+			want:     "3h",
+		},
+		{
+			name:     "one hour",
+			duration: time.Hour,
+			want:     "1h",
+		},
+		{
+			name:     "days",
+			duration: 48 * time.Hour,
+			want:     "2d",
+		},
+		{
+			name:     "one day",
+			duration: 24 * time.Hour,
+			want:     "1d",
+		},
+		{
+			name:     "mixed minutes and seconds shows minutes",
+			duration: 2*time.Minute + 30*time.Second,
+			want:     "2m",
+		},
+		{
+			name:     "mixed hours and minutes shows hours",
+			duration: 2*time.Hour + 30*time.Minute,
+			want:     "2h",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatDuration(tt.duration)
+			if got != tt.want {
+				t.Errorf("formatDuration(%v) = %q, want %q", tt.duration, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestManagerState(t *testing.T) {
+	cfg := &TunnelConfig{
+		Sheds: make(map[string]ShedConfig),
+	}
+	state := &TunnelState{
+		Tunnels: make(map[string]TunnelEntry),
+	}
+	mgr := NewManagerWithConfig(cfg, state)
+
+	// State() should never return nil
+	if mgr.State() == nil {
+		t.Error("State() should never return nil")
+	}
+
+	// Config() should never return nil
+	if mgr.Config() == nil {
+		t.Error("Config() should never return nil")
+	}
+}
+
+func TestCheckHealth(t *testing.T) {
+	cfg := &TunnelConfig{
+		Sheds: make(map[string]ShedConfig),
+	}
+
+	t.Run("unknown tunnel returns false", func(t *testing.T) {
+		state := &TunnelState{
+			Tunnels: make(map[string]TunnelEntry),
+		}
+		mgr := NewManagerWithConfig(cfg, state)
+
+		alive, err := mgr.CheckHealth("nonexistent")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if alive {
+			t.Error("expected false for nonexistent tunnel")
+		}
+	})
+
+	t.Run("dead process returns false", func(t *testing.T) {
+		state := &TunnelState{
+			Tunnels: map[string]TunnelEntry{
+				"dead": {
+					ShedName: "dead",
+					PID:      999999999, // Unlikely to be a real process
+				},
+			},
+		}
+		mgr := NewManagerWithConfig(cfg, state)
+
+		alive, err := mgr.CheckHealth("dead")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if alive {
+			t.Error("expected false for dead process")
+		}
+	})
+
+	t.Run("own process returns true", func(t *testing.T) {
+		// Use our own PID which we know is alive
+		ourPID := os.Getpid()
+		state := &TunnelState{
+			Tunnels: map[string]TunnelEntry{
+				"self": {
+					ShedName: "self",
+					PID:      ourPID,
+				},
+			},
+		}
+		mgr := NewManagerWithConfig(cfg, state)
+
+		alive, err := mgr.CheckHealth("self")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !alive {
+			t.Error("expected true for our own process")
+		}
+	})
+}

--- a/internal/tunnels/state.go
+++ b/internal/tunnels/state.go
@@ -1,0 +1,140 @@
+package tunnels
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+// TunnelState represents the runtime state of all tunnels.
+type TunnelState struct {
+	Tunnels map[string]TunnelEntry `json:"tunnels"`
+
+	// Path to state file (not serialized)
+	path string `json:"-"`
+}
+
+// TunnelEntry represents a running tunnel.
+type TunnelEntry struct {
+	ShedName   string        `json:"shed_name"`
+	Profile    string        `json:"profile"`
+	PID        int           `json:"pid"`
+	Ports      []PortMapping `json:"ports"`
+	StartedAt  time.Time     `json:"started_at"`
+	ServerName string        `json:"server_name"`
+}
+
+// LoadTunnelState loads the tunnel state from disk.
+func LoadTunnelState() (*TunnelState, error) {
+	return LoadTunnelStateFromPath(config.GetTunnelStatePath())
+}
+
+// LoadTunnelStateFromPath loads tunnel state from a specific path.
+func LoadTunnelStateFromPath(path string) (*TunnelState, error) {
+	// Acquire lock for reading
+	lock := NewFileLock(path)
+	if err := lock.Lock(); err != nil {
+		return nil, fmt.Errorf("failed to acquire state lock: %w", err)
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	state := &TunnelState{
+		Tunnels: make(map[string]TunnelEntry),
+		path:    path,
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return state, nil
+		}
+		return nil, fmt.Errorf("failed to read tunnel state: %w", err)
+	}
+
+	if err := json.Unmarshal(data, state); err != nil {
+		return nil, fmt.Errorf("failed to parse tunnel state: %w", err)
+	}
+
+	if state.Tunnels == nil {
+		state.Tunnels = make(map[string]TunnelEntry)
+	}
+
+	state.path = path
+	return state, nil
+}
+
+// Save writes the tunnel state to disk.
+func (s *TunnelState) Save() error {
+	return s.SaveToPath(s.path)
+}
+
+// SaveToPath writes the tunnel state to a specific path.
+func (s *TunnelState) SaveToPath(path string) error {
+	// Acquire lock for writing
+	lock := NewFileLock(path)
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("failed to acquire state lock: %w", err)
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create state directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal state: %w", err)
+	}
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write state file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to save state file: %w", err)
+	}
+
+	s.path = path
+	return nil
+}
+
+// GetTunnel returns the tunnel entry for a shed.
+func (s *TunnelState) GetTunnel(shedName string) (TunnelEntry, bool) {
+	entry, ok := s.Tunnels[shedName]
+	return entry, ok
+}
+
+// SetTunnel sets the tunnel entry for a shed.
+func (s *TunnelState) SetTunnel(shedName string, entry TunnelEntry) {
+	s.Tunnels[shedName] = entry
+}
+
+// RemoveTunnel removes the tunnel entry for a shed.
+func (s *TunnelState) RemoveTunnel(shedName string) {
+	delete(s.Tunnels, shedName)
+}
+
+// GetAllTunnels returns all tunnel entries.
+func (s *TunnelState) GetAllTunnels() map[string]TunnelEntry {
+	return s.Tunnels
+}
+
+// FindTunnelUsingPort returns the shed name using a specific local port.
+func (s *TunnelState) FindTunnelUsingPort(port int) (string, *TunnelEntry) {
+	for shedName, entry := range s.Tunnels {
+		for _, pm := range entry.Ports {
+			if pm.Local == port {
+				entryCopy := entry
+				return shedName, &entryCopy
+			}
+		}
+	}
+	return "", nil
+}

--- a/internal/tunnels/state_test.go
+++ b/internal/tunnels/state_test.go
@@ -1,0 +1,198 @@
+package tunnels
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoadTunnelState(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	t.Run("file not exists returns empty state", func(t *testing.T) {
+		state, err := LoadTunnelStateFromPath(filepath.Join(tmpDir, "nonexistent.json"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if state.Tunnels == nil {
+			t.Error("Tunnels map should be initialized")
+		}
+		if len(state.Tunnels) != 0 {
+			t.Errorf("expected empty tunnels, got %d", len(state.Tunnels))
+		}
+	})
+
+	t.Run("valid state", func(t *testing.T) {
+		statePath := filepath.Join(tmpDir, "state.json")
+		content := `{
+  "tunnels": {
+    "myproj": {
+      "shed_name": "myproj",
+      "profile": "dev",
+      "pid": 12345,
+      "ports": [{"local": 4501, "remote": 4096}],
+      "started_at": "2024-01-17T10:30:00Z",
+      "server_name": "home"
+    }
+  }
+}`
+		if err := os.WriteFile(statePath, []byte(content), 0600); err != nil {
+			t.Fatalf("failed to write state: %v", err)
+		}
+
+		state, err := LoadTunnelStateFromPath(statePath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		entry, ok := state.GetTunnel("myproj")
+		if !ok {
+			t.Fatal("expected tunnel entry for myproj")
+		}
+		if entry.PID != 12345 {
+			t.Errorf("PID = %d, want 12345", entry.PID)
+		}
+		if entry.Profile != "dev" {
+			t.Errorf("Profile = %s, want dev", entry.Profile)
+		}
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		statePath := filepath.Join(tmpDir, "invalid.json")
+		if err := os.WriteFile(statePath, []byte("not json"), 0600); err != nil {
+			t.Fatalf("failed to write state: %v", err)
+		}
+
+		_, err := LoadTunnelStateFromPath(statePath)
+		if err == nil {
+			t.Error("expected error for invalid JSON")
+		}
+	})
+}
+
+func TestTunnelStateSave(t *testing.T) {
+	tmpDir := t.TempDir()
+	statePath := filepath.Join(tmpDir, "state.json")
+
+	state := &TunnelState{
+		Tunnels: make(map[string]TunnelEntry),
+		path:    statePath,
+	}
+
+	state.SetTunnel("myproj", TunnelEntry{
+		ShedName:   "myproj",
+		Profile:    "default",
+		PID:        54321,
+		Ports:      []PortMapping{{Local: 3000, Remote: 3000}},
+		StartedAt:  time.Now(),
+		ServerName: "home",
+	})
+
+	if err := state.Save(); err != nil {
+		t.Fatalf("failed to save state: %v", err)
+	}
+
+	// Reload and verify
+	loaded, err := LoadTunnelStateFromPath(statePath)
+	if err != nil {
+		t.Fatalf("failed to reload state: %v", err)
+	}
+
+	entry, ok := loaded.GetTunnel("myproj")
+	if !ok {
+		t.Fatal("expected tunnel entry")
+	}
+	if entry.PID != 54321 {
+		t.Errorf("PID = %d, want 54321", entry.PID)
+	}
+}
+
+func TestTunnelStateOperations(t *testing.T) {
+	state := &TunnelState{
+		Tunnels: make(map[string]TunnelEntry),
+	}
+
+	// Set tunnel
+	state.SetTunnel("proj1", TunnelEntry{
+		ShedName:  "proj1",
+		Profile:   "default",
+		PID:       1000,
+		Ports:     []PortMapping{{Local: 3000, Remote: 3000}},
+		StartedAt: time.Now(),
+	})
+
+	// Get tunnel
+	entry, ok := state.GetTunnel("proj1")
+	if !ok {
+		t.Fatal("expected tunnel entry")
+	}
+	if entry.PID != 1000 {
+		t.Errorf("PID = %d, want 1000", entry.PID)
+	}
+
+	// Get nonexistent
+	_, ok = state.GetTunnel("nonexistent")
+	if ok {
+		t.Error("expected false for nonexistent tunnel")
+	}
+
+	// Remove tunnel
+	state.RemoveTunnel("proj1")
+	_, ok = state.GetTunnel("proj1")
+	if ok {
+		t.Error("tunnel should be removed")
+	}
+}
+
+func TestFindTunnelUsingPort(t *testing.T) {
+	state := &TunnelState{
+		Tunnels: map[string]TunnelEntry{
+			"proj1": {
+				ShedName: "proj1",
+				Profile:  "default",
+				PID:      1000,
+				Ports:    []PortMapping{{Local: 3000, Remote: 3000}},
+			},
+			"proj2": {
+				ShedName: "proj2",
+				Profile:  "dev",
+				PID:      2000,
+				Ports: []PortMapping{
+					{Local: 4000, Remote: 4000},
+					{Local: 5000, Remote: 5000},
+				},
+			},
+		},
+	}
+
+	t.Run("find port in first project", func(t *testing.T) {
+		name, entry := state.FindTunnelUsingPort(3000)
+		if name != "proj1" {
+			t.Errorf("name = %s, want proj1", name)
+		}
+		if entry == nil {
+			t.Fatal("expected entry")
+		}
+	})
+
+	t.Run("find port in second project", func(t *testing.T) {
+		name, entry := state.FindTunnelUsingPort(5000)
+		if name != "proj2" {
+			t.Errorf("name = %s, want proj2", name)
+		}
+		if entry == nil {
+			t.Fatal("expected entry")
+		}
+	})
+
+	t.Run("port not found", func(t *testing.T) {
+		name, entry := state.FindTunnelUsingPort(9999)
+		if name != "" {
+			t.Errorf("expected empty name, got %s", name)
+		}
+		if entry != nil {
+			t.Error("expected nil entry")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `shed tunnels start/stop/list/config` commands for SSH port forwarding to sheds
- Profile-based tunnel configuration via `~/.shed/tunnels.yaml`
- Supports background daemon mode with health checking and automatic cleanup
- Auto-starts stopped sheds when attaching, opening console, or starting tunnels
- Cleans up tunnels automatically when sheds are stopped or deleted

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [ ] CI build passes
- [ ] Manual testing of tunnel commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full SSH tunnel CLI: start/stop/list/config with profiles, foreground/background modes, JSON output, and relative timing
  * SSH local port-forwarding now proxies directly into shed containers; container IPs are discoverable

* **Changes**
  * Sheds will be auto-started when attaching or opening a console
  * Related tunnels are stopped/cleaned up before stopping or deleting a shed

* **Tests**
  * Comprehensive unit tests for tunnel config, manager, state, and file-locking

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->