### PR TITLE
Add configurable timeout for create and start operations

### DIFF
--- a/cmd/shed/attach.go
+++ b/cmd/shed/attach.go
@@ -60,7 +60,7 @@ func runAttach(cmd *cobra.Command, args []string) error {
 	}
 
 	// Ensure the shed is running (auto-start if stopped)
-	client := NewAPIClientFromEntry(entry)
+	client := NewAPIClientFromEntry(entry, clientConfig.GetCreateTimeout())
 	if _, err := ensureRunningShed(client, name); err != nil {
 		return err
 	}

--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,25 +12,32 @@ import (
 	"github.com/charliek/shed/internal/config"
 )
 
+const (
+	// DefaultTimeout for quick API operations (list, stop, delete, etc.)
+	DefaultTimeout = 30 * time.Second
+)
+
 // APIClient provides methods for interacting with the shed server API.
 type APIClient struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL       string
+	httpClient    *http.Client
+	createTimeout time.Duration
 }
 
 // NewAPIClient creates a new API client for the given host and port.
-func NewAPIClient(host string, port int) *APIClient {
+func NewAPIClient(host string, port int, createTimeout time.Duration) *APIClient {
 	return &APIClient{
 		baseURL: fmt.Sprintf("http://%s:%d", host, port),
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: DefaultTimeout,
 		},
+		createTimeout: createTimeout,
 	}
 }
 
 // NewAPIClientFromEntry creates a new API client from a server entry.
-func NewAPIClientFromEntry(entry *config.ServerEntry) *APIClient {
-	return NewAPIClient(entry.Host, entry.HTTPPort)
+func NewAPIClientFromEntry(entry *config.ServerEntry, createTimeout time.Duration) *APIClient {
+	return NewAPIClient(entry.Host, entry.HTTPPort, createTimeout)
 }
 
 // doRequest performs an HTTP request with JSON body and response handling.
@@ -54,6 +62,70 @@ func (c *APIClient) doRequest(method, path string, body, result interface{}, exp
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		return fmt.Errorf("failed to connect to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check for expected status codes
+	validStatus := false
+	if len(expectedStatus) == 0 {
+		validStatus = resp.StatusCode == http.StatusOK
+	} else {
+		for _, s := range expectedStatus {
+			if resp.StatusCode == s {
+				validStatus = true
+				break
+			}
+		}
+	}
+	if !validStatus {
+		return c.parseError(resp)
+	}
+
+	// Decode result if provided
+	if result != nil {
+		if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+			return fmt.Errorf("failed to parse response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// doRequestWithTimeout performs an HTTP request with a custom timeout using context.
+// Used for long-running operations like create and start that may need more time.
+func (c *APIClient) doRequestWithTimeout(method, path string, body, result interface{}, timeout time.Duration, expectedStatus ...int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyData, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to encode request: %w", err)
+		}
+		bodyReader = bytes.NewReader(bodyData)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	// Create a client without a Timeout for long-running requests.
+	// Important: When both http.Client.Timeout and context deadline are set,
+	// the shorter one wins. Since c.httpClient has a 30s timeout, we must use
+	// a separate client here to allow the context timeout (potentially minutes)
+	// to control cancellation.
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("request timed out after %v (use --timeout to increase)", timeout)
+		}
 		return fmt.Errorf("failed to connect to server: %w", err)
 	}
 	defer resp.Body.Close()
@@ -114,7 +186,7 @@ func (c *APIClient) ListSheds() (*config.ShedsResponse, error) {
 // CreateShed creates a new shed.
 func (c *APIClient) CreateShed(req *config.CreateShedRequest) (*config.Shed, error) {
 	var shed config.Shed
-	if err := c.doRequest(http.MethodPost, "/api/sheds", req, &shed, http.StatusCreated, http.StatusOK); err != nil {
+	if err := c.doRequestWithTimeout(http.MethodPost, "/api/sheds", req, &shed, c.createTimeout, http.StatusCreated, http.StatusOK); err != nil {
 		return nil, err
 	}
 	return &shed, nil
@@ -141,7 +213,7 @@ func (c *APIClient) DeleteShed(name string, keepVolume bool) error {
 // StartShed starts a stopped shed.
 func (c *APIClient) StartShed(name string) (*config.Shed, error) {
 	var shed config.Shed
-	if err := c.doRequest(http.MethodPost, "/api/sheds/"+name+"/start", nil, &shed); err != nil {
+	if err := c.doRequestWithTimeout(http.MethodPost, "/api/sheds/"+name+"/start", nil, &shed, c.createTimeout); err != nil {
 		return nil, err
 	}
 	return &shed, nil

--- a/cmd/shed/console.go
+++ b/cmd/shed/console.go
@@ -93,7 +93,7 @@ func sshToShed(name string, command []string) error {
 	}
 
 	// Ensure the shed is running (auto-start if stopped)
-	client := NewAPIClientFromEntry(entry)
+	client := NewAPIClientFromEntry(entry, clientConfig.GetCreateTimeout())
 	if _, err := ensureRunningShed(client, name); err != nil {
 		return err
 	}

--- a/cmd/shed/server.go
+++ b/cmd/shed/server.go
@@ -77,7 +77,7 @@ func runServerAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Connect and get server info
-	client := NewAPIClient(host, serverAddPort)
+	client := NewAPIClient(host, serverAddPort, DefaultTimeout)
 	info, err := client.GetInfo()
 	if err != nil {
 		return fmt.Errorf("failed to get server info: %w", err)
@@ -150,7 +150,7 @@ func runServerList(cmd *cobra.Command, args []string) error {
 		entry := clientConfig.Servers[name]
 
 		// Check if server is online
-		client := NewAPIClientFromEntry(&entry)
+		client := NewAPIClientFromEntry(&entry, DefaultTimeout)
 		status := "offline"
 		if client.Ping() {
 			status = "online"

--- a/cmd/shed/sessions.go
+++ b/cmd/shed/sessions.go
@@ -59,7 +59,7 @@ func runSessions(cmd *cobra.Command, args []string) error {
 	if sessionsAllFlag {
 		// Query all servers
 		for serverName, entry := range clientConfig.Servers {
-			client := NewAPIClientFromEntry(&entry)
+			client := NewAPIClientFromEntry(&entry, DefaultTimeout)
 			resp, err := client.ListAllSessions()
 			if err != nil {
 				if verboseFlag {
@@ -83,7 +83,7 @@ func runSessions(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		client := NewAPIClientFromEntry(entry)
+		client := NewAPIClientFromEntry(entry, DefaultTimeout)
 
 		if len(args) == 1 {
 			// List sessions for a specific shed
@@ -129,7 +129,7 @@ func runSessionsKill(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	client := NewAPIClientFromEntry(entry)
+	client := NewAPIClientFromEntry(entry, DefaultTimeout)
 	if err := client.KillSession(shedName, sessionName); err != nil {
 		return fmt.Errorf("failed to kill session: %w", err)
 	}

--- a/cmd/shed/shed.go
+++ b/cmd/shed/shed.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -64,6 +65,8 @@ var (
 	createNoProvision bool
 	createNoSync      bool
 	createSyncProfile string
+	createTimeout     time.Duration
+	startTimeout      time.Duration
 	listAll           bool
 	deleteKeep        bool
 	deleteForce       bool
@@ -75,6 +78,9 @@ func init() {
 	createCmd.Flags().BoolVar(&createNoProvision, "no-provision", false, "Skip running provisioning hooks")
 	createCmd.Flags().BoolVar(&createNoSync, "no-sync", false, "Skip syncing default profile")
 	createCmd.Flags().StringVar(&createSyncProfile, "sync-profile", "", "Profile to sync after creation (default: 'default')")
+	createCmd.Flags().DurationVar(&createTimeout, "timeout", 0, "Timeout for create operation (default: from config or 10m)")
+
+	startCmd.Flags().DurationVar(&startTimeout, "timeout", 0, "Timeout for start operation (default: from config or 10m)")
 
 	listCmd.Flags().BoolVarP(&listAll, "all", "a", false, "List sheds from all servers")
 
@@ -102,7 +108,14 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Creating shed %s on %s...\n", name, serverName)
 	}
 
-	client := NewAPIClientFromEntry(entry)
+	// Determine timeout: CLI flag > config > default
+	// Note: --timeout 0 is treated as "not set" and uses config/default value
+	timeout := createTimeout
+	if timeout == 0 {
+		timeout = clientConfig.GetCreateTimeout()
+	}
+
+	client := NewAPIClientFromEntry(entry, timeout)
 	req := &config.CreateShedRequest{
 		Name:        name,
 		Repo:        createRepo,
@@ -153,7 +166,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	if listAll {
 		// Query all servers
 		for name, e := range clientConfig.Servers {
-			client := NewAPIClientFromEntry(&e)
+			client := NewAPIClientFromEntry(&e, DefaultTimeout)
 			resp, err := client.ListSheds()
 			if err != nil {
 				if verboseFlag {
@@ -168,7 +181,7 @@ func runList(cmd *cobra.Command, args []string) error {
 			}
 		}
 	} else {
-		client := NewAPIClientFromEntry(entry)
+		client := NewAPIClientFromEntry(entry, DefaultTimeout)
 		resp, err := client.ListSheds()
 		if err != nil {
 			return fmt.Errorf("failed to list sheds: %w", err)
@@ -248,7 +261,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	// Stop any associated tunnels first
 	stopTunnelsForShed(name)
 
-	client := NewAPIClientFromEntry(entry)
+	client := NewAPIClientFromEntry(entry, DefaultTimeout)
 	if err := client.DeleteShed(name, deleteKeep); err != nil {
 		return fmt.Errorf("failed to delete shed: %w", err)
 	}
@@ -277,7 +290,14 @@ func runStart(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Starting shed %s on %s...\n", name, serverName)
 	}
 
-	client := NewAPIClientFromEntry(entry)
+	// Determine timeout: CLI flag > config > default
+	// Note: --timeout 0 is treated as "not set" and uses config/default value
+	timeout := startTimeout
+	if timeout == 0 {
+		timeout = clientConfig.GetCreateTimeout()
+	}
+
+	client := NewAPIClientFromEntry(entry, timeout)
 	shed, err := client.StartShed(name)
 	if err != nil {
 		return fmt.Errorf("failed to start shed: %w", err)
@@ -310,7 +330,7 @@ func runStop(cmd *cobra.Command, args []string) error {
 	// Stop any associated tunnels first
 	stopTunnelsForShed(name)
 
-	client := NewAPIClientFromEntry(entry)
+	client := NewAPIClientFromEntry(entry, DefaultTimeout)
 	shed, err := client.StopShed(name)
 	if err != nil {
 		return fmt.Errorf("failed to stop shed: %w", err)
@@ -353,7 +373,7 @@ func findShedServer(name string) (string, *config.ServerEntry, error) {
 		entry, err := clientConfig.GetServer(cachedServer)
 		if err == nil {
 			// Verify the shed still exists
-			client := NewAPIClientFromEntry(entry)
+			client := NewAPIClientFromEntry(entry, DefaultTimeout)
 			if _, err := client.GetShed(name); err == nil {
 				return cachedServer, entry, nil
 			}
@@ -368,7 +388,7 @@ func findShedServer(name string) (string, *config.ServerEntry, error) {
 		if err != nil {
 			return "", nil, err
 		}
-		client := NewAPIClientFromEntry(entry)
+		client := NewAPIClientFromEntry(entry, DefaultTimeout)
 		if _, err := client.GetShed(name); err != nil {
 			printError(fmt.Sprintf("shed %q not found on %s", name, serverFlag),
 				"shed list --all       # Find which server has it",
@@ -382,7 +402,7 @@ func findShedServer(name string) (string, *config.ServerEntry, error) {
 	if clientConfig.DefaultServer != "" {
 		entry, _ := clientConfig.GetServer(clientConfig.DefaultServer)
 		if entry != nil {
-			client := NewAPIClientFromEntry(entry)
+			client := NewAPIClientFromEntry(entry, DefaultTimeout)
 			if _, err := client.GetShed(name); err == nil {
 				clientConfig.CacheShed(name, clientConfig.DefaultServer, "")
 				return clientConfig.DefaultServer, entry, nil
@@ -395,7 +415,7 @@ func findShedServer(name string) (string, *config.ServerEntry, error) {
 		if serverName == clientConfig.DefaultServer {
 			continue // Already checked
 		}
-		client := NewAPIClientFromEntry(&entry)
+		client := NewAPIClientFromEntry(&entry, DefaultTimeout)
 		if _, err := client.GetShed(name); err == nil {
 			// Update cache
 			clientConfig.CacheShed(name, serverName, "")

--- a/cmd/shed/ssh_config.go
+++ b/cmd/shed/ssh_config.go
@@ -117,7 +117,7 @@ func getAllShedsInfo() ([]shedInfo, error) {
 	// Query all servers for their sheds
 	for serverName, entry := range clientConfig.Servers {
 		entryCopy := entry
-		client := NewAPIClientFromEntry(&entryCopy)
+		client := NewAPIClientFromEntry(&entryCopy, DefaultTimeout)
 		resp, err := client.ListSheds()
 		if err != nil {
 			if verboseFlag {

--- a/cmd/shed/sync.go
+++ b/cmd/shed/sync.go
@@ -64,7 +64,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 	}
 
 	// Ensure shed is running
-	client := NewAPIClientFromEntry(entry)
+	client := NewAPIClientFromEntry(entry, clientConfig.GetCreateTimeout())
 	if _, err := ensureRunningShed(client, name); err != nil {
 		return err
 	}

--- a/cmd/shed/tunnels.go
+++ b/cmd/shed/tunnels.go
@@ -181,7 +181,7 @@ func runTunnelsStart(cmd *cobra.Command, args []string) error {
 	}
 
 	// Ensure the shed is running (auto-start if stopped)
-	client := NewAPIClientFromEntry(entry)
+	client := NewAPIClientFromEntry(entry, clientConfig.GetCreateTimeout())
 	if _, err := ensureRunningShed(client, shedName); err != nil {
 		return err
 	}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -83,6 +83,7 @@ shed create <name> [flags]
 | `--no-provision` | | `false` | Skip provisioning hooks |
 | `--sync-profile` | | `default` | Profile to sync after creation |
 | `--no-sync` | | `false` | Skip syncing default profile |
+| `--timeout` | | `10m` | Timeout for create operation (e.g., `30s`, `5m`, `2h`) |
 
 **Examples:**
 
@@ -92,6 +93,7 @@ shed create codelens --repo charliek/codelens
 shed create stbot --repo charliek/stbot --server cloud-vps
 shed create myproj --sync-profile full
 shed create myproj --no-sync
+shed create bigproj --repo org/large-repo --timeout 30m
 ```
 
 ### shed list
@@ -120,8 +122,12 @@ mini-desktop    mcp-test      stopped    3 days ago       -
 Starts a stopped shed.
 
 ```bash
-shed start <name>
+shed start <name> [flags]
 ```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--timeout` | | `10m` | Timeout for start operation (e.g., `30s`, `5m`, `2h`) |
 
 ### shed stop
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -24,6 +24,9 @@ servers:
 
 default_server: mini-desktop
 
+# Timeout for shed create and start operations
+create_timeout: 30m
+
 sheds:
   codelens:
     server: mini-desktop
@@ -41,6 +44,7 @@ sheds:
 | `servers.<name>.ssh_port` | int | SSH server port |
 | `default_server` | string | Default server for commands |
 | `sheds` | map | Cached shed locations |
+| `create_timeout` | duration | Timeout for create/start operations (default: `10m`) |
 
 ## Server Configuration
 

--- a/images/shed-base/Dockerfile
+++ b/images/shed-base/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:24.04
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # System packages
 RUN apt-get update && apt-get install -y \
     curl \
@@ -15,10 +17,15 @@ RUN apt-get update && apt-get install -y \
     ncurses-term \
     tree \
     ripgrep \
+    unzip \
+    sudo \
     && rm -rf /var/lib/apt/lists/*
+# unzip: for extracting archives in provisioning scripts
+# sudo: for provisioning scripts that need elevated privileges
 
 # mise
 RUN curl https://mise.run | sh
+ENV PATH="/root/.local/share/mise/shims:/root/.local/bin:${PATH}"
 
 # RUN mise install \
 #     java@temurin-21 \

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -14,9 +14,18 @@ type ClientConfig struct {
 	Servers       map[string]ServerEntry `yaml:"servers"`
 	DefaultServer string                 `yaml:"default_server"`
 	Sheds         map[string]ShedCache   `yaml:"sheds"`
+	CreateTimeout time.Duration          `yaml:"create_timeout,omitempty"`
 
 	// Path to config file (not serialized)
 	path string `yaml:"-"`
+}
+
+// GetCreateTimeout returns the configured create timeout or the default (10 minutes).
+func (c *ClientConfig) GetCreateTimeout() time.Duration {
+	if c.CreateTimeout > 0 {
+		return c.CreateTimeout
+	}
+	return 10 * time.Minute
 }
 
 // ServerEntry represents a configured server.


### PR DESCRIPTION
## Summary

- Add `--timeout` flag to `shed create` and `shed start` commands to support long-running operations involving git clone and provisioning
- Add `create_timeout` config option for global timeout setting
- Add `unzip` and `sudo` packages to base Docker image for provisioning scripts
- Code cleanup: remove unused constant, improve HTTP client reuse, document zero-timeout behavior

## Test plan

- [ ] Run `go build ./cmd/shed` to verify compilation
- [ ] Test `shed create` with `--timeout` flag
- [ ] Test `shed start` with `--timeout` flag  
- [ ] Test default timeout behavior (no flag)
- [ ] Verify timeouts work correctly for long operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-operation timeouts for create/start and other shed operations; timeouts are applied consistently across client interactions.
  * New CLI --timeout flags for create and start (default 10m) and config-driven create_timeout for persistent settings.

* **Documentation**
  * Updated CLI reference and configuration docs with timeout flags, defaults, and examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->