### PR TITLE
Add backend abstraction layer

### DIFF
--- a/cmd/shed-server/serve.go
+++ b/cmd/shed-server/serve.go
@@ -3,17 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/spf13/cobra"
 
 	"github.com/charliek/shed/internal/api"
@@ -53,22 +49,21 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create docker client: %w", err)
 	}
-	defer dockerClient.Close()
 	log.Printf("Connected to Docker")
 
-	// Create adapters for the different interfaces
-	apiAdapter := &dockerAPIAdapter{client: dockerClient}
-	sshAdapter := &dockerSSHAdapter{client: dockerClient}
+	// Create backend wrapper
+	backend := docker.NewBackend(dockerClient)
+	defer backend.Close()
 
 	// Initialize SSH server
-	sshServer, err := sshd.NewServer(sshAdapter, DefaultHostKeyPath, cfg.SSHPort, cfg.Terminal)
+	sshServer, err := sshd.NewServer(backend, DefaultHostKeyPath, cfg.SSHPort, cfg.Terminal)
 	if err != nil {
 		return fmt.Errorf("failed to create SSH server: %w", err)
 	}
 	hostKey := sshServer.GetHostPublicKey()
 
 	// Initialize HTTP API server
-	apiServer := api.NewServer(apiAdapter, cfg, hostKey)
+	apiServer := api.NewServer(backend, cfg, hostKey)
 	router := apiServer.Router()
 
 	// Create HTTP server
@@ -136,190 +131,4 @@ func loadConfig() (*config.ServerConfig, error) {
 		return config.LoadServerConfigFromPath(configPath)
 	}
 	return config.LoadServerConfig()
-}
-
-// dockerAPIAdapter adapts the docker.Client to the api.DockerClient interface.
-type dockerAPIAdapter struct {
-	client *docker.Client
-}
-
-// ListSheds returns all shed containers.
-func (a *dockerAPIAdapter) ListSheds(ctx context.Context) ([]config.Shed, error) {
-	return a.client.ListSheds(ctx)
-}
-
-// GetShed returns a single shed by name.
-func (a *dockerAPIAdapter) GetShed(ctx context.Context, name string) (*config.Shed, error) {
-	return a.client.GetShed(ctx, name)
-}
-
-// CreateShed creates a new shed container.
-func (a *dockerAPIAdapter) CreateShed(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error) {
-	return a.client.CreateShed(ctx, req)
-}
-
-// DeleteShed removes a shed container and optionally its volume.
-func (a *dockerAPIAdapter) DeleteShed(ctx context.Context, name string, keepVolume bool) error {
-	return a.client.DeleteShed(ctx, name, keepVolume)
-}
-
-// StartShed starts a stopped shed container.
-func (a *dockerAPIAdapter) StartShed(ctx context.Context, name string) (*config.Shed, error) {
-	return a.client.StartShed(ctx, name)
-}
-
-// StopShed stops a running shed container.
-func (a *dockerAPIAdapter) StopShed(ctx context.Context, name string) (*config.Shed, error) {
-	return a.client.StopShed(ctx, name)
-}
-
-// ListSessions returns all tmux sessions in a shed container.
-func (a *dockerAPIAdapter) ListSessions(ctx context.Context, shedName string) ([]config.Session, error) {
-	return a.client.ListSessions(ctx, shedName)
-}
-
-// KillSession terminates a tmux session in a shed container.
-func (a *dockerAPIAdapter) KillSession(ctx context.Context, shedName, sessionName string) error {
-	return a.client.KillSession(ctx, shedName, sessionName)
-}
-
-// dockerSSHAdapter adapts the docker.Client to the sshd.DockerClient interface.
-type dockerSSHAdapter struct {
-	client *docker.Client
-}
-
-// GetShed returns a shed by name.
-func (a *dockerSSHAdapter) GetShed(ctx context.Context, name string) (*sshd.ShedInfo, error) {
-	shed, err := a.client.GetShed(ctx, name)
-	if err != nil {
-		return nil, err
-	}
-
-	return &sshd.ShedInfo{
-		Name:        shed.Name,
-		Status:      shed.Status,
-		ContainerID: shed.ContainerID,
-	}, nil
-}
-
-// StartShed starts a stopped shed.
-func (a *dockerSSHAdapter) StartShed(ctx context.Context, name string) error {
-	_, err := a.client.StartShed(ctx, name)
-	return err
-}
-
-// GetContainerIP returns the IP address of a container.
-func (a *dockerSSHAdapter) GetContainerIP(ctx context.Context, containerID string) (string, error) {
-	return a.client.GetContainerIP(ctx, containerID)
-}
-
-// ExecInContainer executes a command in a container with the given options.
-func (a *dockerSSHAdapter) ExecInContainer(ctx context.Context, containerID string, opts sshd.ExecOptions) error {
-	dockerClient := a.client.Docker()
-
-	// Build command - if empty, use default login shell
-	cmd := opts.Cmd
-	if len(cmd) == 0 {
-		cmd = []string{"/bin/bash", "--login"}
-	} else {
-		// Wrap command in shell to support operators like &&, ||, |, etc.
-		// SSH sends the command as space-separated tokens, but Docker exec
-		// expects an argv. The shell parses operators correctly.
-		cmd = []string{"/bin/sh", "-c", strings.Join(cmd, " ")}
-	}
-
-	// Create exec configuration
-	execConfig := container.ExecOptions{
-		Cmd:          cmd,
-		AttachStdin:  opts.Stdin != nil,
-		AttachStdout: opts.Stdout != nil,
-		AttachStderr: opts.Stderr != nil,
-		Tty:          opts.TTY,
-		Env:          opts.Env,
-		WorkingDir:   config.WorkspacePath,
-	}
-
-	execResp, err := dockerClient.ContainerExecCreate(ctx, containerID, execConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create exec: %w", err)
-	}
-
-	// Attach to the exec session
-	attachResp, err := dockerClient.ContainerExecAttach(ctx, execResp.ID, container.ExecStartOptions{
-		Tty: opts.TTY,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to attach to exec: %w", err)
-	}
-	defer attachResp.Close()
-
-	// Handle terminal resize if TTY is enabled
-	if opts.TTY && opts.ResizeChan != nil {
-		go func() {
-			for size := range opts.ResizeChan {
-				_ = dockerClient.ContainerExecResize(ctx, execResp.ID, container.ResizeOptions{
-					Height: size.Height,
-					Width:  size.Width,
-				})
-			}
-		}()
-
-		// Set initial size
-		if opts.InitialSize != nil {
-			_ = dockerClient.ContainerExecResize(ctx, execResp.ID, container.ResizeOptions{
-				Height: opts.InitialSize.Height,
-				Width:  opts.InitialSize.Width,
-			})
-		}
-	}
-
-	// Channel to signal when stdout completes (container exited)
-	done := make(chan struct{})
-
-	// Copy stdin to container (fire and forget - don't wait for it)
-	if opts.Stdin != nil {
-		go func() {
-			_, _ = io.Copy(attachResp.Conn, opts.Stdin)
-			// Close the connection's write side when stdin is done
-			if cw, ok := attachResp.Conn.(interface{ CloseWrite() error }); ok {
-				_ = cw.CloseWrite()
-			}
-		}()
-	}
-
-	// Copy container output to stdout - when this finishes, container has exited
-	go func() {
-		defer close(done)
-		if opts.TTY {
-			// In TTY mode, all output goes to stdout
-			if opts.Stdout != nil {
-				_, _ = io.Copy(opts.Stdout, attachResp.Reader)
-			}
-		} else {
-			// In non-TTY mode, Docker multiplexes stdout/stderr with headers
-			// Use stdcopy to demux the stream
-			if opts.Stdout != nil {
-				stderr := opts.Stderr
-				if stderr == nil {
-					stderr = opts.Stdout // fallback: send stderr to stdout
-				}
-				_, _ = stdcopy.StdCopy(opts.Stdout, stderr, attachResp.Reader)
-			}
-		}
-	}()
-
-	// Wait only for stdout to complete (container exit), not stdin
-	<-done
-
-	// Check exit code
-	inspectResp, err := dockerClient.ContainerExecInspect(ctx, execResp.ID)
-	if err != nil {
-		return fmt.Errorf("failed to inspect exec: %w", err)
-	}
-
-	if inspectResp.ExitCode != 0 {
-		return fmt.Errorf("command exited with code %d", inspectResp.ExitCode)
-	}
-
-	return nil
 }

--- a/cmd/shed/attach.go
+++ b/cmd/shed/attach.go
@@ -60,7 +60,7 @@ func runAttach(cmd *cobra.Command, args []string) error {
 	}
 
 	// Ensure the shed is running (auto-start if stopped)
-	client := NewAPIClientFromEntry(entry)
+	client := NewAPIClientFromEntry(entry, clientConfig.GetCreateTimeout())
 	if _, err := ensureRunningShed(client, name); err != nil {
 		return err
 	}

--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,25 +12,32 @@ import (
 	"github.com/charliek/shed/internal/config"
 )
 
+const (
+	// DefaultTimeout for quick API operations (list, stop, delete, etc.)
+	DefaultTimeout = 30 * time.Second
+)
+
 // APIClient provides methods for interacting with the shed server API.
 type APIClient struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL       string
+	httpClient    *http.Client
+	createTimeout time.Duration
 }
 
 // NewAPIClient creates a new API client for the given host and port.
-func NewAPIClient(host string, port int) *APIClient {
+func NewAPIClient(host string, port int, createTimeout time.Duration) *APIClient {
 	return &APIClient{
 		baseURL: fmt.Sprintf("http://%s:%d", host, port),
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: DefaultTimeout,
 		},
+		createTimeout: createTimeout,
 	}
 }
 
 // NewAPIClientFromEntry creates a new API client from a server entry.
-func NewAPIClientFromEntry(entry *config.ServerEntry) *APIClient {
-	return NewAPIClient(entry.Host, entry.HTTPPort)
+func NewAPIClientFromEntry(entry *config.ServerEntry, createTimeout time.Duration) *APIClient {
+	return NewAPIClient(entry.Host, entry.HTTPPort, createTimeout)
 }
 
 // doRequest performs an HTTP request with JSON body and response handling.
@@ -54,6 +62,70 @@ func (c *APIClient) doRequest(method, path string, body, result interface{}, exp
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		return fmt.Errorf("failed to connect to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check for expected status codes
+	validStatus := false
+	if len(expectedStatus) == 0 {
+		validStatus = resp.StatusCode == http.StatusOK
+	} else {
+		for _, s := range expectedStatus {
+			if resp.StatusCode == s {
+				validStatus = true
+				break
+			}
+		}
+	}
+	if !validStatus {
+		return c.parseError(resp)
+	}
+
+	// Decode result if provided
+	if result != nil {
+		if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+			return fmt.Errorf("failed to parse response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// doRequestWithTimeout performs an HTTP request with a custom timeout using context.
+// Used for long-running operations like create and start that may need more time.
+func (c *APIClient) doRequestWithTimeout(method, path string, body, result interface{}, timeout time.Duration, expectedStatus ...int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyData, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to encode request: %w", err)
+		}
+		bodyReader = bytes.NewReader(bodyData)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	// Create a client without a Timeout for long-running requests.
+	// Important: When both http.Client.Timeout and context deadline are set,
+	// the shorter one wins. Since c.httpClient has a 30s timeout, we must use
+	// a separate client here to allow the context timeout (potentially minutes)
+	// to control cancellation.
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("request timed out after %v (use --timeout to increase)", timeout)
+		}
 		return fmt.Errorf("failed to connect to server: %w", err)
 	}
 	defer resp.Body.Close()
@@ -114,7 +186,7 @@ func (c *APIClient) ListSheds() (*config.ShedsResponse, error) {
 // CreateShed creates a new shed.
 func (c *APIClient) CreateShed(req *config.CreateShedRequest) (*config.Shed, error) {
 	var shed config.Shed
-	if err := c.doRequest(http.MethodPost, "/api/sheds", req, &shed, http.StatusCreated, http.StatusOK); err != nil {
+	if err := c.doRequestWithTimeout(http.MethodPost, "/api/sheds", req, &shed, c.createTimeout, http.StatusCreated, http.StatusOK); err != nil {
 		return nil, err
 	}
 	return &shed, nil
@@ -141,7 +213,7 @@ func (c *APIClient) DeleteShed(name string, keepVolume bool) error {
 // StartShed starts a stopped shed.
 func (c *APIClient) StartShed(name string) (*config.Shed, error) {
 	var shed config.Shed
-	if err := c.doRequest(http.MethodPost, "/api/sheds/"+name+"/start", nil, &shed); err != nil {
+	if err := c.doRequestWithTimeout(http.MethodPost, "/api/sheds/"+name+"/start", nil, &shed, c.createTimeout); err != nil {
 		return nil, err
 	}
 	return &shed, nil

--- a/cmd/shed/console.go
+++ b/cmd/shed/console.go
@@ -93,7 +93,7 @@ func sshToShed(name string, command []string) error {
 	}
 
 	// Ensure the shed is running (auto-start if stopped)
-	client := NewAPIClientFromEntry(entry)
+	client := NewAPIClientFromEntry(entry, clientConfig.GetCreateTimeout())
 	if _, err := ensureRunningShed(client, name); err != nil {
 		return err
 	}

--- a/cmd/shed/server.go
+++ b/cmd/shed/server.go
@@ -77,7 +77,7 @@ func runServerAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Connect and get server info
-	client := NewAPIClient(host, serverAddPort)
+	client := NewAPIClient(host, serverAddPort, DefaultTimeout)
 	info, err := client.GetInfo()
 	if err != nil {
 		return fmt.Errorf("failed to get server info: %w", err)
@@ -150,7 +150,7 @@ func runServerList(cmd *cobra.Command, args []string) error {
 		entry := clientConfig.Servers[name]
 
 		// Check if server is online
-		client := NewAPIClientFromEntry(&entry)
+		client := NewAPIClientFromEntry(&entry, DefaultTimeout)
 		status := "offline"
 		if client.Ping() {
 			status = "online"

--- a/cmd/shed/sessions.go
+++ b/cmd/shed/sessions.go
@@ -59,7 +59,7 @@ func runSessions(cmd *cobra.Command, args []string) error {
 	if sessionsAllFlag {
 		// Query all servers
 		for serverName, entry := range clientConfig.Servers {
-			client := NewAPIClientFromEntry(&entry)
+			client := NewAPIClientFromEntry(&entry, DefaultTimeout)
 			resp, err := client.ListAllSessions()
 			if err != nil {
 				if verboseFlag {
@@ -83,7 +83,7 @@ func runSessions(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		client := NewAPIClientFromEntry(entry)
+		client := NewAPIClientFromEntry(entry, DefaultTimeout)
 
 		if len(args) == 1 {
 			// List sessions for a specific shed
@@ -129,7 +129,7 @@ func runSessionsKill(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	client := NewAPIClientFromEntry(entry)
+	client := NewAPIClientFromEntry(entry, DefaultTimeout)
 	if err := client.KillSession(shedName, sessionName); err != nil {
 		return fmt.Errorf("failed to kill session: %w", err)
 	}

--- a/cmd/shed/shed.go
+++ b/cmd/shed/shed.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -64,6 +65,8 @@ var (
 	createNoProvision bool
 	createNoSync      bool
 	createSyncProfile string
+	createTimeout     time.Duration
+	startTimeout      time.Duration
 	listAll           bool
 	deleteKeep        bool
 	deleteForce       bool
@@ -75,6 +78,9 @@ func init() {
 	createCmd.Flags().BoolVar(&createNoProvision, "no-provision", false, "Skip running provisioning hooks")
 	createCmd.Flags().BoolVar(&createNoSync, "no-sync", false, "Skip syncing default profile")
 	createCmd.Flags().StringVar(&createSyncProfile, "sync-profile", "", "Profile to sync after creation (default: 'default')")
+	createCmd.Flags().DurationVar(&createTimeout, "timeout", 0, "Timeout for create operation (default: from config or 10m)")
+
+	startCmd.Flags().DurationVar(&startTimeout, "timeout", 0, "Timeout for start operation (default: from config or 10m)")
 
 	listCmd.Flags().BoolVarP(&listAll, "all", "a", false, "List sheds from all servers")
 
@@ -102,7 +108,14 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Creating shed %s on %s...\n", name, serverName)
 	}
 
-	client := NewAPIClientFromEntry(entry)
+	// Determine timeout: CLI flag > config > default
+	// Note: --timeout 0 is treated as "not set" and uses config/default value
+	timeout := createTimeout
+	if timeout == 0 {
+		timeout = clientConfig.GetCreateTimeout()
+	}
+
+	client := NewAPIClientFromEntry(entry, timeout)
 	req := &config.CreateShedRequest{
 		Name:        name,
 		Repo:        createRepo,
@@ -153,7 +166,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	if listAll {
 		// Query all servers
 		for name, e := range clientConfig.Servers {
-			client := NewAPIClientFromEntry(&e)
+			client := NewAPIClientFromEntry(&e, DefaultTimeout)
 			resp, err := client.ListSheds()
 			if err != nil {
 				if verboseFlag {
@@ -168,7 +181,7 @@ func runList(cmd *cobra.Command, args []string) error {
 			}
 		}
 	} else {
-		client := NewAPIClientFromEntry(entry)
+		client := NewAPIClientFromEntry(entry, DefaultTimeout)
 		resp, err := client.ListSheds()
 		if err != nil {
 			return fmt.Errorf("failed to list sheds: %w", err)
@@ -248,7 +261,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	// Stop any associated tunnels first
 	stopTunnelsForShed(name)
 
-	client := NewAPIClientFromEntry(entry)
+	client := NewAPIClientFromEntry(entry, DefaultTimeout)
 	if err := client.DeleteShed(name, deleteKeep); err != nil {
 		return fmt.Errorf("failed to delete shed: %w", err)
 	}
@@ -277,7 +290,14 @@ func runStart(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Starting shed %s on %s...\n", name, serverName)
 	}
 
-	client := NewAPIClientFromEntry(entry)
+	// Determine timeout: CLI flag > config > default
+	// Note: --timeout 0 is treated as "not set" and uses config/default value
+	timeout := startTimeout
+	if timeout == 0 {
+		timeout = clientConfig.GetCreateTimeout()
+	}
+
+	client := NewAPIClientFromEntry(entry, timeout)
 	shed, err := client.StartShed(name)
 	if err != nil {
 		return fmt.Errorf("failed to start shed: %w", err)
@@ -310,7 +330,7 @@ func runStop(cmd *cobra.Command, args []string) error {
 	// Stop any associated tunnels first
 	stopTunnelsForShed(name)
 
-	client := NewAPIClientFromEntry(entry)
+	client := NewAPIClientFromEntry(entry, DefaultTimeout)
 	shed, err := client.StopShed(name)
 	if err != nil {
 		return fmt.Errorf("failed to stop shed: %w", err)
@@ -353,7 +373,7 @@ func findShedServer(name string) (string, *config.ServerEntry, error) {
 		entry, err := clientConfig.GetServer(cachedServer)
 		if err == nil {
 			// Verify the shed still exists
-			client := NewAPIClientFromEntry(entry)
+			client := NewAPIClientFromEntry(entry, DefaultTimeout)
 			if _, err := client.GetShed(name); err == nil {
 				return cachedServer, entry, nil
 			}
@@ -368,7 +388,7 @@ func findShedServer(name string) (string, *config.ServerEntry, error) {
 		if err != nil {
 			return "", nil, err
 		}
-		client := NewAPIClientFromEntry(entry)
+		client := NewAPIClientFromEntry(entry, DefaultTimeout)
 		if _, err := client.GetShed(name); err != nil {
 			printError(fmt.Sprintf("shed %q not found on %s", name, serverFlag),
 				"shed list --all       # Find which server has it",
@@ -382,7 +402,7 @@ func findShedServer(name string) (string, *config.ServerEntry, error) {
 	if clientConfig.DefaultServer != "" {
 		entry, _ := clientConfig.GetServer(clientConfig.DefaultServer)
 		if entry != nil {
-			client := NewAPIClientFromEntry(entry)
+			client := NewAPIClientFromEntry(entry, DefaultTimeout)
 			if _, err := client.GetShed(name); err == nil {
 				clientConfig.CacheShed(name, clientConfig.DefaultServer, "")
 				return clientConfig.DefaultServer, entry, nil
@@ -395,7 +415,7 @@ func findShedServer(name string) (string, *config.ServerEntry, error) {
 		if serverName == clientConfig.DefaultServer {
 			continue // Already checked
 		}
-		client := NewAPIClientFromEntry(&entry)
+		client := NewAPIClientFromEntry(&entry, DefaultTimeout)
 		if _, err := client.GetShed(name); err == nil {
 			// Update cache
 			clientConfig.CacheShed(name, serverName, "")

--- a/cmd/shed/ssh_config.go
+++ b/cmd/shed/ssh_config.go
@@ -117,7 +117,7 @@ func getAllShedsInfo() ([]shedInfo, error) {
 	// Query all servers for their sheds
 	for serverName, entry := range clientConfig.Servers {
 		entryCopy := entry
-		client := NewAPIClientFromEntry(&entryCopy)
+		client := NewAPIClientFromEntry(&entryCopy, DefaultTimeout)
 		resp, err := client.ListSheds()
 		if err != nil {
 			if verboseFlag {

--- a/cmd/shed/sync.go
+++ b/cmd/shed/sync.go
@@ -64,7 +64,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 	}
 
 	// Ensure shed is running
-	client := NewAPIClientFromEntry(entry)
+	client := NewAPIClientFromEntry(entry, clientConfig.GetCreateTimeout())
 	if _, err := ensureRunningShed(client, name); err != nil {
 		return err
 	}

--- a/cmd/shed/tunnels.go
+++ b/cmd/shed/tunnels.go
@@ -181,7 +181,7 @@ func runTunnelsStart(cmd *cobra.Command, args []string) error {
 	}
 
 	// Ensure the shed is running (auto-start if stopped)
-	client := NewAPIClientFromEntry(entry)
+	client := NewAPIClientFromEntry(entry, clientConfig.GetCreateTimeout())
 	if _, err := ensureRunningShed(client, shedName); err != nil {
 		return err
 	}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -83,6 +83,7 @@ shed create <name> [flags]
 | `--no-provision` | | `false` | Skip provisioning hooks |
 | `--sync-profile` | | `default` | Profile to sync after creation |
 | `--no-sync` | | `false` | Skip syncing default profile |
+| `--timeout` | | `10m` | Timeout for create operation (e.g., `30s`, `5m`, `2h`) |
 
 **Examples:**
 
@@ -92,6 +93,7 @@ shed create codelens --repo charliek/codelens
 shed create stbot --repo charliek/stbot --server cloud-vps
 shed create myproj --sync-profile full
 shed create myproj --no-sync
+shed create bigproj --repo org/large-repo --timeout 30m
 ```
 
 ### shed list
@@ -120,8 +122,12 @@ mini-desktop    mcp-test      stopped    3 days ago       -
 Starts a stopped shed.
 
 ```bash
-shed start <name>
+shed start <name> [flags]
 ```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--timeout` | | `10m` | Timeout for start operation (e.g., `30s`, `5m`, `2h`) |
 
 ### shed stop
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -24,6 +24,9 @@ servers:
 
 default_server: mini-desktop
 
+# Timeout for shed create and start operations
+create_timeout: 30m
+
 sheds:
   codelens:
     server: mini-desktop
@@ -41,6 +44,7 @@ sheds:
 | `servers.<name>.ssh_port` | int | SSH server port |
 | `default_server` | string | Default server for commands |
 | `sheds` | map | Cached shed locations |
+| `create_timeout` | duration | Timeout for create/start operations (default: `10m`) |
 
 ## Server Configuration
 

--- a/images/shed-base/Dockerfile
+++ b/images/shed-base/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:24.04
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # System packages
 RUN apt-get update && apt-get install -y \
     curl \
@@ -15,10 +17,15 @@ RUN apt-get update && apt-get install -y \
     ncurses-term \
     tree \
     ripgrep \
+    unzip \
+    sudo \
     && rm -rf /var/lib/apt/lists/*
+# unzip: for extracting archives in provisioning scripts
+# sudo: for provisioning scripts that need elevated privileges
 
 # mise
 RUN curl https://mise.run | sh
+ENV PATH="/root/.local/share/mise/shims:/root/.local/bin:${PATH}"
 
 # RUN mise install \
 #     java@temurin-21 \

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -37,9 +37,9 @@ func (s *Server) handleGetSSHHostKey(w http.ResponseWriter, r *http.Request) {
 // handleListSheds returns all sheds.
 // GET /api/sheds
 func (s *Server) handleListSheds(w http.ResponseWriter, r *http.Request) {
-	sheds, err := s.docker.ListSheds(r.Context())
+	sheds, err := s.backend.ListSheds(r.Context())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, config.ErrDockerError, err.Error())
+		writeError(w, http.StatusInternalServerError, config.ErrBackendError, err.Error())
 		return
 	}
 
@@ -74,7 +74,7 @@ func (s *Server) handleCreateShed(w http.ResponseWriter, r *http.Request) {
 		req.Image = s.cfg.DefaultImage
 	}
 
-	shed, err := s.docker.CreateShed(r.Context(), req)
+	shed, err := s.backend.CreateShed(r.Context(), req)
 	if err != nil {
 		code, errCode, msg := mapDockerError(err)
 		writeError(w, code, errCode, msg)
@@ -89,7 +89,7 @@ func (s *Server) handleCreateShed(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleGetShed(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 
-	shed, err := s.docker.GetShed(r.Context(), name)
+	shed, err := s.backend.GetShed(r.Context(), name)
 	if err != nil {
 		code, errCode, msg := mapDockerError(err)
 		writeError(w, code, errCode, msg)
@@ -105,7 +105,7 @@ func (s *Server) handleDeleteShed(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	keepVolume := r.URL.Query().Get("keep_volume") == "true"
 
-	if err := s.docker.DeleteShed(r.Context(), name, keepVolume); err != nil {
+	if err := s.backend.DeleteShed(r.Context(), name, keepVolume); err != nil {
 		code, errCode, msg := mapDockerError(err)
 		writeError(w, code, errCode, msg)
 		return
@@ -119,7 +119,7 @@ func (s *Server) handleDeleteShed(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleStartShed(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 
-	shed, err := s.docker.StartShed(r.Context(), name)
+	shed, err := s.backend.StartShed(r.Context(), name)
 	if err != nil {
 		code, errCode, msg := mapDockerError(err)
 		writeError(w, code, errCode, msg)
@@ -134,7 +134,7 @@ func (s *Server) handleStartShed(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleStopShed(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 
-	shed, err := s.docker.StopShed(r.Context(), name)
+	shed, err := s.backend.StopShed(r.Context(), name)
 	if err != nil {
 		code, errCode, msg := mapDockerError(err)
 		writeError(w, code, errCode, msg)
@@ -149,7 +149,7 @@ func (s *Server) handleStopShed(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 
-	sessions, err := s.docker.ListSessions(r.Context(), name)
+	sessions, err := s.backend.ListSessions(r.Context(), name)
 	if err != nil {
 		code, errCode, msg := mapSessionError(err)
 		writeError(w, code, errCode, msg)
@@ -175,7 +175,7 @@ func (s *Server) handleKillSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.docker.KillSession(r.Context(), name, sessionName); err != nil {
+	if err := s.backend.KillSession(r.Context(), name, sessionName); err != nil {
 		code, errCode, msg := mapSessionError(err)
 		writeError(w, code, errCode, msg)
 		return
@@ -187,9 +187,9 @@ func (s *Server) handleKillSession(w http.ResponseWriter, r *http.Request) {
 // handleListAllSessions returns all tmux sessions across all running sheds.
 // GET /api/sessions
 func (s *Server) handleListAllSessions(w http.ResponseWriter, r *http.Request) {
-	sheds, err := s.docker.ListSheds(r.Context())
+	sheds, err := s.backend.ListSheds(r.Context())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, config.ErrDockerError, err.Error())
+		writeError(w, http.StatusInternalServerError, config.ErrBackendError, err.Error())
 		return
 	}
 
@@ -199,7 +199,7 @@ func (s *Server) handleListAllSessions(w http.ResponseWriter, r *http.Request) {
 		if shed.Status != config.StatusRunning {
 			continue
 		}
-		sessions, err := s.docker.ListSessions(r.Context(), shed.Name)
+		sessions, err := s.backend.ListSessions(r.Context(), shed.Name)
 		if err != nil {
 			// Record warning for sheds where we can't list sessions
 			if errors.Is(err, config.ErrTmuxNotAvailableSentinel) {
@@ -284,7 +284,7 @@ func mapDockerError(err error) (int, string, string) {
 	}
 
 	// For unknown errors, return a generic message to avoid leaking Docker internals
-	return http.StatusInternalServerError, config.ErrDockerError, "internal server error"
+	return http.StatusInternalServerError, config.ErrBackendError, "internal server error"
 }
 
 // sanitizeErrorMessage extracts shed-related information while hiding Docker implementation details.
@@ -324,5 +324,5 @@ func mapSessionError(err error) (int, string, string) {
 		return http.StatusNotFound, config.ErrShedNotFound, errMsg
 	}
 
-	return http.StatusInternalServerError, config.ErrDockerError, "internal server error"
+	return http.StatusInternalServerError, config.ErrBackendError, "internal server error"
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2,52 +2,23 @@
 package api
 
 import (
-	"context"
-
+	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 )
 
-// DockerClient defines the interface for Docker operations required by the API.
-// This interface will be implemented by the docker package.
-type DockerClient interface {
-	// ListSheds returns all shed containers.
-	ListSheds(ctx context.Context) ([]config.Shed, error)
-
-	// GetShed returns a single shed by name.
-	GetShed(ctx context.Context, name string) (*config.Shed, error)
-
-	// CreateShed creates a new shed container.
-	CreateShed(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error)
-
-	// DeleteShed removes a shed container and optionally its volume.
-	DeleteShed(ctx context.Context, name string, keepVolume bool) error
-
-	// StartShed starts a stopped shed container.
-	StartShed(ctx context.Context, name string) (*config.Shed, error)
-
-	// StopShed stops a running shed container.
-	StopShed(ctx context.Context, name string) (*config.Shed, error)
-
-	// ListSessions returns all tmux sessions in a shed container.
-	ListSessions(ctx context.Context, shedName string) ([]config.Session, error)
-
-	// KillSession terminates a tmux session in a shed container.
-	KillSession(ctx context.Context, shedName, sessionName string) error
-}
-
 // Server is the HTTP API server for shed.
 type Server struct {
-	docker     DockerClient
+	backend    backend.Backend
 	cfg        *config.ServerConfig
 	sshHostKey string
 }
 
 // NewServer creates a new API server.
-func NewServer(dockerClient DockerClient, cfg *config.ServerConfig, sshHostKey string) *Server {
+func NewServer(b backend.Backend, cfg *config.ServerConfig, sshHostKey string) *Server {
 	return &Server{
-		docker:     dockerClient,
+		backend:    b,
 		cfg:        cfg,
 		sshHostKey: sshHostKey,
 	}

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -1,0 +1,68 @@
+// Package backend provides the abstraction layer for different execution backends.
+package backend
+
+import (
+	"context"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+// Type identifies the backend implementation.
+type Type string
+
+const (
+	// TypeDocker is the Docker-based backend.
+	TypeDocker Type = "docker"
+	// TypeFirecracker is the Firecracker-based backend (future).
+	TypeFirecracker Type = "firecracker"
+)
+
+// Backend defines the interface for shed execution backends.
+// Different backends (Docker, Firecracker, etc.) implement this interface
+// to provide shed lifecycle management, session handling, and command execution.
+type Backend interface {
+	// Type returns the backend type identifier.
+	Type() Type
+
+	// Close releases any resources held by the backend.
+	Close() error
+
+	// Shed lifecycle operations
+
+	// CreateShed creates a new shed with the given configuration.
+	CreateShed(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error)
+
+	// GetShed returns a shed by name, or an error if not found.
+	GetShed(ctx context.Context, name string) (*config.Shed, error)
+
+	// ListSheds returns all sheds managed by this backend.
+	ListSheds(ctx context.Context) ([]config.Shed, error)
+
+	// DeleteShed removes a shed. If keepVolume is true, the workspace is preserved.
+	DeleteShed(ctx context.Context, name string, keepVolume bool) error
+
+	// StartShed starts a stopped shed.
+	StartShed(ctx context.Context, name string) (*config.Shed, error)
+
+	// StopShed stops a running shed.
+	StopShed(ctx context.Context, name string) (*config.Shed, error)
+
+	// Session operations
+
+	// ListSessions returns all sessions in a shed.
+	ListSessions(ctx context.Context, shedName string) ([]config.Session, error)
+
+	// KillSession terminates a session in a shed.
+	KillSession(ctx context.Context, shedName, sessionName string) error
+
+	// Execution
+
+	// Exec executes a command in a shed with the given options.
+	Exec(ctx context.Context, shedName string, opts ExecOptions) error
+
+	// Network
+
+	// GetNetworkEndpoint returns the network endpoint (IP or hostname) for a shed.
+	// This is used for port forwarding and other network operations.
+	GetNetworkEndpoint(ctx context.Context, shedName string) (string, error)
+}

--- a/internal/backend/types.go
+++ b/internal/backend/types.go
@@ -1,0 +1,33 @@
+// Package backend provides the abstraction layer for different execution backends.
+package backend
+
+import "io"
+
+// ExecOptions contains options for executing a command in a shed.
+type ExecOptions struct {
+	// Cmd is the command to execute. If empty, defaults to the shed's shell.
+	Cmd []string
+
+	// Stdin, Stdout, Stderr are the I/O streams.
+	Stdin  io.ReadCloser
+	Stdout io.WriteCloser
+	Stderr io.WriteCloser
+
+	// TTY indicates whether to allocate a pseudo-TTY.
+	TTY bool
+
+	// Env contains additional environment variables.
+	Env []string
+
+	// InitialSize is the initial terminal size (if TTY is true).
+	InitialSize *TerminalSize
+
+	// ResizeChan receives terminal resize events.
+	ResizeChan <-chan TerminalSize
+}
+
+// TerminalSize represents terminal dimensions.
+type TerminalSize struct {
+	Width  uint
+	Height uint
+}

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -14,9 +14,18 @@ type ClientConfig struct {
 	Servers       map[string]ServerEntry `yaml:"servers"`
 	DefaultServer string                 `yaml:"default_server"`
 	Sheds         map[string]ShedCache   `yaml:"sheds"`
+	CreateTimeout time.Duration          `yaml:"create_timeout,omitempty"`
 
 	// Path to config file (not serialized)
 	path string `yaml:"-"`
+}
+
+// GetCreateTimeout returns the configured create timeout or the default (10 minutes).
+func (c *ClientConfig) GetCreateTimeout() time.Duration {
+	if c.CreateTimeout > 0 {
+		return c.CreateTimeout
+	}
+	return 10 * time.Minute
 }
 
 // ServerEntry represents a configured server.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -55,6 +55,7 @@ type Shed struct {
 	CreatedAt   time.Time `json:"created_at" yaml:"created_at"`
 	Repo        string    `json:"repo,omitempty" yaml:"repo,omitempty"`
 	ContainerID string    `json:"container_id" yaml:"container_id"`
+	Backend     string    `json:"backend,omitempty" yaml:"backend,omitempty"`
 }
 
 // Shed status constants.
@@ -164,7 +165,7 @@ const (
 	ErrShedAlreadyStopped = "SHED_ALREADY_STOPPED"
 	ErrInvalidShedName    = "INVALID_SHED_NAME"
 	ErrCloneFailed        = "CLONE_FAILED"
-	ErrDockerError        = "DOCKER_ERROR"
+	ErrBackendError       = "BACKEND_ERROR"
 	ErrInternalError      = "INTERNAL_ERROR"
 	ErrSessionNotFound    = "SESSION_NOT_FOUND"
 	ErrInvalidSessionName = "INVALID_SESSION_NAME"
@@ -177,6 +178,13 @@ const (
 	LabelShedName    = "shed.name"
 	LabelShedCreated = "shed.created"
 	LabelShedRepo    = "shed.repo"
+	LabelShedBackend = "shed.backend"
+)
+
+// Backend type constants for Shed.Backend field.
+const (
+	BackendDocker      = "docker"
+	BackendFirecracker = "firecracker"
 )
 
 // ContainerPrefix is prepended to shed names for Docker containers.

--- a/internal/docker/backend.go
+++ b/internal/docker/backend.go
@@ -1,0 +1,209 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/stdcopy"
+
+	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/config"
+)
+
+// Compile-time check that DockerBackend implements backend.Backend.
+var _ backend.Backend = (*DockerBackend)(nil)
+
+// DockerBackend implements backend.Backend using Docker containers.
+type DockerBackend struct {
+	client *Client
+}
+
+// NewBackend creates a new DockerBackend wrapping the given Client.
+func NewBackend(client *Client) *DockerBackend {
+	return &DockerBackend{client: client}
+}
+
+// Type returns the backend type identifier.
+func (b *DockerBackend) Type() backend.Type {
+	return backend.TypeDocker
+}
+
+// Close releases any resources held by the backend.
+func (b *DockerBackend) Close() error {
+	return b.client.Close()
+}
+
+// CreateShed creates a new shed with the given configuration.
+func (b *DockerBackend) CreateShed(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error) {
+	return b.client.CreateShed(ctx, req)
+}
+
+// GetShed returns a shed by name, or an error if not found.
+func (b *DockerBackend) GetShed(ctx context.Context, name string) (*config.Shed, error) {
+	return b.client.GetShed(ctx, name)
+}
+
+// ListSheds returns all sheds managed by this backend.
+func (b *DockerBackend) ListSheds(ctx context.Context) ([]config.Shed, error) {
+	return b.client.ListSheds(ctx)
+}
+
+// DeleteShed removes a shed. If keepVolume is true, the workspace is preserved.
+func (b *DockerBackend) DeleteShed(ctx context.Context, name string, keepVolume bool) error {
+	return b.client.DeleteShed(ctx, name, keepVolume)
+}
+
+// StartShed starts a stopped shed.
+func (b *DockerBackend) StartShed(ctx context.Context, name string) (*config.Shed, error) {
+	return b.client.StartShed(ctx, name)
+}
+
+// StopShed stops a running shed.
+func (b *DockerBackend) StopShed(ctx context.Context, name string) (*config.Shed, error) {
+	return b.client.StopShed(ctx, name)
+}
+
+// ListSessions returns all sessions in a shed.
+func (b *DockerBackend) ListSessions(ctx context.Context, shedName string) ([]config.Session, error) {
+	return b.client.ListSessions(ctx, shedName)
+}
+
+// KillSession terminates a session in a shed.
+func (b *DockerBackend) KillSession(ctx context.Context, shedName, sessionName string) error {
+	return b.client.KillSession(ctx, shedName, sessionName)
+}
+
+// Exec executes a command in a shed with the given options.
+func (b *DockerBackend) Exec(ctx context.Context, shedName string, opts backend.ExecOptions) error {
+	// Get the shed to find the container ID
+	shed, err := b.client.GetShed(ctx, shedName)
+	if err != nil {
+		return err
+	}
+
+	return b.execInContainer(ctx, shed.ContainerID, opts)
+}
+
+// execInContainer executes a command in a container with the given options.
+func (b *DockerBackend) execInContainer(ctx context.Context, containerID string, opts backend.ExecOptions) error {
+	dockerClient := b.client.Docker()
+
+	// Build command - if empty, use default login shell
+	cmd := opts.Cmd
+	if len(cmd) == 0 {
+		cmd = []string{"/bin/bash", "--login"}
+	} else {
+		// Wrap command in shell to support operators like &&, ||, |, etc.
+		// SSH sends the command as space-separated tokens, but Docker exec
+		// expects an argv. The shell parses operators correctly.
+		cmd = []string{"/bin/sh", "-c", strings.Join(cmd, " ")}
+	}
+
+	// Create exec configuration
+	execConfig := container.ExecOptions{
+		Cmd:          cmd,
+		AttachStdin:  opts.Stdin != nil,
+		AttachStdout: opts.Stdout != nil,
+		AttachStderr: opts.Stderr != nil,
+		Tty:          opts.TTY,
+		Env:          opts.Env,
+		WorkingDir:   config.WorkspacePath,
+	}
+
+	execResp, err := dockerClient.ContainerExecCreate(ctx, containerID, execConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create exec: %w", err)
+	}
+
+	// Attach to the exec session
+	attachResp, err := dockerClient.ContainerExecAttach(ctx, execResp.ID, container.ExecStartOptions{
+		Tty: opts.TTY,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to attach to exec: %w", err)
+	}
+	defer attachResp.Close()
+
+	// Handle terminal resize if TTY is enabled
+	if opts.TTY && opts.ResizeChan != nil {
+		go func() {
+			for size := range opts.ResizeChan {
+				_ = dockerClient.ContainerExecResize(ctx, execResp.ID, container.ResizeOptions{
+					Height: size.Height,
+					Width:  size.Width,
+				})
+			}
+		}()
+
+		// Set initial size
+		if opts.InitialSize != nil {
+			_ = dockerClient.ContainerExecResize(ctx, execResp.ID, container.ResizeOptions{
+				Height: opts.InitialSize.Height,
+				Width:  opts.InitialSize.Width,
+			})
+		}
+	}
+
+	// Channel to signal when stdout completes (container exited)
+	done := make(chan struct{})
+
+	// Copy stdin to container (fire and forget - don't wait for it)
+	if opts.Stdin != nil {
+		go func() {
+			_, _ = io.Copy(attachResp.Conn, opts.Stdin)
+			// Close the connection's write side when stdin is done
+			if cw, ok := attachResp.Conn.(interface{ CloseWrite() error }); ok {
+				_ = cw.CloseWrite()
+			}
+		}()
+	}
+
+	// Copy container output to stdout - when this finishes, container has exited
+	go func() {
+		defer close(done)
+		if opts.TTY {
+			// In TTY mode, all output goes to stdout
+			if opts.Stdout != nil {
+				_, _ = io.Copy(opts.Stdout, attachResp.Reader)
+			}
+		} else {
+			// In non-TTY mode, Docker multiplexes stdout/stderr with headers
+			// Use stdcopy to demux the stream
+			if opts.Stdout != nil {
+				stderr := opts.Stderr
+				if stderr == nil {
+					stderr = opts.Stdout // fallback: send stderr to stdout
+				}
+				_, _ = stdcopy.StdCopy(opts.Stdout, stderr, attachResp.Reader)
+			}
+		}
+	}()
+
+	// Wait only for stdout to complete (container exit), not stdin
+	<-done
+
+	// Check exit code
+	inspectResp, err := dockerClient.ContainerExecInspect(ctx, execResp.ID)
+	if err != nil {
+		return fmt.Errorf("failed to inspect exec: %w", err)
+	}
+
+	if inspectResp.ExitCode != 0 {
+		return fmt.Errorf("command exited with code %d", inspectResp.ExitCode)
+	}
+
+	return nil
+}
+
+// GetNetworkEndpoint returns the network endpoint (IP) for a shed.
+func (b *DockerBackend) GetNetworkEndpoint(ctx context.Context, shedName string) (string, error) {
+	shed, err := b.client.GetShed(ctx, shedName)
+	if err != nil {
+		return "", err
+	}
+
+	return b.client.GetContainerIP(ctx, shed.ContainerID)
+}

--- a/internal/docker/backend_test.go
+++ b/internal/docker/backend_test.go
@@ -1,0 +1,12 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/charliek/shed/internal/backend"
+)
+
+func TestDockerBackendImplementsInterface(t *testing.T) {
+	// Compile-time check (also in backend.go, but explicit test is good)
+	var _ backend.Backend = (*DockerBackend)(nil)
+}

--- a/internal/docker/containers.go
+++ b/internal/docker/containers.go
@@ -99,6 +99,7 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		config.LabelShed:        "true",
 		config.LabelShedName:    req.Name,
 		config.LabelShedCreated: createdAt.Format(time.RFC3339),
+		config.LabelShedBackend: config.BackendDocker,
 	}
 	if req.Repo != "" {
 		labels[config.LabelShedRepo] = req.Repo
@@ -161,6 +162,7 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		CreatedAt:   createdAt,
 		Repo:        req.Repo,
 		ContainerID: resp.ID,
+		Backend:     config.BackendDocker,
 	}, nil
 }
 
@@ -372,6 +374,11 @@ func containerToShed(ctr container.Summary) config.Shed {
 
 	name := labels[config.LabelShedName]
 	repo := labels[config.LabelShedRepo]
+	// Default to docker for backwards compatibility with existing containers
+	backend := labels[config.LabelShedBackend]
+	if backend == "" {
+		backend = config.BackendDocker
+	}
 
 	var createdAt time.Time
 	if created := labels[config.LabelShedCreated]; created != "" {
@@ -386,6 +393,7 @@ func containerToShed(ctr container.Summary) config.Shed {
 		CreatedAt:   createdAt,
 		Repo:        repo,
 		ContainerID: ctr.ID,
+		Backend:     backend,
 	}
 }
 
@@ -395,6 +403,11 @@ func inspectToShed(ctr container.InspectResponse) *config.Shed {
 
 	name := labels[config.LabelShedName]
 	repo := labels[config.LabelShedRepo]
+	// Default to docker for backwards compatibility with existing containers
+	backend := labels[config.LabelShedBackend]
+	if backend == "" {
+		backend = config.BackendDocker
+	}
 
 	var createdAt time.Time
 	if created := labels[config.LabelShedCreated]; created != "" {
@@ -409,6 +422,7 @@ func inspectToShed(ctr container.InspectResponse) *config.Shed {
 		CreatedAt:   createdAt,
 		Repo:        repo,
 		ContainerID: ctr.ID,
+		Backend:     backend,
 	}
 }
 

--- a/internal/sshd/server.go
+++ b/internal/sshd/server.go
@@ -18,77 +18,14 @@ import (
 	"github.com/gliderlabs/ssh"
 	gossh "golang.org/x/crypto/ssh"
 
+	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/terminal"
 )
-
-// DockerClient defines the interface for docker operations needed by the SSH server.
-// This allows the sshd package to compile independently of the docker package.
-type DockerClient interface {
-	// GetShed returns a shed by name, or an error if not found.
-	GetShed(ctx context.Context, name string) (*ShedInfo, error)
-
-	// StartShed starts a stopped shed.
-	StartShed(ctx context.Context, name string) error
-
-	// ExecInContainer executes a command in a container with the given options.
-	ExecInContainer(ctx context.Context, containerID string, opts ExecOptions) error
-
-	// GetContainerIP returns the IP address of a container.
-	GetContainerIP(ctx context.Context, containerID string) (string, error)
-}
-
-// ShedInfo contains information about a shed needed by the SSH server.
-type ShedInfo struct {
-	Name        string
-	Status      string
-	ContainerID string
-}
-
-// ExecOptions contains options for executing a command in a container.
-type ExecOptions struct {
-	// Cmd is the command to execute. If empty, defaults to the container's shell.
-	Cmd []string
-
-	// Stdin, Stdout, Stderr are the I/O streams.
-	Stdin  ReadCloser
-	Stdout WriteCloser
-	Stderr WriteCloser
-
-	// TTY indicates whether to allocate a pseudo-TTY.
-	TTY bool
-
-	// Env contains additional environment variables.
-	Env []string
-
-	// InitialSize is the initial terminal size (if TTY is true).
-	InitialSize *TerminalSize
-
-	// ResizeChan receives terminal resize events.
-	ResizeChan <-chan TerminalSize
-}
-
-// TerminalSize represents terminal dimensions.
-type TerminalSize struct {
-	Width  uint
-	Height uint
-}
-
-// ReadCloser is an interface for reading with close capability.
-type ReadCloser interface {
-	Read(p []byte) (n int, err error)
-	Close() error
-}
-
-// WriteCloser is an interface for writing with close capability.
-type WriteCloser interface {
-	Write(p []byte) (n int, err error)
-	Close() error
-}
 
 // Server is an SSH server that connects users to shed containers.
 type Server struct {
 	sshServer   *ssh.Server
-	docker      DockerClient
+	backend     backend.Backend
 	hostKeyPath string
 	port        int
 	hostKey     gossh.Signer
@@ -97,9 +34,9 @@ type Server struct {
 }
 
 // NewServer creates a new SSH server.
-func NewServer(dockerClient DockerClient, hostKeyPath string, port int, termConfig *terminal.Config) (*Server, error) {
+func NewServer(b backend.Backend, hostKeyPath string, port int, termConfig *terminal.Config) (*Server, error) {
 	s := &Server{
-		docker:      dockerClient,
+		backend:     b,
 		hostKeyPath: hostKeyPath,
 		port:        port,
 		termConfig:  termConfig,
@@ -270,18 +207,18 @@ func (s *Server) handleDirectTCPIP(srv *ssh.Server, conn *gossh.ServerConn,
 	}
 
 	// Look up container for this shed
-	shed, err := s.docker.GetShed(ctx, user)
+	shed, err := s.backend.GetShed(ctx, user)
 	if err != nil {
 		log.Printf("Port forward: shed not found for user %s: %v", user, err)
 		_ = newChan.Reject(gossh.ConnectionFailed, "shed not found")
 		return
 	}
 
-	// Get container IP to forward to
-	containerIP, err := s.docker.GetContainerIP(ctx, shed.ContainerID)
+	// Get network endpoint to forward to
+	containerIP, err := s.backend.GetNetworkEndpoint(ctx, shed.Name)
 	if err != nil {
-		log.Printf("Port forward: cannot get container IP for %s: %v", user, err)
-		_ = newChan.Reject(gossh.ConnectionFailed, "cannot get container IP")
+		log.Printf("Port forward: cannot get network endpoint for %s: %v", user, err)
+		_ = newChan.Reject(gossh.ConnectionFailed, "cannot get network endpoint")
 		return
 	}
 

--- a/internal/sshd/session.go
+++ b/internal/sshd/session.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gliderlabs/ssh"
 
+	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
 )
 
@@ -52,7 +53,7 @@ func (s *Server) handleSession(sess ssh.Session) {
 	ctx := sess.Context()
 
 	// Look up the shed.
-	shed, err := s.docker.GetShed(ctx, shedName)
+	shed, err := s.backend.GetShed(ctx, shedName)
 	if err != nil {
 		log.Printf("Failed to get shed %s: %v", shedName, err)
 		fmt.Fprintf(sess.Stderr(), "Error: shed '%s' not found\n", shedName)
@@ -65,7 +66,7 @@ func (s *Server) handleSession(sess ssh.Session) {
 		log.Printf("Auto-starting stopped shed: %s", shedName)
 		fmt.Fprintf(sess.Stderr(), "Starting shed '%s'...\n", shedName)
 
-		if err := s.docker.StartShed(ctx, shedName); err != nil {
+		if _, err := s.backend.StartShed(ctx, shedName); err != nil {
 			log.Printf("Failed to start shed %s: %v", shedName, err)
 			fmt.Fprintf(sess.Stderr(), "Error: failed to start shed: %v\n", err)
 			_ = sess.Exit(1)
@@ -81,7 +82,7 @@ func (s *Server) handleSession(sess ssh.Session) {
 		}
 
 		// Refresh shed info after starting.
-		shed, err = s.docker.GetShed(ctx, shedName)
+		shed, err = s.backend.GetShed(ctx, shedName)
 		if err != nil {
 			log.Printf("Failed to get shed %s after start: %v", shedName, err)
 			fmt.Fprintf(sess.Stderr(), "Error: failed to get shed after start: %v\n", err)
@@ -124,7 +125,7 @@ func (s *Server) waitForReady(ctx context.Context, shedName string) error {
 				return fmt.Errorf("timeout waiting for shed to be ready")
 			}
 
-			shed, err := s.docker.GetShed(ctx, shedName)
+			shed, err := s.backend.GetShed(ctx, shedName)
 			if err != nil {
 				continue // Keep trying.
 			}
@@ -140,8 +141,8 @@ func (s *Server) waitForReady(ctx context.Context, shedName string) error {
 	}
 }
 
-// execInContainer executes a command or shell in the container.
-func (s *Server) execInContainer(ctx context.Context, sess ssh.Session, shed *ShedInfo) error {
+// execInContainer executes a command or shell in the shed.
+func (s *Server) execInContainer(ctx context.Context, sess ssh.Session, shed *config.Shed) error {
 	// Get the command to execute.
 	cmd := sess.Command()
 
@@ -160,7 +161,7 @@ func (s *Server) execInContainer(ctx context.Context, sess ssh.Session, shed *Sh
 	env = append(env, fmt.Sprintf("SHED_NAME=%s", shed.Name))
 
 	// Create resize channel for window changes.
-	resizeChan := make(chan TerminalSize, 10)
+	resizeChan := make(chan backend.TerminalSize, 10)
 	defer close(resizeChan)
 
 	// Handle window resize events in a goroutine.
@@ -169,16 +170,16 @@ func (s *Server) execInContainer(ctx context.Context, sess ssh.Session, shed *Sh
 	}
 
 	// Build initial terminal size.
-	var initialSize *TerminalSize
+	var initialSize *backend.TerminalSize
 	if isPTY {
-		initialSize = &TerminalSize{
+		initialSize = &backend.TerminalSize{
 			Width:  uint(ptyReq.Window.Width),
 			Height: uint(ptyReq.Window.Height),
 		}
 	}
 
 	// Create the exec options.
-	opts := ExecOptions{
+	opts := backend.ExecOptions{
 		Cmd:         cmd,
 		Stdin:       &sessionReadCloser{sess},
 		Stdout:      &sessionWriteCloser{sess},
@@ -189,13 +190,13 @@ func (s *Server) execInContainer(ctx context.Context, sess ssh.Session, shed *Sh
 		ResizeChan:  resizeChan,
 	}
 
-	log.Printf("Executing in container %s: tty=%v cmd=%v", shed.ContainerID, isPTY, cmd)
+	log.Printf("Executing in shed %s: tty=%v cmd=%v", shed.Name, isPTY, cmd)
 
-	return s.docker.ExecInContainer(ctx, shed.ContainerID, opts)
+	return s.backend.Exec(ctx, shed.Name, opts)
 }
 
 // handleWindowResize forwards window resize events from SSH to the resize channel.
-func (s *Server) handleWindowResize(ctx context.Context, winCh <-chan ssh.Window, resizeChan chan<- TerminalSize) {
+func (s *Server) handleWindowResize(ctx context.Context, winCh <-chan ssh.Window, resizeChan chan<- backend.TerminalSize) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -206,7 +207,7 @@ func (s *Server) handleWindowResize(ctx context.Context, winCh <-chan ssh.Window
 			}
 			// Non-blocking send to resize channel.
 			select {
-			case resizeChan <- TerminalSize{
+			case resizeChan <- backend.TerminalSize{
 				Width:  uint(win.Width),
 				Height: uint(win.Height),
 			}:


### PR DESCRIPTION
## Summary

- Introduce `backend.Backend` interface to abstract execution backends (Docker, future Firecracker)
- Add `DockerBackend` implementation that wraps the existing Docker client
- Refactor API and SSH servers to use the backend interface instead of direct Docker client
- Remove ~185 lines of adapter boilerplate from serve.go
- Add backend type constants (`BackendDocker`, `BackendFirecracker`) in config package
- Rename `ErrDockerError` to `ErrBackendError` for backend-agnostic error handling

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Added compile-time interface check test in `internal/docker/backend_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--timeout` flag to `shed create` and `shed start` commands (default: 10m) for controlling operation duration.
  * Added `create_timeout` configuration option to set default timeouts for shed operations.
  * Introduced backend abstraction enabling support for multiple execution environments.

* **Chores**
  * Enhanced Docker base image with additional system utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->