### PR TITLE
Resolve Firecracker e2e gaps: add mise to rootfs, expand boot cleanup

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,20 +13,13 @@ Follow-up improvements to consider after the initial Firecracker backend merges.
 - Consider reducing `MaxMessageSize` (16MB) or adding streaming for large messages in agentproto.
 - Document integration test strategy (requires KVM, can't be automated in CI without nested virtualization).
 
-## Firecracker E2E Gaps (Deferred)
+## Firecracker Graceful Shutdown (Deferred)
 
-Issues found during e2e testing that are non-blocking but should be addressed:
+Remaining improvement for stop/start resilience after most e2e gaps were resolved:
 
-### Credential Transfer Size Limit
-- Current limit: 100KB base64 (~75KB raw) per credential via shell argument
-- Large credentials fail (Claude config ~5MB, OpenCode ~3.7MB)
-- Fix options: stdin-based transfer (now possible with framed stdin), chunked transfers, or dedicated file-transfer vsock port
-- Most credentials (SSH keys, git config, gh CLI) are well under the limit
-
-### Stop/Start Service Resilience
-- Partial fix: network-setup.sh cleans known stale PID locations (PostgreSQL, Redis)
-- General solution: configurable stop timeout, pre-shutdown hooks, or startup hook best practices
-- Startup hooks should handle stale state from unclean prior shutdown (PID files, lock files, shared memory segments)
+- Boot cleanup now handles stale PIDs, shared memory, lock files, and temp files (via `network-setup.sh`)
+- Still deferred: configurable stop timeout, pre-shutdown hooks for graceful service termination
+- Still deferred: startup hook best practices documentation
 
 ## Firecracker Live Mounts (SSHFS over vsock)
 

--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -39,6 +39,10 @@ RUN apt-get update && apt-get install -y \
     # Clean up
     && rm -rf /var/lib/apt/lists/*
 
+# Install mise (version manager) - matches Docker base image
+RUN curl https://mise.run | sh
+ENV PATH="/root/.local/share/mise/shims:/root/.local/bin:${PATH}"
+
 # Configure systemd
 # Remove unnecessary services
 RUN rm -f /lib/systemd/system/multi-user.target.wants/* \

--- a/firecracker/network-setup.sh
+++ b/firecracker/network-setup.sh
@@ -63,10 +63,26 @@ HOSTS_EOF
 
 # Clean stale runtime state from unclean VM shutdown.
 # The rootfs overlay persists across stop/start, but services expect
-# clean state on boot. Remove stale PID/socket files.
+# clean state on boot. Remove stale PID files, sockets, lock files,
+# and shared memory segments left by killed processes.
+
+# Service-specific runtime directories (remove and recreate with correct ownership)
 rm -rf /var/run/postgresql /var/run/redis /var/run/sshd
 mkdir -p /var/run/postgresql && chown postgres:postgres /var/run/postgresql 2>/dev/null || true
 mkdir -p /var/run/redis && chown redis:redis /var/run/redis 2>/dev/null || true
 mkdir -p /var/run/sshd
+
+# Additional known service PID files
+rm -f /var/run/mysqld/mysqld.pid /var/run/nginx.pid /var/run/docker.pid /var/run/crond.pid 2>/dev/null || true
+mkdir -p /var/run/mysqld && chown mysql:mysql /var/run/mysqld 2>/dev/null || true
+
+# Shared memory cleanup (e.g., PostgreSQL POSIX shared memory segments)
+rm -rf /dev/shm/* 2>/dev/null || true
+
+# Lock file cleanup
+rm -f /var/lock/*.lock /run/lock/*.lock 2>/dev/null || true
+
+# Temp file cleanup (stale sockets, lock files from previous boot)
+find /tmp -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true
 
 echo "Network configuration complete"


### PR DESCRIPTION
## Summary

- **Add mise to Firecracker rootfs** — installs the mise version manager in `firecracker/Dockerfile`, matching the Docker base image (`images/shed-base/Dockerfile`). Provisioning code already detects mise shims via `captureInstalledPaths`, so this just works.
- **Expand boot cleanup** — `network-setup.sh` now cleans additional stale PID files (mysql, nginx, docker, cron), shared memory (`/dev/shm/*`), lock files, and temp directories on boot. Safe because `network-setup.service` runs before any user services.
- **Update ROADMAP.md** — removes the resolved credential transfer size limit section, renames the e2e gaps section, and documents remaining graceful shutdown work as deferred.

## Test plan

- [ ] Rebuild rootfs: `make firecracker-rootfs`
- [ ] Start a Firecracker VM and verify `which mise` returns `/root/.local/bin/mise`
- [ ] Test stop/start cycle: install PostgreSQL, run it, `shed stop` + `shed start`, verify PostgreSQL starts cleanly
- [ ] Review ROADMAP.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced boot cleanup process that removes stale PID files, shared memory segments, lock files, and temporary files for improved boot reliability.

* **Documentation**
  * Updated roadmap to reflect graceful shutdown work and ongoing stop/start resilience improvements.
  * Deferred items clarified: stop timeout, pre-shutdown hooks, and startup hook best practices.

* **Chores**
  * Added mise version manager to build infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->