### PR TITLE
Move service cleanup from network-setup.sh to startup hooks

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,9 +17,8 @@ Follow-up improvements to consider after the initial Firecracker backend merges.
 
 Remaining improvement for stop/start resilience after most e2e gaps were resolved:
 
-- Boot cleanup now handles stale PIDs, shared memory, lock files, and temp files (via `network-setup.sh`)
+- Boot cleanup handles generic stale state (shared memory, lock files, temp files) via `network-setup.sh`; service-specific cleanup moved to startup hooks (documented in provisioning guide)
 - Still deferred: configurable stop timeout, pre-shutdown hooks for graceful service termination
-- Still deferred: startup hook best practices documentation
 
 ## Firecracker Live Mounts (SSHFS over vsock)
 

--- a/docs/reference/provisioning.md
+++ b/docs/reference/provisioning.md
@@ -107,6 +107,12 @@ echo "PostgreSQL installed"
 #!/bin/bash
 set -euo pipefail
 
+# Clean stale PostgreSQL state from prior stop
+sudo rm -rf /var/run/postgresql
+sudo mkdir -p /var/run/postgresql
+sudo chown postgres:postgres /var/run/postgresql 2>/dev/null || true
+sudo rm -f /var/lib/postgresql/16/main/postmaster.pid 2>/dev/null || true
+
 # Start PostgreSQL if not running
 if ! pg_isready -q 2>/dev/null; then
     echo "Starting PostgreSQL..."
@@ -120,6 +126,37 @@ fi
 
 echo "PostgreSQL is ready"
 ```
+
+## Startup Hook Best Practices
+
+### Handling Stale State After Stop/Start
+
+When you run `shed stop`, services are killed without a chance to clean up — leaving stale PID files, sockets, and shared memory. On the next `shed start`, these stale files can prevent services from restarting. This applies to both Docker and Firecracker backends (only `shed delete` + `shed create` gives a clean slate).
+
+Your startup hook should clean stale runtime state **before** starting services:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Clean stale PostgreSQL state from prior stop
+sudo rm -rf /var/run/postgresql
+sudo mkdir -p /var/run/postgresql
+sudo chown postgres:postgres /var/run/postgresql 2>/dev/null || true
+sudo rm -f /var/lib/postgresql/16/main/postmaster.pid 2>/dev/null || true
+
+# Start PostgreSQL
+if ! pg_isready -q 2>/dev/null; then
+    sudo pg_ctlcluster 16 main start
+fi
+```
+
+**Key points:**
+
+- Remove and recreate runtime directories (`/var/run/<service>`) with correct ownership
+- Remove stale PID files from data directories (e.g., `postmaster.pid`)
+- Guard commands with `2>/dev/null || true` so cleanup is safe on first boot (e.g., `chown` won't fail if the service user doesn't exist yet, `rm` won't fail if PID files are missing)
+- This pattern works identically on Docker and Firecracker
 
 ## Environment Variables
 

--- a/firecracker/network-setup.sh
+++ b/firecracker/network-setup.sh
@@ -63,20 +63,13 @@ HOSTS_EOF
 
 # Clean stale runtime state from unclean VM shutdown.
 # The rootfs overlay persists across stop/start, but services expect
-# clean state on boot. Remove stale PID files, sockets, lock files,
-# and shared memory segments left by killed processes.
+# clean state on boot. Generic system-level cleanup only —
+# service-specific cleanup belongs in the startup hook.
 
-# Service-specific runtime directories (remove and recreate with correct ownership)
-rm -rf /var/run/postgresql /var/run/redis /var/run/sshd
-mkdir -p /var/run/postgresql && chown postgres:postgres /var/run/postgresql 2>/dev/null || true
-mkdir -p /var/run/redis && chown redis:redis /var/run/redis 2>/dev/null || true
+# Ensure sshd run directory exists (rootfs-level service)
 mkdir -p /var/run/sshd
 
-# Additional known service PID files
-rm -f /var/run/mysqld/mysqld.pid /var/run/nginx.pid /var/run/docker.pid /var/run/crond.pid 2>/dev/null || true
-mkdir -p /var/run/mysqld && chown mysql:mysql /var/run/mysqld 2>/dev/null || true
-
-# Shared memory cleanup (e.g., PostgreSQL POSIX shared memory segments)
+# Shared memory cleanup (e.g., stale POSIX shared memory segments)
 rm -rf /dev/shm/* 2>/dev/null || true
 
 # Lock file cleanup


### PR DESCRIPTION
## Summary

- Strip service-specific stale state cleanup (PostgreSQL, Redis, MySQL) from `firecracker/network-setup.sh` — keep only generic system cleanup (sshd, shared memory, lock files, temp files)
- Add "Startup Hook Best Practices" section to provisioning docs documenting the stale state pattern for stop/start resilience
- Update the existing PostgreSQL startup example to include cleanup before service start

## Context

`network-setup.sh` was mixing two concerns: network configuration (its job) and service-specific cleanup (not its job). The service cleanup was added as a convenient early-boot insertion point during e2e testing, but it bakes user-level service knowledge into system infrastructure. The startup hook already runs on every start (both backends) and is the right place for this.

The companion change to `sltstodo/.shed/scripts/startup.sh` was committed directly to that repo.

## Test plan

- [ ] Review `network-setup.sh` diff — only generic cleanup and sshd remain
- [ ] Verify provisioning docs render correctly
- [ ] Test stop/start cycle on both backends with sltstodo: create, start PostgreSQL/Redis, `shed stop`, `shed start`, verify services come back

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Startup Hook Best Practices section with cleanup guidance and examples.
  * Updated ROADMAP with revised boot cleanup descriptions.

* **Chores**
  * Refactored boot cleanup script to focus on generic system-level state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->