### PR TITLE
Add --json flag for machine-readable CLI output

### DIFF
--- a/cmd/shed/main.go
+++ b/cmd/shed/main.go
@@ -16,6 +16,7 @@ var (
 	serverFlag  string
 	verboseFlag bool
 	configFlag  string
+	jsonFlag    bool
 
 	// Loaded configuration
 	clientConfig *config.ClientConfig
@@ -31,6 +32,11 @@ on one or more shed servers.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// JSON mode suppresses verbose output to keep stdout machine-readable
+		if jsonFlag {
+			verboseFlag = false
+		}
+
 		// Skip config loading for version command
 		if cmd.Name() == "version" {
 			return nil
@@ -52,12 +58,24 @@ on one or more shed servers.`,
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if jsonFlag {
+			return outputJSON(struct {
+				Version   string `json:"version"`
+				GitCommit string `json:"git_commit"`
+				BuildDate string `json:"build_date"`
+			}{
+				Version:   version.Version,
+				GitCommit: version.GitCommit,
+				BuildDate: version.BuildDate,
+			})
+		}
 		if verboseFlag {
 			fmt.Println(version.FullInfo())
 		} else {
 			fmt.Printf("shed %s\n", version.Info())
 		}
+		return nil
 	},
 }
 
@@ -66,6 +84,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&serverFlag, "server", "s", "", "Server to use (default: configured default)")
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "Enable verbose output")
 	rootCmd.PersistentFlags().StringVarP(&configFlag, "config", "c", "", "Path to config file")
+	rootCmd.PersistentFlags().BoolVar(&jsonFlag, "json", false, "Output as JSON")
 
 	// Add subcommand defined in this file
 	rootCmd.AddCommand(versionCmd)
@@ -73,7 +92,11 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		if jsonFlag {
+			_ = outputError(err)
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		os.Exit(1)
 	}
 }
@@ -91,12 +114,20 @@ func getServerEntry() (*config.ServerEntry, string, error) {
 }
 
 // printSuccess prints a success message with a checkmark.
+// In JSON mode, this is a no-op; callers emit structured output instead.
 func printSuccess(format string, args ...interface{}) {
+	if jsonFlag {
+		return
+	}
 	fmt.Printf("✓ "+format+"\n", args...)
 }
 
 // printError prints an error message with suggestions.
+// In JSON mode, this is a no-op; errors are returned and handled by main().
 func printError(msg string, suggestions ...string) {
+	if jsonFlag {
+		return
+	}
 	fmt.Fprintf(os.Stderr, "Error: %s\n", msg)
 	if len(suggestions) > 0 {
 		fmt.Fprintln(os.Stderr, "\nTry:")
@@ -119,11 +150,15 @@ func ensureRunningShed(client *APIClient, name string) (*config.Shed, error) {
 	}
 
 	// Auto-start the shed
-	fmt.Printf("Starting shed %s...\n", name)
+	if !jsonFlag {
+		fmt.Printf("Starting shed %s...\n", name)
+	}
 	shed, err = client.StartShed(name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start shed: %w", err)
 	}
-	printSuccess("Shed %s started", name)
+	if !jsonFlag {
+		printSuccess("Shed %s started", name)
+	}
 	return shed, nil
 }

--- a/cmd/shed/output.go
+++ b/cmd/shed/output.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// ActionResult is the standard envelope for mutation commands in JSON mode.
+type ActionResult struct {
+	Status  string      `json:"status"`
+	Action  string      `json:"action"`
+	Name    string      `json:"name,omitempty"`
+	Server  string      `json:"server,omitempty"`
+	Details interface{} `json:"details,omitempty"`
+}
+
+// outputJSON writes v as indented JSON to stdout.
+func outputJSON(v interface{}) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// outputError writes a JSON error object to stderr.
+func outputError(err error) error {
+	obj := struct {
+		Error string `json:"error"`
+	}{
+		Error: err.Error(),
+	}
+	enc := json.NewEncoder(os.Stderr)
+	enc.SetIndent("", "  ")
+	return enc.Encode(obj)
+}

--- a/cmd/shed/output_test.go
+++ b/cmd/shed/output_test.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestOutputJSON(t *testing.T) {
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	data := map[string]string{"key": "value"}
+	if err := outputJSON(data); err != nil {
+		t.Fatalf("outputJSON returned error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Verify it's valid JSON
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, output)
+	}
+
+	if parsed["key"] != "value" {
+		t.Errorf("expected key=value, got key=%s", parsed["key"])
+	}
+
+	// Verify indentation
+	if output != "{\n  \"key\": \"value\"\n}\n" {
+		t.Errorf("unexpected indentation:\n%s", output)
+	}
+}
+
+func TestOutputJSONEmptySlice(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Ensure empty slice produces [] not null
+	data := make([]string, 0)
+	if err := outputJSON(data); err != nil {
+		t.Fatalf("outputJSON returned error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if output != "[]\n" {
+		t.Errorf("expected []\n, got %q", output)
+	}
+}
+
+func TestOutputJSONNilSlice(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// nil slice produces null in JSON — callers should use make([]T, 0)
+	var data []string
+	if err := outputJSON(data); err != nil {
+		t.Fatalf("outputJSON returned error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if output != "null\n" {
+		t.Errorf("expected null\n, got %q", output)
+	}
+}
+
+func TestActionResultSerialization(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	result := ActionResult{
+		Status: "ok",
+		Action: "created",
+		Name:   "myproj",
+		Server: "devbox",
+	}
+	if err := outputJSON(result); err != nil {
+		t.Fatalf("outputJSON returned error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	var parsed ActionResult
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if parsed.Status != "ok" {
+		t.Errorf("expected status=ok, got %s", parsed.Status)
+	}
+	if parsed.Action != "created" {
+		t.Errorf("expected action=created, got %s", parsed.Action)
+	}
+	if parsed.Name != "myproj" {
+		t.Errorf("expected name=myproj, got %s", parsed.Name)
+	}
+	if parsed.Server != "devbox" {
+		t.Errorf("expected server=devbox, got %s", parsed.Server)
+	}
+	if parsed.Details != nil {
+		t.Errorf("expected details=nil, got %v", parsed.Details)
+	}
+}
+
+func TestActionResultWithDetails(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	result := ActionResult{
+		Status: "ok",
+		Action: "started",
+		Name:   "myproj",
+		Details: struct {
+			Backend string `json:"backend"`
+		}{Backend: "docker"},
+	}
+	if err := outputJSON(result); err != nil {
+		t.Fatalf("outputJSON returned error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	details, ok := parsed["details"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected details to be an object, got %T", parsed["details"])
+	}
+	if details["backend"] != "docker" {
+		t.Errorf("expected backend=docker, got %v", details["backend"])
+	}
+}
+
+func TestActionResultOmitsEmptyFields(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	result := ActionResult{
+		Status: "ok",
+		Action: "removed",
+		Name:   "devbox",
+	}
+	if err := outputJSON(result); err != nil {
+		t.Fatalf("outputJSON returned error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// server and details should be omitted
+	if _, ok := parsed["server"]; ok {
+		t.Error("expected server to be omitted")
+	}
+	if _, ok := parsed["details"]; ok {
+		t.Error("expected details to be omitted")
+	}
+}
+
+func TestOutputError(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	if err := outputError(fmt.Errorf("something went wrong")); err != nil {
+		t.Fatalf("outputError returned error: %v", err)
+	}
+
+	w.Close()
+	os.Stderr = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	var parsed struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, buf.String())
+	}
+
+	if parsed.Error != "something went wrong" {
+		t.Errorf("expected error='something went wrong', got %q", parsed.Error)
+	}
+}

--- a/cmd/shed/server.go
+++ b/cmd/shed/server.go
@@ -120,6 +120,25 @@ func runServerAdd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 
+	if jsonFlag {
+		return outputJSON(ActionResult{
+			Status: "ok",
+			Action: "added",
+			Name:   name,
+			Details: struct {
+				Host     string `json:"host"`
+				HTTPPort int    `json:"http_port"`
+				SSHPort  int    `json:"ssh_port"`
+				Default  bool   `json:"default"`
+			}{
+				Host:     host,
+				HTTPPort: info.HTTPPort,
+				SSHPort:  info.SSHPort,
+				Default:  clientConfig.DefaultServer == name,
+			},
+		})
+	}
+
 	printSuccess("Added server %s (%s:%d)", name, host, info.HTTPPort)
 	if clientConfig.DefaultServer == name {
 		fmt.Println("  Set as default server")
@@ -129,19 +148,48 @@ func runServerAdd(cmd *cobra.Command, args []string) error {
 }
 
 func runServerList(cmd *cobra.Command, args []string) error {
-	if len(clientConfig.Servers) == 0 {
-		fmt.Println("No servers configured.")
-		fmt.Println("\nTo add a server:")
-		fmt.Println("  shed server add <hostname>")
-		return nil
-	}
-
 	// Sort server names for consistent output
 	names := make([]string, 0, len(clientConfig.Servers))
 	for name := range clientConfig.Servers {
 		names = append(names, name)
 	}
 	sort.Strings(names)
+
+	if jsonFlag {
+		type serverJSON struct {
+			Name     string `json:"name"`
+			Host     string `json:"host"`
+			HTTPPort int    `json:"http_port"`
+			SSHPort  int    `json:"ssh_port"`
+			Status   string `json:"status"`
+			Default  bool   `json:"default"`
+		}
+		result := make([]serverJSON, 0, len(names))
+		for _, name := range names {
+			entry := clientConfig.Servers[name]
+			client := NewAPIClientFromEntry(&entry, DefaultTimeout)
+			status := "offline"
+			if client.Ping() {
+				status = "online"
+			}
+			result = append(result, serverJSON{
+				Name:     name,
+				Host:     entry.Host,
+				HTTPPort: entry.HTTPPort,
+				SSHPort:  entry.SSHPort,
+				Status:   status,
+				Default:  name == clientConfig.DefaultServer,
+			})
+		}
+		return outputJSON(result)
+	}
+
+	if len(clientConfig.Servers) == 0 {
+		fmt.Println("No servers configured.")
+		fmt.Println("\nTo add a server:")
+		fmt.Println("  shed server add <hostname>")
+		return nil
+	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "NAME\tHOST\tHTTP\tSSH\tSTATUS\tDEFAULT")
@@ -181,6 +229,14 @@ func runServerRemove(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 
+	if jsonFlag {
+		return outputJSON(ActionResult{
+			Status: "ok",
+			Action: "removed",
+			Name:   name,
+		})
+	}
+
 	printSuccess("Removed server %s", name)
 	return nil
 }
@@ -194,6 +250,14 @@ func runServerSetDefault(cmd *cobra.Command, args []string) error {
 
 	if err := clientConfig.Save(); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	if jsonFlag {
+		return outputJSON(ActionResult{
+			Status: "ok",
+			Action: "set-default",
+			Name:   name,
+		})
 	}
 
 	printSuccess("Set %s as default server", name)

--- a/cmd/shed/sessions.go
+++ b/cmd/shed/sessions.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -12,10 +11,7 @@ import (
 	"github.com/charliek/shed/internal/config"
 )
 
-var (
-	sessionsAllFlag  bool
-	sessionsJSONFlag bool
-)
+var sessionsAllFlag bool
 
 var sessionsCmd = &cobra.Command{
 	Use:   "sessions [shed-name]",
@@ -47,7 +43,6 @@ Example:
 
 func init() {
 	sessionsCmd.Flags().BoolVarP(&sessionsAllFlag, "all", "a", false, "List sessions from all servers")
-	sessionsCmd.Flags().BoolVar(&sessionsJSONFlag, "json", false, "Output as JSON")
 
 	sessionsCmd.AddCommand(sessionsKillCmd)
 	rootCmd.AddCommand(sessionsCmd)
@@ -113,8 +108,11 @@ func runSessions(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if sessionsJSONFlag {
-		return printSessionsJSON(allSessions)
+	if jsonFlag {
+		if allSessions == nil {
+			allSessions = make([]config.Session, 0)
+		}
+		return outputJSON(allSessions)
 	}
 	return printSessionsTable(allSessions)
 }
@@ -132,6 +130,17 @@ func runSessionsKill(cmd *cobra.Command, args []string) error {
 	client := NewAPIClientFromEntry(entry, DefaultTimeout)
 	if err := client.KillSession(shedName, sessionName); err != nil {
 		return fmt.Errorf("failed to kill session: %w", err)
+	}
+
+	if jsonFlag {
+		return outputJSON(ActionResult{
+			Status: "ok",
+			Action: "killed",
+			Name:   sessionName,
+			Details: struct {
+				Shed string `json:"shed"`
+			}{Shed: shedName},
+		})
 	}
 
 	printSuccess("Killed session %q in shed %q", sessionName, shedName)
@@ -165,12 +174,6 @@ func printSessionsTable(sessions []config.Session) error {
 	}
 
 	return w.Flush()
-}
-
-func printSessionsJSON(sessions []config.Session) error {
-	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
-	return enc.Encode(sessions)
 }
 
 func formatTimeAgo(t time.Time) string {

--- a/cmd/shed/shed.go
+++ b/cmd/shed/shed.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -176,6 +177,16 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if jsonFlag {
+		return outputJSON(ActionResult{
+			Status:  "ok",
+			Action:  "created",
+			Name:    name,
+			Server:  serverName,
+			Details: shed,
+		})
+	}
+
 	printSuccess("Created shed %s on %s (backend: %s)", name, serverName, resolvedBackend)
 	fmt.Printf("\nConnect with:\n  shed console %s\n", name)
 
@@ -277,17 +288,38 @@ func runList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Sort by name (applies to both JSON and table output)
+	sort.Slice(allSheds, func(i, j int) bool {
+		return allSheds[i].shed.Name < allSheds[j].shed.Name
+	})
+
+	if jsonFlag {
+		type shedJSON struct {
+			Name      string    `json:"name"`
+			Server    string    `json:"server"`
+			Status    string    `json:"status"`
+			CreatedAt time.Time `json:"created_at"`
+			Backend   string    `json:"backend,omitempty"`
+		}
+		result := make([]shedJSON, 0, len(allSheds))
+		for _, s := range allSheds {
+			result = append(result, shedJSON{
+				Name:      s.shed.Name,
+				Server:    s.server,
+				Status:    s.shed.Status,
+				CreatedAt: s.shed.CreatedAt,
+				Backend:   s.shed.Backend,
+			})
+		}
+		return outputJSON(result)
+	}
+
 	if len(allSheds) == 0 {
 		fmt.Println("No sheds found.")
 		fmt.Println("\nTo create a shed:")
 		fmt.Println("  shed create <name>")
 		return nil
 	}
-
-	// Sort by name
-	sort.Slice(allSheds, func(i, j int) bool {
-		return allSheds[i].shed.Name < allSheds[j].shed.Name
-	})
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	if listAll {
@@ -311,6 +343,11 @@ func runList(cmd *cobra.Command, args []string) error {
 
 func runDelete(cmd *cobra.Command, args []string) error {
 	name := args[0]
+
+	// In JSON mode, require --force to avoid interactive prompts
+	if jsonFlag && !deleteForce {
+		return fmt.Errorf("--force is required when using --json")
+	}
 
 	// Find the server for this shed
 	serverName, entry, err := findShedServer(name)
@@ -351,6 +388,15 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if jsonFlag {
+		return outputJSON(ActionResult{
+			Status: "ok",
+			Action: "deleted",
+			Name:   name,
+			Server: serverName,
+		})
+	}
+
 	printSuccess("Deleted shed %s", name)
 	return nil
 }
@@ -388,6 +434,16 @@ func runStart(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if jsonFlag {
+		return outputJSON(ActionResult{
+			Status:  "ok",
+			Action:  "started",
+			Name:    name,
+			Server:  serverName,
+			Details: shed,
+		})
+	}
+
 	printSuccess("Started shed %s", name)
 	return nil
 }
@@ -419,6 +475,16 @@ func runStop(cmd *cobra.Command, args []string) error {
 		if verboseFlag {
 			fmt.Fprintf(os.Stderr, "Warning: failed to save cache: %v\n", err)
 		}
+	}
+
+	if jsonFlag {
+		return outputJSON(ActionResult{
+			Status:  "ok",
+			Action:  "stopped",
+			Name:    name,
+			Server:  serverName,
+			Details: shed,
+		})
 	}
 
 	printSuccess("Stopped shed %s", name)
@@ -539,8 +605,13 @@ func autoSyncAfterCreate(ctx context.Context, shedName string, entry *config.Ser
 		}
 	}
 
-	fmt.Printf("Syncing %s profile...\n", profile)
+	if !jsonFlag {
+		fmt.Printf("Syncing %s profile...\n", profile)
+	}
 
 	syncer := sync.NewSyncer(cfg)
+	if jsonFlag {
+		syncer.SetOutput(io.Discard)
+	}
 	return syncer.SyncProfile(ctx, profile, shedName, entry, false)
 }

--- a/cmd/shed/ssh_config.go
+++ b/cmd/shed/ssh_config.go
@@ -40,6 +40,25 @@ func init() {
 	rootCmd.AddCommand(sshConfigCmd)
 }
 
+type sshEntryJSON struct {
+	Name           string `json:"name"`
+	Host           string `json:"host"`
+	Port           int    `json:"port"`
+	User           string `json:"user"`
+	KnownHostsFile string `json:"known_hosts_file"`
+}
+
+type sshConfigInstallResult struct {
+	Path    string   `json:"path"`
+	Added   []string `json:"added"`
+	Removed []string `json:"removed"`
+}
+
+type sshConfigUninstallResult struct {
+	Path    string   `json:"path"`
+	Removed []string `json:"removed"`
+}
+
 func runSSHConfig(cmd *cobra.Command, args []string) error {
 	// Validate mutually exclusive flags
 	if sshConfigInstall && sshConfigUninstall {
@@ -71,6 +90,9 @@ func runSSHConfig(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(sheds) == 0 {
+		if jsonFlag {
+			return outputJSON(make([]sshEntryJSON, 0))
+		}
 		fmt.Println("No sheds found.")
 		fmt.Println("\nTo create a shed:")
 		fmt.Println("  shed create <name>")
@@ -85,7 +107,21 @@ func runSSHConfig(cmd *cobra.Command, args []string) error {
 		return runSSHConfigInstall(entries)
 	}
 
-	// Default: print config
+	// Default: print config (or JSON)
+	if jsonFlag {
+		result := make([]sshEntryJSON, 0, len(entries))
+		for _, e := range entries {
+			result = append(result, sshEntryJSON{
+				Name:           e.Name,
+				Host:           e.Host,
+				Port:           e.Port,
+				User:           e.User,
+				KnownHostsFile: e.KnownHostsFile,
+			})
+		}
+		return outputJSON(result)
+	}
+
 	printSSHConfig(entries)
 	return nil
 }
@@ -203,39 +239,63 @@ func runSSHConfigInstall(entries []sshconfig.Entry) error {
 
 	// Show diff
 	if !diff.HasChanges() && parsed.HasManagedBlock {
+		if jsonFlag {
+			return outputJSON(ActionResult{
+				Status: "ok",
+				Action: "installed",
+				Details: sshConfigInstallResult{
+					Path:    sshConfigPath,
+					Added:   []string{},
+					Removed: []string{},
+				},
+			})
+		}
 		fmt.Println("SSH config is already up to date.")
 		return nil
 	}
 
-	fmt.Printf("SSH config file: %s\n\n", sshConfigPath)
+	if !jsonFlag {
+		fmt.Printf("SSH config file: %s\n\n", sshConfigPath)
 
-	if len(diff.Additions) > 0 {
-		fmt.Println("Entries to add:")
-		for _, name := range diff.Additions {
-			fmt.Printf("  + %s\n", name)
+		if len(diff.Additions) > 0 {
+			fmt.Println("Entries to add:")
+			for _, name := range diff.Additions {
+				fmt.Printf("  + %s\n", name)
+			}
 		}
-	}
 
-	if len(diff.Removals) > 0 {
-		fmt.Println("Entries to remove:")
-		for _, name := range diff.Removals {
-			fmt.Printf("  - %s\n", name)
+		if len(diff.Removals) > 0 {
+			fmt.Println("Entries to remove:")
+			for _, name := range diff.Removals {
+				fmt.Printf("  - %s\n", name)
+			}
 		}
-	}
 
-	if len(diff.Unchanged) > 0 && verboseFlag {
-		fmt.Println("Entries unchanged:")
-		for _, name := range diff.Unchanged {
-			fmt.Printf("  = %s\n", name)
+		if len(diff.Unchanged) > 0 && verboseFlag {
+			fmt.Println("Entries unchanged:")
+			for _, name := range diff.Unchanged {
+				fmt.Printf("  = %s\n", name)
+			}
 		}
-	}
 
-	if !parsed.HasManagedBlock && len(entries) > 0 {
-		fmt.Println("\nManaged block will be created.")
+		if !parsed.HasManagedBlock && len(entries) > 0 {
+			fmt.Println("\nManaged block will be created.")
+		}
 	}
 
 	// Dry run - stop here
 	if sshConfigDryRun {
+		if jsonFlag {
+			return outputJSON(ActionResult{
+				Status: "ok",
+				Action: "dry-run",
+				Details: sshConfigInstallResult{
+					Path:    sshConfigPath,
+					Added:   diff.Additions,
+					Removed: diff.Removals,
+				},
+			})
+		}
 		fmt.Println("\n(dry run - no changes made)")
 		return nil
 	}
@@ -244,6 +304,18 @@ func runSSHConfigInstall(entries []sshconfig.Entry) error {
 	err = sshconfig.Write(sshConfigPath, parsed.BeforeBlock, entries, parsed.AfterBlock)
 	if err != nil {
 		return fmt.Errorf("failed to write SSH config: %w", err)
+	}
+
+	if jsonFlag {
+		return outputJSON(ActionResult{
+			Status: "ok",
+			Action: "installed",
+			Details: sshConfigInstallResult{
+				Path:    sshConfigPath,
+				Added:   diff.Additions,
+				Removed: diff.Removals,
+			},
+		})
 	}
 
 	printSuccess("Updated SSH config at %s", sshConfigPath)
@@ -266,6 +338,16 @@ func runSSHConfigUninstall() error {
 	data, err := os.ReadFile(sshConfigPath)
 	if err != nil {
 		if os.IsNotExist(err) {
+			if jsonFlag {
+				return outputJSON(ActionResult{
+					Status: "ok",
+					Action: "uninstalled",
+					Details: sshConfigUninstallResult{
+						Path:    sshConfigPath,
+						Removed: []string{},
+					},
+				})
+			}
 			fmt.Println("No SSH config file found.")
 			return nil
 		}
@@ -276,19 +358,46 @@ func runSSHConfigUninstall() error {
 	parsed := sshconfig.Parse(string(data))
 
 	if !parsed.HasManagedBlock {
+		if jsonFlag {
+			return outputJSON(ActionResult{
+				Status: "ok",
+				Action: "uninstalled",
+				Details: sshConfigUninstallResult{
+					Path:    sshConfigPath,
+					Removed: []string{},
+				},
+			})
+		}
 		fmt.Println("No shed-managed entries found in SSH config.")
 		return nil
 	}
 
-	// Show what will be removed
-	fmt.Printf("SSH config file: %s\n\n", sshConfigPath)
-	fmt.Println("Entries to remove:")
-	for _, entry := range parsed.ManagedEntries {
-		fmt.Printf("  - %s\n", entry.Name)
+	names := make([]string, 0, len(parsed.ManagedEntries))
+	for _, e := range parsed.ManagedEntries {
+		names = append(names, e.Name)
+	}
+
+	if !jsonFlag {
+		// Show what will be removed
+		fmt.Printf("SSH config file: %s\n\n", sshConfigPath)
+		fmt.Println("Entries to remove:")
+		for _, name := range names {
+			fmt.Printf("  - %s\n", name)
+		}
 	}
 
 	// Dry run - stop here
 	if sshConfigDryRun {
+		if jsonFlag {
+			return outputJSON(ActionResult{
+				Status: "ok",
+				Action: "dry-run",
+				Details: sshConfigUninstallResult{
+					Path:    sshConfigPath,
+					Removed: names,
+				},
+			})
+		}
 		fmt.Println("\n(dry run - no changes made)")
 		return nil
 	}
@@ -297,6 +406,17 @@ func runSSHConfigUninstall() error {
 	err = sshconfig.Remove(sshConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to update SSH config: %w", err)
+	}
+
+	if jsonFlag {
+		return outputJSON(ActionResult{
+			Status: "ok",
+			Action: "uninstalled",
+			Details: sshConfigUninstallResult{
+				Path:    sshConfigPath,
+				Removed: names,
+			},
+		})
 	}
 
 	printSuccess("Removed shed-managed entries from %s", sshConfigPath)

--- a/cmd/shed/sync.go
+++ b/cmd/shed/sync.go
@@ -74,7 +74,13 @@ func runSync(cmd *cobra.Command, args []string) error {
 
 	// Capture output for log file
 	var logBuffer bytes.Buffer
-	multiWriter := io.MultiWriter(os.Stdout, &logBuffer)
+	var multiWriter io.Writer
+	if jsonFlag {
+		// In JSON mode, only capture to log buffer, suppress stdout
+		multiWriter = &logBuffer
+	} else {
+		multiWriter = io.MultiWriter(os.Stdout, &logBuffer)
+	}
 	syncer.SetOutput(multiWriter)
 
 	if verboseFlag {
@@ -121,6 +127,19 @@ func runSync(cmd *cobra.Command, args []string) error {
 		if err := syncer.SaveSyncLog(ctx, logBuffer.String(), name, entry); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to save sync log: %v\n", err)
 		}
+	}
+
+	if jsonFlag {
+		action := "synced"
+		if syncDryRun {
+			action = "dry-run"
+		}
+		return outputJSON(ActionResult{
+			Status: "ok",
+			Action: action,
+			Name:   name,
+			Server: serverName,
+		})
 	}
 
 	if syncDryRun {

--- a/cmd/shed/tunnels.go
+++ b/cmd/shed/tunnels.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -23,7 +22,6 @@ var (
 	tunnelReplace     bool
 	tunnelStopAll     bool
 	tunnelListVerbose bool
-	tunnelListJSON    bool
 )
 
 var tunnelsCmd = &cobra.Command{
@@ -108,7 +106,6 @@ func init() {
 
 	// tunnels list flags
 	tunnelsListCmd.Flags().BoolVarP(&tunnelListVerbose, "verbose", "v", false, "Show detailed port mappings")
-	tunnelsListCmd.Flags().BoolVar(&tunnelListJSON, "json", false, "Output as JSON")
 
 	// tunnels config flags
 	tunnelsConfigCmd.Flags().StringArrayVarP(&tunnelProfiles, "profile", "p", nil, "Profile to preview")
@@ -174,6 +171,10 @@ func collectPortMappings(mgr *tunnels.Manager, shedName string, profiles, ports 
 func runTunnelsStart(cmd *cobra.Command, args []string) error {
 	shedName := args[0]
 
+	if jsonFlag && !tunnelBackground {
+		return fmt.Errorf("--json requires --background (-d) for tunnel start")
+	}
+
 	// Find the server hosting this shed
 	serverName, entry, err := findShedServer(shedName)
 	if err != nil {
@@ -206,7 +207,10 @@ func runTunnelsStart(cmd *cobra.Command, args []string) error {
 		}
 		if alive {
 			if !tunnelReplace {
-				// Prompt for replacement
+				if jsonFlag {
+					return fmt.Errorf("tunnel already running for %s; use --replace with --json", shedName)
+				}
+
 				fmt.Printf("Tunnel already running for %s (profile: %s, PID %d).\n",
 					shedName, existingEntry.Profile, existingEntry.PID)
 
@@ -226,7 +230,9 @@ func runTunnelsStart(cmd *cobra.Command, args []string) error {
 				}
 			}
 
-			fmt.Println("Stopping existing tunnel...")
+			if !jsonFlag {
+				fmt.Println("Stopping existing tunnel...")
+			}
 			if err := mgr.Stop(shedName); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to stop existing tunnel: %v\n", err)
 			}
@@ -266,6 +272,21 @@ func runTunnelsStart(cmd *cobra.Command, args []string) error {
 		if err := mgr.StartBackground(shedName, serverName, entry, allPorts, profileName); err != nil {
 			return fmt.Errorf("failed to start tunnel: %w", err)
 		}
+		if jsonFlag {
+			return outputJSON(ActionResult{
+				Status: "ok",
+				Action: "started",
+				Name:   shedName,
+				Server: serverName,
+				Details: struct {
+					Profile string                `json:"profile"`
+					Ports   []tunnels.PortMapping `json:"ports"`
+				}{
+					Profile: profileName,
+					Ports:   allPorts,
+				},
+			})
+		}
 		printSuccess("Tunnel started for %s (profile: %s)", shedName, profileName)
 		fmt.Println("Forwarding:")
 		for _, pm := range allPorts {
@@ -273,11 +294,13 @@ func runTunnelsStart(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		// Start in foreground
-		fmt.Printf("Starting tunnel to %s (Ctrl+C to stop)...\n", shedName)
-		for _, pm := range allPorts {
-			fmt.Printf("  localhost:%d -> %s:%d\n", pm.Local, shedName, pm.Remote)
+		if !jsonFlag {
+			fmt.Printf("Starting tunnel to %s (Ctrl+C to stop)...\n", shedName)
+			for _, pm := range allPorts {
+				fmt.Printf("  localhost:%d -> %s:%d\n", pm.Local, shedName, pm.Remote)
+			}
+			fmt.Println()
 		}
-		fmt.Println()
 
 		// This replaces the current process
 		if err := mgr.StartForeground(shedName, serverName, entry, allPorts, profileName); err != nil {
@@ -297,16 +320,36 @@ func runTunnelsStop(cmd *cobra.Command, args []string) error {
 	if tunnelStopAll {
 		allTunnels := mgr.State().GetAllTunnels()
 		if len(allTunnels) == 0 {
+			if jsonFlag {
+				return outputJSON(ActionResult{
+					Status: "ok",
+					Action: "stopped",
+				})
+			}
 			fmt.Println("No tunnels running.")
 			return nil
 		}
 
+		stopped := make([]string, 0)
 		for shedName := range allTunnels {
 			if err := mgr.Stop(shedName); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to stop tunnel for %s: %v\n", shedName, err)
 			} else {
-				printSuccess("Stopped tunnel for %s", shedName)
+				stopped = append(stopped, shedName)
+				if !jsonFlag {
+					printSuccess("Stopped tunnel for %s", shedName)
+				}
 			}
+		}
+		sort.Strings(stopped)
+		if jsonFlag {
+			return outputJSON(ActionResult{
+				Status: "ok",
+				Action: "stopped",
+				Details: struct {
+					Stopped []string `json:"stopped"`
+				}{Stopped: stopped},
+			})
 		}
 		return nil
 	}
@@ -325,6 +368,14 @@ func runTunnelsStop(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to stop tunnel: %w", err)
 	}
 
+	if jsonFlag {
+		return outputJSON(ActionResult{
+			Status: "ok",
+			Action: "stopped",
+			Name:   shedName,
+		})
+	}
+
 	printSuccess("Stopped tunnel for %s", shedName)
 	return nil
 }
@@ -341,9 +392,12 @@ func runTunnelsList(cmd *cobra.Command, args []string) error {
 	}
 
 	allTunnels := mgr.State().GetAllTunnels()
+	if allTunnels == nil {
+		allTunnels = make(map[string]tunnels.TunnelEntry)
+	}
 
-	if tunnelListJSON {
-		return outputTunnelsJSON(allTunnels)
+	if jsonFlag {
+		return outputJSON(allTunnels)
 	}
 
 	if len(allTunnels) == 0 {
@@ -404,6 +458,20 @@ func runTunnelsConfig(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if jsonFlag {
+		return outputJSON(struct {
+			Shed    string                `json:"shed"`
+			Server  string                `json:"server"`
+			Profile string                `json:"profile"`
+			Ports   []tunnels.PortMapping `json:"ports"`
+		}{
+			Shed:    shedName,
+			Server:  serverName,
+			Profile: profileName,
+			Ports:   allPorts,
+		})
+	}
+
 	fmt.Printf("Tunnel configuration for %s\n", shedName)
 	fmt.Printf("Server: %s\n", serverName)
 	fmt.Printf("Profile: %s\n", profileName)
@@ -420,15 +488,6 @@ func runTunnelsConfig(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  %s\n", strings.Join(mgr.BuildSSHArgs(shedName, entry, allPorts), " "))
 	}
 
-	return nil
-}
-
-func outputTunnelsJSON(entries map[string]tunnels.TunnelEntry) error {
-	data, err := json.MarshalIndent(entries, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %w", err)
-	}
-	fmt.Println(string(data))
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Adds a global `--json` flag that emits structured JSON to stdout across all shed commands: version, server (add/list/remove/set-default), create, list, delete, start, stop, sessions (list/kill), sync, tunnels (start/stop/list/config), and ssh-config (print/install/uninstall)
- JSON mode suppresses verbose output, guards interactive prompts (`delete` requires `--force`, tunnel replace requires `--replace`), emits `{}` instead of `null` for empty maps, and uses deterministic ordering for all list outputs
- Errors are written as structured JSON to stderr via `outputError()`
- Extracts shared `ActionResult` envelope and `outputJSON`/`outputError` helpers into `output.go` with comprehensive tests

## Test plan

- [x] `go build ./cmd/shed/` compiles
- [x] `go test ./cmd/shed/` passes (including new output_test.go)
- [x] `go vet ./...` clean
- [x] Manual e2e testing against live shed-server (Docker backend) — all 23 JSON command variants produce valid JSON
- [ ] Verify `--json` flag appears in `shed --help` output
- [ ] Test with Firecracker backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent --json flag: global structured JSON output for version, servers, sheds, SSH config, tunnels, sessions, and sync
  * Commands return machine-readable success/error payloads and suppress human prompts/messages in JSON mode; some flows become non-interactive
  * Deterministic name-sorted listings for sheds and other list outputs

* **Tests**
  * Added tests covering JSON output serialization and error formatting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->