### PR TITLE
Update docs for --json flag, config validation, and non-root user (#11-#13)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,10 +8,10 @@ Follow-up improvements to consider after the initial Firecracker backend merges.
 
 - ~~Disable root SSH login by default in the Firecracker rootfs and switch to a non-root user workflow.~~ **Done** — shed-agent now runs commands as the `shed` user (UID 1000), matching the Docker backend's non-root model.
 - ~~Add deeper graceful shutdown handling for `shed-agent` connection goroutines (beyond basic timeout-driven exit).~~ **Done** — `Stop()` now uses a 5s drain timeout so hung connections don't block VM shutdown.
-- Consider stricter validation defaults for Firecracker configs (additional guardrails beyond `vsock_base_cid`).
-- Add metadata JSON version field for forward/backward compatibility of the metadata format.
+- ~~Consider stricter validation defaults for Firecracker configs (additional guardrails beyond `vsock_base_cid`).~~ **Done** — upper-bound validation added for CPUs, memory, disk, vsock CID/ports, and timeouts; kernel/rootfs paths checked at startup.
+- ~~Add metadata JSON version field for forward/backward compatibility of the metadata format.~~ **Done** — `MetadataVersion = 1`, backward-compat for pre-version files.
 - Consider reducing `MaxMessageSize` (16MB) or adding streaming for large messages in agentproto.
-- Document integration test strategy (requires KVM, can't be automated in CI without nested virtualization).
+- ~~Document integration test strategy (requires KVM, can't be automated in CI without nested virtualization).~~ **Done** — `docs/development/testing.md` covers unit, integration, and e2e tiers.
 
 ## Firecracker Graceful Shutdown (Deferred)
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -179,6 +179,7 @@ Shed relies on network-level trust:
 - Assumes all machines are on a private network (Tailscale)
 - No authentication on HTTP API
 - SSH accepts all keys (network access = trust)
+- Workloads run as a non-root `shed` user (UID 1000) with passwordless sudo
 - Not suitable for multi-tenant or public deployments
 
 ## Container Lifecycle

--- a/docs/firecracker_howto.md
+++ b/docs/firecracker_howto.md
@@ -172,6 +172,7 @@ cat /var/lib/shed/firecracker/instances/myproject/metadata.json
 Example output:
 ```json
 {
+  "version": 1,
   "name": "myproject",
   "status": "running",
   "created_at": "2024-01-15T10:30:00Z",

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,6 +9,7 @@ Complete reference for the `shed` command-line interface.
 | `--server` | `-s` | Target server (overrides default) |
 | `--verbose` | `-v` | Enable debug output |
 | `--config` | `-c` | Config file path (default: `~/.shed/config.yaml`) |
+| `--json` | | Emit structured JSON to stdout (suppresses verbose output) |
 
 ## Server Management
 
@@ -150,6 +151,8 @@ shed delete <name> [flags]
 | `--keep-volume` | | `false` | Preserve workspace data |
 | `--force` | `-f` | `false` | Skip confirmation |
 
+**Note:** When using `--json`, the `--force` flag is required (interactive confirmation is not supported in JSON mode).
+
 ## Interactive Access
 
 ### shed console
@@ -218,7 +221,6 @@ shed sessions [shed-name] [flags]
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--all` | `-a` | `false` | List from all servers |
-| `--json` | | `false` | Output as JSON |
 
 **Examples:**
 
@@ -293,7 +295,6 @@ shed tunnels list [flags]
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--verbose` | `-v` | `false` | Show detailed info |
-| `--json` | | `false` | Output as JSON |
 
 ### shed tunnels config
 


### PR DESCRIPTION
## Summary

- Add global `--json` flag to CLI reference and remove stale per-command `--json` flags from `sessions` and `tunnels list`
- Document `--force` requirement when using `--json` with `shed delete`
- Mark 3 completed ROADMAP items as done (config validation bounds, metadata version field, integration test docs)
- Add `version` field to Firecracker metadata JSON example
- Add non-root `shed` user to architecture security model

## Test plan

- [x] `mkdocs build --strict` passes with no new errors
- [ ] Verify Global Flags table now has 4 rows
- [ ] Verify per-command `--json` removed from sessions and tunnels list
- [ ] Verify metadata JSON example starts with `"version": 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global `--json` flag to CLI commands for structured JSON output, consolidating previous command-specific JSON options

* **Documentation**
  * Updated security documentation with workload execution details
  * Added versioning support to VM metadata schema
  * Enhanced architecture and CLI reference guides for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->