### PR TITLE
Upgrade golangci-lint to v2.10.1, managed via mise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64.5
+          version: v2.10.1
 
   dockerfile-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,9 +29,9 @@ jobs:
         run: go test ./...
 
       - name: Run Linter
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64.5
+          version: v2.10.1
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,26 +1,31 @@
+version: "2"
+
 linters:
+  default: none
   enable:
     - errcheck
     - staticcheck
     - unused
     - govet
     - ineffassign
+    - misspell
+  settings:
+    errcheck:
+      exclude-functions:
+        - (io.Closer).Close
+        - (net/http.ResponseWriter).Write
+  exclusions:
+    presets:
+      - std-error-handling
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
+      - path: _test\.go
+        linters:
+          - unused
+
+formatters:
+  enable:
     - gofmt
     - goimports
-    - gosimple
-    - misspell
-
-linters-settings:
-  errcheck:
-    exclude-functions:
-      - (io.Closer).Close
-      - (net/http.ResponseWriter).Write
-
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck
-    - path: _test\.go
-      linters:
-        - unused

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,3 @@
 [tools]
 go = "1.24"
+golangci-lint = "2.10.1"

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -4,7 +4,7 @@ This guide covers setting up a development environment for contributing to Shed.
 
 ## Prerequisites
 
-- Go 1.24 or later
+- [mise](https://mise.jdx.dev/) (manages Go, golangci-lint, and other tool versions)
 - Docker (for building the base image and testing)
 - Make
 - Git
@@ -16,6 +16,13 @@ This guide covers setting up a development environment for contributing to Shed.
 ```bash
 git clone https://github.com/charliek/shed.git
 cd shed
+```
+
+### Install Tools
+
+```bash
+# Install Go, golangci-lint, and other tools defined in .mise.toml
+mise install
 ```
 
 ### Build
@@ -217,8 +224,8 @@ make check
 ### Installing Tools
 
 ```bash
-# golangci-lint
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
+# Go and golangci-lint are managed by mise (see .mise.toml)
+mise install
 
 # hadolint (for Dockerfile linting)
 # macOS: brew install hadolint

--- a/internal/firecracker/provisioning.go
+++ b/internal/firecracker/provisioning.go
@@ -389,7 +389,7 @@ func (s *ProvisionState) writeStateFile(ctx context.Context, state map[string]st
 	// Build content with escaped values to handle newlines safely
 	var content strings.Builder
 	for key, value := range state {
-		content.WriteString(fmt.Sprintf("%s=%s\n", key, escapeStateValue(value)))
+		fmt.Fprintf(&content, "%s=%s\n", key, escapeStateValue(value))
 	}
 
 	// Use heredoc to safely write content.

--- a/internal/provision/state.go
+++ b/internal/provision/state.go
@@ -106,7 +106,7 @@ func (s *State) writeStateFile(ctx context.Context, containerID string, state ma
 	// Build the content
 	var content strings.Builder
 	for key, value := range state {
-		content.WriteString(fmt.Sprintf("%s=%s\n", key, value))
+		fmt.Fprintf(&content, "%s=%s\n", key, value)
 	}
 
 	// Encode content as base64 to safely pass through shell without delimiter issues.

--- a/internal/sshconfig/writer.go
+++ b/internal/sshconfig/writer.go
@@ -37,12 +37,12 @@ type Diff struct {
 func GenerateEntry(entry Entry) string {
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("Host %s\n", entry.Name))
-	sb.WriteString(fmt.Sprintf("    HostName %s\n", entry.Host))
-	sb.WriteString(fmt.Sprintf("    Port %d\n", entry.Port))
-	sb.WriteString(fmt.Sprintf("    User %s\n", entry.User))
+	fmt.Fprintf(&sb, "Host %s\n", entry.Name)
+	fmt.Fprintf(&sb, "    HostName %s\n", entry.Host)
+	fmt.Fprintf(&sb, "    Port %d\n", entry.Port)
+	fmt.Fprintf(&sb, "    User %s\n", entry.User)
 	if entry.KnownHostsFile != "" {
-		sb.WriteString(fmt.Sprintf("    UserKnownHostsFile %s\n", entry.KnownHostsFile))
+		fmt.Fprintf(&sb, "    UserKnownHostsFile %s\n", entry.KnownHostsFile)
 	}
 
 	return sb.String()
@@ -58,7 +58,7 @@ func GenerateManagedBlock(entries []Entry) string {
 
 	sb.WriteString(BeginMarker + "\n")
 	sb.WriteString("# Do not edit manually - managed by shed CLI\n")
-	sb.WriteString(fmt.Sprintf("# Last updated: %s\n", time.Now().UTC().Format(time.RFC3339)))
+	fmt.Fprintf(&sb, "# Last updated: %s\n", time.Now().UTC().Format(time.RFC3339))
 	sb.WriteString("\n")
 
 	// Sort entries by name for consistent output


### PR DESCRIPTION
## Summary
- Upgrade golangci-lint from v1.64.5 to v2.10.1, now managed by mise (matching prox/envsecrets pattern)
- Migrate `.golangci.yml` to v2 format (`version: "2"`, `default: none`, `formatters` section, `exclusions` presets)
- Upgrade CI and release workflows to `golangci-lint-action@v7`
- Update dev setup docs to use `mise install` instead of manual `go install`
- Fix 6 QF1012 staticcheck violations (`WriteString(Sprintf(...))` → `Fprintf`)

## Test plan
- [x] `mise install` installs golangci-lint v2.10.1
- [x] `golangci-lint run ./...` passes with 0 issues
- [x] `go test ./...` all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded CI linting tooling and linter versions; declared golangci-lint in project tool manifest

* **Documentation**
  * Switched developer setup to use the new tool manager and simplified install/build instructions

* **Refactor**
  * Streamlined internal formatting to use direct formatted writes while preserving output and behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->