### PR TITLE
Fix race condition in Exec() causing flaky TestExecStdinFraming

### DIFF
--- a/internal/firecracker/vsock.go
+++ b/internal/firecracker/vsock.go
@@ -235,7 +235,11 @@ func (c *VsockClient) Exec(ctx context.Context, opts backend.ExecOptions) error 
 		// Wait for the stdin goroutine to finish so that all writes
 		// (including MsgTypeStdinEOF) complete before defer conn.Close().
 		if stdinDone != nil {
-			<-stdinDone
+			select {
+			case <-stdinDone:
+			case <-ctx.Done():
+				// Intentional teardown/cancel: skip waiting for stdin flush.
+			}
 		}
 		return err
 	case <-ctx.Done():


### PR DESCRIPTION
## Summary
- Fix race condition where `defer conn.Close()` fires before the stdin goroutine finishes writing `MsgTypeStdinEOF`
- Add a `stdinDone` channel so the main goroutine waits for stdin writes to complete before returning
- Context cancellation skips the wait since teardown is intentional

## Test plan
- [x] `go test -count=50 -run TestExecStdinFraming ./internal/firecracker/` — 50/50 pass
- [x] `make check` — full lint + test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a synchronization issue so stdin input is fully flushed and processed before connections are closed, preventing potential incomplete data writes; teardown still respects cancellation so shutdowns can proceed immediately when canceled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->