### PR TITLE
Fix git clone failures: SSH config compat and mount path

### DIFF
--- a/configs/server.local.yaml
+++ b/configs/server.local.yaml
@@ -15,7 +15,7 @@ default_image: shed-base:latest
 credentials:
   git_ssh:
     source: /home/charliek/.ssh
-    target: /mnt/ssh-host
+    target: /home/shed/.ssh
     readonly: true
 
   git_config:

--- a/configs/server.localmac.yaml
+++ b/configs/server.localmac.yaml
@@ -13,7 +13,7 @@ default_image: shed-base:latest
 credentials:
   git_ssh:
     source: ~/.ssh
-    target: /mnt/ssh-host
+    target: /home/shed/.ssh
     readonly: true
 
   git_config:

--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -103,6 +103,14 @@ RUN mkdir -p /run/sshd /etc/ssh/sshd_config.d && \
     "PasswordAuthentication no" \
     > /etc/ssh/sshd_config.d/10-shed.conf
 
+# SSH client compatibility: ignore macOS-specific config directives
+# (UseKeychain, AddKeysToAgent) that may be present in transferred host SSH configs
+RUN mkdir -p /etc/ssh/ssh_config.d && \
+    printf "%s\n" \
+    "Host *" \
+    "    IgnoreUnknown UseKeychain,AddKeysToAgent" \
+    > /etc/ssh/ssh_config.d/10-macos-compat.conf
+
 # Create non-root shed user (UID 1000) with passwordless sudo (devcontainer pattern)
 # Ubuntu 24.04 ships a default 'ubuntu' user at UID 1000; remove it first so
 # files created inside the VM are owned by shed (UID 1000).

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -97,6 +97,14 @@ RUN mkdir -p /run/sshd /etc/ssh/sshd_config.d && \
     "PasswordAuthentication no" \
     > /etc/ssh/sshd_config.d/10-shed.conf
 
+# SSH client compatibility: ignore macOS-specific config directives
+# (UseKeychain, AddKeysToAgent) that may be present in transferred host SSH configs
+RUN mkdir -p /etc/ssh/ssh_config.d && \
+    printf "%s\n" \
+    "Host *" \
+    "    IgnoreUnknown UseKeychain,AddKeysToAgent" \
+    > /etc/ssh/ssh_config.d/10-macos-compat.conf
+
 # Create non-root shed user (UID 1000) with passwordless sudo (devcontainer pattern)
 # Ubuntu 24.04 ships a default 'ubuntu' user at UID 1000; remove it first so
 # files created inside the VM are owned by shed (UID 1000).


### PR DESCRIPTION
## Summary
- Add `IgnoreUnknown UseKeychain,AddKeysToAgent` SSH client config to both VZ and Firecracker VM images so macOS-specific directives in transferred host `~/.ssh/config` are silently ignored instead of causing SSH to fail
- Fix SSH credential mount target from `/mnt/ssh-host` to `/home/shed/.ssh` in both server config files so keys are found at the standard path

## Test plan
- [x] `go test ./...` passes
- [x] Rebuilt VZ rootfs with `./scripts/build-vz-rootfs.sh`
- [x] Created a shed and verified `/etc/ssh/ssh_config.d/10-macos-compat.conf` exists with correct contents
- [x] Verified SSH keys are mounted at `/home/shed/.ssh/`
- [x] Verified Ubuntu's `/etc/ssh/ssh_config` includes `ssh_config.d/*.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated SSH credentials paths in server configuration files to reflect new credential storage locations.
  * Added SSH client configuration to Docker images to improve compatibility with macOS-originated SSH directives, enabling seamless cross-platform development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->