### PR TITLE
Add shed lifecycle documentation across all backends

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -97,25 +97,107 @@ sequenceDiagram
 
 ### Shed Creation
 
-```mermaid
-sequenceDiagram
-    participant CLI
-    participant Server
-    participant Docker
+For the user-facing lifecycle documentation (what happens at each step across all backends), see [Provisioning: Shed Lifecycle](../reference/provisioning.md#shed-lifecycle).
 
-    CLI->>Server: POST /api/sheds {name, repo, local_dir}
-    alt local_dir specified
-        Server->>Docker: Create container (bind mount)
-    else
-        Server->>Docker: Create volume
-        Server->>Docker: Create container
-    end
-    Server->>Docker: Start container
-    alt repo specified
-        Server->>Docker: git clone in container
-    end
-    Server-->>CLI: {name, status, ...}
-```
+The diagrams below show the internal implementation flow for each backend.
+
+=== "Docker"
+
+    ```mermaid
+    sequenceDiagram
+        participant CLI
+        participant Server
+        participant Docker
+
+        CLI->>Server: POST /api/sheds {name, repo, local_dir}
+        alt local_dir specified
+            Server->>Docker: Create container (bind mount + credential bind mounts)
+        else
+            Server->>Docker: Create volume
+            Server->>Docker: Create container (volume + credential bind mounts)
+        end
+        Server->>Docker: Start container
+        Server->>Docker: Fix workspace ownership (chown)
+        alt repo specified
+            Server->>Docker: git clone via docker exec
+        end
+        Server->>Docker: Run install hook via docker exec
+        Server->>Docker: Capture PATH → /etc/profile.d/
+        Server->>Docker: Run startup hook via docker exec
+        Server-->>CLI: {name, status, ...}
+        CLI->>CLI: Auto-sync default profile via SSH+tar
+    ```
+
+=== "Firecracker"
+
+    ```mermaid
+    sequenceDiagram
+        participant CLI
+        participant Server
+        participant VM as Firecracker VM
+        participant Agent as shed-agent
+
+        CLI->>Server: POST /api/sheds {name, repo, local_dir}
+        Server->>Server: Copy base rootfs to instance dir
+        Server->>Server: Allocate CID, TAP device, IP address
+        Server->>VM: Spawn Firecracker process
+        Server->>Agent: Wait for agent health (poll vsock:1025)
+        Agent-->>Server: Healthy
+        Server->>Agent: Transfer credentials via tar-over-vsock
+        alt repo specified
+            Server->>Agent: git clone via vsock exec
+        end
+        Server->>Agent: Run install hook via vsock exec
+        Server->>Agent: Capture PATH → /etc/profile.d/
+        Server->>Agent: Run startup hook via vsock exec
+        Server-->>CLI: {name, status, ...}
+        CLI->>CLI: Auto-sync default profile via SSH+tar
+    ```
+
+=== "VZ"
+
+    ```mermaid
+    sequenceDiagram
+        participant CLI
+        participant Server
+        participant vfkit
+        participant Agent as shed-agent
+
+        CLI->>Server: POST /api/sheds {name, repo, local_dir}
+        Server->>Server: Copy base rootfs to instance dir
+        Server->>Server: Classify credentials (VirtioFS vs tar)
+        Server->>vfkit: Spawn vfkit with VirtioFS devices
+        Note right of vfkit: Devices: rootfs, local-dir share,<br/>credential directory shares
+        Server->>Agent: Wait for agent health (poll vsock:1025)
+        Agent-->>Server: Healthy
+        alt local-dir specified
+            Server->>Agent: Mount VirtioFS share at /workspace
+        end
+        Server->>Agent: Mount VirtioFS credential directories
+        Server->>Agent: Transfer file credentials via tar-over-vsock
+        alt repo specified
+            Server->>Agent: git clone via vsock exec
+        end
+        Server->>Agent: Run install hook via vsock exec
+        Server->>Agent: Capture PATH → /etc/profile.d/
+        Server->>Agent: Run startup hook via vsock exec
+        Server-->>CLI: {name, status, ...}
+        CLI->>CLI: Auto-sync default profile via SSH+tar
+    ```
+
+### Credential Mechanisms
+
+Each backend handles credentials differently based on its isolation model:
+
+**Docker** — Credentials are bind-mounted into the container at creation time. They persist across stop/start and reflect host changes immediately (live sync). Configured in `server.yaml` under `credentials`.
+
+**Firecracker** — No bind mount support. All credentials are transferred as gzipped tar archives over vsock on every `create` and `start`. Writable credentials (`readonly: false`) are synced bidirectionally: the agent watches target paths with fsnotify and sends change notifications to the host over vsock port 1026. The host pulls changed files and pushes host-side changes to all running VMs.
+
+**VZ** — Hybrid approach. `classifyCredentials()` in `internal/vz/client.go` splits credentials by type:
+
+- **Directory credentials** get VirtioFS shares added as vfkit device arguments at VM launch, then mounted inside the guest. Changes are immediately visible on both sides (like Docker bind mounts).
+- **Single-file credentials** cannot use VirtioFS (it only supports directories), so they use the same tar-over-vsock transfer as Firecracker.
+- Writable tar-transferred credentials use the same fsnotify + vsock bidirectional sync as Firecracker.
 
 ### SSH Connection
 

--- a/docs/firecracker_howto.md
+++ b/docs/firecracker_howto.md
@@ -98,23 +98,7 @@ Shed supports automatic provisioning via `.shed/provision.yaml` in your reposito
 
 ### Provisioning Flow
 
-1. **On Create** (with `--repo`):
-   - Credentials are transferred
-   - Repository is cloned
-   - Install hook runs (if configured)
-   - Startup hook runs (if configured)
-
-2. **On Start** (restart):
-   - Credentials are refreshed
-   - Startup hook runs (install hook is skipped)
-
-3. **On Stop**:
-   - Shutdown hook runs (if configured)
-   - VM is stopped
-
-4. **On Delete**:
-   - Shutdown hook runs (via stop)
-   - VM and instance data are removed
+Provisioning hooks work the same as all backends — credentials are transferred via tar-over-vsock, then hooks execute via vsock. For the full sequence of operations during create, start, stop, and delete (including when credentials and mounts are set up relative to hooks), see [Shed Lifecycle](reference/provisioning.md#shed-lifecycle).
 
 ### Skip Provisioning
 

--- a/docs/reference/provisioning.md
+++ b/docs/reference/provisioning.md
@@ -8,6 +8,76 @@ Provisioning works with all three backends:
 - **Firecracker**: Hooks execute via vsock
 - **VZ**: Hooks execute via vsock (same mechanism as Firecracker)
 
+## Shed Lifecycle
+
+Understanding the full sequence of events during shed operations helps you know what's available at each stage — for example, credentials are set up before hooks run, so your install script can use SSH keys or API tokens.
+
+### Create Sequence
+
+When you run `shed create`, the following steps execute in order:
+
+| Step | Docker | Firecracker | VZ |
+|------|--------|-------------|-----|
+| 1. Storage setup | Create named volume (or bind mount for `--local-dir`) | Copy base rootfs to instance directory | Copy base rootfs to instance directory |
+| 2. Container/VM start | Create and start container | Spawn Firecracker process, allocate TAP device and IP, wait for agent health | Spawn vfkit process, wait for agent health |
+| 3. Local-dir mount | Already bind-mounted at container creation | Not supported | VirtioFS mount at `/workspace` |
+| 4. Credential setup | Already bind-mounted at container creation | All credentials transferred via tar-over-vsock | Directory credentials mounted via VirtioFS; single-file credentials transferred via tar-over-vsock |
+| 5. Repo clone | `git clone` in `/workspace` (skipped if `--local-dir`) | Same | Same |
+| 6. Install hook | Runs via `docker exec`; state file marks completion | Runs via vsock; state file marks completion | Same as Firecracker |
+| 7. PATH capture | Captures installed tool paths to `/etc/profile.d/shed-installed-tools.sh` | Same | Same |
+| 8. Startup hook | Runs via `docker exec` | Runs via vsock | Same as Firecracker |
+| 9. Auto-sync | Default [sync](sync.md) profile from `~/.shed/sync.yaml` runs (unless `--no-sync`) | Same | Same |
+
+Steps 1–8 are server-side. Step 9 runs on the CLI client after the server returns.
+
+### Start Sequence
+
+When you run `shed start` on a stopped shed, the sequence is shorter:
+
+| Step | Docker | Firecracker | VZ |
+|------|--------|-------------|-----|
+| 1. Container/VM start | Start existing container | Spawn Firecracker process, wait for agent health | Spawn vfkit process, wait for agent health |
+| 2. Local-dir re-mount | Bind mount persists across restarts | Not supported | VirtioFS re-mount (mounts do not persist across VM reboots) |
+| 3. Credential refresh | Bind mounts persist (no action needed) | All credentials re-transferred via tar-over-vsock | Directory credentials re-mounted via VirtioFS; file credentials re-transferred via tar |
+| 4. Startup hook | Runs (install hook skipped — state file records it already ran) | Same | Same |
+
+No storage setup, repo clone, install hook, or auto-sync on start.
+
+### Stop Sequence
+
+| Step | Docker | Firecracker | VZ |
+|------|--------|-------------|-----|
+| 1. Shutdown hook | Not supported — Docker sends SIGTERM directly | Runs via vsock (budget: half of stop timeout, max 30s) | Same as Firecracker |
+| 2. Agent drain | N/A | 5-second drain timeout for in-flight operations | Same as Firecracker |
+| 3. Process stop | `docker stop` (SIGTERM, then SIGKILL after timeout) | Firecracker API shutdown, SIGKILL fallback | vfkit SIGTERM, then SIGKILL fallback |
+
+### Delete Sequence
+
+`shed delete` calls stop (running the shutdown hook if supported), then removes all resources — container and volume for Docker, instance directory for VM backends.
+
+### Backend Differences at a Glance
+
+| Feature | Docker | Firecracker | VZ |
+|---------|--------|-------------|-----|
+| Credential mechanism | Bind mount | Tar-over-vsock | VirtioFS (directories) + tar-over-vsock (files) |
+| Local-dir support | Bind mount | Not supported | VirtioFS |
+| Shutdown hook | Not supported | Supported | Supported |
+| Credential live sync | Automatic via bind mount | Bidirectional via fsnotify + vsock | VirtioFS for directories; fsnotify + vsock for tar-transferred files |
+| Workspace persistence | Named volume (survives stop/start) | Rootfs image (survives stop/start) | Rootfs image (survives stop/start) |
+
+### Error Handling
+
+Not all failures during create are fatal:
+
+| Step | On failure |
+|------|-----------|
+| Storage setup, container/VM start, agent health check | **Fatal** — create fails, resources cleaned up |
+| Local-dir mount (VZ) | **Fatal** — VM stopped, create fails |
+| Credential setup | Warning logged, create continues |
+| Repo clone | Warning logged, create continues |
+| Provisioning hooks | Warning logged, create continues |
+| Auto-sync | Warning logged, create continues |
+
 ## Quick Start
 
 Create `.shed/provision.yaml` in your repository root:
@@ -200,16 +270,6 @@ env:
   DATABASE_URL: "postgresql://localhost/myapp"
   NODE_ENV: "development"
 ```
-
-## Lifecycle
-
-On `shed create`: The container starts, the repository is cloned, then the install hook runs followed by the startup hook.
-
-On `shed start`: Only the startup hook runs.
-
-On `shed stop`: The shutdown hook runs (if configured), then the shed stops.
-
-On `shed delete`: Calls stop (which runs the shutdown hook), then deletes the shed.
 
 ## Skipping Provisioning
 

--- a/docs/reference/vz-operations.md
+++ b/docs/reference/vz-operations.md
@@ -76,16 +76,9 @@ credentials:
 
 ## Provisioning
 
-Provisioning hooks work identically to Firecracker — they execute commands in the VM via vsock. Place a `.shed/provision.yaml` in your repository:
+Provisioning hooks execute in the VM via vsock, identically to Firecracker. Directory credentials are mounted via VirtioFS; single-file credentials are transferred via tar-over-vsock. Both are set up before hooks run.
 
-```yaml
-hooks:
-  install: scripts/provision/install.sh
-  startup: scripts/provision/startup.sh
-  shutdown: scripts/provision/shutdown.sh
-```
-
-See [Provisioning](provisioning.md) for details.
+For the full sequence of operations during create, start, stop, and delete (including how VZ differs from other backends), see [Shed Lifecycle](provisioning.md#shed-lifecycle). For hook configuration, see [Provisioning](provisioning.md).
 
 ## Inspecting VMs
 


### PR DESCRIPTION
## Summary

- Adds a comprehensive **Shed Lifecycle** section to `docs/reference/provisioning.md` with per-backend tables covering the full create, start, stop, and delete sequences
- Replaces the Docker-only creation diagram in `docs/development/architecture.md` with tabbed mermaid diagrams for all three backends (Docker, Firecracker, VZ) and adds a **Credential Mechanisms** subsection
- Replaces scattered inline provisioning flow descriptions in `firecracker_howto.md` and `vz-operations.md` with cross-references to the authoritative lifecycle section

## Test plan

- [ ] Run `make docs` to verify the docs build without errors
- [ ] Run `make docs-serve` and verify:
  - Lifecycle tables render correctly on the [Provisioning](http://127.0.0.1:7070/reference/provisioning/) page
  - Tabbed mermaid diagrams switch correctly on the [Architecture](http://127.0.0.1:7070/development/architecture/) page
  - Cross-reference links from Firecracker and VZ operations pages navigate to `#shed-lifecycle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Enhanced architecture documentation with detailed backend-specific lifecycle diagrams and credential handling mechanisms
* Added comprehensive Shed Lifecycle reference guide covering Create, Start, Stop, and Delete sequences for Docker, Firecracker, and VZ backends
* Improved provisioning documentation with clearer navigation and backend comparison reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->