### PR TITLE
Fix credential docs and add Docker credential mount tests

### DIFF
--- a/docs/getting-started/server-setup.md
+++ b/docs/getting-started/server-setup.md
@@ -58,11 +58,11 @@ default_image: shed-base:latest
 
 credentials:
   # Git credentials
-  git_ssh:
+  git-ssh:
     source: ~/.ssh
-    target: /mnt/ssh-host
+    target: /home/shed/.ssh
     readonly: true
-  git_config:
+  git-config:
     source: ~/.gitconfig
     target: /home/shed/.gitconfig
     readonly: true
@@ -74,15 +74,15 @@ credentials:
     readonly: false
 
   # OpenCode - data, state, and cache directories
-  opencode_data:
+  opencode-data:
     source: ~/.shed/mounts/opencode/share
     target: /home/shed/.local/share/opencode
     readonly: false
-  opencode_state:
+  opencode-state:
     source: ~/.shed/mounts/opencode/state
     target: /home/shed/.local/state/opencode
     readonly: false
-  opencode_cache:
+  opencode-cache:
     source: ~/.shed/mounts/opencode/cache
     target: /home/shed/.cache/opencode
     readonly: false
@@ -96,6 +96,8 @@ credentials:
 env_file: ~/.shed/env
 log_level: info
 ```
+
+**Credential source paths:** The example above uses curated directories under `~/.shed/mounts/` as credential sources. This lets you prepare separate credential sets for your sheds. You can also mount host paths directly (e.g., `source: ~/.ssh`, `source: ~/.claude`) as shown in the [VZ Setup](vz-setup.md) guide. Both approaches work identically. See the [configuration reference](../reference/configuration.md#credentials) for details.
 
 ### 4. Create Environment File
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -102,9 +102,11 @@ log_level: info
 
 Credentials are made available to sheds. The method depends on the backend:
 
-- **Docker**: Credentials are bind-mounted (live sync with host)
-- **Firecracker/VZ (read-only)**: Credentials are copied at create/start time via tar-over-vsock; no live sync
-- **Firecracker/VZ (writable)**: Credentials are copied at create/start time and synced bidirectionally via fsnotify + vsock (port 1026) while the VM is running
+- **Docker**: Bind-mounted into the container (live sync with host).
+- **Firecracker (read-only)**: Copied at create/start time via tar-over-vsock; no live sync.
+- **Firecracker (writable)**: Copied at create/start time and synced bidirectionally via fsnotify + vsock (port 1026) while the VM is running.
+- **VZ (directory credentials)**: Mounted via VirtioFS (live sync with host, like Docker bind mounts).
+- **VZ (single-file credentials)**: Transferred via tar-over-vsock. Read-only files have no live sync; writable files sync bidirectionally like Firecracker.
 
 ```yaml
 credentials:
@@ -116,7 +118,7 @@ credentials:
 
 **Missing sources:** If a credential's source path does not exist on the host, it is skipped with a log warning. The credential is not transferred to the VM and is not registered for bidirectional sync. Create the source directory on the host before starting the shed to enable sync.
 
-**Note:** For Firecracker and VZ, only read-only credentials lack live sync — changes on either side require a restart. Writable credentials (`readonly: false`) sync bidirectionally while the VM is running: host-side changes push to the VM, and in-VM changes (e.g., token refreshes) sync back to the host with 2-second echo suppression.
+**Note:** For Firecracker, only read-only credentials lack live sync — writable credentials sync bidirectionally while the VM is running with 2-second echo suppression. For VZ, directory credentials always have live sync via VirtioFS regardless of the `readonly` setting. Only VZ single-file credentials use tar transfer and follow the same sync rules as Firecracker.
 
 **Common credential mounts:**
 
@@ -158,6 +160,32 @@ credentials:
     target: /home/shed/.config/gcloud
     readonly: true
 ```
+
+### Exclude Patterns
+
+For tar-transferred credentials (Firecracker, and VZ single-file credentials), you can specify glob patterns to exclude files from transfer and sync:
+
+```yaml
+credentials:
+  claude:
+    source: ~/.claude
+    target: /home/shed/.claude
+    readonly: false
+    exclude:
+      - "*.db"
+      - "*.db-shm"
+      - "*.db-wal"
+      - "log/*"
+      - "storage/*"
+```
+
+| Detail | Description |
+|--------|-------------|
+| Syntax | `filepath.Match` glob patterns (e.g., `*.db`, `log/*`) |
+| Directory patterns | `dir/*` also excludes the directory itself and all nested content |
+| Scope | Applied during tar archive creation and agent-side fsnotify filtering |
+| Docker | Ignored — Docker bind mounts the entire source path |
+| VZ VirtioFS | Ignored — VirtioFS mounts entire directories |
 
 ## Firecracker Configuration
 

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -55,3 +55,80 @@ func TestBuildMounts_BindMount(t *testing.T) {
 		t.Errorf("expected target %q, got %q", config.WorkspacePath, m.Target)
 	}
 }
+
+func TestBuildMounts_WithCredentials(t *testing.T) {
+	sshDir := t.TempDir()
+	claudeDir := t.TempDir()
+
+	c := &Client{
+		config: &config.ServerConfig{
+			Credentials: map[string]config.MountConfig{
+				"git-ssh": {
+					Source:   sshDir,
+					Target:   "/home/shed/.ssh",
+					ReadOnly: true,
+				},
+				"claude": {
+					Source:   claudeDir,
+					Target:   "/home/shed/.claude",
+					ReadOnly: false,
+				},
+			},
+		},
+	}
+
+	mounts := c.buildMounts("myproject", "")
+	if len(mounts) != 3 {
+		t.Fatalf("expected 3 mounts (1 workspace + 2 credentials), got %d", len(mounts))
+	}
+
+	// Build lookup by target (map iteration order is nondeterministic)
+	byTarget := make(map[string]mount.Mount)
+	for _, m := range mounts {
+		byTarget[m.Target] = m
+	}
+
+	ssh := byTarget["/home/shed/.ssh"]
+	if ssh.Type != mount.TypeBind {
+		t.Errorf("ssh mount type = %s, want bind", ssh.Type)
+	}
+	if ssh.Source != sshDir {
+		t.Errorf("ssh mount source = %q, want %q", ssh.Source, sshDir)
+	}
+	if !ssh.ReadOnly {
+		t.Error("ssh mount should be read-only")
+	}
+
+	claude := byTarget["/home/shed/.claude"]
+	if claude.Type != mount.TypeBind {
+		t.Errorf("claude mount type = %s, want bind", claude.Type)
+	}
+	if claude.Source != claudeDir {
+		t.Errorf("claude mount source = %q, want %q", claude.Source, claudeDir)
+	}
+	if claude.ReadOnly {
+		t.Error("claude mount should not be read-only")
+	}
+}
+
+func TestBuildMounts_SkipsMissingSource(t *testing.T) {
+	c := &Client{
+		config: &config.ServerConfig{
+			Credentials: map[string]config.MountConfig{
+				"missing": {
+					Source:   "/nonexistent/path/for/testing",
+					Target:   "/home/shed/.missing",
+					ReadOnly: true,
+				},
+			},
+		},
+	}
+
+	mounts := c.buildMounts("myproject", "")
+	if len(mounts) != 1 {
+		t.Fatalf("expected 1 mount (workspace only, missing credential skipped), got %d", len(mounts))
+	}
+	if mounts[0].Target != config.WorkspacePath {
+		t.Errorf("expected workspace mount, got target %q", mounts[0].Target)
+	}
+}


### PR DESCRIPTION
## Summary

Audit of credential handling across all three backends revealed Docker already uses bind mounts (equivalent to VZ's VirtioFS). No code changes needed for Docker credential handling itself, but the audit uncovered documentation gaps and missing test coverage.

- **configuration.md**: Fix inaccurate VZ credential description (was grouped with Firecracker as tar-only; now correctly describes VZ's hybrid VirtioFS + tar approach). Add new "Exclude Patterns" subsection documenting the previously undocumented `exclude` field on credential mounts.
- **server-setup.md**: Fix credential naming inconsistency (underscores to hyphens), fix SSH target from `/mnt/ssh-host` to `/home/shed/.ssh`, add note about credential source path approaches.
- **Docker tests**: Add `TestBuildMounts_WithCredentials` and `TestBuildMounts_SkipsMissingSource` covering credential bind mount behavior that was previously untested.

## Test plan

- [x] `make check` passes (tests, lint, fmt)
- [ ] Review rendered docs via `make docs-serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Clarified credential behavior for different deployment backends (Docker, Firecracker, VZ) with detailed sync explanations
- Added new Exclude Patterns section for controlling file exclusions from transfers and live synchronization
- Expanded configuration examples with additional credential types and improved guidance on credential source paths and mounting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->