### PR TITLE
Add .bash_profile and remove captureInstalledPaths

### DIFF
--- a/docs/reference/provisioning.md
+++ b/docs/reference/provisioning.md
@@ -24,11 +24,10 @@ When you run `shed create`, the following steps execute in order:
 | 4. Credential setup | Already bind-mounted at container creation | All credentials transferred via tar-over-vsock | Directory credentials mounted via VirtioFS; single-file credentials transferred via tar-over-vsock |
 | 5. Repo clone | `git clone` in `/workspace` (skipped if `--local-dir`) | Same | Same |
 | 6. Install hook | Runs via `docker exec`; state file marks completion | Runs via vsock; state file marks completion | Same as Firecracker |
-| 7. PATH capture | Captures installed tool paths to `/etc/profile.d/shed-installed-tools.sh` | Same | Same |
-| 8. Startup hook | Runs via `docker exec` | Runs via vsock | Same as Firecracker |
-| 9. Auto-sync | Default [sync](sync.md) profile from `~/.shed/sync.yaml` runs (unless `--no-sync`) | Same | Same |
+| 7. Startup hook | Runs via `docker exec` | Runs via vsock | Same as Firecracker |
+| 8. Auto-sync | Default [sync](sync.md) profile from `~/.shed/sync.yaml` runs (unless `--no-sync`) | Same | Same |
 
-Steps 1–8 are server-side. Step 9 runs on the CLI client after the server returns.
+Steps 1–7 are server-side. Step 8 runs on the CLI client after the server returns.
 
 ### Start Sequence
 
@@ -141,23 +140,9 @@ After the shutdown hook completes, the agent enforces a 5-second drain timeout o
 
 ## PATH Propagation
 
-After the install hook completes, shed captures the PATH (including any additions made by installers to `~/.bashrc`) and persists it to `/etc/profile.d/shed-installed-tools.sh`. This ensures tools installed by the install hook are available to the startup hook and subsequent commands.
+All shed hooks run as login shells (`bash --login -c`), which source `~/.bash_profile`. The shed base images set up `~/.bash_profile` to source `~/.bashrc`, so tools that add PATH entries to `~/.bashrc` (e.g., bun, nvm) are automatically available to subsequent hooks.
 
-For example, if your install hook runs `curl -fsSL https://bun.sh/install | bash`, bun's installer adds `~/.bun/bin` to `~/.bashrc`. Shed detects this and writes:
-
-```bash
-export PATH="/home/shed/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
-```
-
-to `/etc/profile.d/shed-installed-tools.sh`. Since startup hooks run as login shells (`bash --login -c`), they automatically source this file and inherit the installed tools.
-
-Shed also detects [mise](https://mise.jdx.dev/) shims. If your install hook uses `mise use --global` to install tools, the mise shims directory (`~/.local/share/mise/shims`) is automatically included in the captured PATH.
-
-**Debugging**: If tools installed by the install hook aren't found during the startup hook, check the captured PATH:
-
-```bash
-shed exec myproject -- cat /etc/profile.d/shed-installed-tools.sh
-```
+The base images also include `/etc/profile.d/shed-path.sh` which ensures [mise](https://mise.jdx.dev/) shims and `~/.local/bin` are in PATH for login shells.
 
 ## Example: PostgreSQL Setup
 

--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -119,6 +119,15 @@ RUN userdel -r ubuntu 2>/dev/null || true \
     && echo 'shed ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/shed \
     && chmod 0440 /etc/sudoers.d/shed
 
+# Set up .bash_profile to handle PATH (login shell) and source .bashrc (interactive).
+# PATH modifications belong here, not in .bashrc, to prevent shell snapshot tools
+# from capturing raw PATH assignments with unexpanded variable references.
+RUN printf '%s\n' \
+    'export PATH="/home/shed/.local/bin:$PATH"' \
+    '[ -f ~/.bashrc ] && . ~/.bashrc' \
+    > /home/shed/.bash_profile \
+    && chown shed:shed /home/shed/.bash_profile
+
 # Create workspace directory owned by shed
 RUN mkdir -p /workspace && chown shed:shed /workspace
 
@@ -151,8 +160,7 @@ USER shed
 RUN curl https://mise.run | sh
 ENV PATH="/home/shed/.local/share/mise/shims:/home/shed/.local/bin:${PATH}"
 
-# Ensure mise shims and local bin are in PATH for non-interactive login shells
-# (shed exec uses bash --login -c "cmd" which sources /etc/profile.d/ but not .bashrc)
+# Ensure mise shims and local bin are in PATH for login shells via profile.d
 USER root
 RUN printf '%s\n' \
     '# Only add shed user paths for the shed user (not root)' \

--- a/images/shed-base/Dockerfile
+++ b/images/shed-base/Dockerfile
@@ -31,6 +31,15 @@ RUN userdel -r ubuntu 2>/dev/null || true \
     && echo 'shed ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/shed \
     && chmod 0440 /etc/sudoers.d/shed
 
+# Set up .bash_profile to handle PATH (login shell) and source .bashrc (interactive).
+# PATH modifications belong here, not in .bashrc, to prevent shell snapshot tools
+# from capturing raw PATH assignments with unexpanded variable references.
+RUN printf '%s\n' \
+    'export PATH="/home/shed/.local/bin:$PATH"' \
+    '[ -f ~/.bashrc ] && . ~/.bashrc' \
+    > /home/shed/.bash_profile \
+    && chown shed:shed /home/shed/.bash_profile
+
 # Pre-create log directory so shed user can write logs without root
 RUN mkdir -p /var/log/shed && chown shed:shed /var/log/shed
 

--- a/internal/docker/containers.go
+++ b/internal/docker/containers.go
@@ -506,14 +506,6 @@ func (c *Client) runProvisioning(ctx context.Context, containerID, shedName stri
 			}
 			fmt.Fprintln(stdout, "✓ Install hook complete")
 			_ = state.MarkInstallComplete(ctx, containerID)
-
-			// Capture installed tool paths for subsequent hooks.
-			// Install hooks often modify ~/.bashrc (e.g., bun adds PATH).
-			// Non-interactive shells don't source .bashrc, so we persist
-			// the PATH to /etc/profile.d/ which login shells source.
-			if err := c.captureInstalledPaths(ctx, containerID); err != nil {
-				fmt.Fprintf(stderr, "Warning: failed to capture installed paths: %v\n", err)
-			}
 		}
 	}
 
@@ -531,46 +523,6 @@ func (c *Client) runProvisioning(ctx context.Context, containerID, shedName stri
 		fmt.Fprintln(stdout, "✓ Startup hook complete")
 	}
 
-	return nil
-}
-
-// captureInstalledPaths captures PATH from an interactive shell and persists
-// it to /etc/profile.d/ so login shells (used by subsequent hooks) inherit
-// tools installed by the install hook (e.g., bun adds itself to ~/.bashrc).
-// Also detects mise shims directory, since mise doesn't modify .bashrc.
-func (c *Client) captureInstalledPaths(ctx context.Context, containerID string) error {
-	cmd := []string{
-		"bash", "-c",
-		`PATH_VAL=$(bash -ic 'echo "$PATH"' 2>/dev/null | tail -1)
-if [ -z "$PATH_VAL" ]; then
-  echo "ERROR: failed to capture PATH" >&2
-  exit 1
-fi
-MISE_SHIMS="$HOME/.local/share/mise/shims"
-if [ -d "$MISE_SHIMS" ] && ! echo "$PATH_VAL" | grep -q "$MISE_SHIMS"; then
-  PATH_VAL="$MISE_SHIMS:$PATH_VAL"
-fi
-echo "export PATH=\"$PATH_VAL\"" | sudo tee /etc/profile.d/shed-installed-tools.sh > /dev/null`,
-	}
-	execConfig := container.ExecOptions{Cmd: cmd, User: config.ContainerUser}
-	execResp, err := c.docker.ContainerExecCreate(ctx, containerID, execConfig)
-	if err != nil {
-		return err
-	}
-	attachResp, err := c.docker.ContainerExecAttach(ctx, execResp.ID, container.ExecStartOptions{})
-	if err != nil {
-		return err
-	}
-	defer attachResp.Close()
-	_, _ = io.Copy(io.Discard, attachResp.Reader)
-
-	inspectResp, err := c.docker.ContainerExecInspect(ctx, execResp.ID)
-	if err != nil {
-		return fmt.Errorf("failed to inspect exec: %w", err)
-	}
-	if inspectResp.ExitCode != 0 {
-		return fmt.Errorf("captureInstalledPaths failed with exit code %d", inspectResp.ExitCode)
-	}
 	return nil
 }
 

--- a/internal/vmutil/provisioning.go
+++ b/internal/vmutil/provisioning.go
@@ -102,10 +102,6 @@ func (p *Provisioner) RunProvisioning(ctx context.Context, cfg *provision.Config
 			fmt.Fprintln(p.output, "Install hook complete")
 			backend.Progress(ctx, "provision", "Install hook complete")
 			_ = state.MarkInstallComplete(ctx)
-
-			if err := p.captureInstalledPaths(ctx); err != nil {
-				fmt.Fprintf(p.errOut, "Warning: failed to capture installed paths: %v\n", err)
-			}
 		}
 	}
 
@@ -215,26 +211,6 @@ func (p *Provisioner) runHook(ctx context.Context, cfg *provision.Config, hookTy
 	}
 
 	return nil
-}
-
-// captureInstalledPaths captures PATH from an interactive shell and persists
-// it to /etc/profile.d/ so login shells inherit tools installed by the install hook.
-func (p *Provisioner) captureInstalledPaths(ctx context.Context) error {
-	cmd := `
-PATH_VAL=$(bash -ic 'echo "$PATH"' 2>/dev/null | tail -1)
-# mise doesn't add shims to .bashrc; detect and prepend if present
-MISE_SHIMS="$HOME/.local/share/mise/shims"
-if [ -d "$MISE_SHIMS" ] && ! echo "$PATH_VAL" | grep -q "$MISE_SHIMS"; then
-  PATH_VAL="$MISE_SHIMS:$PATH_VAL"
-fi
-echo "export PATH=\"$PATH_VAL\"" | sudo tee /etc/profile.d/shed-installed-tools.sh > /dev/null
-`
-	opts := backend.ExecOptions{
-		Cmd:        []string{"bash", "-c", cmd},
-		WorkingDir: "/",
-		TTY:        false,
-	}
-	return p.agent.Exec(ctx, opts)
 }
 
 // ensureLogDir creates the log directory in the VM if it doesn't exist.

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -125,6 +125,15 @@ RUN userdel -r ubuntu 2>/dev/null || true \
     && echo 'shed ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/shed \
     && chmod 0440 /etc/sudoers.d/shed
 
+# Set up .bash_profile to handle PATH (login shell) and source .bashrc (interactive).
+# PATH modifications belong here, not in .bashrc, to prevent shell snapshot tools
+# from capturing raw PATH assignments with unexpanded variable references.
+RUN printf '%s\n' \
+    'export PATH="/home/shed/.local/bin:$PATH"' \
+    '[ -f ~/.bashrc ] && . ~/.bashrc' \
+    > /home/shed/.bash_profile \
+    && chown shed:shed /home/shed/.bash_profile
+
 # Create workspace directory owned by shed
 RUN mkdir -p /workspace && chown shed:shed /workspace
 
@@ -206,14 +215,12 @@ ENV PATH="/home/shed/.local/bin:${PATH}"
 
 # mise (version manager)
 RUN curl https://mise.run | sh
-RUN echo 'export PATH="$HOME/.local/bin:$PATH"' >> /home/shed/.bashrc \
-    && echo 'eval "$(mise activate bash)"' >> /home/shed/.bashrc
+RUN echo 'eval "$(mise activate bash)"' >> /home/shed/.bashrc
 ENV PATH="/home/shed/.local/share/mise/shims:${PATH}"
 
 RUN mise use -g node@lts
 
-# Ensure mise shims and local bin are in PATH for non-interactive login shells
-# (shed exec uses bash --login -c "cmd" which sources /etc/profile.d/ but not .bashrc)
+# Ensure mise shims and local bin are in PATH for login shells via profile.d
 USER root
 RUN printf '%s\n' \
     '# Only add shed user paths for the shed user (not root)' \


### PR DESCRIPTION
## Summary

- Add `.bash_profile` to all base images (VZ, Firecracker, Docker) right after user creation — handles PATH and sources `.bashrc`
- Remove PATH assignment from VZ `.bashrc` (keep only `eval "$(mise activate bash)"`)
- Remove `captureInstalledPaths` from Docker and VM backends — no longer needed since `.bash_profile` sources `.bashrc`
- Update provisioning docs to reflect the change

## Context

Shell snapshot tools (e.g., Claude Code) capture `.bashrc` content including raw PATH assignments like `export PATH=$HOME/.local/bin:$PATH`. When replayed in a degraded context, `$HOME` and `$PATH` don't expand, corrupting PATH and making system utilities unreachable.

The fix follows the standard bash convention:
- **`.bash_profile`** — login shell setup: PATH + `source ~/.bashrc`
- **`.bashrc`** — interactive features only: prompt, aliases, mise activation

This also eliminates `captureInstalledPaths`, which existed solely because `bash --login` didn't source `.bashrc`. With `.bash_profile` bridging the two, tools installed by hooks (which modify `.bashrc`) are automatically available to subsequent hooks.

## Test plan

- [ ] `make build` passes
- [ ] `make test` passes
- [ ] `make lint` passes (0 issues)
- [ ] Create a VZ shed with an install hook that installs bun — verify `bash --login -c 'which bun'` works
- [ ] Verify interactive shell has correct PATH
- [ ] Verify `~/.bash_profile` exists and sources `.bashrc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated provisioning lifecycle documentation: server-side steps reduced from 8 to 7 with revised step numbering.
  * Clarified PATH propagation behavior for installed tools using login shell configuration.

* **Refactor**
  * Streamlined tool PATH availability mechanism by removing post-install capture and utilizing login shell environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->