### PR TITLE
Add Docker credential helper to experimental images

### DIFF
--- a/configs/server.localfc.yaml
+++ b/configs/server.localfc.yaml
@@ -17,19 +17,6 @@ credentials:
     source: /home/charliek/.shed/mounts/claude
     target: /home/shed/.claude
     readonly: false
-    exclude:
-      - "debug/*"
-      - "file-history/*"
-      - "plans/*"
-      - "backups/*"
-      - "cache/*"
-      - "tasks/*"
-      - "todos/*"
-      - "paste-cache/*"
-      - "shell-snapshots/*"
-      - "session-env/*"
-      - "downloads/*"
-      - "telemetry/*"
 
   # GitHub CLI - credentials and config
   gh:

--- a/configs/server.localmac.yaml
+++ b/configs/server.localmac.yaml
@@ -18,29 +18,11 @@ credentials:
     source: ~/.shed/mounts/codex
     target: /home/shed/.codex
     readonly: false
-    exclude:
-      - "sessions/*"
-      - "archived_sessions/*"
-      - "vendor_imports/*"
-      - "log/*"
-      - "tmp/*"
-      - "shell_snapshots/*"
-      - "sqlite/*"
-      - "*.sqlite"
-      - "*.sqlite-shm"
-      - "*.sqlite-wal"
-      - "models_cache.json"
 
   opencode_data:
     source: ~/.shed/mounts/opencode/share
     target: /home/shed/.local/share/opencode
     readonly: false
-    exclude:
-      - "*.db"
-      - "*.db-shm"
-      - "*.db-wal"
-      - "log/*"
-      - "storage/*"
 
   opencode_state:
     source: ~/.shed/mounts/opencode/state
@@ -62,17 +44,28 @@ env_file: ~/.shed/env
 
 log_level: debug
 
+extensions:
+  enabled:
+    - ssh-agent
+    - aws-credentials
+
 default_backend: vz
 
 vz:
   vfkit_path: vfkit
   kernel_path: ~/Library/Application Support/shed/vz/vmlinux
   initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-  base_rootfs: ~/Library/Application Support/shed/vz/default-rootfs.ext4
+  # base_rootfs: ~/Library/Application Support/shed/vz/default-rootfs.ext4
+  # images:
+  #   base: ~/Library/Application Support/shed/vz/base-rootfs.ext4
+  #   default: ~/Library/Application Support/shed/vz/default-rootfs.ext4
+  #   experimental: ~/Library/Application Support/shed/vz/experimental-rootfs.ext4
+
+  base_rootfs: ghcr.io/charliek/shed-vz-experimental:v0.3.0
   images:
-    base: ~/Library/Application Support/shed/vz/base-rootfs.ext4
-    default: ~/Library/Application Support/shed/vz/default-rootfs.ext4
-    experimental: ~/Library/Application Support/shed/vz/experimental-rootfs.ext4
+    base: ghcr.io/charliek/shed-vz-base:v0.3.0
+    experimental: ghcr.io/charliek/shed-vz-experimental:v0.3.0
+  
   instance_dir: ~/Library/Application Support/shed/vz/instances
   socket_dir: ~/.shed/vz/sockets
   default_cpus: 2

--- a/configs/server.localmac.yaml
+++ b/configs/server.localmac.yaml
@@ -48,6 +48,7 @@ extensions:
   enabled:
     - ssh-agent
     - aws-credentials
+    - docker-credentials
 
 default_backend: vz
 

--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -286,18 +286,24 @@ ENTRYPOINT ["/sbin/init"]
 
 # =============================================================================
 # Stage: shed-fc-experimental
-# Default tools + shed-extensions credential brokering (SSH agent, AWS proxy).
+# Default tools + shed-extensions credential brokering (SSH agent, AWS proxy, Docker credentials).
 # See https://github.com/charliek/shed-extensions for details.
 # =============================================================================
 FROM shed-fc-default AS shed-fc-experimental
 
 COPY --from=shed-extensions /usr/local/bin/shed-ext-ssh-agent /usr/local/bin/shed-ext-ssh-agent
 COPY --from=shed-extensions /usr/local/bin/shed-ext-aws-credentials /usr/local/bin/shed-ext-aws-credentials
+COPY --from=shed-extensions /usr/local/bin/docker-credential-shed /usr/local/bin/docker-credential-shed
 COPY --from=shed-extensions /etc/systemd/system/shed-ext-ssh-agent.service /etc/systemd/system/
 COPY --from=shed-extensions /etc/systemd/system/shed-ext-aws-credentials.service /etc/systemd/system/
 COPY --from=shed-extensions /etc/environment.d/shed-extensions.conf /etc/environment.d/
 COPY --from=shed-extensions /etc/shed-extensions.d/ /etc/shed-extensions.d/
 # Units ship disabled — shed-agent enables them from server config
+
+# Configure Docker inside the guest to use shed credential helper
+RUN mkdir -p /home/shed/.docker && \
+    echo '{"credsStore": "shed"}' > /home/shed/.docker/config.json && \
+    chown -R shed:shed /home/shed/.docker
 
 USER root
 

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -281,18 +281,24 @@ ENTRYPOINT ["/sbin/init"]
 
 # =============================================================================
 # Stage: shed-vz-experimental
-# Default tools + shed-extensions credential brokering (SSH agent, AWS proxy).
+# Default tools + shed-extensions credential brokering (SSH agent, AWS proxy, Docker credentials).
 # See https://github.com/charliek/shed-extensions for details.
 # =============================================================================
 FROM shed-vz-default AS shed-vz-experimental
 
 COPY --from=shed-extensions /usr/local/bin/shed-ext-ssh-agent /usr/local/bin/shed-ext-ssh-agent
 COPY --from=shed-extensions /usr/local/bin/shed-ext-aws-credentials /usr/local/bin/shed-ext-aws-credentials
+COPY --from=shed-extensions /usr/local/bin/docker-credential-shed /usr/local/bin/docker-credential-shed
 COPY --from=shed-extensions /etc/systemd/system/shed-ext-ssh-agent.service /etc/systemd/system/
 COPY --from=shed-extensions /etc/systemd/system/shed-ext-aws-credentials.service /etc/systemd/system/
 COPY --from=shed-extensions /etc/environment.d/shed-extensions.conf /etc/environment.d/
 COPY --from=shed-extensions /etc/shed-extensions.d/ /etc/shed-extensions.d/
 # Units ship disabled — shed-agent enables them from server config
+
+# Configure Docker inside the guest to use shed credential helper
+RUN mkdir -p /home/shed/.docker && \
+    echo '{"credsStore": "shed"}' > /home/shed/.docker/config.json && \
+    chown -R shed:shed /home/shed/.docker
 
 USER root
 


### PR DESCRIPTION
## Summary

- Copies `docker-credential-shed` binary from shed-extensions into both VZ and Firecracker experimental image stages
- Configures guest Docker to use the shed credential helper (`credsStore: shed`)
- Enables `docker-credentials` namespace in the local dev server config

This integrates the Docker credential brokering extension from charliek/shed-extensions#7. With this change, `docker pull` from private registries works inside shed VMs without any in-guest credential configuration -- credentials are transparently resolved from the host machine.

## Test plan

- [x] Built local experimental image with `--shed-ext-version dev`
- [x] Created shed VM, verified `docker-credential-shed` binary present at `/usr/local/bin/`
- [x] Verified guest `~/.docker/config.json` contains `{"credsStore": "shed"}`
- [x] `docker pull` from private GCP Artifact Registry succeeded inside VM
- [x] Audit log on host recorded all credential operations
- [x] No credentials exist in VM filesystem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Docker credential support alongside existing AWS and SSH credential authentication methods.

* **Chores**
  * Updated remote execution environment configurations.
  * Container images now sourced from registry instead of local filesystem paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->