### PR TITLE
Add Homebrew tap automation via GoReleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,3 +40,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -111,6 +111,7 @@ brews:
     license: "MIT"
     dependencies:
       - name: vfkit
+        os: mac
     install: |
       bin.install "shed"
       bin.install "shed-server"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -85,6 +85,55 @@ archives:
     files:
       - none*
 
+  - id: shed-homebrew
+    ids:
+      - shed
+      - shed-server
+    formats:
+      - tar.gz
+    name_template: "shed-homebrew_{{ .Os }}_{{ .Arch }}"
+    files:
+      - src: configs/server.example.yaml
+        dst: .
+        strip_parent: true
+
+brews:
+  - name: shed
+    ids:
+      - shed-homebrew
+    repository:
+      owner: charliek
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/charliek/shed"
+    description: "CLI and server for managing persistent VM-based dev environments"
+    license: "MIT"
+    dependencies:
+      - name: vfkit
+    install: |
+      bin.install "shed"
+      bin.install "shed-server"
+      (etc/"shed").mkpath
+      (etc/"shed").install "server.example.yaml" => "server.yaml" unless (etc/"shed/server.yaml").exist?
+    service: |
+      run [opt_bin/"shed-server", "serve", "--config", etc/"shed/server.yaml"]
+      keep_alive true
+      log_path var/"log/shed-server.log"
+      error_log_path var/"log/shed-server.log"
+    caveats: |
+      The shed-server config has been installed to:
+        #{HOMEBREW_PREFIX}/etc/shed/server.yaml
+
+      To start shed-server as a background service:
+        brew services start shed
+
+      Logs: #{var}/log/shed-server.log
+
+      Note: shed-server requires Docker for VM image management.
+    test: |
+      system bin/"shed", "version"
+
 checksum:
   name_template: "checksums.txt"
   algorithm: sha256


### PR DESCRIPTION
## Summary
- Add combined `shed-homebrew` archive bundling shed + shed-server + server config template
- Add `brews` section to auto-publish `Formula/shed.rb` to `charliek/homebrew-tap` on release
- Pass `HOMEBREW_TAP_TOKEN` in release workflow for cross-repo push

## Test plan
- [ ] `goreleaser check` passes
- [ ] `goreleaser release --snapshot --clean` produces `shed-homebrew_darwin_arm64.tar.gz` with both binaries + config
- [ ] Tag a release and verify formula is auto-updated in homebrew-tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Application now available via Homebrew for easy install and updates.
  * Installs both shed and shed-server binaries and places a default server config at /etc/shed/server.yaml (won’t overwrite existing config).
  * Provides a Homebrew service to run the server with log paths, caveats about config location and Docker, and a test command to verify installation via `shed version`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->