### PR TITLE
Codesign shed-server with VZ entitlements in post_install

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -242,6 +242,23 @@ brews:
           YAML
         end
       end
+    post_install: |
+      if OS.mac?
+        entitlements = Pathname.new(Dir.tmpdir)/"shed-entitlements.plist"
+        entitlements.write <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>com.apple.security.virtualization</key>
+            <true/>
+          </dict>
+          </plist>
+        XML
+        system "codesign", "--force", "--sign", "-",
+               "--entitlements", entitlements.to_s,
+               "#{bin}/shed-server"
+      end
     service: |
       run [opt_bin/"shed-server", "serve", "--config", etc/"shed/server.yaml"]
       keep_alive true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -244,8 +244,9 @@ brews:
       end
     post_install: |
       if OS.mac?
-        entitlements = Pathname.new(Dir.tmpdir)/"shed-entitlements.plist"
-        entitlements.write <<~XML
+        require "tempfile"
+        tmp = Tempfile.new(["shed-entitlements", ".plist"])
+        tmp.write <<~XML
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -255,9 +256,11 @@ brews:
           </dict>
           </plist>
         XML
+        tmp.flush
         system "codesign", "--force", "--sign", "-",
-               "--entitlements", entitlements.to_s,
+               "--entitlements", tmp.path,
                "#{bin}/shed-server"
+        tmp.close!
       end
     service: |
       run [opt_bin/"shed-server", "serve", "--config", etc/"shed/server.yaml"]


### PR DESCRIPTION
## Summary
- Add `post_install` to GoReleaser brews config that codesigns `shed-server` with VZ entitlements on macOS
- Ensures the auto-generated formula includes codesigning on future releases

## Test plan
- [ ] `goreleaser check` passes
- [ ] Generated formula includes `post_install` with codesign logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Homebrew installation on macOS now performs an additional code-signing step during package installation to ensure the installed server binary is signed appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->