### PR TITLE
Add required vsock ports and Docker PATH to brew service

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -178,6 +178,9 @@ brews:
               default_cpus: 2
               default_memory_mb: 4096
               default_disk_gb: 20
+              console_port: 1024
+              notify_port: 1026
+              tcp_proxy_port: 1028
               start_timeout: 60s
               stop_timeout: 10s
           YAML
@@ -234,6 +237,8 @@ brews:
               default_memory_mb: 4096
               default_disk_gb: 20
               vsock_base_cid: 100
+              console_port: 1024
+              notify_port: 1026
               start_timeout: 90s
               stop_timeout: 10s
               bridge_name: shed-br0
@@ -267,6 +272,7 @@ brews:
       keep_alive true
       log_path var/"log/shed-server.log"
       error_log_path var/"log/shed-server.log"
+      environment_variables PATH: "/usr/local/bin:#{std_service_path_env}"
     caveats: |
       The shed-server config has been installed to:
         #{HOMEBREW_PREFIX}/etc/shed/server.yaml


### PR DESCRIPTION
Adds missing ports required by config validation and Docker Desktop PATH for launchd service in GoReleaser brew template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration for Homebrew-installed shed-server with additional port settings for console, notify, and TCP proxy functionality on the vz backend.
  * Added port configuration for console and notify services on the firecracker backend.
  * Configured environment PATH variables for shed-server background service operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->