### PR TITLE
Add Homebrew as recommended install method in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,25 @@ Shed is a lightweight tool for managing persistent, VM-based development environ
 
 ## Quick Start
 
-### 1. Install the CLI
+### 1. Install
+
+#### Homebrew (macOS, Recommended)
 
 ```bash
-# Build from source
+brew install charliek/tap/shed
+brew install charliek/tap/shed-host-agent  # optional: credential brokering
+```
+
+This installs `shed` (CLI) and `shed-server`, generates a default server config, codesigns the server binary, and sets up launchd services. See [VZ Setup](docs/getting-started/vz-setup.md) for the full macOS setup guide.
+
+#### Build from Source
+
+```bash
+git clone https://github.com/charliek/shed.git
+cd shed
 make build
 
-# Or install directly
+# Or install the CLI only
 go install github.com/charliek/shed/cmd/shed@latest
 ```
 
@@ -94,17 +106,18 @@ See [Firecracker Setup](docs/getting-started/fc-setup.md) and [Firecracker Opera
 
 ## Requirements
 
-- **Client**: macOS or Linux with Go 1.24+
-- **Server (VZ)**: macOS 13+ (Ventura) on Apple Silicon (arm64)
-- **Server (Firecracker)**: Linux with KVM support
+- **Client**: macOS or Linux (Homebrew or Go 1.24+ for source builds)
+- **Server (VZ)**: macOS 13+ (Ventura) on Apple Silicon (arm64), Docker
+- **Server (Firecracker)**: Linux with KVM support, Docker
 - **Network**: Tailscale (or any private network) connecting all machines
 
 ## Architecture
 
-Shed consists of two binaries:
+Shed consists of three binaries:
 
 - **`shed`** - CLI for developer machines
 - **`shed-server`** - Server daemon exposing HTTP API (port 8080) and SSH server (port 2222)
+- **`shed-host-agent`** - Optional host-side credential brokering daemon (from [shed-extensions](https://github.com/charliek/shed-extensions))
 
 The server supports two backends:
 - **VZ** - Uses Apple Virtualization.framework VMs via vfkit (macOS Apple Silicon only)

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -4,25 +4,48 @@ Get up and running with Shed in a few minutes.
 
 ## Prerequisites
 
-- Go 1.24+ (for building from source)
-- A server running `shed-server` with one of:
-    - **macOS Apple Silicon** — VZ backend (Virtualization.framework via vfkit)
-    - **Linux with KVM** — Firecracker backend (microVMs)
-- Tailscale (or other private network) connecting your machines
+- **macOS Apple Silicon** — Homebrew (recommended) or Go 1.24+ for source builds
+- **Linux with KVM** — Go 1.24+ for source builds
+- Docker (for VM image management)
+- Tailscale (or other private network) if connecting to remote servers
 
-The `detect` backend (the default) automatically selects VZ on macOS Apple Silicon and Firecracker on Linux, so you typically don't need to specify a backend.
+## Install
 
-## Install the CLI
+### Homebrew (macOS, Recommended)
 
 ```bash
-# Build from source
+brew install charliek/tap/shed
+```
+
+This installs both `shed` (CLI) and `shed-server`, generates a default server config with the VZ backend, codesigns the server binary, and sets up a launchd service.
+
+For credential brokering (SSH agent forwarding, AWS credentials, Docker registry auth), also install the host agent:
+
+```bash
+brew install charliek/tap/shed-host-agent
+```
+
+Edit the server config at `$(brew --prefix)/etc/shed/server.yaml` to configure credentials and extensions, then start the services:
+
+```bash
+brew services start shed
+brew services start shed-host-agent  # if installed
+```
+
+See [VZ Setup](vz-setup.md) for the full macOS setup guide.
+
+### Build from Source
+
+```bash
 git clone https://github.com/charliek/shed.git
 cd shed
 make build
 
-# Or install directly
+# Or install the CLI only
 go install github.com/charliek/shed/cmd/shed@latest
 ```
+
+See [VZ Setup](vz-setup.md) or [Firecracker Setup](fc-setup.md) for server setup instructions when building from source.
 
 ## Add a Server
 

--- a/docs/getting-started/vz-setup.md
+++ b/docs/getting-started/vz-setup.md
@@ -59,10 +59,10 @@ The first `shed create` pulls the VM image from the container registry and conve
 
 ```bash
 brew services list                  # check status
-brew services log shed              # view server logs
-brew services log shed-host-agent   # view host agent logs
 brew services restart shed          # restart after config changes
 ```
+
+Logs are at `$(brew --prefix)/var/log/shed-server.log` and `$(brew --prefix)/var/log/shed-host-agent.log`.
 
 ## Build from Source (Alternative)
 

--- a/docs/getting-started/vz-setup.md
+++ b/docs/getting-started/vz-setup.md
@@ -5,27 +5,73 @@ This guide covers setting up the VZ backend, which uses Apple's Virtualization.f
 ## Prerequisites
 
 - macOS 13+ (Ventura) on Apple Silicon (arm64)
-- Go 1.24+ (for building from source)
-- Docker (for building the rootfs image)
-- Homebrew (for installing vfkit)
+- Docker (for VM image management)
 
 Intel macOS support is not currently available.
 
-## Installation
+## Homebrew Install (Recommended)
+
+The fastest way to get started. Homebrew handles vfkit, code signing, config generation, and service management.
+
+### 1. Install
+
+```bash
+brew install charliek/tap/shed
+```
+
+This installs `shed` (CLI) and `shed-server`, installs the vfkit dependency, generates a default server config with version-pinned VZ images, and codesigns the server binary.
+
+For credential brokering (SSH agent forwarding, AWS credentials, Docker registry auth):
+
+```bash
+brew install charliek/tap/shed-host-agent
+```
+
+### 2. Configure
+
+Edit the server config to enable credential mounts and extensions:
+
+```bash
+# Open the config in your editor
+$EDITOR $(brew --prefix)/etc/shed/server.yaml
+```
+
+Uncomment the `credentials` section to mount tool configs into VMs, and the `extensions` section if you installed `shed-host-agent`.
+
+### 3. Start services
+
+```bash
+brew services start shed
+brew services start shed-host-agent  # if installed
+```
+
+### 4. Create a test shed
+
+```bash
+shed server add localhost
+shed create test
+shed console test
+```
+
+The first `shed create` pulls the VM image from the container registry and converts it to ext4. This takes a minute on the first run.
+
+### Service management
+
+```bash
+brew services list                  # check status
+brew services log shed              # view server logs
+brew services log shed-host-agent   # view host agent logs
+brew services restart shed          # restart after config changes
+```
+
+## Build from Source (Alternative)
+
+Use this if you're contributing to shed or need a custom build.
 
 ### 1. Install vfkit
 
 ```bash
 brew install vfkit
-```
-
-Or build from source:
-
-```bash
-git clone https://github.com/crc-org/vfkit.git
-cd vfkit
-make
-sudo cp vfkit /usr/local/bin/
 ```
 
 ### 2. Build shed-server
@@ -38,50 +84,37 @@ make build
 
 ### 3. Set up VZ images
 
-#### Option A: Use published images (recommended)
+#### Published images (recommended)
 
 Configure your server to use published Docker image references. Shed auto-pulls and converts them to ext4 on first use:
 
 ```yaml
 vz:
-  base_rootfs: ghcr.io/charliek/shed-vz-base:{version}
+  base_rootfs: ghcr.io/charliek/shed-vz-experimental:{version}
   images:
     base: ghcr.io/charliek/shed-vz-base:{version}
+    experimental: ghcr.io/charliek/shed-vz-experimental:{version}
 ```
 
 Replace `{version}` with the version matching your `shed` binary — run `shed version` to check.
 
 The first `shed create` will pull the image, convert it to ext4, and extract the kernel and initrd automatically.
 
-#### Option B: Build from source
-
-The rootfs build script creates an ext4 disk image, extracts the kernel, and extracts the initrd:
+#### Build images from source
 
 ```bash
 ./scripts/build-vz-rootfs.sh
 ```
 
-This builds the `default` variant and produces:
-
-- `~/Library/Application Support/shed/vz/default-rootfs.ext4` - Root filesystem
-- `~/Library/Application Support/shed/vz/vmlinux` - Decompressed kernel
-- `~/Library/Application Support/shed/vz/initrd.img` - Initial RAM disk
-
-You can build other variants with `--variant`:
+This builds the `default` variant. Build other variants with `--variant`:
 
 ```bash
 ./scripts/build-vz-rootfs.sh --variant base           # Minimal image
 ./scripts/build-vz-rootfs.sh --variant experimental   # Default + credential brokering
-./scripts/build-vz-rootfs.sh --all                  # All variants
+./scripts/build-vz-rootfs.sh --all                    # All variants
 ```
 
-See [Image Variants](../reference/images.md) for details on available variants.
-
-You can override the output directory with `OUTPUT_DIR`:
-
-```bash
-OUTPUT_DIR=/path/to/output ./scripts/build-vz-rootfs.sh
-```
+See [Image Variants](../reference/images.md) for details.
 
 ### 4. Create directories
 
@@ -98,27 +131,30 @@ Create `~/.config/shed/server.yaml`:
 name: my-mac
 http_port: 8080
 ssh_port: 2222
-
-enabled_backends:
-  - vz
 default_backend: vz
 
 vz:
   vfkit_path: vfkit
   kernel_path: ~/Library/Application Support/shed/vz/vmlinux
   initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-  base_rootfs: ~/Library/Application Support/shed/vz/default-rootfs.ext4
+  base_rootfs: ghcr.io/charliek/shed-vz-experimental:{version}
+  images:
+    base: ghcr.io/charliek/shed-vz-base:{version}
+    experimental: ghcr.io/charliek/shed-vz-experimental:{version}
   instance_dir: ~/Library/Application Support/shed/vz/instances
-  socket_dir: ~/.shed/vz/sockets  # Must not contain spaces (vfkit limitation)
+  socket_dir: ~/.shed/vz/sockets
   default_cpus: 2
   default_memory_mb: 4096
   default_disk_gb: 20
+  console_port: 1024
+  notify_port: 1026
+  tcp_proxy_port: 1028
   start_timeout: 60s
   stop_timeout: 10s
 
 credentials:
   claude:
-    source: ~/.claude
+    source: ~/.shed/mounts/claude
     target: /home/shed/.claude
     readonly: false
 
@@ -127,7 +163,7 @@ env_file: ~/.shed/env
 
 ### 6. Code signing
 
-The shed-server binary needs the `com.apple.security.virtualization` entitlement to use Virtualization.framework:
+The shed-server binary needs the `com.apple.security.virtualization` entitlement:
 
 ```bash
 codesign --entitlements internal/vz/entitlements.plist -s - ./bin/shed-server
@@ -142,7 +178,8 @@ codesign --entitlements internal/vz/entitlements.plist -s - ./bin/shed-server
 ### 8. Create a test shed
 
 ```bash
-shed create test --backend=vz
+shed server add localhost
+shed create test
 shed console test
 ```
 


### PR DESCRIPTION
Update README, quick-start, and VZ setup to show Homebrew as the recommended macOS install. Source builds as alternative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Homebrew-based macOS install path with optional credential-brokering daemon and service setup
  * Added Docker as a requirement/option for VM image management
  * Clarified build-from-source vs. CLI-only installation and streamlined install flow
  * Expanded and reorganized architecture and platform-specific server setup guidance (VZ/Firecracker)
  * Simplified post-install configuration, defaults, and test VM creation steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->