### PR TITLE
Add deb packaging, setup command, and pull-images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ __debug_bin*
 Thumbs.db
 ehthumbs.db
 
+# Packaging build artifacts
+packaging/server.yaml.generated
+
 # Documentation build
 site-build/
 .venv/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,7 @@ project_name: shed
 before:
   hooks:
     - go mod tidy
+    - sh -c 'sed "s/{{"{{"}}VERSION{{"}}"}}/{{ .Version }}/g" packaging/server.yaml.tmpl > packaging/server.yaml.generated'
 
 builds:
   - id: shed
@@ -290,6 +291,43 @@ brews:
       Note: shed-server requires Docker for VM image management.
     test: |
       system bin/"shed", "version"
+
+nfpms:
+  - id: shed-deb
+    package_name: shed
+    file_name_template: "shed_{{ .Version }}_{{ .Arch }}"
+    vendor: charliek
+    homepage: "https://github.com/charliek/shed"
+    maintainer: "Charlie Knudsen"
+    description: "CLI and server for managing persistent VM-based dev environments"
+    license: MIT
+    formats:
+      - deb
+    bindir: /usr/local/bin
+    ids:
+      - shed
+      - shed-server
+    contents:
+      - src: packaging/shed-server.service
+        dst: /etc/systemd/system/shed-server.service
+        type: config
+      - src: packaging/server.yaml.generated
+        dst: /etc/shed/server.yaml
+        type: "config|noreplace"
+      - dst: /var/lib/shed/firecracker/instances
+        type: dir
+        file_info:
+          mode: 0755
+      - dst: /var/lib/shed/firecracker/images
+        type: dir
+        file_info:
+          mode: 0755
+      - dst: /var/run/shed/firecracker
+        type: dir
+        file_info:
+          mode: 0755
+    scripts:
+      postinstall: packaging/postinstall.sh
 
 checksum:
   name_template: "checksums.txt"

--- a/cmd/shed-server/main.go
+++ b/cmd/shed-server/main.go
@@ -36,6 +36,7 @@ func init() {
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(installCmd)
 	rootCmd.AddCommand(uninstallCmd)
+	rootCmd.AddCommand(pullImagesCmd)
 }
 
 func main() {

--- a/cmd/shed-server/pull_images.go
+++ b/cmd/shed-server/pull_images.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/signal"
+	"sort"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/vmimage"
+)
+
+var (
+	pullVariant string
+)
+
+var pullImagesCmd = &cobra.Command{
+	Use:   "pull-images",
+	Short: "Pre-pull configured VM images",
+	Long: `Pull and convert Docker images to ext4 rootfs for the configured backend.
+
+This pre-caches images so the first 'shed create' doesn't wait for image conversion.
+Uses the images configured in server.yaml for the active backend (VZ or Firecracker).`,
+	RunE: runPullImages,
+}
+
+func init() {
+	pullImagesCmd.Flags().StringVar(&pullVariant, "variant", "", "pull a specific image variant only")
+}
+
+func runPullImages(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	var imgCfg vmimage.ImageConfig
+	switch cfg.DefaultBackend {
+	case config.BackendFirecracker:
+		if cfg.Firecracker == nil {
+			return fmt.Errorf("firecracker config is required when backend is firecracker")
+		}
+		imgCfg = cfg.Firecracker
+	case config.BackendVZ:
+		if cfg.VZ == nil {
+			return fmt.Errorf("vz config is required when backend is vz")
+		}
+		imgCfg = cfg.VZ
+	default:
+		return fmt.Errorf("unsupported backend: %s", cfg.DefaultBackend)
+	}
+
+	images := imgCfg.GetImages()
+	if len(images) == 0 {
+		fmt.Println("No images configured in server.yaml.")
+		return nil
+	}
+
+	// Filter to specific variant if requested
+	if pullVariant != "" {
+		ref, ok := images[pullVariant]
+		if !ok {
+			var names []string
+			for name := range images {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			return fmt.Errorf("unknown variant %q; available: %v", pullVariant, names)
+		}
+		images = map[string]string{pullVariant: ref}
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	mgr := vmimage.NewManager(imgCfg)
+	pulled := 0
+
+	// Sort variant names for deterministic output
+	var names []string
+	for name := range images {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		ref := images[name]
+		if !vmimage.IsDockerRef(ref) {
+			fmt.Printf("Skipping %s (local path: %s)\n", name, ref)
+			continue
+		}
+
+		fmt.Printf("Pulling %s (%s)...\n", name, ref)
+		_, err := mgr.EnsureImage(ctx, vmimage.ResolvedRef{
+			DockerRef: ref,
+			Name:      name,
+		}, func(stage, msg string) {
+			fmt.Printf("  [%s] %s\n", stage, msg)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to pull image %s: %w", name, err)
+		}
+		fmt.Printf("Done: %s\n", name)
+		pulled++
+	}
+
+	// Also pull the base rootfs if it's a Docker ref not already covered
+	baseRootfs := imgCfg.GetBaseRootfs()
+	if vmimage.IsDockerRef(baseRootfs) {
+		alreadyPulled := false
+		for _, ref := range images {
+			if ref == baseRootfs {
+				alreadyPulled = true
+				break
+			}
+		}
+		if !alreadyPulled {
+			fmt.Printf("Pulling base rootfs (%s)...\n", baseRootfs)
+			_, err := mgr.EnsureImage(ctx, vmimage.ResolvedRef{
+				DockerRef: baseRootfs,
+				Name:      "_base",
+			}, func(stage, msg string) {
+				fmt.Printf("  [%s] %s\n", stage, msg)
+			})
+			if err != nil {
+				return fmt.Errorf("failed to pull base rootfs: %w", err)
+			}
+			fmt.Println("Done: base rootfs")
+			pulled++
+		}
+	}
+
+	if pulled == 0 {
+		fmt.Println("All images already cached.")
+	} else {
+		fmt.Printf("\n%d image(s) pulled successfully.\n", pulled)
+	}
+
+	return nil
+}

--- a/cmd/shed-server/pull_images.go
+++ b/cmd/shed-server/pull_images.go
@@ -54,10 +54,6 @@ func runPullImages(cmd *cobra.Command, args []string) error {
 	}
 
 	images := imgCfg.GetImages()
-	if len(images) == 0 {
-		fmt.Println("No images configured in server.yaml.")
-		return nil
-	}
 
 	// Filter to specific variant if requested
 	if pullVariant != "" {

--- a/cmd/shed-server/setup_linux.go
+++ b/cmd/shed-server/setup_linux.go
@@ -1,0 +1,453 @@
+//go:build linux
+
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/firecracker"
+)
+
+const (
+	defaultFirecrackerVersion = "v1.14.1"
+	firecrackerBinPath        = "/usr/local/bin/firecracker"
+	jailerBinPath             = "/usr/local/bin/jailer"
+)
+
+var setupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Set up Firecracker infrastructure on this machine",
+	Long: `Set up the Firecracker backend infrastructure for shed-server.
+
+This command is idempotent and safe to re-run. It performs:
+  - KVM and Docker availability checks
+  - Firecracker binary download and installation
+  - Directory creation for instances, images, and sockets
+  - Bridge network creation and NAT configuration
+  - Linux capability assignment for shed-server and firecracker
+
+Requires root privileges.`,
+	RunE: runSetup,
+}
+
+func init() {
+	rootCmd.AddCommand(setupCmd)
+}
+
+func runSetup(cmd *cobra.Command, args []string) error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("this command must be run as root (try: sudo shed-server setup)")
+	}
+
+	// Step 1: Check KVM
+	fmt.Println("=== Checking prerequisites ===")
+	if _, err := os.Stat("/dev/kvm"); err != nil {
+		return fmt.Errorf("/dev/kvm not found: KVM is required for Firecracker\n  Enable hardware virtualization in your BIOS/VM settings")
+	}
+	fmt.Println("KVM: available")
+
+	// Step 2: Check Docker
+	if _, err := exec.LookPath("docker"); err != nil {
+		return fmt.Errorf("docker not found in PATH: Docker is required for VM image management\n  Install Docker CE from https://docs.docker.com/engine/install/ubuntu/")
+	}
+	fmt.Println("Docker: available")
+
+	// Step 3: Download Firecracker
+	fmt.Println()
+	fmt.Println("=== Firecracker ===")
+	if err := ensureFirecracker(defaultFirecrackerVersion); err != nil {
+		return fmt.Errorf("failed to install firecracker: %w", err)
+	}
+
+	// Step 4: Create directories
+	fmt.Println()
+	fmt.Println("=== Directories ===")
+	dirs := []string{
+		"/var/lib/shed/firecracker/instances",
+		"/var/lib/shed/firecracker/images",
+		"/var/run/shed/firecracker",
+		"/etc/shed",
+	}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+		fmt.Printf("Directory: %s\n", dir)
+	}
+
+	// Step 5: Bridge network
+	fmt.Println()
+	fmt.Println("=== Network ===")
+	bridgeName, bridgeCIDR, tapPrefix := loadBridgeConfig()
+
+	nm, err := firecracker.NewNetworkManager(bridgeName, bridgeCIDR, tapPrefix)
+	if err != nil {
+		return fmt.Errorf("invalid network config: %w", err)
+	}
+	if err := nm.EnsureBridgeExists(); err != nil {
+		return fmt.Errorf("failed to create bridge: %w", err)
+	}
+	fmt.Printf("Bridge: %s (%s)\n", bridgeName, bridgeCIDR)
+
+	// Step 6: NAT setup
+	if err := nm.SetupNAT(); err != nil {
+		return fmt.Errorf("failed to setup NAT: %w", err)
+	}
+	fmt.Println("NAT: IP forwarding and iptables rules configured")
+
+	// Step 7: Set capabilities
+	fmt.Println()
+	fmt.Println("=== Capabilities ===")
+	for _, path := range []string{firecrackerBinPath, "/usr/local/bin/shed-server"} {
+		if _, err := os.Stat(path); err != nil {
+			fmt.Printf("Skipping %s (not found)\n", path)
+			continue
+		}
+		cmd := exec.Command("setcap", "cap_net_admin+eip", path)
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Warning: failed to set CAP_NET_ADMIN on %s: %v\n", path, err)
+		} else {
+			fmt.Printf("Set CAP_NET_ADMIN on %s\n", path)
+		}
+	}
+
+	// Summary
+	fmt.Println()
+	fmt.Println("=== Setup complete ===")
+	fmt.Println()
+	fmt.Println("Next steps:")
+	fmt.Println("  1. Edit /etc/shed/server.yaml (if not already configured)")
+	fmt.Println("  2. Pull VM images: sudo shed-server pull-images")
+	fmt.Println("  3. Start the server: sudo systemctl start shed-server")
+	fmt.Println("  4. Check status: sudo systemctl status shed-server")
+
+	return nil
+}
+
+// loadBridgeConfig reads bridge configuration from server config if available,
+// falling back to defaults.
+func loadBridgeConfig() (bridgeName, bridgeCIDR, tapPrefix string) {
+	bridgeName = "shed-br0"
+	bridgeCIDR = "172.30.0.1/24"
+	tapPrefix = "shed-tap"
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return
+	}
+	if cfg.Firecracker != nil {
+		if cfg.Firecracker.BridgeName != "" {
+			bridgeName = cfg.Firecracker.BridgeName
+		}
+		if cfg.Firecracker.BridgeCIDR != "" {
+			bridgeCIDR = cfg.Firecracker.BridgeCIDR
+		}
+		if cfg.Firecracker.TAPPrefix != "" {
+			tapPrefix = cfg.Firecracker.TAPPrefix
+		}
+	}
+	return
+}
+
+// ensureFirecracker downloads and installs the firecracker and jailer binaries
+// if they are not already installed at the expected version.
+func ensureFirecracker(version string) error {
+	// Check if already installed at the right version
+	if out, err := exec.Command(firecrackerBinPath, "--version").CombinedOutput(); err == nil {
+		if strings.Contains(string(out), strings.TrimPrefix(version, "v")) {
+			fmt.Printf("Firecracker %s already installed\n", version)
+			return ensureKernel(version)
+		}
+	}
+
+	arch := runtime.GOARCH
+	var fcArch string
+	switch arch {
+	case "amd64":
+		fcArch = "x86_64"
+	case "arm64":
+		fcArch = "aarch64"
+	default:
+		return fmt.Errorf("unsupported architecture: %s", arch)
+	}
+
+	url := fmt.Sprintf("https://github.com/firecracker-microvm/firecracker/releases/download/%s/firecracker-%s-%s.tgz",
+		version, version, fcArch)
+	fmt.Printf("Downloading Firecracker %s for %s...\n", version, fcArch)
+
+	resp, err := http.Get(url) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("download failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed: HTTP %d", resp.StatusCode)
+	}
+
+	// Extract to temp directory
+	tmpDir, err := os.MkdirTemp("", "shed-firecracker-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := extractTarGz(resp.Body, tmpDir); err != nil {
+		return fmt.Errorf("extraction failed: %w", err)
+	}
+
+	// Find and install binaries
+	fcPrefix := fmt.Sprintf("firecracker-%s-", version)
+	jailerPrefix := fmt.Sprintf("jailer-%s-", version)
+
+	var checksums map[string]string
+	if data, err := findAndReadFile(tmpDir, "SHA256SUMS"); err == nil {
+		checksums = parseSHA256Sums(data)
+	}
+
+	installed := 0
+	err = filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		name := info.Name()
+
+		// Skip debug symbols and yaml files
+		if strings.HasSuffix(name, ".debug") || strings.HasSuffix(name, ".yaml") {
+			return nil
+		}
+
+		var destPath string
+		if strings.HasPrefix(name, fcPrefix) {
+			destPath = firecrackerBinPath
+		} else if strings.HasPrefix(name, jailerPrefix) {
+			destPath = jailerBinPath
+		} else {
+			return nil
+		}
+
+		// Verify checksum if available
+		if checksums != nil {
+			if expected, ok := checksums[name]; ok {
+				actual, hashErr := hashFile(path)
+				if hashErr != nil {
+					return fmt.Errorf("failed to hash %s: %w", name, hashErr)
+				}
+				if actual != expected {
+					return fmt.Errorf("checksum mismatch for %s: expected %s, got %s", name, expected, actual)
+				}
+				fmt.Printf("Checksum verified: %s\n", name)
+			}
+		}
+
+		if err := copyFile(path, destPath, 0755); err != nil {
+			return fmt.Errorf("failed to install %s: %w", destPath, err)
+		}
+		fmt.Printf("Installed: %s\n", destPath)
+		installed++
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if installed == 0 {
+		return fmt.Errorf("no firecracker binaries found in archive")
+	}
+
+	return ensureKernel(version)
+}
+
+// ensureKernel downloads the CI fallback kernel if one doesn't exist.
+func ensureKernel(version string) error {
+	kernelPath := config.DefaultFirecrackerImagesDir + "/vmlinux"
+
+	if _, err := os.Stat(kernelPath); err == nil {
+		fmt.Printf("Kernel already exists at %s\n", kernelPath)
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(kernelPath), 0755); err != nil {
+		return err
+	}
+
+	arch := runtime.GOARCH
+	var fcArch string
+	switch arch {
+	case "amd64":
+		fcArch = "x86_64"
+	case "arm64":
+		fcArch = "aarch64"
+	default:
+		return fmt.Errorf("unsupported architecture: %s", arch)
+	}
+
+	// The v1.9 in the URL is the CI artifact path, not the Firecracker version.
+	url := fmt.Sprintf("https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.9/%s/vmlinux-6.1.102", fcArch)
+	fmt.Printf("Downloading CI kernel (fallback)...\n")
+	fmt.Println("  (For full Docker support, build a custom kernel: ./scripts/build-firecracker-kernel.sh)")
+
+	resp, err := http.Get(url) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("kernel download failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("kernel download failed: HTTP %d", resp.StatusCode)
+	}
+
+	f, err := os.Create(kernelPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		os.Remove(kernelPath)
+		return fmt.Errorf("kernel download failed: %w", err)
+	}
+
+	fmt.Printf("Downloaded kernel to %s\n", kernelPath)
+	return nil
+}
+
+// extractTarGz extracts a .tar.gz stream to the given directory.
+func extractTarGz(r io.Reader, dest string) error {
+	gr, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		target := filepath.Join(dest, filepath.Clean(hdr.Name))
+
+		// Prevent path traversal
+		if !strings.HasPrefix(target, filepath.Clean(dest)+string(os.PathSeparator)) && target != filepath.Clean(dest) {
+			continue
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode))
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return err
+			}
+			f.Close()
+		}
+	}
+	return nil
+}
+
+// findAndReadFile walks a directory looking for a file by name and returns its contents.
+func findAndReadFile(dir, name string) ([]byte, error) {
+	var result []byte
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && info.Name() == name {
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			result = data
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, fmt.Errorf("%s not found in %s", name, dir)
+	}
+	return result, nil
+}
+
+// parseSHA256Sums parses a SHA256SUMS file into a map of filename → hash.
+func parseSHA256Sums(data []byte) map[string]string {
+	sums := make(map[string]string)
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 2 {
+			continue
+		}
+		hash := parts[0]
+		name := strings.TrimPrefix(parts[1], "./")
+		sums[name] = hash
+	}
+	return sums
+}
+
+// hashFile computes the SHA256 hash of a file.
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// copyFile copies a file from src to dst with the given permissions.
+func copyFile(src, dst string, perm os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}

--- a/cmd/shed-server/setup_linux.go
+++ b/cmd/shed-server/setup_linux.go
@@ -5,6 +5,7 @@ package main
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -15,12 +16,16 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/firecracker"
 )
+
+// httpClient is used for all downloads, with a 5-minute timeout to prevent hangs.
+var httpClient = &http.Client{Timeout: 5 * time.Minute}
 
 const (
 	defaultFirecrackerVersion = "v1.14.1"
@@ -69,7 +74,7 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	// Step 3: Download Firecracker
 	fmt.Println()
 	fmt.Println("=== Firecracker ===")
-	if err := ensureFirecracker(defaultFirecrackerVersion); err != nil {
+	if err := ensureFirecracker(cmd.Context(), defaultFirecrackerVersion); err != nil {
 		return fmt.Errorf("failed to install firecracker: %w", err)
 	}
 
@@ -165,12 +170,12 @@ func loadBridgeConfig() (bridgeName, bridgeCIDR, tapPrefix string) {
 
 // ensureFirecracker downloads and installs the firecracker and jailer binaries
 // if they are not already installed at the expected version.
-func ensureFirecracker(version string) error {
+func ensureFirecracker(ctx context.Context, version string) error {
 	// Check if already installed at the right version
 	if out, err := exec.Command(firecrackerBinPath, "--version").CombinedOutput(); err == nil {
 		if strings.Contains(string(out), strings.TrimPrefix(version, "v")) {
 			fmt.Printf("Firecracker %s already installed\n", version)
-			return ensureKernel(version)
+			return ensureKernel(ctx, version)
 		}
 	}
 
@@ -189,7 +194,11 @@ func ensureFirecracker(version string) error {
 		version, version, fcArch)
 	fmt.Printf("Downloading Firecracker %s for %s...\n", version, fcArch)
 
-	resp, err := http.Get(url) //nolint:gosec
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("download failed: %w", err)
+	}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("download failed: %w", err)
 	}
@@ -268,11 +277,11 @@ func ensureFirecracker(version string) error {
 		return fmt.Errorf("no firecracker binaries found in archive")
 	}
 
-	return ensureKernel(version)
+	return ensureKernel(ctx, version)
 }
 
 // ensureKernel downloads the CI fallback kernel if one doesn't exist.
-func ensureKernel(version string) error {
+func ensureKernel(ctx context.Context, _ string) error {
 	kernelPath := config.DefaultFirecrackerImagesDir + "/vmlinux"
 
 	if _, err := os.Stat(kernelPath); err == nil {
@@ -300,7 +309,11 @@ func ensureKernel(version string) error {
 	fmt.Printf("Downloading CI kernel (fallback)...\n")
 	fmt.Println("  (For full Docker support, build a custom kernel: ./scripts/build-firecracker-kernel.sh)")
 
-	resp, err := http.Get(url) //nolint:gosec
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("kernel download failed: %w", err)
+	}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("kernel download failed: %w", err)
 	}

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Reload systemd to pick up the unit file
+systemctl daemon-reload
+
+# Enable the service (but do NOT start it)
+systemctl enable shed-server.service || true
+
+echo ""
+echo "shed-server has been installed and enabled."
+echo ""
+echo "Next steps:"
+echo "  1. Edit /etc/shed/server.yaml"
+echo "  2. Run: sudo shed-server setup"
+echo "  3. Run: sudo systemctl start shed-server"

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e
 
-# Reload systemd to pick up the unit file
-systemctl daemon-reload
-
-# Enable the service (but do NOT start it)
-systemctl enable shed-server.service || true
+# Guard against non-systemd environments (chroots, container builds)
+if command -v systemctl >/dev/null 2>&1 && systemctl --system 2>/dev/null; then
+    systemctl daemon-reload
+    systemctl enable shed-server.service || true
+fi
 
 echo ""
 echo "shed-server has been installed and enabled."

--- a/packaging/server.yaml.tmpl
+++ b/packaging/server.yaml.tmpl
@@ -1,0 +1,56 @@
+# Shed Server Configuration
+# Full reference: https://github.com/charliek/shed/blob/main/configs/server.example.yaml
+
+name: my-server
+
+http_port: 8080
+ssh_port: 2222
+
+default_backend: firecracker
+log_level: info
+
+# Credentials to mount into VMs
+# Using ~/.shed/mounts/ keeps host and VM configs separate.
+# credentials:
+#   claude:
+#     source: /root/.shed/mounts/claude
+#     target: /home/shed/.claude
+#     readonly: false
+#   codex:
+#     source: /root/.shed/mounts/codex
+#     target: /home/shed/.codex
+#     readonly: false
+#   gh:
+#     source: /root/.shed/mounts/gh
+#     target: /home/shed/.config/gh
+#     readonly: false
+
+# Environment file (KEY=value per line, injected into VMs)
+# env_file: /root/.shed/env
+
+# Extensions provide credential brokering from host to VM.
+# Requires shed-host-agent to be installed and running.
+# extensions:
+#   enabled:
+#     - ssh-agent
+#     - aws-credentials
+#     - docker-credentials
+
+firecracker:
+  kernel_path: /var/lib/shed/firecracker/images/vmlinux
+  base_rootfs: ghcr.io/charliek/shed-fc-base:v{{VERSION}}
+  images:
+    base: ghcr.io/charliek/shed-fc-base:v{{VERSION}}
+  instance_dir: /var/lib/shed/firecracker/instances
+  socket_dir: /var/run/shed/firecracker
+  default_cpus: 2
+  default_memory_mb: 4096
+  default_disk_gb: 20
+  vsock_base_cid: 100
+  console_port: 1024
+  notify_port: 1026
+  start_timeout: 90s
+  stop_timeout: 10s
+  bridge_name: shed-br0
+  bridge_cidr: 172.30.0.1/24
+  tap_prefix: shed-tap

--- a/packaging/shed-server.service
+++ b/packaging/shed-server.service
@@ -9,6 +9,8 @@ ExecStart=/usr/local/bin/shed-server serve --config /etc/shed/server.yaml
 Restart=on-failure
 RestartSec=5
 LimitNOFILE=65536
+RuntimeDirectory=shed/firecracker
+RuntimeDirectoryPreserve=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/shed-server.service
+++ b/packaging/shed-server.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Shed Development Environment Server
+After=network.target docker.service
+Wants=docker.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/shed-server serve --config /etc/shed/server.yaml
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Add `.deb` package via GoReleaser nfpm for Linux (Ubuntu/Pop!OS) deployment — installs `shed` + `shed-server` binaries, systemd unit (enabled but not started), and Firecracker config template
- Add `shed-server setup` command (Linux-only) — downloads Firecracker, creates bridge network, sets capabilities, configures NAT. Idempotent and safe to re-run
- Add `shed-server pull-images` command (cross-platform) — pre-caches VM images from Docker refs so first `shed create` doesn't wait for conversion

## Test plan

- [x] `make check` passes (0 lint issues, all tests pass)
- [x] `goreleaser check` validates config
- [x] `goreleaser release --snapshot --clean` produces valid `.deb` with correct contents
- [x] `dpkg-deb -c` confirms binaries, systemd unit, config, and directories are present
- [x] Config in deb has version correctly templated into Docker image refs
- [x] Both new commands appear in `shed-server --help`
- [ ] Install deb on Ubuntu, run `sudo shed-server setup`, verify bridge/firecracker/capabilities
- [ ] Run `sudo shed-server pull-images` and verify images cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debian package distribution with systemd service and automatic install/post-install guidance.
  * New CLI: pull-images — pre-fetches and prepares VM images for the configured backend.
  * New CLI: setup — bootstraps host (Firecracker/jailer, networking) and prints next-step instructions.

* **Documentation**
  * Added server configuration template with sensible defaults and versioned base image placeholder.
  * Added post-install workflow guidance.

* **Chores**
  * Ignore generated packaging artifact from source control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->