### PR TITLE
Rename deb package shed → shed-server (Ubuntu collision fix)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -294,8 +294,8 @@ brews:
 
 nfpms:
   - id: shed-deb
-    package_name: shed
-    file_name_template: "shed_{{ .Version }}_{{ .Arch }}"
+    package_name: shed-server
+    file_name_template: "shed-server_{{ .Version }}_{{ .Arch }}"
     vendor: charliek
     homepage: "https://github.com/charliek/shed"
     maintainer: "Charlie Knudsen"
@@ -307,6 +307,8 @@ nfpms:
     ids:
       - shed
       - shed-server
+    conflicts:
+      - shed
     contents:
       - src: packaging/shed-server.service
         dst: /etc/systemd/system/shed-server.service

--- a/docs/getting-started/fc-setup.md
+++ b/docs/getting-started/fc-setup.md
@@ -15,9 +15,9 @@ This guide covers the installation and setup of the Firecracker backend for shed
 Download and install the `.deb` from the [latest release](https://github.com/charliek/shed/releases):
 
 ```bash
-VERSION=0.3.2  # replace with desired version
-wget https://github.com/charliek/shed/releases/download/v${VERSION}/shed_${VERSION}_amd64.deb
-sudo dpkg -i shed_${VERSION}_amd64.deb
+VERSION=0.3.3  # replace with desired version
+wget https://github.com/charliek/shed/releases/download/v${VERSION}/shed-server_${VERSION}_amd64.deb
+sudo dpkg -i shed-server_${VERSION}_amd64.deb
 ```
 
 This installs:

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -39,9 +39,9 @@ See [VZ Setup](vz-setup.md) for the full macOS setup guide.
 Download and install the `.deb` from the [latest release](https://github.com/charliek/shed/releases):
 
 ```bash
-VERSION=0.3.2  # replace with desired version
-wget https://github.com/charliek/shed/releases/download/v${VERSION}/shed_${VERSION}_amd64.deb
-sudo dpkg -i shed_${VERSION}_amd64.deb
+VERSION=0.3.3  # replace with desired version
+wget https://github.com/charliek/shed/releases/download/v${VERSION}/shed-server_${VERSION}_amd64.deb
+sudo dpkg -i shed-server_${VERSION}_amd64.deb
 ```
 
 This installs `shed` (CLI) and `shed-server`, generates a default Firecracker server config, and sets up a systemd service.


### PR DESCRIPTION
## Summary

- Renames our deb's `Package:` from `shed` (which collides with Ubuntu's `shed 1.16-1` hex editor) to `shed-server`. Renames the release artifact to match.
- Adds `Conflicts: shed` so dpkg refuses to install both side-by-side, replacing the prior silent-wipe behavior with a clear error.
- Bumps doc examples to `VERSION=0.3.3` and the new filename.

## Why

dpkg keys on `Package:` name. Our v0.3.2 deb declared `Package: shed`, identical to Ubuntu's hex editor. Any `apt upgrade` or `apt install shed` on a host with our deb would silently replace `/usr/local/bin/shed{,-server}` with the hex editor — the running daemon kept serving from a deleted inode until restart, hiding the breakage. Hit live on at least two deployed hosts.

The Homebrew formula (`brews:` in `.goreleaser.yaml`) is unaffected — Homebrew tap namespaces don't collide with apt.

## Test plan

- [x] `make check` (lint + unit tests) — green
- [x] `goreleaser release --snapshot --clean --skip=publish`
- [x] `dpkg-deb -I dist/shed-server_*_amd64.deb` shows `Package: shed-server` and `Conflicts: shed`
- [x] Snapshot deb still ships `/usr/local/bin/shed`, `/usr/local/bin/shed-server`, `/etc/shed/server.yaml`, and the systemd unit
- [ ] After merge: cut v0.3.3 release, then on previously-affected hosts: `apt purge shed && rm -rf /var/lib/shed /etc/shed && dpkg -i shed-server_0.3.3_amd64.deb`, verify `readlink /proc/<pid>/exe` no longer shows `(deleted)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Debian package renamed from `shed` to `shed-server` with conflict declaration against previous package version

* **Documentation**
  * Updated installation guides to reflect version 0.3.3 and revised package filenames

<!-- end of auto-generated comment: release notes by coderabbit.ai -->