### PR TITLE
Fix Firecracker PS1 prompt, 9P credential mount ownership, and missing 9P ops

### DIFF
--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -101,6 +101,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     netcat-openbsd \
     # Build essentials (for compiling code)
     build-essential \
+    # Sandbox (used by Codex CLI)
+    bubblewrap \
     # Clean up
     && rm -rf /var/lib/apt/lists/*
 
@@ -207,9 +209,18 @@ RUN SYSTEMD_OFFLINE=1 systemctl enable network-setup
 # Copy custom Firecracker kernel (extracted by shed during image conversion)
 COPY --from=kernel-builder /build/linux/vmlinux /boot/vmlinux
 
-# Shell customization - colored prompt showing shed name and path
+# Shell customization - colored prompt showing shed name, path, and git branch
 USER shed
-RUN echo 'export PS1="\\[\\033[1;36m\\][\\[\\033[1;32m\\]shed:\\${SHED_NAME:-dev}\\[\\033[1;36m\\]]\\[\\033[0m\\] \\[\\033[1;34m\\]\\w\\[\\033[0m\\]\\$ "' >> /home/shed/.bashrc
+RUN cat >> /home/shed/.bashrc << 'PROMPT_EOF'
+__git_prompt() {
+    local branch
+    branch=$(git symbolic-ref --short HEAD 2>/dev/null) || return
+    local dirty=""
+    [ -n "$(git status --porcelain 2>/dev/null)" ] && dirty=$'\001\033[31m\002✗'
+    printf " \001\033[01;32m\002(%s)%s\001\033[00m\002" "$branch" "$dirty"
+}
+export PS1='\[\033[1;36m\][\[\033[1;32m\]shed:${SHED_NAME:-dev}\[\033[1;36m\]]\[\033[0m\] \[\033[01;34m\]\w\[\033[00m\]$(__git_prompt) \$ '
+PROMPT_EOF
 USER root
 
 # Set default working directory

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package firecracker
 
@@ -220,7 +219,15 @@ func resolvePathOwner(hostPath string) (uid, gid int) {
 		return 1000, 1000 // fallback to default shed user
 	}
 	stat := info.Sys().(*syscall.Stat_t)
-	return int(stat.Uid), int(stat.Gid)
+	uid, gid = int(stat.Uid), int(stat.Gid)
+	// Root-owned directories trigger passthrough mode in NewP9Server
+	// (no UID remapping), which causes credential mounts to appear as
+	// root inside the guest. Fall back to the shed user UID so the
+	// remapping attacher activates and the guest sees correct ownership.
+	if uid == 0 {
+		return 1000, 1000
+	}
+	return uid, gid
 }
 
 // startP9Server creates, starts, and registers a P9 server for a VM.

--- a/internal/firecracker/p9_remap.go
+++ b/internal/firecracker/p9_remap.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package firecracker
 
@@ -8,6 +7,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"syscall"
+	"time"
 
 	"github.com/hugelgupf/p9/p9"
 )
@@ -157,9 +158,10 @@ func (f *remappingFile) GetAttr(req p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, 
 	return qid, mask, attr, nil
 }
 
-// SetAttr implements p9.File.SetAttr. localfs.SetAttr returns ENOSYS for
-// UID/GID changes, so we handle ownership via os.Lchown directly and
-// delegate remaining attributes to the inner file.
+// SetAttr implements p9.File.SetAttr. localfs.SetAttr only supports Size
+// (truncate) and silently ignores MTime/CTime; it returns ENOSYS for
+// everything else (Permissions, UID, GID, ATime). We handle the common
+// attributes directly on the host filesystem and delegate only Size.
 func (f *remappingFile) SetAttr(valid p9.SetAttrMask, attr p9.SetAttr) error {
 	if valid.UID || valid.GID {
 		uid := -1
@@ -173,17 +175,63 @@ func (f *remappingFile) SetAttr(valid p9.SetAttrMask, attr p9.SetAttr) error {
 		if err := os.Lchown(f.hostPath, uid, gid); err != nil {
 			return err
 		}
-
-		// Strip UID/GID from the mask before delegating
 		valid.UID = false
 		valid.GID = false
 	}
 
-	// Delegate remaining attributes (if any) to inner file
+	if valid.Permissions {
+		if err := os.Chmod(f.hostPath, os.FileMode(attr.Permissions)); err != nil {
+			return err
+		}
+		valid.Permissions = false
+	}
+
+	if valid.ATime || valid.MTime {
+		// Read current times so we only change what was requested.
+		info, err := os.Lstat(f.hostPath)
+		if err != nil {
+			return err
+		}
+		stat := info.Sys().(*syscall.Stat_t)
+		atime := time.Unix(stat.Atim.Sec, stat.Atim.Nsec)
+		mtime := info.ModTime()
+
+		if valid.ATime {
+			if valid.ATimeNotSystemTime {
+				atime = time.Unix(int64(attr.ATimeSeconds), int64(attr.ATimeNanoSeconds))
+			} else {
+				atime = time.Now()
+			}
+		}
+		if valid.MTime {
+			if valid.MTimeNotSystemTime {
+				mtime = time.Unix(int64(attr.MTimeSeconds), int64(attr.MTimeNanoSeconds))
+			} else {
+				mtime = time.Now()
+			}
+		}
+
+		if err := os.Chtimes(f.hostPath, atime, mtime); err != nil {
+			return err
+		}
+		valid.ATime = false
+		valid.MTime = false
+		valid.ATimeNotSystemTime = false
+		valid.MTimeNotSystemTime = false
+		valid.CTime = false // CTime is set by the kernel, not user-settable
+	}
+
+	// Delegate remaining attributes (Size) to inner file
 	if !valid.Empty() {
 		return f.File.SetAttr(valid, attr)
 	}
 	return nil
+}
+
+// UnlinkAt implements p9.File.UnlinkAt. localfs does not implement UnlinkAt
+// (returns ENOSYS), so we perform the removal directly on the host filesystem.
+func (f *remappingFile) UnlinkAt(name string, flags uint32) error {
+	return os.Remove(filepath.Join(f.hostPath, name))
 }
 
 // Link implements p9.File.Link. Unwrap the target before delegating so

--- a/internal/firecracker/p9_remap.go
+++ b/internal/firecracker/p9_remap.go
@@ -179,46 +179,57 @@ func (f *remappingFile) SetAttr(valid p9.SetAttrMask, attr p9.SetAttr) error {
 		valid.GID = false
 	}
 
-	if valid.Permissions {
-		if err := os.Chmod(f.hostPath, os.FileMode(attr.Permissions)); err != nil {
-			return err
-		}
-		valid.Permissions = false
-	}
-
-	if valid.ATime || valid.MTime {
-		// Read current times so we only change what was requested.
+	if valid.Permissions || valid.ATime || valid.MTime {
+		// Lstat to detect symlinks. os.Chmod and os.Chtimes follow
+		// symlinks, which would let a guest modify files outside the
+		// shared directory by creating a symlink. Skip these operations
+		// on symlinks (matching the safety of os.Lchown above).
 		info, err := os.Lstat(f.hostPath)
 		if err != nil {
 			return err
 		}
-		stat := info.Sys().(*syscall.Stat_t)
-		atime := time.Unix(stat.Atim.Sec, stat.Atim.Nsec)
-		mtime := info.ModTime()
+		isSymlink := info.Mode()&os.ModeSymlink != 0
 
-		if valid.ATime {
-			if valid.ATimeNotSystemTime {
-				atime = time.Unix(int64(attr.ATimeSeconds), int64(attr.ATimeNanoSeconds))
-			} else {
-				atime = time.Now()
+		if valid.Permissions {
+			if !isSymlink {
+				if err := os.Chmod(f.hostPath, os.FileMode(attr.Permissions)); err != nil {
+					return err
+				}
 			}
-		}
-		if valid.MTime {
-			if valid.MTimeNotSystemTime {
-				mtime = time.Unix(int64(attr.MTimeSeconds), int64(attr.MTimeNanoSeconds))
-			} else {
-				mtime = time.Now()
-			}
+			valid.Permissions = false
 		}
 
-		if err := os.Chtimes(f.hostPath, atime, mtime); err != nil {
-			return err
+		if valid.ATime || valid.MTime {
+			stat := info.Sys().(*syscall.Stat_t)
+			atime := time.Unix(stat.Atim.Sec, stat.Atim.Nsec)
+			mtime := info.ModTime()
+
+			if valid.ATime {
+				if valid.ATimeNotSystemTime {
+					atime = time.Unix(int64(attr.ATimeSeconds), int64(attr.ATimeNanoSeconds))
+				} else {
+					atime = time.Now()
+				}
+			}
+			if valid.MTime {
+				if valid.MTimeNotSystemTime {
+					mtime = time.Unix(int64(attr.MTimeSeconds), int64(attr.MTimeNanoSeconds))
+				} else {
+					mtime = time.Now()
+				}
+			}
+
+			if !isSymlink {
+				if err := os.Chtimes(f.hostPath, atime, mtime); err != nil {
+					return err
+				}
+			}
+			valid.ATime = false
+			valid.MTime = false
+			valid.ATimeNotSystemTime = false
+			valid.MTimeNotSystemTime = false
+			valid.CTime = false // CTime is set by the kernel, not user-settable
 		}
-		valid.ATime = false
-		valid.MTime = false
-		valid.ATimeNotSystemTime = false
-		valid.MTimeNotSystemTime = false
-		valid.CTime = false // CTime is set by the kernel, not user-settable
 	}
 
 	// Delegate remaining attributes (Size) to inner file

--- a/internal/firecracker/p9_remap_test.go
+++ b/internal/firecracker/p9_remap_test.go
@@ -482,6 +482,79 @@ func TestRemappingSetAttrTimestamps(t *testing.T) {
 	}
 }
 
+func TestRemappingSetAttrSkipsSymlinks(t *testing.T) {
+	hostDir := t.TempDir()
+
+	// Create a target file and a symlink to it
+	targetFile := filepath.Join(hostDir, "target")
+	if err := os.WriteFile(targetFile, []byte("data"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Symlink("target", filepath.Join(hostDir, "link")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	inner := localfs.Attacher(hostDir)
+	att := newRemappingAttacher(inner, hostDir, 1000, 1000)
+
+	root, err := att.Attach()
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	defer root.Close()
+
+	_, link, err := root.Walk([]string{"link"})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	defer link.Close()
+
+	// SetAttr with Permissions on a symlink should succeed (no error)
+	// but NOT modify the target file's permissions
+	err = link.SetAttr(
+		p9.SetAttrMask{Permissions: true},
+		p9.SetAttr{Permissions: 0777},
+	)
+	if err != nil {
+		t.Fatalf("SetAttr Permissions on symlink: %v", err)
+	}
+
+	info, err := os.Lstat(targetFile)
+	if err != nil {
+		t.Fatalf("Lstat target: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0644 {
+		t.Errorf("target permissions = %o, want 0644 (unchanged)", got)
+	}
+
+	// SetAttr with timestamps on a symlink should succeed
+	// but NOT modify the target file's timestamps
+	origInfo, _ := os.Lstat(targetFile)
+	origMtime := origInfo.ModTime()
+
+	err = link.SetAttr(
+		p9.SetAttrMask{
+			MTime:              true,
+			MTimeNotSystemTime: true,
+		},
+		p9.SetAttr{
+			MTimeSeconds:     uint64(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).Unix()),
+			MTimeNanoSeconds: 0,
+		},
+	)
+	if err != nil {
+		t.Fatalf("SetAttr timestamps on symlink: %v", err)
+	}
+
+	info, err = os.Lstat(targetFile)
+	if err != nil {
+		t.Fatalf("Lstat target after chtimes: %v", err)
+	}
+	if got := info.ModTime(); got != origMtime {
+		t.Errorf("target mtime changed to %v, want %v (unchanged)", got, origMtime)
+	}
+}
+
 func TestRemappingSetAttrChown(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("requires root")

--- a/internal/firecracker/p9_remap_test.go
+++ b/internal/firecracker/p9_remap_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package firecracker
 
@@ -137,6 +136,50 @@ func TestRemappingGetAttrPassesNonRoot(t *testing.T) {
 	// Current user is non-root; UID should pass through unchanged
 	if int(attr.UID) != os.Geteuid() {
 		t.Errorf("UID = %d, want %d (unchanged)", attr.UID, os.Geteuid())
+	}
+}
+
+func TestRemappingUnlinkAt(t *testing.T) {
+	hostDir := t.TempDir()
+
+	// Create a file and a subdirectory to unlink
+	testFile := filepath.Join(hostDir, "deleteme")
+	if err := os.WriteFile(testFile, []byte("data"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	testDir := filepath.Join(hostDir, "removedir")
+	if err := os.Mkdir(testDir, 0755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	inner := localfs.Attacher(hostDir)
+	att := newRemappingAttacher(inner, hostDir, 1000, 1000)
+
+	root, err := att.Attach()
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	defer root.Close()
+
+	// Unlink the file
+	if err := root.UnlinkAt("deleteme", 0); err != nil {
+		t.Fatalf("UnlinkAt file: %v", err)
+	}
+	if _, err := os.Stat(testFile); !os.IsNotExist(err) {
+		t.Errorf("file still exists after UnlinkAt")
+	}
+
+	// Unlink the directory
+	if err := root.UnlinkAt("removedir", 0); err != nil {
+		t.Fatalf("UnlinkAt dir: %v", err)
+	}
+	if _, err := os.Stat(testDir); !os.IsNotExist(err) {
+		t.Errorf("directory still exists after UnlinkAt")
+	}
+
+	// Unlink non-existent file should return error
+	if err := root.UnlinkAt("nonexistent", 0); err == nil {
+		t.Error("UnlinkAt nonexistent should return error")
 	}
 }
 
@@ -338,6 +381,104 @@ func TestRemappingSymlinkLchown(t *testing.T) {
 	targetStat := targetInfo.Sys().(*syscall.Stat_t)
 	if int(targetStat.Uid) != 0 {
 		t.Errorf("target UID = %d, want 0 (unchanged)", targetStat.Uid)
+	}
+}
+
+func TestRemappingSetAttrChmod(t *testing.T) {
+	hostDir := t.TempDir()
+
+	testFile := filepath.Join(hostDir, "chmod-test")
+	if err := os.WriteFile(testFile, []byte("data"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	inner := localfs.Attacher(hostDir)
+	att := newRemappingAttacher(inner, hostDir, 1000, 1000)
+
+	root, err := att.Attach()
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	defer root.Close()
+
+	_, child, err := root.Walk([]string{"chmod-test"})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	defer child.Close()
+
+	// Change permissions to 0755
+	err = child.SetAttr(
+		p9.SetAttrMask{Permissions: true},
+		p9.SetAttr{Permissions: 0755},
+	)
+	if err != nil {
+		t.Fatalf("SetAttr Permissions: %v", err)
+	}
+
+	info, err := os.Lstat(testFile)
+	if err != nil {
+		t.Fatalf("Lstat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0755 {
+		t.Errorf("permissions = %o, want 0755", got)
+	}
+}
+
+func TestRemappingSetAttrTimestamps(t *testing.T) {
+	hostDir := t.TempDir()
+
+	testFile := filepath.Join(hostDir, "time-test")
+	if err := os.WriteFile(testFile, []byte("data"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	inner := localfs.Attacher(hostDir)
+	att := newRemappingAttacher(inner, hostDir, 1000, 1000)
+
+	root, err := att.Attach()
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	defer root.Close()
+
+	_, child, err := root.Walk([]string{"time-test"})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	defer child.Close()
+
+	// Set explicit timestamps (2024-01-01 00:00:00 UTC)
+	wantTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	err = child.SetAttr(
+		p9.SetAttrMask{
+			ATime:              true,
+			MTime:              true,
+			ATimeNotSystemTime: true,
+			MTimeNotSystemTime: true,
+		},
+		p9.SetAttr{
+			ATimeSeconds:     uint64(wantTime.Unix()),
+			ATimeNanoSeconds: 0,
+			MTimeSeconds:     uint64(wantTime.Unix()),
+			MTimeNanoSeconds: 0,
+		},
+	)
+	if err != nil {
+		t.Fatalf("SetAttr timestamps: %v", err)
+	}
+
+	info, err := os.Lstat(testFile)
+	if err != nil {
+		t.Fatalf("Lstat: %v", err)
+	}
+	if got := info.ModTime().Unix(); got != wantTime.Unix() {
+		t.Errorf("mtime = %d, want %d", got, wantTime.Unix())
+	}
+
+	stat := info.Sys().(*syscall.Stat_t)
+	if got := stat.Atim.Sec; got != wantTime.Unix() {
+		t.Errorf("atime = %d, want %d", got, wantTime.Unix())
 	}
 }
 

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -67,6 +67,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     netcat-openbsd \
     # Build essentials (for compiling code)
     build-essential \
+    # Sandbox (used by Codex CLI)
+    bubblewrap \
     # Linux kernel (needed for VZ LinuxBootloader and in-VM modules)
     # initramfs-tools is a recommended dep of linux-image-generic that
     # --no-install-recommends drops; it's required to generate initrd.


### PR DESCRIPTION
## Summary

- **PS1 prompt fix**: Firecracker Dockerfile used `echo` with double-quoted PS1, causing `\t` (bash time escape) to replace the shed name. Switched to heredoc with single-quoted PS1 matching VZ, and added missing `__git_prompt` function.
- **Credential mount ownership**: `resolvePathOwner` returned `(0,0)` for root-owned host directories (created by root-running shed-server), triggering passthrough mode in `NewP9Server` which skips UID remapping. Credential mounts (`~/.codex`, `~/.claude`, `~/.config/gh`) appeared as `root:root` inside the VM. Now falls back to UID 1000.
- **Missing 9P operations**: `localfs` in the p9 library lacks `UnlinkAt`, `SetAttr` chmod, and `SetAttr` timestamp support (all return ENOSYS). Implemented these on `remappingFile` using `os.Remove`, `os.Chmod`, and `os.Chtimes`. This fixes codex "could not update PATH: Function not implemented" and `touch`/`rm` failures on credential mounts.
- **bubblewrap**: Added to both Dockerfiles for Codex CLI sandbox support.

## Test plan

- [x] Verified on mini2: `codex --version` runs without warnings
- [x] Verified on mini2: `stat ~/.codex` shows `shed:shed` ownership
- [x] Verified on mini2: `touch` and `rm` work on 9P credential mounts
- [x] Verified on mini2: PS1 bashrc fix shows correct shed name
- [ ] `make check` passes (lint + unit tests)
- [ ] Rebuild Firecracker image to pick up Dockerfile changes (PS1, bubblewrap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandboxing support via bubblewrap for improved process isolation.
  * Shell prompt now shows current Git branch and dirty-state indicator.

* **Improvements**
  * Host filesystem attribute handling expanded: permissions and timestamps are applied more accurately and symlinks are preserved.
  * File removal now performs direct host-side deletion for more reliable cleanup.

* **Tests**
  * Added Linux-only tests covering remapping, unlinking, chmod, and timestamp behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->