### PR TITLE
Hydrate _base via hardlink in pull-images + source-aware prune + docs

### DIFF
--- a/cmd/shed-server/pull_images.go
+++ b/cmd/shed-server/pull_images.go
@@ -103,18 +103,38 @@ func runPullImages(cmd *cobra.Command, args []string) error {
 		pulled++
 	}
 
-	// Also pull the base rootfs if it's a Docker ref not already covered
+	// Hydrate _base from base_rootfs. If base_rootfs shares a Docker ref
+	// with any cached variant in the full config, hardlink _base to that
+	// variant (zero extra disk). Otherwise pull a fresh copy. This makes
+	// `shed create` (no --image) immediate after `pull-images`, which
+	// previously skipped _base whenever the ref matched a variant.
 	baseRootfs := imgCfg.GetBaseRootfs()
 	if vmimage.IsDockerRef(baseRootfs) {
-		alreadyPulled := false
-		for _, ref := range images {
-			if ref == baseRootfs {
-				alreadyPulled = true
+		imagesDir := imgCfg.GetImagesDir()
+		var linkFrom string
+		for name, ref := range imgCfg.GetImages() {
+			if ref != baseRootfs || !vmimage.IsDockerRef(ref) {
+				continue
+			}
+			if vmimage.CheckCache(imagesDir, name, ref) != "" {
+				linkFrom = name
 				break
 			}
 		}
-		if !alreadyPulled {
-			fmt.Printf("Pulling base rootfs (%s)...\n", baseRootfs)
+
+		linked := false
+		if linkFrom != "" {
+			if err := vmimage.LinkCachedImage(imagesDir, linkFrom, "_base", baseRootfs); err != nil {
+				fmt.Printf("  [warn] hardlink of _base to %s failed (%v); falling back to full pull\n", linkFrom, err)
+			} else {
+				fmt.Printf("Done: _base (linked to %s)\n", linkFrom)
+				pulled++
+				linked = true
+			}
+		}
+
+		if !linked {
+			fmt.Printf("Pulling _base (%s)...\n", baseRootfs)
 			_, err := mgr.EnsureImage(ctx, vmimage.ResolvedRef{
 				DockerRef: baseRootfs,
 				Name:      "_base",
@@ -124,7 +144,7 @@ func runPullImages(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return fmt.Errorf("failed to pull base rootfs: %w", err)
 			}
-			fmt.Println("Done: base rootfs")
+			fmt.Println("Done: _base")
 			pulled++
 		}
 	}

--- a/configs/server.localfc.yaml
+++ b/configs/server.localfc.yaml
@@ -53,10 +53,10 @@ extensions:
 default_backend: firecracker
 
 firecracker:
-  base_rootfs: ghcr.io/charliek/shed-fc-experimental:v0.3.1
+  base_rootfs: ghcr.io/charliek/shed-fc-experimental:v0.3.4
   images:
-    base: ghcr.io/charliek/shed-fc-base:v0.3.1
-    experimental: ghcr.io/charliek/shed-fc-experimental:v0.3.1
+    base: ghcr.io/charliek/shed-fc-base:v0.3.4
+    experimental: ghcr.io/charliek/shed-fc-experimental:v0.3.4
   instance_dir: /var/lib/shed/firecracker/instances
   socket_dir: /var/run/shed/firecracker
   default_cpus: 2

--- a/configs/server.localmac.yaml
+++ b/configs/server.localmac.yaml
@@ -62,10 +62,10 @@ vz:
   #   default: ~/Library/Application Support/shed/vz/default-rootfs.ext4
   #   experimental: ~/Library/Application Support/shed/vz/experimental-rootfs.ext4
 
-  base_rootfs: ghcr.io/charliek/shed-vz-experimental:v0.3.1
+  base_rootfs: ghcr.io/charliek/shed-vz-experimental:v0.3.4
   images:
-    base: ghcr.io/charliek/shed-vz-base:v0.3.1
-    experimental: ghcr.io/charliek/shed-vz-experimental:v0.3.1
+    base: ghcr.io/charliek/shed-vz-base:v0.3.4
+    experimental: ghcr.io/charliek/shed-vz-experimental:v0.3.4
   
   instance_dir: ~/Library/Application Support/shed/vz/instances
   socket_dir: ~/.shed/vz/sockets

--- a/docs/getting-started/fc-setup.md
+++ b/docs/getting-started/fc-setup.md
@@ -69,6 +69,8 @@ sudo shed-server pull-images
 
 This downloads the configured Docker image, converts it to ext4, and extracts the kernel. Without this step, the first `shed create` performs the conversion automatically (which takes a few minutes).
 
+Cached images live under `/var/lib/shed/firecracker/images/`. See the [image storage reference](../reference/images.md#on-disk-layout) for the full layout and the [upgrade-and-reclaim cookbook](../reference/images.md#cookbook-upgrading-image-versions-and-reclaiming-disk) for how to bump image versions and free disk space.
+
 ## 4. Configure
 
 Edit `/etc/shed/server.yaml` to configure credentials and extensions:

--- a/docs/getting-started/vz-setup.md
+++ b/docs/getting-started/vz-setup.md
@@ -114,7 +114,7 @@ This builds the `default` variant. Build other variants with `--variant`:
 ./scripts/build-vz-rootfs.sh --all                    # All variants
 ```
 
-See [Image Variants](../reference/images.md) for details.
+See [Image Variants](../reference/images.md) for details. Cached images and per-shed rootfs copies live under `~/Library/Application Support/shed/vz/` — see the [on-disk layout reference](../reference/images.md#on-disk-layout) and the [upgrade-and-reclaim cookbook](../reference/images.md#cookbook-upgrading-image-versions-and-reclaiming-disk) for how to manage disk space.
 
 ### 4. Create directories
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -260,7 +260,7 @@ shed image prune [flags]
 | `--force` | | `false` | Skip confirmation prompt |
 | `--dry-run` | | `false` | List candidates without deleting |
 
-Images referenced by server config or any existing shed are preserved. Only unreferenced cached images are removed.
+A cached `.ext4` is preserved only if it is referenced by the current server config **and** its `.source` sidecar matches the current Docker ref (or the entry is a local path), or if it is referenced by an existing shed's metadata. Stale caches left behind after a config ref bump are reclaimed; see the [upgrade-and-reclaim cookbook](images.md#cookbook-upgrading-image-versions-and-reclaiming-disk) for the full flow.
 
 **Note:** When using `--json`, the `--force` flag is required.
 
@@ -524,7 +524,7 @@ sudo shed-server pull-images                  # Pull all configured variants
 sudo shed-server pull-images --variant base   # Pull only the base variant
 ```
 
-Works on both macOS (VZ) and Linux (Firecracker). Uses the images configured in `server.yaml` for the active backend.
+Works on both macOS (VZ) and Linux (Firecracker). Uses the images configured in `server.yaml` for the active backend. When `base_rootfs` shares a Docker ref with any `images:` entry, the `_base` cache is hardlinked to the matching variant rather than being re-pulled — `shed create` without `--image` is then immediate. See the [on-disk layout](images.md#on-disk-layout) and [upgrade cookbook](images.md#cookbook-upgrading-image-versions-and-reclaiming-disk) in the images reference.
 
 ### shed-server install
 

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -304,9 +304,9 @@ When the Docker ref in your config changes (for example after a version bump), s
 Cached images can be 2–5 GB each, and every running shed adds another 2–5 GB for its instance rootfs. Use these commands to reclaim disk space:
 
 ```bash
-# Delete a specific cached image (will not free disk if the image
-# shares an inode with another cached name, e.g. _base hardlinked
-# to experimental — remove both to reclaim)
+# Delete a specific cached image (refused if it is currently referenced
+# by the config images: map, or if it is _base while base_rootfs is a
+# Docker ref, or if an existing shed still depends on it)
 shed image delete myimage
 
 # Preview which images would be pruned
@@ -315,6 +315,8 @@ shed image prune --dry-run
 # Remove all unused or stale cached images
 shed image prune
 ```
+
+When `_base` shares an inode with a variant (because `base_rootfs` and an `images:` entry point at the same Docker ref), `shed image delete _base` is refused — `_base` is still backing the configured `base_rootfs`. Freeing that shared storage requires bumping the `base_rootfs` ref in config (or removing the `base_rootfs` field entirely) and then running `shed image prune`. The [cookbook](#cookbook-upgrading-image-versions-and-reclaiming-disk) below walks through the version-bump case.
 
 `shed image prune` preserves an image only when it matches the current config. Specifically, a cached `.ext4` is preserved when:
 

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -132,6 +132,15 @@ You can mix Docker refs and local paths in the same config.
 
 The `base_rootfs` field is used when no `--image` flag is specified. The `images` map enables per-shed variant selection via `--image`. The `images_dir` directory is scanned for auto-discovered images matching `{name}-rootfs.ext4`.
 
+### `base_rootfs` vs `images:` — how they interact
+
+The two fields play different roles:
+
+- `images:` is a map of named variants. Each entry is cacheable, pre-pullable via `shed-server pull-images`, visible in `shed image list`, and selectable with `shed create --image <name>`.
+- `base_rootfs` is a single top-level fallback used when `shed create` is invoked without `--image`. It is stored on disk as `_base-rootfs.ext4` (underscore prefix).
+
+When `base_rootfs` equals one of the `images:` refs (a common pattern where `base_rootfs` and `images.experimental` both point at the same Docker ref), `shed-server pull-images` stores `_base-rootfs.ext4` as a **hardlink** to the matching variant file — zero extra disk cost. Because the two names share the same inode, running `shed image delete experimental` will not reclaim disk until the other name (`_base`) is also removed; `shed image prune` after a config-ref bump handles this cleanly.
+
 ## Using Variants
 
 Create a shed with a specific variant:
@@ -251,55 +260,132 @@ shed image build -f Dockerfile.shed -n acmeco
 
 ## Image Caching
 
-Converted ext4 images are cached in `images_dir`. A `.source` sidecar file tracks which Docker ref produced each image.
+Converted ext4 images are cached in `images_dir`. A `.source` sidecar file tracks which Docker ref produced each image, and a `.lock` sidecar coordinates concurrent pulls.
 
-| Backend | Default cache directory |
-|---------|----------------------|
-| VZ | `~/Library/Application Support/shed/vz/` |
-| Firecracker | `/var/lib/shed/firecracker/images/` |
+When the Docker ref in your config changes (for example after a version bump), shed compares each cached `.ext4`'s `.source` against the current config ref. On mismatch, the cache is considered stale — `shed-server pull-images` re-pulls it, and `shed image prune` treats it as a candidate for deletion.
 
-When the Docker ref in your config changes (e.g., after a version bump), shed detects the mismatch and re-converts automatically on the next `shed create`.
+## On-Disk Layout
+
+=== "Firecracker (Linux)"
+
+    Default `images_dir`: `/var/lib/shed/firecracker/images/`
+
+    | File | Description |
+    |------|-------------|
+    | `{name}-rootfs.ext4` | Cached variant rootfs (20GB sparse, 2–5GB actual). One per entry in `firecracker.images:`. |
+    | `{name}-rootfs.ext4.source` | Docker ref this cache was built from. Used by `shed image prune` to detect stale caches. |
+    | `{name}-rootfs.ext4.lock` | Empty flock file. Preserved across deletes to avoid a lock-inode race — safe to ignore. |
+    | `_base-rootfs.ext4` (+ `.source`, `.lock`) | Backing cache for `firecracker.base_rootfs` (the fallback used when `shed create` is invoked without `--image`). Stored as a hardlink to a matching variant when refs align, otherwise a full copy. |
+    | `vmlinux` | Extracted kernel (~40MB). |
+
+    Per running shed, the server creates a full copy of the base image at `/var/lib/shed/firecracker/instances/{shed-name}/rootfs.ext4` (another 20GB sparse, 2–5GB actual) plus `metadata.json`. Deleting the shed removes this whole directory.
+
+    Control sockets live in `/var/run/shed/firecracker/` (tiny files).
+
+=== "VZ (macOS)"
+
+    Default `images_dir`: `~/Library/Application Support/shed/vz/`
+
+    | File | Description |
+    |------|-------------|
+    | `{name}-rootfs.ext4` | Cached variant rootfs (20GB sparse, 2–5GB actual). One per entry in `vz.images:`. |
+    | `{name}-rootfs.ext4.source` | Docker ref this cache was built from. Used by `shed image prune` to detect stale caches. |
+    | `{name}-rootfs.ext4.lock` | Empty flock file. Preserved across deletes — safe to ignore. |
+    | `_base-rootfs.ext4` (+ `.source`, `.lock`) | Backing cache for `vz.base_rootfs`. Stored as a hardlink to a matching variant when refs align, otherwise a full copy. |
+    | `vmlinux` | Extracted kernel. |
+    | `initrd.img` | Extracted initial RAM disk (VZ requires this; Firecracker boots directly from `vmlinux`). |
+
+    Per running shed, the server creates a full copy at `~/Library/Application Support/shed/vz/instances/{shed-name}/rootfs.ext4` plus `metadata.json`. Deleting the shed removes this directory.
+
+    Vsock sockets live in `~/.shed/vz/sockets/` (tiny files).
 
 ## Cleaning Up Images
 
-Cached images can be 2-5 GB each. Use these commands to reclaim disk space:
+Cached images can be 2–5 GB each, and every running shed adds another 2–5 GB for its instance rootfs. Use these commands to reclaim disk space:
 
 ```bash
-# Delete a specific cached image
+# Delete a specific cached image (will not free disk if the image
+# shares an inode with another cached name, e.g. _base hardlinked
+# to experimental — remove both to reclaim)
 shed image delete myimage
 
 # Preview which images would be pruned
 shed image prune --dry-run
 
-# Remove all unused cached images
+# Remove all unused or stale cached images
 shed image prune
 ```
 
-`shed image prune` preserves images that are:
+`shed image prune` preserves an image only when it matches the current config. Specifically, a cached `.ext4` is preserved when:
 
-- Referenced in the server config `images` map
-- Used as the `base_rootfs` (when it's a Docker reference)
-- Referenced by any existing shed's metadata
+- It is referenced in the `images:` map **and** its `.source` sidecar matches the configured Docker ref (or the config entry is a local path, in which case it is always preserved).
+- Or it is `_base` **and** its `.source` sidecar matches the configured `base_rootfs`.
+- Or it is referenced by an existing shed's metadata.
 
-Deleting a cached image does not affect running sheds — each shed uses its own copy of the rootfs. However, you'll need to re-pull/rebuild the image to create new sheds from it.
+Anything else — stale caches after a config ref bump, leftover variants from a renamed image, and the underscore-prefixed `_base` when it no longer matches — is a candidate for deletion. Prune removes the `.ext4` and `.source` files; `.lock` files are intentionally left behind (removing them creates a race where concurrent processes can hold locks on different inodes).
+
+Deleting a cached image does not affect running sheds — each shed uses its own copy of the rootfs. You'll need to re-pull or rebuild the image before creating new sheds from it.
+
+### Cookbook: upgrading image versions and reclaiming disk
+
+The common end-to-end flow when bumping image refs (for example, moving config from `:v0.3.3` to `:v0.3.4`):
+
+1. Delete any running sheds you no longer need — this frees their per-instance rootfs.
+   ```bash
+   shed delete <name>
+   ```
+2. Edit the server config and bump the image refs. Update both `base_rootfs` and any entries in `images:` that reference the same Docker ref.
+3. Restart the server:
+
+    === "Linux (deb)"
+
+        ```bash
+        sudo systemctl restart shed-server
+        ```
+
+    === "macOS (Homebrew)"
+
+        ```bash
+        brew services restart shed
+        ```
+
+4. Pull the new images. If `base_rootfs` shares a ref with a variant, `_base-rootfs.ext4` is hardlinked to the variant (no extra disk, no extra pull).
+   ```bash
+   sudo shed-server pull-images
+   ```
+5. Reclaim stale caches. The `--dry-run` preview shows which stale files would go; `--force` actually deletes them.
+   ```bash
+   shed image prune --dry-run
+   shed image prune --force
+   ```
+6. Verify.
+   ```bash
+   shed image list
+   du -sh <images_dir>      # cached variants + _base + kernel
+   du -sh <instances_dir>   # running shed rootfs copies
+   ```
+
+## Disk Space
+
+Each variant produces a 20GB sparse ext4 image. Actual disk usage is much smaller (typically 2–5GB depending on the variant). Each running shed adds another 2–5GB for its own rootfs copy.
+
+Use `du -sh` to check actual usage:
+
+```bash
+# VZ
+du -sh ~/Library/Application\ Support/shed/vz/*-rootfs.ext4
+du -sh ~/Library/Application\ Support/shed/vz/instances/*
+
+# Firecracker
+du -sh /var/lib/shed/firecracker/images/*-rootfs.ext4
+du -sh /var/lib/shed/firecracker/instances/*
+```
 
 ## Requirements
 
 Image conversion requires Docker with privileged container support. The ext4 creation step uses a privileged Docker container for loop mounting.
 
 For VZ images, the kernel and initrd are automatically extracted alongside the rootfs during conversion. Both `shed image build --from` and the auto-pull on `shed create` handle this — no manual kernel extraction is needed.
-
-## Disk Space
-
-Each variant produces a 20GB sparse ext4 image. Actual disk usage is much smaller (typically 2-5GB depending on the variant). Use `du -sh` to check actual usage:
-
-```bash
-# VZ
-du -sh ~/Library/Application\ Support/shed/vz/*-rootfs.ext4
-
-# Firecracker
-du -sh /var/lib/shed/firecracker/images/*-rootfs.ext4
-```
 
 ## Building from Source
 

--- a/internal/vmimage/convert.go
+++ b/internal/vmimage/convert.go
@@ -144,6 +144,11 @@ func LinkCachedImage(imagesDir, sourceName, targetName, ref string) error {
 	}
 
 	if err := WriteSource(imagesDir, targetName, ref); err != nil {
+		// Keep the "no partial state on error" contract: a successful
+		// rename already replaced targetPath, so tearing it down here
+		// avoids leaving a rootfs with a missing/stale sidecar behind.
+		_ = os.Remove(targetPath)
+		_ = os.Remove(filepath.Join(imagesDir, SourceFilename(targetName)))
 		return fmt.Errorf("writing source sidecar for %q: %w", targetName, err)
 	}
 

--- a/internal/vmimage/convert.go
+++ b/internal/vmimage/convert.go
@@ -106,6 +106,50 @@ func WriteSource(imagesDir, name, ref string) error {
 	return os.WriteFile(sourceFile, []byte(ref+"\n"), 0644)
 }
 
+// LinkCachedImage hardlinks an existing cached ext4 under sourceName to
+// targetName in the same imagesDir and writes targetName's .source sidecar
+// so callers see a matching cache entry.
+//
+// It acquires targetName's .lock flock for the duration of the rename and
+// sidecar write, serializing against EnsureImage / DeleteImage / PruneImages.
+// The replace uses link-to-tmp + rename to stay atomic and preserve any open
+// FDs an in-flight CopyRootfs holds against the old target inode.
+//
+// Returns an error if os.Link fails (e.g. cross-device, missing source, or
+// permission issue). Callers should treat this as a signal to fall back to
+// a full pull. No partial state is left on error.
+func LinkCachedImage(imagesDir, sourceName, targetName, ref string) error {
+	sourcePath := filepath.Join(imagesDir, RootfsFilename(sourceName))
+	targetPath := filepath.Join(imagesDir, RootfsFilename(targetName))
+
+	if _, err := os.Stat(sourcePath); err != nil {
+		return fmt.Errorf("source image %q: %w", sourceName, err)
+	}
+
+	unlock, err := acquireFileLock(targetPath + ".lock")
+	if err != nil {
+		return fmt.Errorf("acquiring lock for %q: %w", targetName, err)
+	}
+	defer unlock()
+
+	tmpPath := fmt.Sprintf("%s.tmp.%d", targetPath, os.Getpid())
+	_ = os.Remove(tmpPath)
+	if err := os.Link(sourcePath, tmpPath); err != nil {
+		return fmt.Errorf("linking %s -> %s: %w", sourcePath, tmpPath, err)
+	}
+
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("renaming %s -> %s: %w", tmpPath, targetPath, err)
+	}
+
+	if err := WriteSource(imagesDir, targetName, ref); err != nil {
+		return fmt.Errorf("writing source sidecar for %q: %w", targetName, err)
+	}
+
+	return nil
+}
+
 // Convert pulls a Docker image and converts it to an ext4 rootfs.
 // The conversion uses a privileged Docker container for ext4 creation (loop mount).
 func Convert(ctx context.Context, opts ConvertOptions) (*ConvertResult, error) {

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -276,9 +276,34 @@ func (m *Manager) PruneImages(dryRun bool, inUseNames func() ([]string, error)) 
 	// delete a file the config explicitly points at.
 	exclude := make(map[string]bool)
 
+	// excludeLocalPath protects the on-disk file a local-path config entry
+	// points at. If the path lives inside imagesDir and follows the
+	// {name}-rootfs.ext4 convention, exclude that derived name — otherwise
+	// the directory scan could match a candidate with a different name
+	// than the config map key and delete a file the config depends on.
+	excludeLocalPath := func(ref string) {
+		if ref == "" {
+			return
+		}
+		if filepath.Dir(ref) != imagesDir {
+			return
+		}
+		base := filepath.Base(ref)
+		if !strings.HasSuffix(base, "-rootfs.ext4") {
+			return
+		}
+		derivedName := strings.TrimSuffix(base, "-rootfs.ext4")
+		if derivedName != "" {
+			exclude[derivedName] = true
+		}
+	}
+
 	for name, ref := range m.cfg.GetImages() {
 		if !IsDockerRef(ref) {
+			// Legacy: protect the config map key. Also protect the
+			// on-disk file the path actually points at (they may differ).
 			exclude[name] = true
+			excludeLocalPath(ref)
 			continue
 		}
 		if cached := CheckCache(imagesDir, name, ref); cached != "" {
@@ -286,9 +311,15 @@ func (m *Manager) PruneImages(dryRun bool, inUseNames func() ([]string, error)) 
 		}
 	}
 
-	if base := m.cfg.GetBaseRootfs(); IsDockerRef(base) {
-		if cached := CheckCache(imagesDir, "_base", base); cached != "" {
-			exclude["_base"] = true
+	if base := m.cfg.GetBaseRootfs(); base != "" {
+		if IsDockerRef(base) {
+			if cached := CheckCache(imagesDir, "_base", base); cached != "" {
+				exclude["_base"] = true
+			}
+		} else {
+			// Local-path base_rootfs: protect its on-disk file if it
+			// lives in imagesDir (mirrors the images: branch above).
+			excludeLocalPath(base)
 		}
 	}
 

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -268,17 +268,28 @@ func (m *Manager) PruneImages(dryRun bool, inUseNames func() ([]string, error)) 
 		return nil, fmt.Errorf("failed to read images directory: %w", err)
 	}
 
-	// Build exclusion set
+	// Build exclusion set. For Docker-ref entries, exclusion is source-aware:
+	// a cached variant or _base is protected only if its .source sidecar
+	// matches the current config ref. After a config bump (e.g. v0.3.3 →
+	// v0.3.4), the stale cache file no longer matches and becomes a prune
+	// candidate. Local-path entries are unconditionally excluded — we never
+	// delete a file the config explicitly points at.
 	exclude := make(map[string]bool)
 
-	// Config-managed images
-	for name := range m.cfg.GetImages() {
-		exclude[name] = true
+	for name, ref := range m.cfg.GetImages() {
+		if !IsDockerRef(ref) {
+			exclude[name] = true
+			continue
+		}
+		if cached := CheckCache(imagesDir, name, ref); cached != "" {
+			exclude[name] = true
+		}
 	}
 
-	// _base if BaseRootfs is a Docker ref
-	if IsDockerRef(m.cfg.GetBaseRootfs()) {
-		exclude["_base"] = true
+	if base := m.cfg.GetBaseRootfs(); IsDockerRef(base) {
+		if cached := CheckCache(imagesDir, "_base", base); cached != "" {
+			exclude["_base"] = true
+		}
 	}
 
 	// Images referenced by existing sheds — fail closed if we can't read metadata

--- a/internal/vmimage/manager_test.go
+++ b/internal/vmimage/manager_test.go
@@ -205,6 +205,16 @@ func TestPruneImages(t *testing.T) {
 		createFakeImage(t, imagesDir, "unused1")
 		createFakeImage(t, imagesDir, "unused2")
 		createFakeImage(t, imagesDir, "_base")
+		// Align _base's sidecar with the config's baseRootfs so the source-aware
+		// exclusion keeps it. The matching-sidecar behavior has its own subtest
+		// below; this one exercises the name-based exclusion path.
+		if err := os.WriteFile(
+			filepath.Join(imagesDir, SourceFilename("_base")),
+			[]byte(mgr.cfg.GetBaseRootfs()+"\n"),
+			0644,
+		); err != nil {
+			t.Fatalf("write _base sidecar: %v", err)
+		}
 
 		deleted, err := mgr.PruneImages(false, inUseNames("shedref"))
 		if err != nil {
@@ -280,6 +290,120 @@ func TestPruneImages(t *testing.T) {
 		}
 		if len(deleted) != 1 || deleted[0].Name != "_base" {
 			t.Errorf("expected [_base], got %+v", deleted)
+		}
+	})
+
+	t.Run("stale _base pruned when source mismatches", func(t *testing.T) {
+		mgr, imagesDir := newTestManager(t)
+		// createFakeImage writes a .source of "ghcr.io/example/_base:v1" — stale
+		// versus the testConfig baseRootfs of "ghcr.io/example/base:v1".
+		createFakeImage(t, imagesDir, "_base")
+
+		deleted, err := mgr.PruneImages(false, noInUseNames)
+		if err != nil {
+			t.Fatalf("PruneImages error: %v", err)
+		}
+		var pruned []string
+		for _, d := range deleted {
+			pruned = append(pruned, d.Name)
+		}
+		found := false
+		for _, n := range pruned {
+			if n == "_base" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected _base in prune list, got %v", pruned)
+		}
+	})
+
+	t.Run("matching _base preserved", func(t *testing.T) {
+		mgr, imagesDir := newTestManager(t)
+		createFakeImage(t, imagesDir, "_base")
+		// Align sidecar with config baseRootfs so CheckCache returns a hit.
+		sidecar := filepath.Join(imagesDir, SourceFilename("_base"))
+		if err := os.WriteFile(sidecar, []byte(mgr.cfg.GetBaseRootfs()+"\n"), 0644); err != nil {
+			t.Fatalf("write sidecar: %v", err)
+		}
+
+		deleted, err := mgr.PruneImages(false, noInUseNames)
+		if err != nil {
+			t.Fatalf("PruneImages error: %v", err)
+		}
+		for _, d := range deleted {
+			if d.Name == "_base" {
+				t.Errorf("_base should be preserved when sidecar matches, got pruned: %+v", deleted)
+			}
+		}
+		if _, err := os.Stat(filepath.Join(imagesDir, RootfsFilename("_base"))); err != nil {
+			t.Errorf("_base rootfs should still exist: %v", err)
+		}
+	})
+
+	t.Run("stale variant pruned when source mismatches", func(t *testing.T) {
+		mgr, imagesDir := newTestManager(t)
+		// createFakeImage writes sidecar "ghcr.io/example/managed:v1" which
+		// matches the managed ref. Overwrite with a stale ref to simulate a
+		// config-ref bump that hasn't been followed by a re-pull yet.
+		createFakeImage(t, imagesDir, "managed")
+		staleSidecar := filepath.Join(imagesDir, SourceFilename("managed"))
+		if err := os.WriteFile(staleSidecar, []byte("ghcr.io/example/managed:v0\n"), 0644); err != nil {
+			t.Fatalf("write stale sidecar: %v", err)
+		}
+
+		deleted, err := mgr.PruneImages(false, noInUseNames)
+		if err != nil {
+			t.Fatalf("PruneImages error: %v", err)
+		}
+		found := false
+		for _, d := range deleted {
+			if d.Name == "managed" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected stale variant 'managed' to be pruned, got %+v", deleted)
+		}
+	})
+
+	t.Run("matching variant preserved", func(t *testing.T) {
+		mgr, imagesDir := newTestManager(t)
+		// createFakeImage writes sidecar that matches the managed ref exactly.
+		createFakeImage(t, imagesDir, "managed")
+
+		deleted, err := mgr.PruneImages(false, noInUseNames)
+		if err != nil {
+			t.Fatalf("PruneImages error: %v", err)
+		}
+		for _, d := range deleted {
+			if d.Name == "managed" {
+				t.Errorf("managed variant should be preserved when sidecar matches, got %+v", deleted)
+			}
+		}
+	})
+
+	t.Run("local-path variant always preserved regardless of sidecar", func(t *testing.T) {
+		mgr, imagesDir := newTestManager(t)
+		// Configure a local-path variant and drop a stale-looking file at
+		// that path to confirm prune never touches it.
+		localPath := filepath.Join(imagesDir, RootfsFilename("custom"))
+		if err := os.WriteFile(localPath, []byte("local-custom"), 0644); err != nil {
+			t.Fatalf("write local image: %v", err)
+		}
+		mgr.cfg.(*testConfig).images["custom"] = localPath
+
+		deleted, err := mgr.PruneImages(false, noInUseNames)
+		if err != nil {
+			t.Fatalf("PruneImages error: %v", err)
+		}
+		for _, d := range deleted {
+			if d.Name == "custom" {
+				t.Errorf("local-path variant should be preserved unconditionally, got %+v", deleted)
+			}
+		}
+		if _, err := os.Stat(localPath); err != nil {
+			t.Errorf("local-path variant file should still exist: %v", err)
 		}
 	})
 }

--- a/internal/vmimage/manager_test.go
+++ b/internal/vmimage/manager_test.go
@@ -406,6 +406,57 @@ func TestPruneImages(t *testing.T) {
 			t.Errorf("local-path variant file should still exist: %v", err)
 		}
 	})
+
+	t.Run("local-path pointing at in-dir file with different basename protects derived name", func(t *testing.T) {
+		mgr, imagesDir := newTestManager(t)
+		mgr.cfg.(*testConfig).baseRootfs = "/elsewhere/ignored.ext4" // not in imagesDir, not docker
+
+		// Create an image at imagesDir/base-rootfs.ext4 and configure the
+		// variant `prod` to point at it. Prune should protect
+		// `base-rootfs.ext4` even though the config map key is `prod`.
+		target := filepath.Join(imagesDir, RootfsFilename("base"))
+		if err := os.WriteFile(target, []byte("shared"), 0644); err != nil {
+			t.Fatalf("write target: %v", err)
+		}
+		mgr.cfg.(*testConfig).images["prod"] = target
+
+		deleted, err := mgr.PruneImages(false, noInUseNames)
+		if err != nil {
+			t.Fatalf("PruneImages error: %v", err)
+		}
+		for _, d := range deleted {
+			if d.Name == "base" {
+				t.Errorf("base-rootfs.ext4 should be protected via local-path derivation, got %+v", deleted)
+			}
+		}
+		if _, err := os.Stat(target); err != nil {
+			t.Errorf("shared local file should still exist after prune: %v", err)
+		}
+	})
+
+	t.Run("local-path base_rootfs pointing at in-dir file protects derived name", func(t *testing.T) {
+		mgr, imagesDir := newTestManager(t)
+		mgr.cfg.(*testConfig).images = map[string]string{} // no variants
+
+		target := filepath.Join(imagesDir, RootfsFilename("experimental"))
+		if err := os.WriteFile(target, []byte("shared-base"), 0644); err != nil {
+			t.Fatalf("write target: %v", err)
+		}
+		mgr.cfg.(*testConfig).baseRootfs = target
+
+		deleted, err := mgr.PruneImages(false, noInUseNames)
+		if err != nil {
+			t.Fatalf("PruneImages error: %v", err)
+		}
+		for _, d := range deleted {
+			if d.Name == "experimental" {
+				t.Errorf("experimental-rootfs.ext4 should be protected as local base_rootfs target, got %+v", deleted)
+			}
+		}
+		if _, err := os.Stat(target); err != nil {
+			t.Errorf("shared base_rootfs file should still exist after prune: %v", err)
+		}
+	})
 }
 
 func TestLinkCachedImage(t *testing.T) {

--- a/internal/vmimage/manager_test.go
+++ b/internal/vmimage/manager_test.go
@@ -2,9 +2,13 @@ package vmimage
 
 import (
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"sync"
+	"syscall"
 	"testing"
+	"time"
 )
 
 // testConfig implements ImageConfig for testing.
@@ -276,6 +280,156 @@ func TestPruneImages(t *testing.T) {
 		}
 		if len(deleted) != 1 || deleted[0].Name != "_base" {
 			t.Errorf("expected [_base], got %+v", deleted)
+		}
+	})
+}
+
+func TestLinkCachedImage(t *testing.T) {
+	t.Run("hardlinks to variant and writes matching sidecar", func(t *testing.T) {
+		imagesDir := t.TempDir()
+		createFakeImage(t, imagesDir, "experimental")
+
+		ref := "ghcr.io/example/experimental:v1"
+		if err := LinkCachedImage(imagesDir, "experimental", "_base", ref); err != nil {
+			t.Fatalf("LinkCachedImage error: %v", err)
+		}
+
+		sourcePath := filepath.Join(imagesDir, RootfsFilename("experimental"))
+		targetPath := filepath.Join(imagesDir, RootfsFilename("_base"))
+
+		srcInfo, err := os.Stat(sourcePath)
+		if err != nil {
+			t.Fatalf("stat source: %v", err)
+		}
+		dstInfo, err := os.Stat(targetPath)
+		if err != nil {
+			t.Fatalf("stat target: %v", err)
+		}
+
+		// Inode match — proves hardlink, not copy.
+		srcSys, srcOK := srcInfo.Sys().(*syscall.Stat_t)
+		dstSys, dstOK := dstInfo.Sys().(*syscall.Stat_t)
+		if !srcOK || !dstOK {
+			t.Skip("syscall.Stat_t not available on this platform")
+		}
+		if srcSys.Ino != dstSys.Ino {
+			t.Errorf("inode mismatch: source %d, target %d (expected hardlink)", srcSys.Ino, dstSys.Ino)
+		}
+		if dstSys.Nlink < 2 {
+			t.Errorf("expected Nlink >= 2 after hardlink, got %d", dstSys.Nlink)
+		}
+
+		// Sidecar matches the provided ref.
+		sidecar, err := os.ReadFile(filepath.Join(imagesDir, SourceFilename("_base")))
+		if err != nil {
+			t.Fatalf("read sidecar: %v", err)
+		}
+		if got := string(sidecar); got != ref+"\n" {
+			t.Errorf("sidecar = %q, want %q", got, ref+"\n")
+		}
+	})
+
+	t.Run("atomic replace preserves open fds on stale target", func(t *testing.T) {
+		imagesDir := t.TempDir()
+		createFakeImage(t, imagesDir, "experimental")
+
+		// Pre-existing stale _base with old contents.
+		stalePath := filepath.Join(imagesDir, RootfsFilename("_base"))
+		staleContent := []byte("stale-content")
+		if err := os.WriteFile(stalePath, staleContent, 0644); err != nil {
+			t.Fatalf("write stale target: %v", err)
+		}
+
+		// Open the stale file BEFORE the link runs.
+		f, err := os.Open(stalePath)
+		if err != nil {
+			t.Fatalf("open stale: %v", err)
+		}
+		defer f.Close()
+
+		if err := LinkCachedImage(imagesDir, "experimental", "_base", "ghcr.io/example/experimental:v1"); err != nil {
+			t.Fatalf("LinkCachedImage error: %v", err)
+		}
+
+		// The held fd still points at the unlinked inode and reads the old content.
+		got, err := io.ReadAll(f)
+		if err != nil {
+			t.Fatalf("read from held fd: %v", err)
+		}
+		if string(got) != string(staleContent) {
+			t.Errorf("held fd read = %q, want %q (unlinked inode should survive)", got, staleContent)
+		}
+
+		// The new target name now matches the experimental variant.
+		newContent, err := os.ReadFile(stalePath)
+		if err != nil {
+			t.Fatalf("read new target: %v", err)
+		}
+		if string(newContent) != "fake-rootfs" {
+			t.Errorf("new target content = %q, want %q", newContent, "fake-rootfs")
+		}
+	})
+
+	t.Run("returns error and leaves no partial state when source is missing", func(t *testing.T) {
+		imagesDir := t.TempDir()
+		// No source image created.
+
+		err := LinkCachedImage(imagesDir, "missing", "_base", "ghcr.io/example/missing:v1")
+		if err == nil {
+			t.Fatal("expected error for missing source, got nil")
+		}
+
+		// No target and no sidecar should have been created.
+		if _, err := os.Stat(filepath.Join(imagesDir, RootfsFilename("_base"))); !os.IsNotExist(err) {
+			t.Errorf("_base-rootfs.ext4 should not exist after failure: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(imagesDir, SourceFilename("_base"))); !os.IsNotExist(err) {
+			t.Errorf("_base source sidecar should not exist after failure: %v", err)
+		}
+	})
+
+	t.Run("blocks while _base .lock is held by another caller", func(t *testing.T) {
+		imagesDir := t.TempDir()
+		createFakeImage(t, imagesDir, "experimental")
+
+		targetPath := filepath.Join(imagesDir, RootfsFilename("_base"))
+		unlockHeld, err := acquireFileLock(targetPath + ".lock")
+		if err != nil {
+			t.Fatalf("acquire holder lock: %v", err)
+		}
+
+		var (
+			wg      sync.WaitGroup
+			linkErr error
+			done    = make(chan struct{})
+		)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			linkErr = LinkCachedImage(imagesDir, "experimental", "_base", "ghcr.io/example/experimental:v1")
+			close(done)
+		}()
+
+		// The link call must block while the other holder keeps the lock.
+		select {
+		case <-done:
+			unlockHeld()
+			t.Fatal("LinkCachedImage returned before lock was released")
+		case <-time.After(100 * time.Millisecond):
+			// expected — still blocked
+		}
+
+		unlockHeld()
+		select {
+		case <-done:
+			// unblocked as expected
+		case <-time.After(5 * time.Second):
+			t.Fatal("LinkCachedImage did not return after lock release")
+		}
+
+		wg.Wait()
+		if linkErr != nil {
+			t.Errorf("LinkCachedImage unexpected error: %v", linkErr)
 		}
 	})
 }

--- a/internal/vz/image_test.go
+++ b/internal/vz/image_test.go
@@ -197,6 +197,16 @@ func TestPruneImages(t *testing.T) {
 		createFakeImage(t, imagesDir, "unused1")
 		createFakeImage(t, imagesDir, "unused2")
 		createFakeImage(t, imagesDir, "_base")
+		// Align _base's sidecar with the config's baseRootfs so the source-aware
+		// exclusion keeps it; otherwise the mismatch would make _base a prune
+		// candidate. Source-awareness is covered by its own subtest.
+		if err := os.WriteFile(
+			filepath.Join(imagesDir, vmimage.SourceFilename("_base")),
+			[]byte(client.cfg.GetBaseRootfs()+"\n"),
+			0644,
+		); err != nil {
+			t.Fatalf("write _base sidecar: %v", err)
+		}
 
 		// Create a shed referencing "shedref"
 		createFakeInstance(t, client.cfg.InstanceDir, "myshed", "shedref")


### PR DESCRIPTION
## Summary

Fixes two bugs in `shed-server` image handling that surfaced while upgrading mini2/mini3 to v0.3.4, and documents the `base_rootfs` vs `images:` model + on-disk layout + cleanup cookbook so operators can self-serve.

**The bugs:**

1. **`shed-server pull-images` didn't hydrate `_base-rootfs.ext4`** when `base_rootfs` shared a Docker ref with any entry in `images:` (`cmd/shed-server/pull_images.go:108-130`). The dedup check was ref-equality, but the on-disk cache is keyed by name. Result: the first subsequent `shed create` (no `--image`) had to lazy-pull the 20GB ext4 again — visible on mini2 as the surprising "Pulling ghcr.io/charliek/shed-fc-experimental:v0.3.4..." line, ~60s, only on the first create.
2. **`shed image prune` was name-based, not source-aware** (`internal/vmimage/manager.go:275-282`). After a config ref bump (e.g. v0.3.3 → v0.3.4), the stale `_base-rootfs.ext4` (and stale variants) survived prune because their names were still in the exclusion set. On mini2/mini3 I had to `sudo rm` the stale file manually.

**The fixes (three commits, stacked for review):**

- `86ef3d1` — New `LinkCachedImage` helper in `internal/vmimage/convert.go` that acquires the target's `.lock` flock, hardlinks `source → target.tmp`, atomically renames over the target, and writes the `.source` sidecar. `pull-images` calls it when any cached variant shares the `base_rootfs` ref; zero extra disk for the common case. Falls back to a full `EnsureImage` pull on `os.Link` failure (EXDEV, permissions, etc). Four subtests: hardlink+sidecar, atomic replace preserves open fds on stale target, partial-state-free failure, flock serialization.
- `adce7e5` — `PruneImages` exclusion is now source-aware for every Docker-ref entry (variants and `_base`). Local-path entries are still always preserved. Existing tests that assumed name-based exclusion are updated to align `_base`'s sidecar with the configured `base_rootfs` (matches real on-disk state after `EnsureImage` / `LinkCachedImage`). New subtests: stale `_base` pruned, matching `_base` preserved, stale variant pruned, matching variant preserved, local-path variant preserved unconditionally. VZ inherits the fix via the shared `vmimage.Manager`; its mirror test gets the same sidecar alignment.
- `9a84dfa` — `docs/reference/images.md` grows a "`base_rootfs` vs `images:`" subsection, a tabbed "On-Disk Layout" per-backend table, and a "Cleaning Up Images" cookbook with the correct `brew services restart shed` / `systemctl restart shed-server` commands. Cross-linked from `fc-setup.md`, `vz-setup.md`, and `cli.md` (both the `shed image prune` and `shed-server pull-images` entries).

Both backends are covered automatically — `vmimage.Manager` is the single shared implementation, and `internal/vz/image.go:19-56` is a thin wrapper over it. No backend-specific code changes.

## Test plan

- [x] `go test ./internal/vmimage/... -run 'TestLinkCachedImage|TestPruneImages'` — all new subtests pass; existing `TestPruneImages/_base with non-docker BaseRootfs is prunable` still passes
- [x] `make test` — all 13 packages green
- [x] `make lint` — 0 issues
- [x] `gofmt` clean
- [ ] CI green on this PR
- [ ] Manual end-to-end on a dev host (fresh cache, same-ref `base_rootfs` + `images.experimental`): `pull-images` → inode match via `stat`, `shed create` (no `--image`) with no "Pulling..." step
- [ ] Manual prune validation after config ref bump: both `_base` and stale variant show up in `--dry-run`, `--force` reclaims both and preserves `.lock`

Once merged, cut a patch release so mini2/mini3 and others can upgrade without the one-time manual `rm` that this PR replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster image creation when the base image shares a Docker ref with a configured variant—uses hardlinking to avoid re-pulling.

* **Documentation**
  * Clarified on-disk image layout for Firecracker and VZ, updated prune/practice guidance, and added a version-bump/upgrade cookbook.

* **CLI**
  * `image prune` and pull behavior clarified: pruning preserves caches only when they match current config refs; pull may link existing cached variants.

* **Tests**
  * Added tests for hardlinking, concurrency, and prune/source-aware scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->