### PR TITLE
Bump local dev configs to v0.3.5

### DIFF
--- a/configs/server.localfc.yaml
+++ b/configs/server.localfc.yaml
@@ -53,10 +53,10 @@ extensions:
 default_backend: firecracker
 
 firecracker:
-  base_rootfs: ghcr.io/charliek/shed-fc-experimental:v0.3.4
+  base_rootfs: ghcr.io/charliek/shed-fc-experimental:v0.3.5
   images:
-    base: ghcr.io/charliek/shed-fc-base:v0.3.4
-    experimental: ghcr.io/charliek/shed-fc-experimental:v0.3.4
+    base: ghcr.io/charliek/shed-fc-base:v0.3.5
+    experimental: ghcr.io/charliek/shed-fc-experimental:v0.3.5
   instance_dir: /var/lib/shed/firecracker/instances
   socket_dir: /var/run/shed/firecracker
   default_cpus: 2

--- a/configs/server.localmac.yaml
+++ b/configs/server.localmac.yaml
@@ -62,10 +62,10 @@ vz:
   #   default: ~/Library/Application Support/shed/vz/default-rootfs.ext4
   #   experimental: ~/Library/Application Support/shed/vz/experimental-rootfs.ext4
 
-  base_rootfs: ghcr.io/charliek/shed-vz-experimental:v0.3.4
+  base_rootfs: ghcr.io/charliek/shed-vz-experimental:v0.3.5
   images:
-    base: ghcr.io/charliek/shed-vz-base:v0.3.4
-    experimental: ghcr.io/charliek/shed-vz-experimental:v0.3.4
+    base: ghcr.io/charliek/shed-vz-base:v0.3.5
+    experimental: ghcr.io/charliek/shed-vz-experimental:v0.3.5
   
   instance_dir: ~/Library/Application Support/shed/vz/instances
   socket_dir: ~/.shed/vz/sockets


### PR DESCRIPTION
## Summary

Bump `configs/server.localfc.yaml` and `configs/server.localmac.yaml` image refs from `:v0.3.4` to `:v0.3.5`. Mirror of the prior v0.3.4 bump (commit `b34cdb6`, merged as part of PR #76).

Purely a template refresh so local dev configs track the current release; no source changes.

## Test plan

- [x] `grep ':v0\.' configs/server.local{fc,mac}.yaml` shows six `:v0.3.5` lines
- [ ] CI passes (fast — only YAML changed, tests and lint run unchanged code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Firecracker backend container images and root filesystem from v0.3.4 to v0.3.5 in local server configuration
  * Updated vz virtualization backend images from v0.3.4 to v0.3.5 in local server configuration for both base and experimental variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->