### PR TITLE
Auto-clean stale .tmp orphans in LinkCachedImage

### DIFF
--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -275,6 +275,7 @@ When the Docker ref in your config changes (for example after a version bump), s
     | `{name}-rootfs.ext4` | Cached variant rootfs (20GB sparse, 2–5GB actual). One per entry in `firecracker.images:`. |
     | `{name}-rootfs.ext4.source` | Docker ref this cache was built from. Used by `shed image prune` to detect stale caches. |
     | `{name}-rootfs.ext4.lock` | Empty flock file. Preserved across deletes to avoid a lock-inode race — safe to ignore. |
+    | `{name}-rootfs.ext4.tmp` | Transient file that may briefly exist while a cached variant is being hardlinked into `_base` (or any other cache slot). Swept on the next invocation of the hydration path if left behind by a crash — no manual cleanup needed. |
     | `_base-rootfs.ext4` (+ `.source`, `.lock`) | Backing cache for `firecracker.base_rootfs` (the fallback used when `shed create` is invoked without `--image`). Stored as a hardlink to a matching variant when refs align, otherwise a full copy. |
     | `vmlinux` | Extracted kernel (~40MB). |
 
@@ -291,6 +292,7 @@ When the Docker ref in your config changes (for example after a version bump), s
     | `{name}-rootfs.ext4` | Cached variant rootfs (20GB sparse, 2–5GB actual). One per entry in `vz.images:`. |
     | `{name}-rootfs.ext4.source` | Docker ref this cache was built from. Used by `shed image prune` to detect stale caches. |
     | `{name}-rootfs.ext4.lock` | Empty flock file. Preserved across deletes — safe to ignore. |
+    | `{name}-rootfs.ext4.tmp` | Transient file that may briefly exist while a cached variant is being hardlinked into `_base` (or any other cache slot). Swept on the next invocation of the hydration path if left behind by a crash — no manual cleanup needed. |
     | `_base-rootfs.ext4` (+ `.source`, `.lock`) | Backing cache for `vz.base_rootfs`. Stored as a hardlink to a matching variant when refs align, otherwise a full copy. |
     | `vmlinux` | Extracted kernel. |
     | `initrd.img` | Extracted initial RAM disk (VZ requires this; Firecracker boots directly from `vmlinux`). |

--- a/internal/vmimage/convert.go
+++ b/internal/vmimage/convert.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -106,6 +107,66 @@ func WriteSource(imagesDir, name, ref string) error {
 	return os.WriteFile(sourceFile, []byte(ref+"\n"), 0644)
 }
 
+// sweepStaleTmp removes orphan tmp files for a single target produced by
+// a prior crashed LinkCachedImage call. It matches only:
+//   - {base}.tmp              — the current fixed tmp name.
+//   - {base}.tmp.<digits>     — the legacy PID-suffixed tmp name from
+//     pre-v0.3.6 builds (fmt.Sprintf("%s.tmp.%d", ...)).
+//
+// Any other suffix (e.g. .keep, .bak, .tmp.tmp) is left alone so operator
+// scratch files in the images directory are never collected.
+//
+// Caller MUST hold {targetPath}.lock — the sweep and the subsequent
+// os.Link must run under the same flock, otherwise a concurrent writer
+// could have an in-flight {base}.tmp that this sweep would destroy.
+//
+// os.Remove failures other than os.IsNotExist are logged but non-fatal:
+// if the stale file is the fixed {base}.tmp, the subsequent os.Link
+// will surface the problem via EEXIST; legacy PID-suffixed orphans that
+// resist removal become visible to the operator via the log line rather
+// than turning into silent long-lived leaks.
+func sweepStaleTmp(targetPath string) error {
+	dir := filepath.Dir(targetPath)
+	base := filepath.Base(targetPath)
+	prefix := base + ".tmp"
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", dir, err)
+	}
+
+	for _, e := range entries {
+		n := e.Name()
+		if !strings.HasPrefix(n, prefix) {
+			continue
+		}
+		suffix := n[len(prefix):]
+		if suffix != "" && !isLegacyPIDSuffix(suffix) {
+			continue
+		}
+		p := filepath.Join(dir, n)
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			log.Printf("warning: failed to remove stale tmp %s: %v", p, err)
+		}
+	}
+	return nil
+}
+
+// isLegacyPIDSuffix reports whether s is "." followed by one or more
+// decimal digits, matching the pre-v0.3.6 tmp-file naming convention
+// fmt.Sprintf("%s.tmp.%d", targetPath, os.Getpid()).
+func isLegacyPIDSuffix(s string) bool {
+	if len(s) < 2 || s[0] != '.' {
+		return false
+	}
+	for _, r := range s[1:] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // LinkCachedImage hardlinks an existing cached ext4 under sourceName to
 // targetName in the same imagesDir and writes targetName's .source sidecar
 // so callers see a matching cache entry.
@@ -132,8 +193,19 @@ func LinkCachedImage(imagesDir, sourceName, targetName, ref string) error {
 	}
 	defer unlock()
 
-	tmpPath := fmt.Sprintf("%s.tmp.%d", targetPath, os.Getpid())
-	_ = os.Remove(tmpPath)
+	// Sweep stale tmp orphans for this exact target only — must not
+	// match siblings (other variants) or operator scratch files.
+	// Matches "{base}.tmp" (the fixed tmp name used below) and the
+	// legacy "{base}.tmp.<digits>" name produced by pre-v0.3.6 builds
+	// that crashed between os.Link and os.Rename.
+	if err := sweepStaleTmp(targetPath); err != nil {
+		return fmt.Errorf("scanning for stale tmp files: %w", err)
+	}
+
+	// Fixed tmp name: the target's .lock flock already serializes all
+	// writers, so a PID suffix adds nothing. A stable name is what lets
+	// the sweep above self-heal across crashes.
+	tmpPath := targetPath + ".tmp"
 	if err := os.Link(sourcePath, tmpPath); err != nil {
 		return fmt.Errorf("linking %s -> %s: %w", sourcePath, tmpPath, err)
 	}

--- a/internal/vmimage/manager_test.go
+++ b/internal/vmimage/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -605,6 +606,147 @@ func TestLinkCachedImage(t *testing.T) {
 		wg.Wait()
 		if linkErr != nil {
 			t.Errorf("LinkCachedImage unexpected error: %v", linkErr)
+		}
+	})
+
+	t.Run("cleans legacy pid-suffixed tmp orphan before linking", func(t *testing.T) {
+		imagesDir := t.TempDir()
+		createFakeImage(t, imagesDir, "experimental")
+
+		// Simulate a crashed prior run that left a 20GB-sized (we use
+		// small bytes in the test) orphan with an arbitrary PID suffix.
+		orphan := filepath.Join(imagesDir, RootfsFilename("_base")+".tmp.99999")
+		if err := os.WriteFile(orphan, []byte("stale-orphan"), 0644); err != nil {
+			t.Fatalf("seed orphan: %v", err)
+		}
+
+		ref := "ghcr.io/example/experimental:v1"
+		if err := LinkCachedImage(imagesDir, "experimental", "_base", ref); err != nil {
+			t.Fatalf("LinkCachedImage error: %v", err)
+		}
+
+		if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+			t.Errorf("legacy pid-suffixed orphan should have been swept: %v", err)
+		}
+
+		srcInfo, _ := os.Stat(filepath.Join(imagesDir, RootfsFilename("experimental")))
+		dstInfo, err := os.Stat(filepath.Join(imagesDir, RootfsFilename("_base")))
+		if err != nil {
+			t.Fatalf("stat target: %v", err)
+		}
+		if srcInfo.Sys().(*syscall.Stat_t).Ino != dstInfo.Sys().(*syscall.Stat_t).Ino {
+			t.Errorf("target should be linked to source after sweep+link")
+		}
+
+		sidecar, err := os.ReadFile(filepath.Join(imagesDir, SourceFilename("_base")))
+		if err != nil {
+			t.Fatalf("read sidecar: %v", err)
+		}
+		if got := strings.TrimSpace(string(sidecar)); got != ref {
+			t.Errorf("sidecar = %q, want %q", got, ref)
+		}
+	})
+
+	t.Run("cleans fixed-name tmp orphan before linking", func(t *testing.T) {
+		imagesDir := t.TempDir()
+		createFakeImage(t, imagesDir, "experimental")
+
+		orphan := filepath.Join(imagesDir, RootfsFilename("_base")+".tmp")
+		if err := os.WriteFile(orphan, []byte("stale-fixed"), 0644); err != nil {
+			t.Fatalf("seed orphan: %v", err)
+		}
+
+		ref := "ghcr.io/example/experimental:v1"
+		if err := LinkCachedImage(imagesDir, "experimental", "_base", ref); err != nil {
+			t.Fatalf("LinkCachedImage error: %v", err)
+		}
+
+		if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+			t.Errorf("fixed-name orphan should have been swept: %v", err)
+		}
+
+		srcInfo, _ := os.Stat(filepath.Join(imagesDir, RootfsFilename("experimental")))
+		dstInfo, _ := os.Stat(filepath.Join(imagesDir, RootfsFilename("_base")))
+		if srcInfo.Sys().(*syscall.Stat_t).Ino != dstInfo.Sys().(*syscall.Stat_t).Ino {
+			t.Errorf("target should be linked to source after sweep+link")
+		}
+	})
+
+	t.Run("cleans multiple pid-suffixed orphans in one call", func(t *testing.T) {
+		imagesDir := t.TempDir()
+		createFakeImage(t, imagesDir, "experimental")
+
+		orphans := []string{
+			filepath.Join(imagesDir, RootfsFilename("_base")+".tmp.11111"),
+			filepath.Join(imagesDir, RootfsFilename("_base")+".tmp.22222"),
+			filepath.Join(imagesDir, RootfsFilename("_base")+".tmp.33333"),
+		}
+		for _, o := range orphans {
+			if err := os.WriteFile(o, []byte("stale"), 0644); err != nil {
+				t.Fatalf("seed orphan %s: %v", o, err)
+			}
+		}
+
+		if err := LinkCachedImage(imagesDir, "experimental", "_base", "ghcr.io/example/experimental:v1"); err != nil {
+			t.Fatalf("LinkCachedImage error: %v", err)
+		}
+
+		for _, o := range orphans {
+			if _, err := os.Stat(o); !os.IsNotExist(err) {
+				t.Errorf("orphan %s should have been swept, got %v", o, err)
+			}
+		}
+
+		srcInfo, _ := os.Stat(filepath.Join(imagesDir, RootfsFilename("experimental")))
+		dstInfo, _ := os.Stat(filepath.Join(imagesDir, RootfsFilename("_base")))
+		if srcInfo.Sys().(*syscall.Stat_t).Ino != dstInfo.Sys().(*syscall.Stat_t).Ino {
+			t.Errorf("target should be linked to source after sweeping orphans")
+		}
+	})
+
+	t.Run("sweep does not touch siblings or operator scratch files", func(t *testing.T) {
+		imagesDir := t.TempDir()
+		createFakeImage(t, imagesDir, "experimental")
+
+		// A different variant's tmp file must survive the sweep.
+		siblingTmp := filepath.Join(imagesDir, RootfsFilename("default")+".tmp.99999")
+		if err := os.WriteFile(siblingTmp, []byte("other-variant"), 0644); err != nil {
+			t.Fatalf("seed sibling tmp: %v", err)
+		}
+
+		// Operator scratch file using our target's prefix but a non-digit
+		// suffix must NOT match the sweep.
+		scratch := filepath.Join(imagesDir, RootfsFilename("_base")+".tmp.keep")
+		if err := os.WriteFile(scratch, []byte("operator-scratch"), 0644); err != nil {
+			t.Fatalf("seed scratch: %v", err)
+		}
+
+		// Pre-seed a legitimate sidecar + lock for the target; the sweep
+		// must not match these either (they end in .source / .lock, not .tmp*).
+		preSidecar := filepath.Join(imagesDir, SourceFilename("_base"))
+		if err := os.WriteFile(preSidecar, []byte("prior-ref\n"), 0644); err != nil {
+			t.Fatalf("seed sidecar: %v", err)
+		}
+		preLock := filepath.Join(imagesDir, RootfsFilename("_base")+".lock")
+		if err := os.WriteFile(preLock, []byte{}, 0644); err != nil {
+			t.Fatalf("seed lock: %v", err)
+		}
+
+		if err := LinkCachedImage(imagesDir, "experimental", "_base", "ghcr.io/example/experimental:v1"); err != nil {
+			t.Fatalf("LinkCachedImage error: %v", err)
+		}
+
+		for _, p := range []string{siblingTmp, scratch, preLock} {
+			if _, err := os.Stat(p); err != nil {
+				t.Errorf("sweep incorrectly removed %s: %v", p, err)
+			}
+		}
+		// Sidecar was legitimately overwritten by the successful call;
+		// just assert it still exists and holds the new ref.
+		if data, err := os.ReadFile(preSidecar); err != nil {
+			t.Errorf("sidecar disappeared: %v", err)
+		} else if strings.TrimSpace(string(data)) != "ghcr.io/example/experimental:v1" {
+			t.Errorf("sidecar = %q, want ref updated by call", string(data))
 		}
 	})
 }

--- a/internal/vmimage/manager_test.go
+++ b/internal/vmimage/manager_test.go
@@ -751,6 +751,35 @@ func TestLinkCachedImage(t *testing.T) {
 	})
 }
 
+func TestIsLegacyPIDSuffix(t *testing.T) {
+	tests := []struct {
+		name   string
+		suffix string
+		want   bool
+	}{
+		{"single digit", ".0", true},
+		{"multi-digit", ".221507", true},
+		{"empty", "", false},
+		{"dot only", ".", false},
+		{"no leading dot", "221507", false},
+		{"letters", ".abc", false},
+		{"mixed digits and letters", ".123abc", false},
+		{"letters then digits", ".abc123", false},
+		{"trailing non-digit", ".123.", false},
+		{"operator scratch suffix", ".keep", false},
+		{"operator bak suffix", ".bak", false},
+		{"dot plus space", ". ", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isLegacyPIDSuffix(tt.suffix)
+			if got != tt.want {
+				t.Errorf("isLegacyPIDSuffix(%q) = %v, want %v", tt.suffix, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidateImageName(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

Fixes a 20 GB disk leak in `LinkCachedImage` that I hit in production on mini2 during the v0.3.5 rollout: a pre-release dev binary was killed mid-run, leaving `_base-rootfs.ext4.tmp.221507` orphaned in `/var/lib/shed/firecracker/images/` forever. The PID-suffixed tmp name meant the `os.Remove` guard before `os.Link` could never match orphans from earlier processes.

- **Fixed tmp name** (`{target}.tmp`) — the existing `{target}.lock` flock already serializes writers, so the PID suffix added nothing.
- **`sweepStaleTmp` helper** runs inside the flock before `os.Link`: `os.ReadDir` the images directory, remove any file whose name is exactly `{base}.tmp` or `{base}.tmp.<digits>`. Literal prefix + digits-only suffix — `filepath.Glob` was rejected during planning because metacharacters in the path would be interpreted as patterns and `.tmp*` would also delete operator scratch files like `.tmp.keep`.
- **Log non-`IsNotExist` `os.Remove` failures** via `log.Printf` (matching `manager.go` `PruneImages`'s pattern) so silent leaks become visible. Fatal errors are unnecessary — the fixed-name failure path surfaces via `os.Link` → `EEXIST` → caller's existing full-pull fallback.

Handles both the new fixed name and legacy PID-suffixed orphans from pre-v0.3.6 binaries in one pass, so upgraded hosts self-heal without any migration step.

## Tests

Adds 4 new subtests to `TestLinkCachedImage` (8 total now):
- `cleans legacy pid-suffixed tmp orphan before linking`
- `cleans fixed-name tmp orphan before linking`
- `cleans multiple pid-suffixed orphans in one call`
- `sweep does not touch siblings or operator scratch files` — safety assertion that the sweep never widens to remove other variants' tmp files, operator `.tmp.keep` scratch, or legitimate `.source` / `.lock` sidecars.

## Docs

One new row per backend in `docs/reference/images.md` On-Disk Layout tables describing the transient `{name}-rootfs.ext4.tmp` file and that it self-cleans.

## Out of scope (flagged in plan, tracked separately)

- `internal/{firecracker,vz}/metadata.go` uses `os.CreateTemp(".metadata-*.json.tmp")` — a crash between create and rename leaves a tiny JSON orphan. Low impact.
- `CopyRootfs` (`internal/{firecracker,vz}/rootfs.go`) writes the per-shed rootfs directly to `dst` with no `.tmp` staging — a crash mid-copy leaves a partial 20 GB sparse file at the instance rootfs path. Real disk-hygiene concern, different fix (reflink or `.tmp` + rename), follow-up PR.

## Test plan

- [x] `go test -run TestLinkCachedImage -v ./internal/vmimage/...` — all 8 subtests pass
- [x] `GOMAXPROCS=2 go test -race -run TestLinkCachedImage -count=20 ./internal/vmimage/` — 20/20 green under race
- [x] `make test` — all packages pass
- [x] `make lint` — 0 issues
- [x] `gofmt` clean
- [ ] CI green on this PR

Once merged, cutting v0.3.6 lets mini2 + mini3 self-clean any lingering orphans on their next `pull-images`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced automatic cleanup of temporary cache files that may persist after crashes, eliminating manual intervention requirements.

* **Documentation**
  * Updated cache layout documentation to describe temporary file handling during cache operations.

* **Tests**
  * Added comprehensive test coverage for temporary file cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->