### PR TITLE
Add shed system df + prune and reflink CopyRootfs

### DIFF
--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -426,6 +426,61 @@ func (c *APIClient) GetSystemDF() (*config.DiskUsage, error) {
 	return &du, nil
 }
 
+// SystemPruneOptions mirrors backend.PruneOptions for the CLI → API path.
+// Using a client-local struct avoids pulling the backend package into the
+// CLI (which doesn't need the rest of the Backend interface).
+type SystemPruneOptions struct {
+	Images       bool
+	Instances    bool
+	Logs         bool
+	Orphans      bool
+	DryRun       bool
+	Until        time.Duration
+	LogTailBytes int64
+}
+
+// pruneTimeout bounds prune requests. Large fleets can exceed DefaultTimeout;
+// use a generous ceiling modeled on create rather than 30s.
+const pruneTimeout = 10 * time.Minute
+
+// SystemPrune triggers a prune pass on the server and returns the report.
+// Scope flags are added as repeatable `scope=` query params; an empty scope
+// (all flags false) lets the server apply its default (images + instances
+// + orphans, no logs).
+func (c *APIClient) SystemPrune(opts SystemPruneOptions) (*config.PruneReport, error) {
+	path := "/api/system/prune"
+	q := make([]string, 0, 6)
+	if opts.Images {
+		q = append(q, "scope=images")
+	}
+	if opts.Instances {
+		q = append(q, "scope=instances")
+	}
+	if opts.Logs {
+		q = append(q, "scope=logs")
+	}
+	if opts.Orphans {
+		q = append(q, "scope=orphans")
+	}
+	if opts.DryRun {
+		q = append(q, "dry_run=true")
+	}
+	if opts.Until > 0 {
+		q = append(q, "until="+opts.Until.String())
+	}
+	if opts.LogTailBytes > 0 {
+		q = append(q, fmt.Sprintf("log_tail_bytes=%d", opts.LogTailBytes))
+	}
+	if len(q) > 0 {
+		path += "?" + strings.Join(q, "&")
+	}
+	var report config.PruneReport
+	if err := c.doRequestWithTimeout(http.MethodPost, path, nil, &report, pruneTimeout); err != nil {
+		return nil, err
+	}
+	return &report, nil
+}
+
 // Ping checks if the server is reachable.
 func (c *APIClient) Ping() bool {
 	client := &http.Client{

--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -465,9 +465,12 @@ func (c *APIClient) SystemPrune(opts SystemPruneOptions) (*config.PruneReport, e
 	if opts.DryRun {
 		q = append(q, "dry_run=true")
 	}
-	if opts.Until > 0 {
-		q = append(q, "until="+opts.Until.String())
-	}
+	// Always send Until on the wire — a zero value from the user
+	// means "prune any age" and must reach the handler, otherwise
+	// the handler's 72h default would override their explicit intent.
+	// The CLI's cobra default (72h) is still preserved: flag unset →
+	// systemPruneFlagUntil == 72h → we send until=72h0m0s explicitly.
+	q = append(q, "until="+opts.Until.String())
 	if opts.LogTailBytes > 0 {
 		q = append(q, fmt.Sprintf("log_tail_bytes=%d", opts.LogTailBytes))
 	}

--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -417,6 +417,15 @@ func (c *APIClient) PruneImages(dryRun bool) (*config.PruneImagesResponse, error
 	return &resp, nil
 }
 
+// GetSystemDF retrieves disk usage information for the server.
+func (c *APIClient) GetSystemDF() (*config.DiskUsage, error) {
+	var du config.DiskUsage
+	if err := c.doRequest(http.MethodGet, "/api/system/df", nil, &du); err != nil {
+		return nil, err
+	}
+	return &du, nil
+}
+
 // Ping checks if the server is reachable.
 func (c *APIClient) Ping() bool {
 	client := &http.Client{

--- a/cmd/shed/fanout.go
+++ b/cmd/shed/fanout.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+// ServerResult is one entry returned by forEachServer: either Value is set
+// (success) or Err is set (failure). ServerName is always populated so the
+// caller can render per-server output even when the call failed.
+type ServerResult[T any] struct {
+	ServerName string
+	Entry      config.ServerEntry
+	Value      T
+	Err        error
+}
+
+// forEachServer invokes fn concurrently for each named server and returns
+// results in deterministic (alphabetical) order. It never aborts early:
+// per-server errors are captured in the corresponding ServerResult.Err so
+// the caller can partially succeed and report what failed.
+//
+// This is the reusable primitive behind `shed system df --all` and
+// `shed system prune --all`.
+func forEachServer[T any](servers map[string]config.ServerEntry, fn func(name string, entry config.ServerEntry) (T, error)) []ServerResult[T] {
+	names := make([]string, 0, len(servers))
+	for name := range servers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	results := make([]ServerResult[T], len(names))
+	var wg sync.WaitGroup
+	for i, name := range names {
+		entry := servers[name]
+		results[i].ServerName = name
+		results[i].Entry = entry
+		wg.Add(1)
+		go func(i int, name string, entry config.ServerEntry) {
+			defer wg.Done()
+			value, err := fn(name, entry)
+			results[i].Value = value
+			results[i].Err = err
+		}(i, name, entry)
+	}
+	wg.Wait()
+	return results
+}

--- a/cmd/shed/fanout_test.go
+++ b/cmd/shed/fanout_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+func TestForEachServer_AllSucceed(t *testing.T) {
+	servers := map[string]config.ServerEntry{
+		"alpha": {Host: "a.example.com", HTTPPort: 8080},
+		"bravo": {Host: "b.example.com", HTTPPort: 8081},
+	}
+
+	var calls int32
+	results := forEachServer(servers, func(name string, _ config.ServerEntry) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "OK:" + name, nil
+	})
+
+	if n := atomic.LoadInt32(&calls); n != 2 {
+		t.Fatalf("calls = %d, want 2", n)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	// Alphabetical order.
+	if results[0].ServerName != "alpha" || results[1].ServerName != "bravo" {
+		t.Errorf("unexpected order: %+v", results)
+	}
+	for _, r := range results {
+		if r.Err != nil {
+			t.Errorf("server %q: unexpected err %v", r.ServerName, r.Err)
+		}
+		if r.Value != "OK:"+r.ServerName {
+			t.Errorf("server %q: value = %q", r.ServerName, r.Value)
+		}
+	}
+}
+
+func TestForEachServer_OneOffline(t *testing.T) {
+	servers := map[string]config.ServerEntry{
+		"online":  {Host: "ok.example.com", HTTPPort: 8080},
+		"offline": {Host: "bad.example.com", HTTPPort: 8080},
+	}
+
+	sentinel := errors.New("connection refused")
+	results := forEachServer(servers, func(name string, _ config.ServerEntry) (string, error) {
+		if name == "offline" {
+			return "", sentinel
+		}
+		return "OK", nil
+	})
+
+	byName := make(map[string]ServerResult[string], len(results))
+	for _, r := range results {
+		byName[r.ServerName] = r
+	}
+	if byName["online"].Err != nil {
+		t.Errorf("online: unexpected err %v", byName["online"].Err)
+	}
+	if byName["online"].Value != "OK" {
+		t.Errorf("online: value = %q", byName["online"].Value)
+	}
+	if byName["offline"].Err == nil {
+		t.Errorf("offline: expected error, got nil")
+	}
+	if !errors.Is(byName["offline"].Err, sentinel) {
+		t.Errorf("offline: err = %v, want sentinel", byName["offline"].Err)
+	}
+}
+
+func TestForEachServer_AllOffline(t *testing.T) {
+	servers := map[string]config.ServerEntry{
+		"a": {Host: "a.example.com", HTTPPort: 8080},
+		"b": {Host: "b.example.com", HTTPPort: 8080},
+	}
+
+	sentinel := errors.New("connection refused")
+	results := forEachServer(servers, func(_ string, _ config.ServerEntry) (string, error) {
+		return "", sentinel
+	})
+
+	for _, r := range results {
+		if r.Err == nil {
+			t.Errorf("server %q: expected error, got nil", r.ServerName)
+		}
+	}
+}
+
+func TestForEachServer_EmptyMap(t *testing.T) {
+	results := forEachServer(map[string]config.ServerEntry{}, func(_ string, _ config.ServerEntry) (string, error) {
+		return "", nil
+	})
+	if len(results) != 0 {
+		t.Errorf("expected zero results, got %d", len(results))
+	}
+}

--- a/cmd/shed/system.go
+++ b/cmd/shed/system.go
@@ -202,8 +202,17 @@ func renderDF(w io.Writer, du config.DiskUsage, verbose bool) {
 	if du.Initrd != nil {
 		imageFiles++
 	}
+	// Per-shed FILES count includes rootfs + optional console_log + any
+	// OtherFiles (typically metadata.json). Matches countFiles() used for
+	// the multi-server aggregate footer.
+	shedFiles := 0
 	runningCount, stoppedCount := 0, 0
 	for _, s := range du.Sheds {
+		shedFiles++ // rootfs
+		if s.ConsoleLog != nil {
+			shedFiles++
+		}
+		shedFiles += len(s.OtherFiles)
 		if s.Status == config.StatusRunning {
 			runningCount++
 		} else {
@@ -217,12 +226,12 @@ func renderDF(w io.Writer, du config.DiskUsage, verbose bool) {
 		imageFiles, formatSize(du.Totals.Images.LogicalBytes), formatSize(du.Totals.Images.PhysicalBytes))
 	shedLabel := fmt.Sprintf("sheds (%d stopped, %d run)", stoppedCount, runningCount)
 	fmt.Fprintf(tw, "%s\t%d\t%s\t%s\n",
-		shedLabel, len(du.Sheds),
+		shedLabel, shedFiles,
 		formatSize(du.Totals.Sheds.LogicalBytes), formatSize(du.Totals.Sheds.PhysicalBytes))
 	fmt.Fprintf(tw, "orphans\t%d\t%s\t%s\n",
 		len(du.Orphans), formatSize(du.Totals.Orphans.LogicalBytes), formatSize(du.Totals.Orphans.PhysicalBytes))
 	fmt.Fprintf(tw, "TOTAL\t%d\t%s\t%s\n",
-		imageFiles+len(du.Sheds)+len(du.Orphans),
+		imageFiles+shedFiles+len(du.Orphans),
 		formatSize(du.Totals.All.LogicalBytes), formatSize(du.Totals.All.PhysicalBytes))
 	tw.Flush()
 

--- a/cmd/shed/system.go
+++ b/cmd/shed/system.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -34,10 +35,55 @@ Use -v to show per-image and per-shed rows; otherwise a rollup is printed.`,
 	RunE: runSystemDF,
 }
 
+var (
+	systemPruneFlagAll       bool
+	systemPruneFlagImages    bool
+	systemPruneFlagInstances bool
+	systemPruneFlagLogs      bool
+	systemPruneFlagOrphans   bool
+	systemPruneFlagDryRun    bool
+	systemPruneFlagForce     bool
+	systemPruneFlagUntil     time.Duration
+	systemPruneFlagLogTail   int64
+)
+
+var systemPruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Reclaim disk space on the shed server",
+	Long: `Reclaim disk space by removing unused images, stopped instances past an
+age threshold, and orphan sidecar files. Optionally truncates VZ console
+logs to their last N bytes.
+
+By default the command runs a dry-run first, prints the candidate table,
+and waits for confirmation. Use --force to skip the prompt.
+
+Scope flags are additive; if none are set, default scope is
+--images --instances --orphans (not --logs, which is always opt-in).
+
+--until filters stopped-instance pruning by mtime(metadata.json);
+  --until 0s prunes every stopped instance regardless of age.
+
+When --json is set, --force is required for the execute path (dry-run
+without --force is still allowed).`,
+	Args: cobra.NoArgs,
+	RunE: runSystemPrune,
+}
+
 func init() {
 	systemDFCmd.Flags().BoolVar(&systemDFFlagAll, "all", false, "Query every configured server")
 
+	systemPruneCmd.Flags().BoolVar(&systemPruneFlagAll, "all", false, "Prune on every configured server")
+	systemPruneCmd.Flags().BoolVar(&systemPruneFlagImages, "images", false, "Prune unreferenced cached images")
+	systemPruneCmd.Flags().BoolVar(&systemPruneFlagInstances, "instances", false, "Prune stopped instances older than --until")
+	systemPruneCmd.Flags().BoolVar(&systemPruneFlagLogs, "logs", false, "Truncate VZ console.log files to --log-tail-bytes")
+	systemPruneCmd.Flags().BoolVar(&systemPruneFlagOrphans, "orphans", false, "Remove orphaned .tmp/.source sidecars")
+	systemPruneCmd.Flags().BoolVar(&systemPruneFlagDryRun, "dry-run", false, "Show candidates without mutating")
+	systemPruneCmd.Flags().BoolVar(&systemPruneFlagForce, "force", false, "Skip confirmation prompt; required with --json for execute")
+	systemPruneCmd.Flags().DurationVar(&systemPruneFlagUntil, "until", 72*time.Hour, "Stopped-instance age threshold (0s = any age)")
+	systemPruneCmd.Flags().Int64Var(&systemPruneFlagLogTail, "log-tail-bytes", 0, "Console log truncation target (0 = server default, 5 MiB)")
+
 	systemCmd.AddCommand(systemDFCmd)
+	systemCmd.AddCommand(systemPruneCmd)
 	rootCmd.AddCommand(systemCmd)
 }
 
@@ -285,6 +331,359 @@ func countFiles(du *config.DiskUsage) int {
 		n += len(s.OtherFiles)
 	}
 	return n
+}
+
+// pruneFlagsToOptions translates CLI flags into client options.
+func pruneFlagsToOptions(dry bool) SystemPruneOptions {
+	return SystemPruneOptions{
+		Images:       systemPruneFlagImages,
+		Instances:    systemPruneFlagInstances,
+		Logs:         systemPruneFlagLogs,
+		Orphans:      systemPruneFlagOrphans,
+		DryRun:       dry,
+		Until:        systemPruneFlagUntil,
+		LogTailBytes: systemPruneFlagLogTail,
+	}
+}
+
+// deletedShedNames returns the shed names that were actually deleted during
+// an execute pass — used for client-side cache invalidation so subsequent
+// `shed list` calls don't show stale entries.
+func deletedShedNames(report *config.PruneReport) []string {
+	var names []string
+	for _, item := range report.Items {
+		if item.Kind == "instance" && item.Action == "deleted" && item.Name != "" {
+			names = append(names, item.Name)
+		}
+	}
+	return names
+}
+
+func runSystemPrune(cmd *cobra.Command, args []string) error {
+	if systemPruneFlagAll && serverFlag != "" {
+		return fmt.Errorf("--all and --server are mutually exclusive")
+	}
+	// `--json` without `--force` blocks the execute path (dry-run is fine).
+	// Mirrors the convention in `shed image prune` / `shed delete`.
+	if jsonFlag && !systemPruneFlagForce && !systemPruneFlagDryRun {
+		return fmt.Errorf("--force is required when combining --json with an execute pass (add --dry-run to preview)")
+	}
+
+	if systemPruneFlagAll {
+		return runSystemPruneAll()
+	}
+	return runSystemPruneSingle()
+}
+
+func runSystemPruneSingle() error {
+	entry, name, err := getServerEntry()
+	if err != nil {
+		return err
+	}
+
+	client := NewAPIClientFromEntry(entry, DefaultTimeout)
+
+	// Always do a dry-run first. --dry-run and the real run return the same
+	// shape; the difference is that the real run shows post-mutation Freed.
+	dryReport, err := client.SystemPrune(pruneFlagsToOptions(true))
+	if err != nil {
+		return fmt.Errorf("failed to preview prune on %s: %w", name, err)
+	}
+	if dryReport.ServerName == "" {
+		dryReport.ServerName = name
+	}
+
+	// Dry-run-only path: print and exit.
+	if systemPruneFlagDryRun {
+		if jsonFlag {
+			return outputJSON(dryReport)
+		}
+		renderPrune(os.Stdout, *dryReport)
+		return nil
+	}
+
+	// In non-JSON mode, show candidates + prompt unless --force.
+	if !jsonFlag {
+		renderPrune(os.Stdout, *dryReport)
+		if dryReport.Totals.Items == 0 {
+			// Nothing to do — don't prompt, don't re-hit the server.
+			fmt.Println("Nothing to prune.")
+			return nil
+		}
+		if !systemPruneFlagForce {
+			fmt.Println()
+			prompt := fmt.Sprintf("Proceed with prune on %s? [y/N] ", name)
+			if !confirmAction(prompt) {
+				fmt.Println("Cancelled.")
+				return nil
+			}
+		}
+	} else if dryReport.Totals.Items == 0 {
+		// JSON + no candidates: emit the dry-run report and stop.
+		return outputJSON(dryReport)
+	}
+
+	// Execute.
+	report, err := client.SystemPrune(pruneFlagsToOptions(false))
+	if err != nil {
+		return fmt.Errorf("prune on %s: %w", name, err)
+	}
+	if report.ServerName == "" {
+		report.ServerName = name
+	}
+
+	// Invalidate client-side shed cache for any instance we deleted.
+	for _, n := range deletedShedNames(report) {
+		clientConfig.RemoveShedCache(n)
+	}
+	if err := clientConfig.Save(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to save client config: %v\n", err)
+	}
+
+	if jsonFlag {
+		return outputJSON(report)
+	}
+	renderPrune(os.Stdout, *report)
+	return nil
+}
+
+func runSystemPruneAll() error {
+	if len(clientConfig.Servers) == 0 {
+		if jsonFlag {
+			return outputJSON(config.SystemPruneResponse{Servers: []config.PruneReportOrError{}})
+		}
+		fmt.Println("No servers configured.")
+		return nil
+	}
+
+	// Phase 1: dry-run fan-out across all servers.
+	dryResults := forEachServer(clientConfig.Servers, func(name string, entry config.ServerEntry) (*config.PruneReport, error) {
+		client := NewAPIClientFromEntry(&entry, DefaultTimeout)
+		report, err := client.SystemPrune(pruneFlagsToOptions(true))
+		if err != nil {
+			return nil, err
+		}
+		if report.ServerName == "" {
+			report.ServerName = name
+		}
+		return report, nil
+	})
+
+	if systemPruneFlagDryRun {
+		return renderPruneAllReports(dryResults)
+	}
+
+	// Render dry-run table to stdout unless --json; always prompt once if
+	// there are any candidates and --force isn't set.
+	if !jsonFlag {
+		for i, r := range dryResults {
+			if i > 0 {
+				fmt.Println()
+			}
+			if r.Err != nil {
+				fmt.Printf("SERVER:  %s\n  error: %v\n", r.ServerName, r.Err)
+				continue
+			}
+			renderPrune(os.Stdout, *r.Value)
+		}
+	}
+
+	total := 0
+	for _, r := range dryResults {
+		if r.Value != nil {
+			total += r.Value.Totals.Items
+		}
+	}
+	if total == 0 {
+		if jsonFlag {
+			return renderPruneAllReports(dryResults)
+		}
+		fmt.Println("\nNothing to prune across all servers.")
+		return nil
+	}
+	if !jsonFlag && !systemPruneFlagForce {
+		fmt.Println()
+		prompt := fmt.Sprintf("Proceed with prune across %d server(s)? [y/N] ", len(dryResults))
+		if !confirmAction(prompt) {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+	}
+
+	// Phase 2: execute fan-out.
+	execResults := forEachServer(clientConfig.Servers, func(name string, entry config.ServerEntry) (*config.PruneReport, error) {
+		client := NewAPIClientFromEntry(&entry, DefaultTimeout)
+		report, err := client.SystemPrune(pruneFlagsToOptions(false))
+		if err != nil {
+			return nil, err
+		}
+		if report.ServerName == "" {
+			report.ServerName = name
+		}
+		return report, nil
+	})
+
+	// Invalidate client shed cache for every deleted instance across servers.
+	cacheDirty := false
+	for _, r := range execResults {
+		if r.Err != nil || r.Value == nil {
+			continue
+		}
+		for _, n := range deletedShedNames(r.Value) {
+			clientConfig.RemoveShedCache(n)
+			cacheDirty = true
+		}
+	}
+	if cacheDirty {
+		if err := clientConfig.Save(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to save client config: %v\n", err)
+		}
+	}
+
+	return renderPruneAllReports(execResults)
+}
+
+// renderPruneAllReports outputs a slice of per-server prune results in the
+// current mode (text or JSON) and returns non-nil if the caller should fail.
+// Per-server errors are reported inline and never cause a non-zero exit.
+func renderPruneAllReports(results []ServerResult[*config.PruneReport]) error {
+	if jsonFlag {
+		resp := config.SystemPruneResponse{Servers: make([]config.PruneReportOrError, 0, len(results))}
+		for _, r := range results {
+			entry := config.PruneReportOrError{ServerName: r.ServerName}
+			if r.Err != nil {
+				entry.Error = r.Err.Error()
+			} else {
+				entry.Report = r.Value
+			}
+			resp.Servers = append(resp.Servers, entry)
+		}
+		return outputJSON(resp)
+	}
+	for i, r := range results {
+		if i > 0 {
+			fmt.Println()
+		}
+		if r.Err != nil {
+			fmt.Printf("SERVER:  %s\n  error: %v\n", r.ServerName, r.Err)
+			continue
+		}
+		renderPrune(os.Stdout, *r.Value)
+	}
+	return nil
+}
+
+// renderPrune writes the prune report to w as a sectioned table.
+func renderPrune(w io.Writer, r config.PruneReport) {
+	mode := "execute"
+	if r.DryRun {
+		mode = "dry-run"
+	}
+	fmt.Fprintf(w, "SERVER: %s (%s)", r.ServerName, mode)
+	if r.Until != "" {
+		fmt.Fprintf(w, " --until %s", r.Until)
+	}
+	if len(r.Scope) > 0 {
+		fmt.Fprintf(w, " scope=%s", strings.Join(r.Scope, "+"))
+	}
+	fmt.Fprintln(w)
+
+	// Bucket items by kind for clearer output.
+	var images, instances, orphans, logs []config.PrunedItem
+	for _, item := range r.Items {
+		switch item.Kind {
+		case "image":
+			images = append(images, item)
+		case "instance":
+			instances = append(instances, item)
+		case "console_log":
+			logs = append(logs, item)
+		default:
+			orphans = append(orphans, item)
+		}
+	}
+
+	if len(images) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "IMAGES (%d, %s)\n", len(images), formatSize(sumFreedLogical(images)))
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "NAME\tPATH\tLOGICAL\tPHYSICAL")
+		for _, it := range images {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", it.Name, it.Path, formatSize(it.Freed.LogicalBytes), formatSize(it.Freed.PhysicalBytes))
+		}
+		tw.Flush()
+	}
+
+	if len(instances) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "INSTANCES (%d, %s)\n", len(instances), formatSize(sumFreedLogical(instances)))
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "NAME\tREASON\tLOGICAL\tPHYSICAL")
+		for _, it := range instances {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", it.Name, it.Reason, formatSize(it.Freed.LogicalBytes), formatSize(it.Freed.PhysicalBytes))
+		}
+		tw.Flush()
+	}
+
+	if len(orphans) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "ORPHANS (%d, %s)\n", len(orphans), formatSize(sumFreedLogical(orphans)))
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "PATH\tKIND\tLOGICAL\tPHYSICAL")
+		for _, it := range orphans {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", it.Path, it.Kind, formatSize(it.Freed.LogicalBytes), formatSize(it.Freed.PhysicalBytes))
+		}
+		tw.Flush()
+	}
+
+	if len(logs) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "LOGS TRUNCATED (%d, %s freed)\n", len(logs), formatSize(sumFreedLogical(logs)))
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "NAME\tPATH\tFREED")
+		for _, it := range logs {
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", it.Name, it.Path, formatSize(it.Freed.LogicalBytes))
+		}
+		tw.Flush()
+	}
+
+	if len(r.Skipped) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "SKIPPED (%d)\n", len(r.Skipped))
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "KIND\tNAME/PATH\tREASON")
+		for _, s := range r.Skipped {
+			label := s.Name
+			if label == "" {
+				label = s.Path
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", s.Kind, label, s.Reason)
+		}
+		tw.Flush()
+	}
+
+	fmt.Fprintln(w)
+	if r.DryRun {
+		fmt.Fprintf(w, "TOTAL TO FREE: %s logical / %s physical (%d items)\n",
+			formatSize(r.Totals.Freed.LogicalBytes), formatSize(r.Totals.Freed.PhysicalBytes), r.Totals.Items)
+	} else {
+		fmt.Fprintf(w, "FREED: %s logical / %s physical (%d items)\n",
+			formatSize(r.Totals.Freed.LogicalBytes), formatSize(r.Totals.Freed.PhysicalBytes), r.Totals.Items)
+	}
+
+	for _, note := range r.Notes {
+		fmt.Fprintf(w, "Note: %s\n", note)
+	}
+}
+
+// sumFreedLogical sums the logical bytes of a slice of items. Used for
+// section headers.
+func sumFreedLogical(items []config.PrunedItem) int64 {
+	var sum int64
+	for _, it := range items {
+		sum += it.Freed.LogicalBytes
+	}
+	return sum
 }
 
 // formatSize renders a byte count with sensible units. Unlike the coarse

--- a/cmd/shed/system.go
+++ b/cmd/shed/system.go
@@ -1,0 +1,309 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+var systemCmd = &cobra.Command{
+	Use:   "system",
+	Short: "Inspect and manage shed server disk usage",
+	Long:  "Inspect and manage disk usage on shed servers (image cache, per-instance rootfs, orphans).",
+}
+
+var systemDFFlagAll bool
+
+var systemDFCmd = &cobra.Command{
+	Use:   "df",
+	Short: "Show disk usage for the shed server",
+	Long: `Show disk usage for the shed server's image cache, per-instance rootfs
+copies, kernel/initrd, and orphan sidecar files.
+
+By default queries the active server. Use -s/--server to target a specific
+server, or --all to fan out to every configured server.
+
+Use -v to show per-image and per-shed rows; otherwise a rollup is printed.`,
+	Args: cobra.NoArgs,
+	RunE: runSystemDF,
+}
+
+func init() {
+	systemDFCmd.Flags().BoolVar(&systemDFFlagAll, "all", false, "Query every configured server")
+
+	systemCmd.AddCommand(systemDFCmd)
+	rootCmd.AddCommand(systemCmd)
+}
+
+func runSystemDF(cmd *cobra.Command, args []string) error {
+	if systemDFFlagAll && serverFlag != "" {
+		return fmt.Errorf("--all and --server are mutually exclusive")
+	}
+
+	if systemDFFlagAll {
+		return runSystemDFAll()
+	}
+	return runSystemDFSingle()
+}
+
+func runSystemDFSingle() error {
+	entry, name, err := getServerEntry()
+	if err != nil {
+		return err
+	}
+
+	client := NewAPIClientFromEntry(entry, DefaultTimeout)
+	du, err := client.GetSystemDF()
+	if err != nil {
+		return fmt.Errorf("failed to get disk usage from %s: %w", name, err)
+	}
+
+	// Server may not know its client-side name; overwrite for display.
+	if du.ServerName == "" {
+		du.ServerName = name
+	}
+
+	if jsonFlag {
+		return outputJSON(du)
+	}
+
+	renderDF(os.Stdout, *du, verboseLevel >= 1)
+	return nil
+}
+
+func runSystemDFAll() error {
+	if len(clientConfig.Servers) == 0 {
+		if jsonFlag {
+			return outputJSON(config.SystemDFResponse{Servers: []config.DiskUsageOrError{}})
+		}
+		fmt.Println("No servers configured.")
+		return nil
+	}
+
+	results := forEachServer(clientConfig.Servers, func(name string, entry config.ServerEntry) (*config.DiskUsage, error) {
+		client := NewAPIClientFromEntry(&entry, DefaultTimeout)
+		du, err := client.GetSystemDF()
+		if err != nil {
+			return nil, err
+		}
+		if du.ServerName == "" {
+			du.ServerName = name
+		}
+		return du, nil
+	})
+
+	if jsonFlag {
+		resp := config.SystemDFResponse{Servers: make([]config.DiskUsageOrError, 0, len(results))}
+		for _, r := range results {
+			entry := config.DiskUsageOrError{ServerName: r.ServerName}
+			if r.Err != nil {
+				entry.Error = r.Err.Error()
+			} else {
+				entry.Usage = r.Value
+			}
+			resp.Servers = append(resp.Servers, entry)
+		}
+		return outputJSON(resp)
+	}
+
+	// Text mode: one section per server, aggregate footer.
+	var totals config.DiskUsageTotals
+	var totalFiles int
+	for i, r := range results {
+		if i > 0 {
+			fmt.Println()
+		}
+		if r.Err != nil {
+			fmt.Printf("SERVER:  %s\n  error: %v\n", r.ServerName, r.Err)
+			continue
+		}
+		renderDF(os.Stdout, *r.Value, verboseLevel >= 1)
+		totals.Images.LogicalBytes += r.Value.Totals.Images.LogicalBytes
+		totals.Images.PhysicalBytes += r.Value.Totals.Images.PhysicalBytes
+		totals.Sheds.LogicalBytes += r.Value.Totals.Sheds.LogicalBytes
+		totals.Sheds.PhysicalBytes += r.Value.Totals.Sheds.PhysicalBytes
+		totals.Orphans.LogicalBytes += r.Value.Totals.Orphans.LogicalBytes
+		totals.Orphans.PhysicalBytes += r.Value.Totals.Orphans.PhysicalBytes
+		totals.All.LogicalBytes += r.Value.Totals.All.LogicalBytes
+		totals.All.PhysicalBytes += r.Value.Totals.All.PhysicalBytes
+		totalFiles += countFiles(r.Value)
+	}
+
+	fmt.Println()
+	fmt.Printf("AGGREGATE across %d server(s): %s logical / %s physical (%d files)\n",
+		len(results), formatSize(totals.All.LogicalBytes), formatSize(totals.All.PhysicalBytes), totalFiles)
+
+	return nil
+}
+
+// renderDF writes a tabular DF report for a single server to w.
+// verbose=true adds per-image and per-shed rows.
+func renderDF(w io.Writer, du config.DiskUsage, verbose bool) {
+	fmt.Fprintf(w, "SERVER:  %s      BACKEND: %s\n", du.ServerName, du.Backend)
+	fmt.Fprintf(w, "GENERATED: %s\n\n", du.GeneratedAt.UTC().Format(time.RFC3339))
+
+	// Rollup table.
+	imageFiles := len(du.Images)
+	if du.Kernel != nil {
+		imageFiles++
+	}
+	if du.Initrd != nil {
+		imageFiles++
+	}
+	runningCount, stoppedCount := 0, 0
+	for _, s := range du.Sheds {
+		if s.Status == config.StatusRunning {
+			runningCount++
+		} else {
+			stoppedCount++
+		}
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "CATEGORY\tFILES\tLOGICAL\tPHYSICAL")
+	fmt.Fprintf(tw, "images\t%d\t%s\t%s\n",
+		imageFiles, formatSize(du.Totals.Images.LogicalBytes), formatSize(du.Totals.Images.PhysicalBytes))
+	shedLabel := fmt.Sprintf("sheds (%d stopped, %d run)", stoppedCount, runningCount)
+	fmt.Fprintf(tw, "%s\t%d\t%s\t%s\n",
+		shedLabel, len(du.Sheds),
+		formatSize(du.Totals.Sheds.LogicalBytes), formatSize(du.Totals.Sheds.PhysicalBytes))
+	fmt.Fprintf(tw, "orphans\t%d\t%s\t%s\n",
+		len(du.Orphans), formatSize(du.Totals.Orphans.LogicalBytes), formatSize(du.Totals.Orphans.PhysicalBytes))
+	fmt.Fprintf(tw, "TOTAL\t%d\t%s\t%s\n",
+		imageFiles+len(du.Sheds)+len(du.Orphans),
+		formatSize(du.Totals.All.LogicalBytes), formatSize(du.Totals.All.PhysicalBytes))
+	tw.Flush()
+
+	if verbose {
+		renderDFVerbose(w, du)
+	}
+
+	if len(du.Notes) > 0 {
+		fmt.Fprintln(w)
+		for _, note := range du.Notes {
+			fmt.Fprintf(w, "Note: %s\n", note)
+		}
+	}
+}
+
+// renderDFVerbose appends per-image and per-shed sections after the rollup.
+func renderDFVerbose(w io.Writer, du config.DiskUsage) {
+	if len(du.Images) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "IMAGES (%d)\n", len(du.Images))
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "NAME\tREF\tLOGICAL\tPHYSICAL")
+		for _, img := range du.Images {
+			ref := img.DockerRef
+			if ref == "" {
+				ref = "-"
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+				img.Name, ref,
+				formatSize(img.Size.LogicalBytes), formatSize(img.Size.PhysicalBytes))
+		}
+		tw.Flush()
+	}
+
+	if du.Kernel != nil || du.Initrd != nil {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "KERNEL / INITRD")
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "PATH\tLOGICAL\tPHYSICAL")
+		if du.Kernel != nil {
+			fmt.Fprintf(tw, "%s\t%s\t%s\n",
+				du.Kernel.Path,
+				formatSize(du.Kernel.Size.LogicalBytes), formatSize(du.Kernel.Size.PhysicalBytes))
+		}
+		if du.Initrd != nil {
+			fmt.Fprintf(tw, "%s\t%s\t%s\n",
+				du.Initrd.Path,
+				formatSize(du.Initrd.Size.LogicalBytes), formatSize(du.Initrd.Size.PhysicalBytes))
+		}
+		tw.Flush()
+	}
+
+	if len(du.Sheds) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "SHEDS (%d)\n", len(du.Sheds))
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "NAME\tSTATUS\tIMAGE\tROOTFS\tCONSOLE\tTOTAL")
+		for _, s := range du.Sheds {
+			console := "n/a"
+			if s.ConsoleLog != nil {
+				console = formatSize(s.ConsoleLog.Size.LogicalBytes)
+			}
+			image := s.Image
+			if image == "" {
+				image = "-"
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				s.Name, s.Status, image,
+				formatSize(s.Rootfs.Size.LogicalBytes),
+				console,
+				formatSize(s.Total.LogicalBytes))
+		}
+		tw.Flush()
+	}
+
+	if len(du.Orphans) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "ORPHANS (%d)\n", len(du.Orphans))
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "PATH\tLOGICAL\tPHYSICAL\tKIND")
+		for _, f := range du.Orphans {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+				f.Path,
+				formatSize(f.Size.LogicalBytes), formatSize(f.Size.PhysicalBytes),
+				f.Kind)
+		}
+		tw.Flush()
+	}
+}
+
+// countFiles returns the number of files represented in a DiskUsage report.
+// Used for the multi-server aggregate footer.
+func countFiles(du *config.DiskUsage) int {
+	n := len(du.Images) + len(du.Orphans)
+	if du.Kernel != nil {
+		n++
+	}
+	if du.Initrd != nil {
+		n++
+	}
+	for _, s := range du.Sheds {
+		n++ // rootfs
+		if s.ConsoleLog != nil {
+			n++
+		}
+		n += len(s.OtherFiles)
+	}
+	return n
+}
+
+// formatSize renders a byte count with sensible units. Unlike the coarse
+// formatBytes in image.go (GB/MB only), this handles B through GB because df
+// surfaces everything from bytes (lock files) to multi-GB rootfs images.
+func formatSize(b int64) string {
+	const (
+		gb = 1024 * 1024 * 1024
+		mb = 1024 * 1024
+		kb = 1024
+	)
+	switch {
+	case b >= gb:
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(gb))
+	case b >= mb:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(mb))
+	case b >= kb:
+		return fmt.Sprintf("%.1f KB", float64(b)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/cmd/shed/system_test.go
+++ b/cmd/shed/system_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+func TestFormatSize(t *testing.T) {
+	tests := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{4 * 1024, "4.0 KB"},
+		{1024 * 1024, "1.0 MB"},
+		{5 * 1024 * 1024, "5.0 MB"},
+		{2 * 1024 * 1024 * 1024, "2.0 GB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := formatSize(tt.in); got != tt.want {
+				t.Errorf("formatSize(%d) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func sampleDiskUsage() config.DiskUsage {
+	return config.DiskUsage{
+		ServerName:  "prod-mac",
+		Backend:     "vz",
+		GeneratedAt: time.Date(2026, 4, 20, 11, 23, 45, 0, time.UTC),
+		Images: []config.ImageDiskEntry{
+			{Name: "default", DockerRef: "ghcr.io/x/default:v1", Size: config.DiskSize{LogicalBytes: 5 * 1024 * 1024 * 1024, PhysicalBytes: 4 * 1024 * 1024 * 1024}},
+			{Name: "_base", IsBase: true, Size: config.DiskSize{LogicalBytes: 5 * 1024 * 1024 * 1024, PhysicalBytes: 0}},
+		},
+		Kernel: &config.FileEntry{Path: "/tmp/vmlinux", Size: config.DiskSize{LogicalBytes: 8 * 1024 * 1024, PhysicalBytes: 8 * 1024 * 1024}, Kind: "kernel"},
+		Initrd: &config.FileEntry{Path: "/tmp/initrd", Size: config.DiskSize{LogicalBytes: 100 * 1024, PhysicalBytes: 100 * 1024}, Kind: "initrd"},
+		Sheds: []config.ShedDiskEntry{
+			{
+				Name:       "api-dev",
+				Status:     config.StatusRunning,
+				Image:      "default",
+				Rootfs:     config.FileEntry{Size: config.DiskSize{LogicalBytes: 2 * 1024 * 1024 * 1024, PhysicalBytes: 2 * 1024 * 1024 * 1024}},
+				ConsoleLog: &config.FileEntry{Size: config.DiskSize{LogicalBytes: 800 * 1024}},
+				Total:      config.DiskSize{LogicalBytes: 2 * 1024 * 1024 * 1024, PhysicalBytes: 2 * 1024 * 1024 * 1024},
+			},
+			{
+				Name:   "api-test",
+				Status: config.StatusStopped,
+				Image:  "default",
+				Rootfs: config.FileEntry{Size: config.DiskSize{LogicalBytes: 2 * 1024 * 1024 * 1024, PhysicalBytes: 2 * 1024 * 1024 * 1024}},
+				Total:  config.DiskSize{LogicalBytes: 2 * 1024 * 1024 * 1024, PhysicalBytes: 2 * 1024 * 1024 * 1024},
+			},
+		},
+		Orphans: []config.FileEntry{
+			{Path: "/tmp/dead.lock", Size: config.DiskSize{LogicalBytes: 0, PhysicalBytes: 0}, Kind: "lock"},
+		},
+		Totals: config.DiskUsageTotals{
+			Images:  config.DiskSize{LogicalBytes: 10 * 1024 * 1024 * 1024, PhysicalBytes: 4 * 1024 * 1024 * 1024},
+			Sheds:   config.DiskSize{LogicalBytes: 4 * 1024 * 1024 * 1024, PhysicalBytes: 4 * 1024 * 1024 * 1024},
+			Orphans: config.DiskSize{LogicalBytes: 0, PhysicalBytes: 0},
+			All:     config.DiskSize{LogicalBytes: 14 * 1024 * 1024 * 1024, PhysicalBytes: 8 * 1024 * 1024 * 1024},
+		},
+		Notes: []string{"physical bytes may overcount shared extents"},
+	}
+}
+
+func TestRenderDF_Rollup(t *testing.T) {
+	var buf bytes.Buffer
+	renderDF(&buf, sampleDiskUsage(), false)
+	got := buf.String()
+
+	for _, want := range []string{
+		"SERVER:  prod-mac",
+		"BACKEND: vz",
+		"CATEGORY",
+		"images",
+		"sheds (1 stopped, 1 run)",
+		"orphans",
+		"TOTAL",
+		"14.0 GB", // Totals.All.LogicalBytes
+		"Note:",   // Notes section
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rollup missing %q.\nOUTPUT:\n%s", want, got)
+		}
+	}
+	// Rollup must NOT contain verbose-only sections.
+	for _, banned := range []string{"IMAGES (", "SHEDS (", "KERNEL / INITRD", "ORPHANS ("} {
+		if strings.Contains(got, banned) {
+			t.Errorf("rollup unexpectedly contains %q.\nOUTPUT:\n%s", banned, got)
+		}
+	}
+}
+
+func TestRenderDF_Verbose(t *testing.T) {
+	var buf bytes.Buffer
+	renderDF(&buf, sampleDiskUsage(), true)
+	got := buf.String()
+
+	for _, want := range []string{
+		"IMAGES (2)",
+		"default",
+		"_base",
+		"SHEDS (2)",
+		"api-dev",
+		"api-test",
+		"KERNEL / INITRD",
+		"/tmp/vmlinux",
+		"/tmp/initrd",
+		"ORPHANS (1)",
+		"lock",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("verbose missing %q.\nOUTPUT:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderDF_FCNoInitrd(t *testing.T) {
+	du := sampleDiskUsage()
+	du.Backend = "firecracker"
+	du.Initrd = nil
+	// FC sheds don't have console.log; nil it out.
+	for i := range du.Sheds {
+		du.Sheds[i].ConsoleLog = nil
+	}
+
+	var buf bytes.Buffer
+	renderDF(&buf, du, true)
+	got := buf.String()
+
+	if !strings.Contains(got, "BACKEND: firecracker") {
+		t.Errorf("expected FC backend header, got:\n%s", got)
+	}
+	// The kernel/initrd section should still render with just kernel.
+	if !strings.Contains(got, "/tmp/vmlinux") {
+		t.Errorf("expected kernel row, got:\n%s", got)
+	}
+	if strings.Contains(got, "/tmp/initrd") {
+		t.Errorf("unexpected initrd row on FC, got:\n%s", got)
+	}
+	// Per-shed CONSOLE column should show "n/a" for FC sheds.
+	if !strings.Contains(got, "n/a") {
+		t.Errorf("expected n/a for FC console column, got:\n%s", got)
+	}
+}
+
+func TestRenderDF_ZeroState(t *testing.T) {
+	du := config.DiskUsage{
+		ServerName:  "empty",
+		Backend:     "vz",
+		GeneratedAt: time.Now().UTC(),
+	}
+	var buf bytes.Buffer
+	renderDF(&buf, du, false)
+	got := buf.String()
+
+	if !strings.Contains(got, "TOTAL") {
+		t.Errorf("expected TOTAL row even for empty state, got:\n%s", got)
+	}
+	if !strings.Contains(got, "0 B") {
+		t.Errorf("expected zero-byte display, got:\n%s", got)
+	}
+}
+
+func TestCountFiles(t *testing.T) {
+	du := sampleDiskUsage()
+	// 2 images + kernel + initrd + (2 sheds × rootfs) + 1 console + 1 orphan = 8
+	got := countFiles(&du)
+	if got != 8 {
+		t.Errorf("countFiles = %d, want 8", got)
+	}
+}

--- a/cmd/shed/system_test.go
+++ b/cmd/shed/system_test.go
@@ -179,3 +179,72 @@ func TestCountFiles(t *testing.T) {
 		t.Errorf("countFiles = %d, want 8", got)
 	}
 }
+
+func samplePruneReport(dry bool) config.PruneReport {
+	return config.PruneReport{
+		DryRun:     dry,
+		ServerName: "prod-mac",
+		Scope:      []string{"images", "instances", "orphans"},
+		Until:      "72h0m0s",
+		Items: []config.PrunedItem{
+			{Kind: "image", Name: "old-variant", Path: "/v/old.ext4", Action: "deleted", Freed: config.DiskSize{LogicalBytes: 5 << 30, PhysicalBytes: 4 << 30}},
+			{Kind: "instance", Name: "api-old", Action: "deleted", Reason: "stopped 5d ago", Freed: config.DiskSize{LogicalBytes: 2 << 30, PhysicalBytes: 2 << 30}},
+			{Kind: "tmp", Path: "/v/stale.ext4.tmp", Action: "deleted", Freed: config.DiskSize{LogicalBytes: 8192, PhysicalBytes: 8192}},
+		},
+		Skipped: []config.SkippedItem{
+			{Kind: "instance", Name: "api-dev", Reason: "cannot prune running shed"},
+			{Kind: "instance", Name: "api-test", Reason: "too recent (3h < 72h)"},
+		},
+		Totals: config.PruneReportTotals{
+			Freed: config.DiskSize{LogicalBytes: (5 << 30) + (2 << 30) + 8192, PhysicalBytes: (4 << 30) + (2 << 30) + 8192},
+			Items: 3,
+		},
+		Notes: []string{"physical bytes are attributed"},
+	}
+}
+
+func TestRenderPrune_DryRun(t *testing.T) {
+	var buf bytes.Buffer
+	renderPrune(&buf, samplePruneReport(true))
+	got := buf.String()
+	for _, want := range []string{
+		"SERVER: prod-mac (dry-run)",
+		"--until 72h0m0s",
+		"scope=images+instances+orphans",
+		"IMAGES (1,",
+		"old-variant",
+		"INSTANCES (1,",
+		"api-old",
+		"stopped 5d ago",
+		"ORPHANS (1,",
+		"stale.ext4.tmp",
+		"SKIPPED (2)",
+		"cannot prune running shed",
+		"too recent",
+		"TOTAL TO FREE:",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("dry-run render missing %q.\nOUTPUT:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderPrune_Execute(t *testing.T) {
+	var buf bytes.Buffer
+	renderPrune(&buf, samplePruneReport(false))
+	got := buf.String()
+	if strings.Contains(got, "dry-run") {
+		t.Errorf("execute output leaked dry-run marker: %s", got)
+	}
+	if !strings.Contains(got, "FREED:") {
+		t.Errorf("execute output missing FREED footer: %s", got)
+	}
+}
+
+func TestDeletedShedNames(t *testing.T) {
+	r := samplePruneReport(false)
+	names := deletedShedNames(&r)
+	if len(names) != 1 || names[0] != "api-old" {
+		t.Errorf("deletedShedNames = %v, want [api-old]", names)
+	}
+}

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -92,6 +92,8 @@ shed create my-project --repo git@github.com:user/repo.git
 shed create my-project --local-dir ~/projects/my-project
 ```
 
+Once you have a few sheds, `shed system df` shows what's on disk and `shed system prune` reclaims unused space. See [Disk Management](../reference/disk-management.md).
+
 ## Connect
 
 ### Direct Shell

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -25,6 +25,8 @@ The `shed-server` exposes a REST API for managing sheds.
 | GET | `/api/images` | List available image variants |
 | DELETE | `/api/images/{name}` | Delete a cached image |
 | POST | `/api/images/prune` | Prune unused cached images |
+| GET | `/api/system/df` | Disk usage report (image cache, sheds, orphans) |
+| POST | `/api/system/prune` | Scoped disk cleanup (dry-run, images/instances/logs/orphans) |
 | GET | `/api/sheds/{name}/connect/{port}` | TCP tunnel via HTTP upgrade |
 | GET | `/api/plugins/listeners` | List active extension listeners |
 | GET | `/api/plugins/listeners/{ns}/messages` | Subscribe to namespace (SSE) |
@@ -411,24 +413,24 @@ Returns disk usage information for the server: image cache, per-instance rootfs 
   "images": [
     {
       "name": "default",
-      "path": "/var/lib/shed/vz/default-rootfs.ext4",
+      "path": "/Users/alice/Library/Application Support/shed/vz/default-rootfs.ext4",
       "docker_ref": "ghcr.io/example/default:v1",
       "size": {"logical_bytes": 5368709120, "physical_bytes": 4831838208}
     },
     {
       "name": "_base",
-      "path": "/var/lib/shed/vz/_base-rootfs.ext4",
+      "path": "/Users/alice/Library/Application Support/shed/vz/_base-rootfs.ext4",
       "size": {"logical_bytes": 5368709120, "physical_bytes": 0},
       "is_base": true
     }
   ],
   "kernel": {
-    "path": "/var/lib/shed/vz/vmlinux",
+    "path": "/Users/alice/Library/Application Support/shed/vz/vmlinux",
     "size": {"logical_bytes": 8388608, "physical_bytes": 8388608},
     "kind": "kernel"
   },
   "initrd": {
-    "path": "/var/lib/shed/vz/initrd",
+    "path": "/Users/alice/Library/Application Support/shed/vz/initrd.img",
     "size": {"logical_bytes": 102400, "physical_bytes": 102400},
     "kind": "initrd"
   },
@@ -438,12 +440,12 @@ Returns disk usage information for the server: image cache, per-instance rootfs 
       "status": "running",
       "image": "default",
       "rootfs": {
-        "path": "/var/lib/shed/vz/instances/api-dev/rootfs.ext4",
+        "path": "/Users/alice/Library/Application Support/shed/vz/instances/api-dev/rootfs.ext4",
         "size": {"logical_bytes": 2147483648, "physical_bytes": 2147483648},
         "kind": "rootfs"
       },
       "console_log": {
-        "path": "/var/lib/shed/vz/instances/api-dev/console.log",
+        "path": "/Users/alice/Library/Application Support/shed/vz/instances/api-dev/console.log",
         "size": {"logical_bytes": 819200, "physical_bytes": 819200},
         "kind": "console_log"
       },
@@ -453,7 +455,7 @@ Returns disk usage information for the server: image cache, per-instance rootfs 
   ],
   "orphans": [
     {
-      "path": "/var/lib/shed/vz/stale-rootfs.ext4.lock",
+      "path": "/Users/alice/Library/Application Support/shed/vz/stale-rootfs.ext4.lock",
       "size": {"logical_bytes": 0, "physical_bytes": 0},
       "kind": "lock"
     }

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -395,6 +395,91 @@ Removes cached images not referenced by config or any existing shed.
 
 The `deleted` array contains the images that were removed (or would be removed if `dry_run=true`).
 
+## System
+
+### GET /api/system/df
+
+Returns disk usage information for the server: image cache, per-instance rootfs copies and console logs, kernel/initrd, and orphan sidecar files.
+
+**Response (200 OK):**
+
+```json
+{
+  "server_name": "prod-mac",
+  "backend": "vz",
+  "generated_at": "2026-04-20T11:23:45Z",
+  "images": [
+    {
+      "name": "default",
+      "path": "/var/lib/shed/vz/default-rootfs.ext4",
+      "docker_ref": "ghcr.io/example/default:v1",
+      "size": {"logical_bytes": 5368709120, "physical_bytes": 4831838208}
+    },
+    {
+      "name": "_base",
+      "path": "/var/lib/shed/vz/_base-rootfs.ext4",
+      "size": {"logical_bytes": 5368709120, "physical_bytes": 0},
+      "is_base": true
+    }
+  ],
+  "kernel": {
+    "path": "/var/lib/shed/vz/vmlinux",
+    "size": {"logical_bytes": 8388608, "physical_bytes": 8388608},
+    "kind": "kernel"
+  },
+  "initrd": {
+    "path": "/var/lib/shed/vz/initrd",
+    "size": {"logical_bytes": 102400, "physical_bytes": 102400},
+    "kind": "initrd"
+  },
+  "sheds": [
+    {
+      "name": "api-dev",
+      "status": "running",
+      "image": "default",
+      "rootfs": {
+        "path": "/var/lib/shed/vz/instances/api-dev/rootfs.ext4",
+        "size": {"logical_bytes": 2147483648, "physical_bytes": 2147483648},
+        "kind": "rootfs"
+      },
+      "console_log": {
+        "path": "/var/lib/shed/vz/instances/api-dev/console.log",
+        "size": {"logical_bytes": 819200, "physical_bytes": 819200},
+        "kind": "console_log"
+      },
+      "other_files": [],
+      "total": {"logical_bytes": 2148302848, "physical_bytes": 2148302848}
+    }
+  ],
+  "orphans": [
+    {
+      "path": "/var/lib/shed/vz/stale-rootfs.ext4.lock",
+      "size": {"logical_bytes": 0, "physical_bytes": 0},
+      "kind": "lock"
+    }
+  ],
+  "totals": {
+    "images":  {"logical_bytes": 10737418240, "physical_bytes": 4840226816},
+    "sheds":   {"logical_bytes": 2148302848,  "physical_bytes": 2148302848},
+    "orphans": {"logical_bytes": 0,           "physical_bytes": 0},
+    "all":     {"logical_bytes": 12885721088, "physical_bytes": 6988529664}
+  },
+  "notes": [
+    "physical bytes may overcount shared extents on APFS (clonefile) or hardlinks"
+  ]
+}
+```
+
+**Field notes:**
+
+- `backend` is `"vz"`, `"firecracker"`, or `"none"` (the last when the native backend isn't available on this platform).
+- `console_log` is always absent on Firecracker (the FC SDK writes to stderr, not a per-instance file).
+- `initrd` is VZ-only — Firecracker has no initrd.
+- `physical_bytes` comes from `stat.Blocks * 512`. Files that share extents via clonefile/FICLONE or hardlinks may have those bytes counted against each referencing file, inflating sums.
+- `is_base` marks the runtime-managed `_base-rootfs.ext4` cache.
+
+**Multi-server aggregation:** the server never fans out; `shed system df --all` issues one request per configured server from the client and assembles the per-server results.
+
 ## Connect API
 
 The Connect API provides TCP tunnels into shed VMs via HTTP upgrade. This is the foundation for port forwarding (tunnels) and the proxy extension.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -480,6 +480,87 @@ Returns disk usage information for the server: image cache, per-instance rootfs 
 
 **Multi-server aggregation:** the server never fans out; `shed system df --all` issues one request per configured server from the client and assembles the per-server results.
 
+### POST /api/system/prune
+
+Runs a disk cleanup pass. Returns a report of what was (or would be) removed or truncated. Dry-run returns the same shape without mutating.
+
+**Query parameters:**
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `scope` | (default scope) | Repeatable. One of `images`, `instances`, `logs`, `orphans`. When omitted, the backend applies the default: `images + instances + orphans`. Unknown values return 400. |
+| `dry_run` | `false` | If true, return candidates without mutating. |
+| `until` | `72h` | Go `time.Duration` string. Stopped instances whose `mtime(metadata.json)` is younger than `now - until` are skipped. `0s` = any age. Negative values return 400. |
+| `log_tail_bytes` | `0` | Size console logs are truncated to when the `logs` scope is active. `0` uses the server default (5 MiB). |
+
+**Scope rules:**
+
+- `images` — runs `vmimage.Manager.PruneImages`; refuses images referenced by config or any surviving instance.
+- `instances` — deletes stopped sheds older than `until`. Uses `Client.DeleteShed` internally so TAP devices (Firecracker) and credential state are cleaned up correctly. Running sheds are never pruned.
+- `orphans` — removes `.tmp`/`.source` sidecars whose parent rootfs is absent, gated by a non-blocking `flock()` probe on the canonical `.lock` and a 1-hour minimum age for `.tmp` files. The canonical `.lock` file itself is always preserved.
+- `logs` — Firecracker: no-op (FC has no per-instance console log; each shed gets a `SkippedItem`). VZ: truncates `console.log` in place to `log_tail_bytes`.
+
+**Internal ordering (within a single Prune call):**
+
+1. Snapshot `mtime(metadata.json)` for every instance **before** calling `ListSheds` (which can refresh mtime via its staleness re-check).
+2. Collect candidates for instances, orphans, and images (image dry-run uses `inUseImageNamesExcept(<candidate sheds>)` to simulate the post-instance-delete state).
+3. If `dry_run`, return. Otherwise: delete instances first so their image references drop from `inUseImageNames`, then prune images, then sweep orphans, then truncate logs.
+
+**Response (200 OK):**
+
+```json
+{
+  "dry_run": false,
+  "server_name": "prod-mac",
+  "scope": ["images", "instances", "orphans"],
+  "until": "72h0m0s",
+  "items": [
+    {
+      "kind": "instance",
+      "name": "api-old",
+      "action": "deleted",
+      "freed": {"logical_bytes": 2147483648, "physical_bytes": 2147483648},
+      "reason": "deleted (stopped 5d)"
+    },
+    {
+      "kind": "image",
+      "name": "old-variant",
+      "path": "/var/lib/shed/vz/old-variant-rootfs.ext4",
+      "action": "deleted",
+      "freed": {"logical_bytes": 5368709120, "physical_bytes": 5368709120}
+    },
+    {
+      "kind": "tmp",
+      "path": "/var/lib/shed/vz/stale-rootfs.ext4.tmp",
+      "action": "deleted",
+      "freed": {"logical_bytes": 4096, "physical_bytes": 4096}
+    }
+  ],
+  "skipped": [
+    {"kind": "instance", "name": "api-dev", "reason": "cannot prune running shed"},
+    {"kind": "instance", "name": "api-test", "reason": "too recent (3h < 72h)"},
+    {"kind": "tmp", "path": "/var/lib/shed/vz/live-rootfs.ext4.tmp", "reason": "lock held (conversion in progress)"}
+  ],
+  "notes": [
+    "physical bytes are attributed (stat.Blocks*512); clonefile/FICLONE clones and hardlinks may report bytes that won't actually be reclaimed"
+  ],
+  "totals": {
+    "freed": {"logical_bytes": 7516196864, "physical_bytes": 7516196864},
+    "items": 3
+  }
+}
+```
+
+**Error responses:**
+
+| Status | When |
+|--------|------|
+| 400 | Invalid `dry_run`, `until`, `log_tail_bytes`, or an unknown `scope` value |
+| 500 | Backend error during prune |
+| 501 | Backend does not support prune (e.g., the VZ stub on non-darwin hosts) |
+
+**Timeouts:** the CLI uses a 10-minute client timeout for this endpoint since large fleets can exceed the default 30-second window used by list/get endpoints.
+
 ## Connect API
 
 The Connect API provides TCP tunnels into shed VMs via HTTP upgrade. This is the foundation for port forwarding (tunnels) and the proxy extension.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -272,6 +272,39 @@ shed image prune                 # Interactive confirmation
 shed image prune --force         # No confirmation
 ```
 
+## System (Disk Usage)
+
+### shed system df
+
+Shows disk usage for shed servers: image cache, per-instance rootfs copies, kernel/initrd, and orphan sidecar files.
+
+```bash
+shed system df [flags]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--all` | | `false` | Query every configured server (client-side fan-out) |
+| `--server` | `-s` | (default server) | Target a specific server (global flag) |
+| `--verbose` | `-v` | | Show per-image, per-shed, kernel, and orphan rows (global flag) |
+| `--json` | | `false` | Emit machine-readable JSON (global flag) |
+
+The rollup view groups files into four categories — images (including kernel and initrd), sheds (per-instance rootfs + console logs), orphans (stale `.lock`/`.tmp`/`.source` files), and totals. `-v` breaks each category into per-file rows.
+
+Both **logical** (apparent) and **physical** (allocated) bytes are reported. Physical bytes come from `stat.Blocks * 512`. On filesystems that support extent sharing (APFS clonefile, ext4/xfs reflink, hardlinks), the same bytes may be attributed to multiple files — so summed physical totals may overcount actual on-disk usage. A note on every report calls this out.
+
+**Multi-server (`--all`):** runs concurrently across every configured server. Offline or older servers (returning errors or 404) are reported inline without aborting; the command exits 0. In `--json` mode the response is `{servers: [{server_name, usage?, error?}, ...]}`.
+
+**Examples:**
+
+```bash
+shed system df                 # Rollup for the active server
+shed system df -v              # Per-image and per-shed detail
+shed system df --json | jq     # Pipe the raw wire type to jq
+shed system df --all           # Fan out across all configured servers
+shed system df -s mini2 --json # Query one specific server in JSON
+```
+
 ## Interactive Access
 
 ### shed console

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -305,6 +305,54 @@ shed system df --all           # Fan out across all configured servers
 shed system df -s mini2 --json # Query one specific server in JSON
 ```
 
+### shed system prune
+
+Reclaims disk space by deleting unused images, stopped instances past an age threshold, and orphaned sidecar files. Optionally truncates VZ `console.log` files.
+
+```bash
+shed system prune [flags]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--images` | `false` | Prune unreferenced cached images |
+| `--instances` | `false` | Prune stopped instances older than `--until` |
+| `--logs` | `false` | Truncate VZ `console.log` files (opt-in; no-op on Firecracker) |
+| `--orphans` | `false` | Remove `.tmp`/`.source` sidecars whose parent rootfs is gone |
+| `--dry-run` | `false` | Show candidates without mutating |
+| `--force` | `false` | Skip confirmation prompt; required with `--json` for the execute path |
+| `--until` | `72h` | Stopped-instance age threshold via `mtime(metadata.json)`. `0s` = any age |
+| `--log-tail-bytes` | `0` | Console log truncation target (`0` = server default, 5 MiB) |
+| `--all` | `false` | Prune on every configured server (client-side fan-out) |
+| `--server` (`-s`) | (default server) | Target a specific server (global flag) |
+| `--json` | `false` | Emit machine-readable JSON (global flag) |
+
+**Scope semantics:** flags are additive. If none of `--images/--instances/--logs/--orphans` is set, the server applies its default scope: images + instances + orphans (NOT logs, which is always opt-in).
+
+**Dry-run-first UX:** the command always previews candidates before mutating. Without `--force` the CLI prints the candidate table and prompts for confirmation. With `--force` it executes immediately. With `--dry-run` it previews and exits.
+
+**Age filtering:** stopped instances are pruned only when `mtime(metadata.json) < now - --until`. The mtime snapshot is captured before the staleness re-check that `shed list` would otherwise trigger, so transient running→stopped transitions don't reset the clock. `--until 0s` disables the age gate.
+
+**Orphan safety:** a sidecar (`.tmp`, `.source`, or `.lock`) is treated as an orphan only when its parent `{name}-rootfs.ext4` is absent **and** a non-blocking `flock()` on `{name}-rootfs.ext4.lock` succeeds (i.e., no conversion is in flight). `.tmp` files younger than 1 hour are skipped unconditionally. The canonical `.lock` file is never removed even when abandoned, to avoid the inode-reuse race documented in `shed image prune`.
+
+**Console log truncation (VZ only):** when `--logs` is set, each surviving VZ shed's `console.log` is truncated to its last `--log-tail-bytes` in place (preserves inode so `vfkit`'s `O_APPEND` file descriptor keeps writing past the new EOF). Firecracker does not produce a per-instance console log, so `--logs` is a silent no-op for FC sheds.
+
+**Freed bytes caveat:** reported `physical_bytes` come from `stat.Blocks * 512` and are attributed to each file — they reflect how much the filesystem said each file occupied, not how much disk is actually reclaimed. Files that share extents via clonefile/FICLONE clones or hardlinks may report bytes that won't be reclaimed until the last reference is removed. Compare `shed system df` before and after for true reclamation.
+
+**JSON + destructive:** `--json` without `--force` blocks the execute path. `--dry-run --json` is always allowed.
+
+**Examples:**
+
+```bash
+shed system prune --dry-run            # Preview default scope
+shed system prune                      # Preview + interactive confirm
+shed system prune --force              # Execute without prompt
+shed system prune --instances --until 1h --force
+shed system prune --logs --log-tail-bytes 1048576 --force
+shed system prune --all --force        # Prune every configured server
+shed system prune --json --dry-run     # Machine-readable preview
+```
+
 ## Interactive Access
 
 ### shed console

--- a/docs/reference/disk-management.md
+++ b/docs/reference/disk-management.md
@@ -1,0 +1,165 @@
+# Disk Management
+
+Shed stores cached VM images, per-shed rootfs copies, and (on VZ) console logs on each server. This page explains what lives on disk, how to measure it, and how to reclaim space safely.
+
+The three tools involved:
+
+- `shed system df` — read-only disk usage report.
+- `shed system prune` — scoped cleanup with a dry-run-first UX.
+- Reflink / clonefile on `shed create` — new sheds share extents with the base image on reflink-capable filesystems, so per-shed disk cost starts at near-zero.
+
+Full flag references live in the [CLI reference](cli.md#system-disk-usage); full API schemas live in the [HTTP API reference](api.md#system). This page focuses on workflows and the reflink behavior that affects every `shed create`.
+
+## What lives on disk
+
+Each server stores four kinds of data in its backend directory:
+
+| Kind | VZ path (macOS) | Firecracker path (Linux) | Created by | Removed by |
+|------|-----------------|---------------------------|------------|------------|
+| `_base` rootfs cache | `~/Library/Application Support/shed/vz/_base-rootfs.ext4` | `/var/lib/shed/firecracker/images/_base-rootfs.ext4` | First `shed create` pulling the configured `base_rootfs` Docker ref | `shed image delete _base` or config change + `shed image prune` |
+| Image variants | `~/Library/Application Support/shed/vz/{name}-rootfs.ext4` | `/var/lib/shed/firecracker/images/{name}-rootfs.ext4` | `shed image build` or `shed-server pull-images` | `shed image delete <name>` or `shed system prune --images` |
+| Kernel / initrd | `~/Library/Application Support/shed/vz/vmlinux`, `initrd.img` | `/var/lib/shed/firecracker/images/vmlinux` (no initrd on FC) | `shed-server setup` or first image pull | Manual |
+| Per-shed rootfs | `~/Library/Application Support/shed/vz/instances/{name}/rootfs.ext4` | `/var/lib/shed/firecracker/instances/{name}/rootfs.ext4` | `shed create` (shares extents with `_base` when possible) | `shed delete` or `shed system prune --instances` |
+| VZ console log | `~/Library/Application Support/shed/vz/instances/{name}/console.log` | _(Firecracker has none — SDK writes to stderr)_ | VM boot | `shed system prune --logs` (truncates to last N bytes) |
+| Orphan sidecars | `*.tmp`, `*.source` whose matching `-rootfs.ext4` is absent | Same | Partial or crashed image conversions | `shed system prune --orphans` |
+
+See [Image Variants](images.md) for how `_base`, variants, and the Docker-ref cache work together.
+
+## Measuring usage with `shed system df`
+
+`shed system df` reports what each server currently holds on disk. The default rollup shows one line per category:
+
+```text
+SERVER:  prod-mac      BACKEND: vz
+GENERATED: 2026-04-21T13:36:15Z
+
+CATEGORY                  FILES  LOGICAL  PHYSICAL
+images                    3      20.1 GB  3.3 GB
+sheds (0 stopped, 2 run)  5      40.0 GB  6.3 GB
+orphans                   1      0 B      0 B
+TOTAL                     9      60.1 GB  9.6 GB
+
+Note: physical bytes may overcount shared extents on APFS (clonefile) or hardlinks
+```
+
+Two columns matter:
+
+- **LOGICAL** (`stat.Size`) — what tools like `du -k --apparent-size` see. For a 20 GB sparse ext4 rootfs, this is 20 GB regardless of how much data is actually in it.
+- **PHYSICAL** (`stat.Blocks * 512`) — how much the filesystem reports as allocated. On non-reflink filesystems this is the real on-disk cost. On APFS, ext4-reflink, btrfs, and xfs, extents shared via clonefile or FICLONE are counted against **every** file that references them, so summed physical bytes can exceed the actual disk consumption.
+
+Add `-v` for per-image and per-shed rows, `--json` for machine-readable output, and `--all` to fan out across every configured server:
+
+```bash
+shed system df
+shed system df -v
+shed system df --json | jq '.totals'
+shed system df --all              # Every configured server
+shed system df -s mini2           # Specific server
+```
+
+The full flag table is in the [CLI reference](cli.md#system-disk-usage). The raw response schema is documented under [`GET /api/system/df`](api.md#get-apisystemdf).
+
+## Reclaiming space with `shed system prune`
+
+`shed system prune` runs a scoped cleanup pass with four scopes that can be combined:
+
+- `--images` — remove cached image variants that aren't referenced by config or any existing shed.
+- `--instances` — delete stopped sheds older than `--until` (default 72 h).
+- `--logs` — truncate VZ console logs to the last `--log-tail-bytes` (default 5 MiB). No-op on Firecracker.
+- `--orphans` — remove `.tmp` / `.source` sidecars whose matching rootfs is absent. Lock files are preserved to avoid an inode-reuse race.
+
+When no scope flags are set, the command applies the default scope: `--images --instances --orphans` (not `--logs`, which is always opt-in).
+
+The command is always dry-run-first. It prints the candidate table, then prompts for confirmation unless `--force` is set:
+
+```text
+$ shed system prune
+SERVER: prod-mac (dry-run) --until 72h0m0s scope=images+instances+orphans
+
+IMAGES (2, 40.0 GB)
+NAME          PATH                                                                          LOGICAL  PHYSICAL
+base          /Users/alice/Library/Application Support/shed/vz/base-rootfs.ext4             20.0 GB  1.9 GB
+experimental  /Users/alice/Library/Application Support/shed/vz/experimental-rootfs.ext4     20.0 GB  3.2 GB
+
+SKIPPED (3)
+KIND      NAME/PATH                                                                 REASON
+instance  api-dev                                                                   cannot prune running shed
+instance  api-test                                                                  too recent (3h < 72h)
+lock      /Users/alice/Library/Application Support/shed/vz/foo-rootfs.ext4.lock     lock file retained (inode-reuse race safety)
+
+TOTAL TO FREE: 40.0 GB logical / 5.1 GB physical (2 items)
+
+Proceed? [y/N]
+```
+
+The 72 h age gate filters by `mtime(metadata.json)`, which is refreshed on every state change. `--until 0s` is an explicit "any age" escape hatch that still skips running sheds. `--all` fans out across every configured server; `--json --force` is required to execute non-interactively, and `--json --dry-run` is always allowed.
+
+Full flag table, scope semantics, and the internal deletion ordering are in the [CLI reference](cli.md#shed-system-prune). The raw request/response schema is under [`POST /api/system/prune`](api.md#post-apisystemprune).
+
+### Physical bytes vs. reclaimed disk
+
+The `PHYSICAL` freed total is attributed per file from `stat.Blocks * 512`. When the file being removed shares extents with another file (clonefile, FICLONE, or hardlinks), the bytes the filesystem actually reclaims may be lower than what the report attributes. Compare `shed system df` before and after to measure true reclamation.
+
+## Reflink and copy-on-write on `shed create`
+
+`shed create` produces a per-shed rootfs under `instances/{name}/rootfs.ext4`. On reflink-capable filesystems the rootfs starts out sharing all its extents with `_base`, so the create adds near-zero physical bytes and completes in under a second on a warm cache. Writes diverge on a copy-on-write basis from that point, so long-lived sheds grow gradually with the changes the VM makes.
+
+The server picks a strategy per create from this chain:
+
+| Host | Filesystem | Strategy | Initial physical cost per shed |
+|------|------------|----------|--------------------------------|
+| macOS | APFS | `clonefile(2)` | ~0 bytes (extents shared with `_base`) |
+| Linux | btrfs, xfs-reflink, or ext4 with `reflink=1` | `FICLONE` ioctl | ~0 bytes (extents shared with `_base`) |
+| Linux | ext4 without reflink, other filesystems | `copy_file_range(2)` | Full image size (~2–5 GB) |
+| Any | Remaining fallback | `io.Copy` | Full image size |
+
+Each `shed create` logs one line to the server journal so operators can confirm which strategy fired:
+
+```text
+rootfs strategy=<clonefile|ficlone|copy_file_range|io_copy> src=<base path> dst=<instance rootfs path> logical_bytes=<size>
+```
+
+On Linux, check whether the images directory supports reflink:
+
+```bash
+sudo tune2fs -l $(findmnt -T /var/lib/shed/firecracker/images -o SOURCE --noheadings) \
+  | grep -i 'features' | grep shared_blocks
+```
+
+If `shared_blocks` is not in the feature list, `shed create` falls back to `copy_file_range` and each shed will cost the full rootfs size. To enable reflink on ext4 you need kernel 6.7+ and the filesystem must have been created with `mkfs.ext4 -O reflink`.
+
+## Workflows
+
+### "Where did 40 GB go?"
+
+```bash
+shed system df -v
+```
+
+The verbose view shows per-image and per-shed rows so you can identify the largest consumers. On APFS the PHYSICAL column overcounts shared extents — cross-check against `du -k -s ~/Library/Application\ Support/shed/vz` if the sum looks higher than the actual disk.
+
+### Clean up before a deploy
+
+```bash
+shed system prune --dry-run       # Preview
+shed system prune                 # Interactive confirm
+```
+
+Default scope covers unreferenced images, stopped sheds older than 72 h, and orphan sidecars. Running sheds, recently-stopped sheds, and live conversion locks are all skipped with an explicit reason.
+
+### Trim runaway console logs
+
+```bash
+shed system prune --logs --log-tail-bytes 1048576 --force
+```
+
+VZ `console.log` files grow unbounded during long-running sheds. This keeps the last 1 MiB of each log and discards the rest. The truncation happens in place so `vfkit` keeps writing past the new EOF; a tiny window of writes can be lost between the read-tail and truncate. On Firecracker this is a no-op (no per-instance console log exists).
+
+### Fleet-wide cleanup
+
+```bash
+shed system prune --all --dry-run
+shed system prune --all --force
+```
+
+Fan-out is client-side: each configured server is queried in parallel. Offline or older-version servers (missing the `/api/system/prune` route) are reported inline and the command still exits 0, so partial fleet upgrades don't block cleanup.

--- a/docs/reference/fc-operations.md
+++ b/docs/reference/fc-operations.md
@@ -222,17 +222,19 @@ shed exec myproject -- curl -I https://google.com
 
 ### VM Disk Layout
 
-Each VM has a copy of the base rootfs:
+Each VM has its own rootfs derived from the base image:
 
 ```text
 /var/lib/shed/firecracker/instances/myproject/
 ├── metadata.json    # VM configuration and state
-└── rootfs.ext4      # VM's root filesystem (copy of base)
+└── rootfs.ext4      # VM's root filesystem (reflink of base when supported)
 
 /var/run/shed/firecracker/  # Runtime sockets (when VM is running)
 ├── myproject.sock   # Firecracker API socket
 └── myproject.vsock  # vsock UDS for guest communication
 ```
+
+On reflink-capable filesystems (btrfs, xfs with reflink, ext4 with `reflink=1` on kernel 6.7+), the per-shed rootfs shares extents with `_base` and adds near-zero physical bytes at create time; writes diverge copy-on-write. On non-reflink ext4 the rootfs is materialized as a full copy (~2–5 GB). See [Disk Management](disk-management.md) for the strategy chain, how to check reflink support, and how to measure per-shed cost.
 
 ### Expanding Disk Space
 

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -371,23 +371,16 @@ The common end-to-end flow when bumping image refs (for example, moving config f
 
 ## Disk Space
 
-Each variant produces a 20GB sparse ext4 image. Actual disk usage is much smaller (typically 2–5GB depending on the variant). When a shed is created, its rootfs starts out sharing disk extents with the base image via `clonefile` on macOS/APFS or `FICLONE` (ext4/xfs/btrfs reflink) on Linux — the copy is near-instant and adds near-zero physical bytes until the VM begins writing. Writes diverge on a CoW basis from that point, so long-lived sheds grow gradually.
+Each variant is a 20 GB sparse ext4 image; actual usage is typically 2–5 GB depending on what the variant installed. Per-shed rootfs copies start out sharing extents with `_base` on reflink-capable filesystems (APFS, btrfs, xfs-reflink, ext4 with `reflink=1`) and grow copy-on-write as the VM writes. On non-reflink filesystems the rootfs is materialized as a full copy.
 
-If the filesystem doesn't support reflink (e.g. ext4 without the `reflink=1` option, tmpfs), the backend falls back to Linux's `copy_file_range(2)` or finally to a userspace copy. The strategy is logged once per `shed create` on the server, with format:
-
-```text
-rootfs strategy=<clonefile|ficlone|copy_file_range|io_copy> src=... dst=... logical_bytes=...
-```
-
-To see current disk consumption, prefer `shed system df` (reports both apparent and allocated bytes and surfaces the APFS extent-sharing overcount caveat):
+To measure usage, use `shed system df`:
 
 ```bash
 shed system df
-shed system df -v    # per-image and per-shed rows
-shed system df --json | jq
+shed system df -v
 ```
 
-`du -sh` works too but is noisy on APFS because each reflink reference counts against every file that holds it.
+See [Disk Management](disk-management.md) for the full reflink strategy chain, the APFS extent-sharing caveat, how to check reflink support on Linux, and how to reclaim space with `shed system prune`.
 
 ## Requirements
 

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -371,19 +371,23 @@ The common end-to-end flow when bumping image refs (for example, moving config f
 
 ## Disk Space
 
-Each variant produces a 20GB sparse ext4 image. Actual disk usage is much smaller (typically 2–5GB depending on the variant). Each running shed adds another 2–5GB for its own rootfs copy.
+Each variant produces a 20GB sparse ext4 image. Actual disk usage is much smaller (typically 2–5GB depending on the variant). When a shed is created, its rootfs starts out sharing disk extents with the base image via `clonefile` on macOS/APFS or `FICLONE` (ext4/xfs/btrfs reflink) on Linux — the copy is near-instant and adds near-zero physical bytes until the VM begins writing. Writes diverge on a CoW basis from that point, so long-lived sheds grow gradually.
 
-Use `du -sh` to check actual usage:
+If the filesystem doesn't support reflink (e.g. ext4 without the `reflink=1` option, tmpfs), the backend falls back to Linux's `copy_file_range(2)` or finally to a userspace copy. The strategy is logged once per `shed create` on the server, with format:
+
+```
+rootfs strategy=<clonefile|ficlone|copy_file_range|io_copy> src=... dst=... logical_bytes=...
+```
+
+To see current disk consumption, prefer `shed system df` (reports both apparent and allocated bytes and surfaces the APFS extent-sharing overcount caveat):
 
 ```bash
-# VZ
-du -sh ~/Library/Application\ Support/shed/vz/*-rootfs.ext4
-du -sh ~/Library/Application\ Support/shed/vz/instances/*
-
-# Firecracker
-du -sh /var/lib/shed/firecracker/images/*-rootfs.ext4
-du -sh /var/lib/shed/firecracker/instances/*
+shed system df
+shed system df -v    # per-image and per-shed rows
+shed system df --json | jq
 ```
+
+`du -sh` works too but is noisy on APFS because each reflink reference counts against every file that holds it.
 
 ## Requirements
 

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -375,7 +375,7 @@ Each variant produces a 20GB sparse ext4 image. Actual disk usage is much smalle
 
 If the filesystem doesn't support reflink (e.g. ext4 without the `reflink=1` option, tmpfs), the backend falls back to Linux's `copy_file_range(2)` or finally to a userspace copy. The strategy is logged once per `shed create` on the server, with format:
 
-```
+```text
 rootfs strategy=<clonefile|ficlone|copy_file_range|io_copy> src=... dst=... logical_bytes=...
 ```
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -56,9 +56,10 @@ func (s *Server) Router() chi.Router {
 			r.Post("/prune", s.handlePruneImages)
 		})
 
-		// System (disk reporting + future prune)
+		// System (disk reporting + prune)
 		r.Route("/system", func(r chi.Router) {
 			r.Get("/df", s.handleSystemDF)
+			r.Post("/prune", s.handleSystemPrune)
 		})
 
 		// Plugins / Extensions

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -56,6 +56,11 @@ func (s *Server) Router() chi.Router {
 			r.Post("/prune", s.handlePruneImages)
 		})
 
+		// System (disk reporting + future prune)
+		r.Route("/system", func(r chi.Router) {
+			r.Get("/df", s.handleSystemDF)
+		})
+
 		// Plugins / Extensions
 		r.Route("/plugins", func(r chi.Router) {
 			r.Get("/listeners", s.handleListListeners)

--- a/internal/api/system_handlers.go
+++ b/internal/api/system_handlers.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+// handleSystemDF returns disk usage information for this server.
+// GET /api/system/df
+func (s *Server) handleSystemDF(w http.ResponseWriter, r *http.Request) {
+	usage, err := s.backend.DiskUsage(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, config.ErrBackendError, err.Error())
+		return
+	}
+	// Defensive: ensure slices are non-nil so JSON renders `[]` not `null`.
+	if usage.Images == nil {
+		usage.Images = []config.ImageDiskEntry{}
+	}
+	if usage.Sheds == nil {
+		usage.Sheds = []config.ShedDiskEntry{}
+	}
+	if usage.Orphans == nil {
+		usage.Orphans = []config.FileEntry{}
+	}
+	writeJSON(w, http.StatusOK, usage)
+}

--- a/internal/api/system_handlers.go
+++ b/internal/api/system_handlers.go
@@ -2,7 +2,10 @@ package api
 
 import (
 	"net/http"
+	"strconv"
+	"time"
 
+	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
 )
 
@@ -25,4 +28,82 @@ func (s *Server) handleSystemDF(w http.ResponseWriter, r *http.Request) {
 		usage.Orphans = []config.FileEntry{}
 	}
 	writeJSON(w, http.StatusOK, usage)
+}
+
+// handleSystemPrune runs a disk cleanup pass. Scope flags are passed as
+// repeated `scope=` query params (any of images, instances, logs, orphans).
+// When no scope is specified, defaults to images+instances+orphans (NOT
+// logs, which is always opt-in).
+//
+// POST /api/system/prune?scope=...&dry_run=bool&until=72h&log_tail_bytes=N
+func (s *Server) handleSystemPrune(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	var opts backend.PruneOptions
+
+	// dry_run
+	if v := q.Get("dry_run"); v != "" {
+		dryRun, err := strconv.ParseBool(v)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, config.ErrBackendError, "invalid dry_run value: "+v)
+			return
+		}
+		opts.DryRun = dryRun
+	}
+
+	// scope=... (repeatable). Unknown values are rejected so typos don't
+	// silently fall through to the default scope.
+	for _, s := range q["scope"] {
+		switch s {
+		case "images":
+			opts.Images = true
+		case "instances":
+			opts.Instances = true
+		case "logs":
+			opts.Logs = true
+		case "orphans":
+			opts.Orphans = true
+		default:
+			writeError(w, http.StatusBadRequest, config.ErrBackendError, "unknown scope: "+s)
+			return
+		}
+	}
+
+	// until
+	if v := q.Get("until"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, config.ErrBackendError, "invalid until value: "+v)
+			return
+		}
+		if d < 0 {
+			writeError(w, http.StatusBadRequest, config.ErrBackendError, "until must be non-negative")
+			return
+		}
+		opts.Until = d
+	}
+
+	// log_tail_bytes
+	if v := q.Get("log_tail_bytes"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil || n < 0 {
+			writeError(w, http.StatusBadRequest, config.ErrBackendError, "invalid log_tail_bytes: "+v)
+			return
+		}
+		opts.LogTailBytes = n
+	}
+
+	report, err := s.backend.Prune(r.Context(), opts)
+	if err != nil {
+		code, errCode, msg := mapBackendError(err)
+		writeError(w, code, errCode, msg)
+		return
+	}
+	if report.Items == nil {
+		report.Items = []config.PrunedItem{}
+	}
+	if report.Skipped == nil {
+		report.Skipped = []config.SkippedItem{}
+	}
+	writeJSON(w, http.StatusOK, report)
 }

--- a/internal/api/system_handlers.go
+++ b/internal/api/system_handlers.go
@@ -30,6 +30,16 @@ func (s *Server) handleSystemDF(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, usage)
 }
 
+// defaultPruneUntil is applied when the `until` query param is omitted.
+// Explicit `until=0s` preserves its "any age" meaning for power users who
+// genuinely want to prune every stopped instance regardless of age.
+const defaultPruneUntil = 72 * time.Hour
+
+// maxLogTailBytes caps the server-side allocation for console log tail
+// preservation. Without this, a request like log_tail_bytes=20GB on a 20GB
+// console.log would allocate a 20GB buffer and OOM the daemon.
+const maxLogTailBytes = 64 * 1024 * 1024 // 64 MiB
+
 // handleSystemPrune runs a disk cleanup pass. Scope flags are passed as
 // repeated `scope=` query params (any of images, instances, logs, orphans).
 // When no scope is specified, defaults to images+instances+orphans (NOT
@@ -41,11 +51,10 @@ func (s *Server) handleSystemPrune(w http.ResponseWriter, r *http.Request) {
 
 	var opts backend.PruneOptions
 
-	// dry_run
 	if v := q.Get("dry_run"); v != "" {
 		dryRun, err := strconv.ParseBool(v)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, config.ErrBackendError, "invalid dry_run value: "+v)
+			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "invalid dry_run value: "+v)
 			return
 		}
 		opts.DryRun = dryRun
@@ -64,30 +73,41 @@ func (s *Server) handleSystemPrune(w http.ResponseWriter, r *http.Request) {
 		case "orphans":
 			opts.Orphans = true
 		default:
-			writeError(w, http.StatusBadRequest, config.ErrBackendError, "unknown scope: "+s)
+			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "unknown scope: "+s)
 			return
 		}
 	}
 
-	// until
-	if v := q.Get("until"); v != "" {
-		d, err := time.ParseDuration(v)
+	// `until` param: present-and-parseable wins; absent falls back to the
+	// 72h default. An explicit until=0s is valid and means "any age."
+	//
+	// Distinguishing "omitted" from "explicit 0" requires the map lookup
+	// rather than q.Get(), since an empty-string value is not the same as
+	// a missing key for our purposes.
+	if vals, ok := q["until"]; ok && len(vals) > 0 && vals[0] != "" {
+		d, err := time.ParseDuration(vals[0])
 		if err != nil {
-			writeError(w, http.StatusBadRequest, config.ErrBackendError, "invalid until value: "+v)
+			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "invalid until value: "+vals[0])
 			return
 		}
 		if d < 0 {
-			writeError(w, http.StatusBadRequest, config.ErrBackendError, "until must be non-negative")
+			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "until must be non-negative")
 			return
 		}
 		opts.Until = d
+	} else {
+		opts.Until = defaultPruneUntil
 	}
 
-	// log_tail_bytes
 	if v := q.Get("log_tail_bytes"); v != "" {
 		n, err := strconv.ParseInt(v, 10, 64)
 		if err != nil || n < 0 {
-			writeError(w, http.StatusBadRequest, config.ErrBackendError, "invalid log_tail_bytes: "+v)
+			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "invalid log_tail_bytes: "+v)
+			return
+		}
+		if n > maxLogTailBytes {
+			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest,
+				"log_tail_bytes exceeds server cap of "+strconv.FormatInt(maxLogTailBytes, 10))
 			return
 		}
 		opts.LogTailBytes = n
@@ -95,6 +115,20 @@ func (s *Server) handleSystemPrune(w http.ResponseWriter, r *http.Request) {
 
 	report, err := s.backend.Prune(r.Context(), opts)
 	if err != nil {
+		// Surface partial progress even on error: the backend may have
+		// deleted instances before an image-prune step failed, and the
+		// client needs visibility into what actually happened.
+		if report.Totals.Items > 0 {
+			if report.Items == nil {
+				report.Items = []config.PrunedItem{}
+			}
+			if report.Skipped == nil {
+				report.Skipped = []config.SkippedItem{}
+			}
+			report.Notes = append(report.Notes, "partial failure: "+err.Error())
+			writeJSON(w, http.StatusOK, report)
+			return
+		}
 		code, errCode, msg := mapBackendError(err)
 		writeError(w, code, errCode, msg)
 		return

--- a/internal/api/system_handlers.go
+++ b/internal/api/system_handlers.go
@@ -51,10 +51,17 @@ func (s *Server) handleSystemPrune(w http.ResponseWriter, r *http.Request) {
 
 	var opts backend.PruneOptions
 
-	if v := q.Get("dry_run"); v != "" {
-		dryRun, err := strconv.ParseBool(v)
+	// Reject present-but-empty scalar params. `?dry_run=` previously fell
+	// through as DryRun=false and a malformed request became an execute
+	// request (CodeRabbit major finding).
+	if vals, ok := q["dry_run"]; ok {
+		if len(vals) == 0 || vals[0] == "" {
+			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "dry_run must not be empty")
+			return
+		}
+		dryRun, err := strconv.ParseBool(vals[0])
 		if err != nil {
-			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "invalid dry_run value: "+v)
+			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "invalid dry_run value: "+vals[0])
 			return
 		}
 		opts.DryRun = dryRun
@@ -84,7 +91,14 @@ func (s *Server) handleSystemPrune(w http.ResponseWriter, r *http.Request) {
 	// Distinguishing "omitted" from "explicit 0" requires the map lookup
 	// rather than q.Get(), since an empty-string value is not the same as
 	// a missing key for our purposes.
-	if vals, ok := q["until"]; ok && len(vals) > 0 && vals[0] != "" {
+	// Present-but-empty `until=` is rejected rather than falling through
+	// to the default (avoids silent ambiguity with malformed clients).
+	// Absent key → 72h default.
+	if vals, ok := q["until"]; ok {
+		if len(vals) == 0 || vals[0] == "" {
+			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "until must not be empty")
+			return
+		}
 		d, err := time.ParseDuration(vals[0])
 		if err != nil {
 			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "invalid until value: "+vals[0])
@@ -99,10 +113,14 @@ func (s *Server) handleSystemPrune(w http.ResponseWriter, r *http.Request) {
 		opts.Until = defaultPruneUntil
 	}
 
-	if v := q.Get("log_tail_bytes"); v != "" {
-		n, err := strconv.ParseInt(v, 10, 64)
+	if vals, ok := q["log_tail_bytes"]; ok {
+		if len(vals) == 0 || vals[0] == "" {
+			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "log_tail_bytes must not be empty")
+			return
+		}
+		n, err := strconv.ParseInt(vals[0], 10, 64)
 		if err != nil || n < 0 {
-			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "invalid log_tail_bytes: "+v)
+			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "invalid log_tail_bytes: "+vals[0])
 			return
 		}
 		if n > maxLogTailBytes {

--- a/internal/api/system_handlers_test.go
+++ b/internal/api/system_handlers_test.go
@@ -1,0 +1,173 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/config"
+)
+
+// fakeBackend implements backend.Backend for system handler tests.
+// Only DiskUsage is wired; other methods panic if called.
+type fakeBackend struct {
+	usage config.DiskUsage
+	err   error
+}
+
+func (f *fakeBackend) Type() backend.Type { return backend.TypeVZ }
+func (f *fakeBackend) Close() error       { return nil }
+
+func (f *fakeBackend) CreateShed(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error) {
+	panic("unexpected")
+}
+func (f *fakeBackend) GetShed(ctx context.Context, name string) (*config.Shed, error) {
+	panic("unexpected")
+}
+func (f *fakeBackend) ListSheds(ctx context.Context) ([]config.Shed, error) { panic("unexpected") }
+func (f *fakeBackend) DeleteShed(ctx context.Context, name string, keepVolume bool) error {
+	panic("unexpected")
+}
+func (f *fakeBackend) StartShed(ctx context.Context, name string) (*config.Shed, error) {
+	panic("unexpected")
+}
+func (f *fakeBackend) StopShed(ctx context.Context, name string) (*config.Shed, error) {
+	panic("unexpected")
+}
+func (f *fakeBackend) ListSessions(ctx context.Context, shedName string) ([]config.Session, error) {
+	panic("unexpected")
+}
+func (f *fakeBackend) KillSession(ctx context.Context, shedName, sessionName string) error {
+	panic("unexpected")
+}
+func (f *fakeBackend) Exec(ctx context.Context, shedName string, opts backend.ExecOptions) error {
+	panic("unexpected")
+}
+func (f *fakeBackend) GetNetworkEndpoint(ctx context.Context, shedName string) (string, error) {
+	panic("unexpected")
+}
+func (f *fakeBackend) DialService(ctx context.Context, shedName string, port uint16) (net.Conn, error) {
+	panic("unexpected")
+}
+func (f *fakeBackend) ListImages(ctx context.Context) ([]config.ImageInfo, error) {
+	panic("unexpected")
+}
+func (f *fakeBackend) DeleteImage(ctx context.Context, name string) error { panic("unexpected") }
+func (f *fakeBackend) PruneImages(ctx context.Context, dryRun bool) ([]config.ImageInfo, error) {
+	panic("unexpected")
+}
+
+func (f *fakeBackend) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
+	return f.usage, f.err
+}
+
+func newSystemTestServer(be backend.Backend) *Server {
+	return NewServer(be, &config.ServerConfig{Name: "test-server"}, "", nil, nil)
+}
+
+func TestHandleSystemDF_Success(t *testing.T) {
+	be := &fakeBackend{
+		usage: config.DiskUsage{
+			ServerName:  "test-server",
+			Backend:     "vz",
+			GeneratedAt: time.Now().UTC(),
+			Images:      []config.ImageDiskEntry{{Name: "default", Size: config.DiskSize{LogicalBytes: 1024, PhysicalBytes: 512}}},
+		},
+	}
+	srv := newSystemTestServer(be)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/system/df", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var got config.DiskUsage
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ServerName != "test-server" || got.Backend != "vz" {
+		t.Errorf("unexpected payload: %+v", got)
+	}
+	if len(got.Images) != 1 || got.Images[0].Name != "default" {
+		t.Errorf("images = %+v", got.Images)
+	}
+}
+
+func TestHandleSystemDF_EmptySlicesNotNull(t *testing.T) {
+	// Verify JSON renders empty slices as `[]`, not `null`, so callers using
+	// `jq -e '.images | length'` don't blow up.
+	be := &fakeBackend{
+		usage: config.DiskUsage{ServerName: "x", Backend: "vz"},
+	}
+	srv := newSystemTestServer(be)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/system/df", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	// Raw-string contains check: `"images":[]` rather than `"images":null`.
+	body := w.Body.String()
+	for _, want := range []string{`"images":[]`, `"sheds":[]`, `"orphans":[]`} {
+		if !jsonContains(body, want) {
+			t.Errorf("expected %s in body, got: %s", want, body)
+		}
+	}
+}
+
+func TestHandleSystemDF_BackendError(t *testing.T) {
+	be := &fakeBackend{err: errors.New("io boom")}
+	srv := newSystemTestServer(be)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/system/df", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", w.Code, w.Body.String())
+	}
+}
+
+// jsonContains is a substring check that ignores insignificant whitespace by
+// stripping spaces/newlines from both the haystack and needle.
+func jsonContains(body, substr string) bool {
+	clean := func(s string) string {
+		out := make([]byte, 0, len(s))
+		for i := 0; i < len(s); i++ {
+			c := s[i]
+			if c == ' ' || c == '\n' || c == '\t' {
+				continue
+			}
+			out = append(out, c)
+		}
+		return string(out)
+	}
+	return contains(clean(body), clean(substr))
+}
+
+func contains(haystack, needle string) bool {
+	return len(needle) == 0 || indexOf(haystack, needle) >= 0
+}
+
+func indexOf(s, sub string) int {
+outer:
+	for i := 0; i+len(sub) <= len(s); i++ {
+		for j := 0; j < len(sub); j++ {
+			if s[i+j] != sub[j] {
+				continue outer
+			}
+		}
+		return i
+	}
+	return -1
+}

--- a/internal/api/system_handlers_test.go
+++ b/internal/api/system_handlers_test.go
@@ -220,6 +220,77 @@ func TestHandleSystemPrune_InvalidDryRun(t *testing.T) {
 	}
 }
 
+func TestHandleSystemPrune_DefaultUntil_72h(t *testing.T) {
+	// Regression for Codex #2: omitting `until` must default to 72h. The
+	// previous handler left opts.Until=0, which the backend interprets
+	// as "any age" — directly calling POST /api/system/prune?scope=instances
+	// would then delete every stopped instance regardless of how recent.
+	be := &fakeBackend{pruneReport: config.PruneReport{ServerName: "x"}}
+	srv := newSystemTestServer(be)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/system/prune?scope=instances", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got, want := be.lastPruneOpts.Until, 72*time.Hour; got != want {
+		t.Errorf("default Until = %v, want %v", got, want)
+	}
+}
+
+func TestHandleSystemPrune_ExplicitUntilZero_AnyAge(t *testing.T) {
+	// Explicit until=0s must preserve the "any age" escape hatch.
+	be := &fakeBackend{pruneReport: config.PruneReport{ServerName: "x"}}
+	srv := newSystemTestServer(be)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/system/prune?scope=instances&until=0s", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := be.lastPruneOpts.Until; got != 0 {
+		t.Errorf("explicit until=0s: got %v, want 0", got)
+	}
+}
+
+func TestHandleSystemPrune_LogTailCap(t *testing.T) {
+	// Regression for Codex #8: unbounded log_tail_bytes would allow a
+	// client to allocate arbitrary memory on the daemon. Cap is 64 MiB.
+	be := &fakeBackend{}
+	srv := newSystemTestServer(be)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/system/prune?log_tail_bytes=1073741824", nil) // 1 GiB
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSystemPrune_UsesInvalidRequestErrCode(t *testing.T) {
+	// Regression for CR finding B: 400 responses must use the dedicated
+	// ErrInvalidRequest code so clients switching on the error code field
+	// can distinguish bad input from backend errors.
+	be := &fakeBackend{}
+	srv := newSystemTestServer(be)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/system/prune?scope=nonsense", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if !jsonContains(w.Body.String(), `"code":"`+config.ErrInvalidRequest+`"`) {
+		t.Errorf("expected error code %s in body, got: %s", config.ErrInvalidRequest, w.Body.String())
+	}
+}
+
 func TestHandleSystemPrune_EmptyScope(t *testing.T) {
 	// No scope flags — backend gets PruneOptions with all flags false and
 	// applies its own defaults.

--- a/internal/api/system_handlers_test.go
+++ b/internal/api/system_handlers_test.go
@@ -15,10 +15,14 @@ import (
 )
 
 // fakeBackend implements backend.Backend for system handler tests.
-// Only DiskUsage is wired; other methods panic if called.
+// Only DiskUsage and Prune are wired; other methods panic if called.
 type fakeBackend struct {
-	usage config.DiskUsage
-	err   error
+	usage       config.DiskUsage
+	err         error
+	pruneReport config.PruneReport
+	pruneErr    error
+	// captured so the test can assert what the handler forwarded.
+	lastPruneOpts backend.PruneOptions
 }
 
 func (f *fakeBackend) Type() backend.Type { return backend.TypeVZ }
@@ -65,6 +69,11 @@ func (f *fakeBackend) PruneImages(ctx context.Context, dryRun bool) ([]config.Im
 
 func (f *fakeBackend) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 	return f.usage, f.err
+}
+
+func (f *fakeBackend) Prune(ctx context.Context, opts backend.PruneOptions) (config.PruneReport, error) {
+	f.lastPruneOpts = opts
+	return f.pruneReport, f.pruneErr
 }
 
 func newSystemTestServer(be backend.Backend) *Server {
@@ -135,6 +144,100 @@ func TestHandleSystemDF_BackendError(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSystemPrune_ParsesQueryParams(t *testing.T) {
+	be := &fakeBackend{
+		pruneReport: config.PruneReport{DryRun: true, ServerName: "x"},
+	}
+	srv := newSystemTestServer(be)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/system/prune?scope=images&scope=instances&dry_run=true&until=72h&log_tail_bytes=1024", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	opts := be.lastPruneOpts
+	if !opts.Images || !opts.Instances {
+		t.Errorf("scopes parsed as %+v, want Images+Instances", opts)
+	}
+	if opts.Logs || opts.Orphans {
+		t.Errorf("unexpected scope enabled: %+v", opts)
+	}
+	if !opts.DryRun {
+		t.Errorf("DryRun should be true")
+	}
+	if opts.Until != 72*time.Hour {
+		t.Errorf("Until = %v, want 72h", opts.Until)
+	}
+	if opts.LogTailBytes != 1024 {
+		t.Errorf("LogTailBytes = %d, want 1024", opts.LogTailBytes)
+	}
+}
+
+func TestHandleSystemPrune_UnknownScope(t *testing.T) {
+	be := &fakeBackend{}
+	srv := newSystemTestServer(be)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/system/prune?scope=bogus", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", w.Code, w.Body.String())
+	}
+	if !jsonContains(w.Body.String(), "unknown scope") {
+		t.Errorf("expected 'unknown scope' in error body, got %s", w.Body.String())
+	}
+}
+
+func TestHandleSystemPrune_InvalidUntil(t *testing.T) {
+	be := &fakeBackend{}
+	srv := newSystemTestServer(be)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/system/prune?until=not-a-duration", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleSystemPrune_InvalidDryRun(t *testing.T) {
+	be := &fakeBackend{}
+	srv := newSystemTestServer(be)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/system/prune?dry_run=maybe", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleSystemPrune_EmptyScope(t *testing.T) {
+	// No scope flags — backend gets PruneOptions with all flags false and
+	// applies its own defaults.
+	be := &fakeBackend{
+		pruneReport: config.PruneReport{ServerName: "x"},
+	}
+	srv := newSystemTestServer(be)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/system/prune", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	opts := be.lastPruneOpts
+	if opts.Images || opts.Instances || opts.Logs || opts.Orphans {
+		t.Errorf("expected all scope flags false (server applies defaults), got %+v", opts)
 	}
 }
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -87,4 +87,12 @@ type Backend interface {
 	// PruneImages removes cached images not referenced by config or existing sheds.
 	// If dryRun is true, returns candidates without deleting.
 	PruneImages(ctx context.Context, dryRun bool) ([]config.ImageInfo, error)
+
+	// System
+
+	// DiskUsage returns disk-usage information for everything this backend
+	// manages on the local server: image cache, per-instance rootfs copies,
+	// console logs, kernel/initrd, and orphan sidecar files. Client-side
+	// state under ~/.shed/ is out of scope.
+	DiskUsage(ctx context.Context) (config.DiskUsage, error)
 }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -95,4 +95,9 @@ type Backend interface {
 	// console logs, kernel/initrd, and orphan sidecar files. Client-side
 	// state under ~/.shed/ is out of scope.
 	DiskUsage(ctx context.Context) (config.DiskUsage, error)
+
+	// Prune removes items selected by opts. DryRun returns the report
+	// without mutating. Age-based instance pruning uses mtime(metadata.json)
+	// as the "last touched" proxy — see opts.Until.
+	Prune(ctx context.Context, opts PruneOptions) (config.PruneReport, error)
 }

--- a/internal/backend/types.go
+++ b/internal/backend/types.go
@@ -1,7 +1,33 @@
 // Package backend provides the abstraction layer for different execution backends.
 package backend
 
-import "io"
+import (
+	"io"
+	"time"
+)
+
+// PruneOptions controls Backend.Prune. If all scope flags are false,
+// the caller should treat it as the default scope (images + instances +
+// orphans). `Logs` is opt-in and never part of the default.
+type PruneOptions struct {
+	// Scope selectors (additive; callers may enable any combination).
+	Images    bool
+	Instances bool
+	Logs      bool
+	Orphans   bool
+
+	// DryRun returns candidates without mutating anything.
+	DryRun bool
+
+	// Until filters stopped instances by mtime(metadata.json): only prune
+	// instances whose mtime is older than now - Until. Zero means "any age"
+	// (prune every stopped instance).
+	Until time.Duration
+
+	// LogTailBytes is the size console.log is truncated to when Logs is true.
+	// Zero uses the backend default (5 MiB).
+	LogTailBytes int64
+}
 
 // ExecOptions contains options for executing a command in a shed.
 type ExecOptions struct {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -270,6 +270,66 @@ type SystemDFResponse struct {
 	Servers []DiskUsageOrError `json:"servers"`
 }
 
+// PrunedItem describes one file or object removed (or proposed for removal)
+// by `shed system prune`.
+type PrunedItem struct {
+	// Kind is one of: "image" | "rootfs" | "console_log" | "metadata" |
+	// "instance" | "lock" | "tmp" | "source".
+	Kind string `json:"kind"`
+	Path string `json:"path,omitempty"`
+	// Name is the shed or image name when applicable.
+	Name string `json:"name,omitempty"`
+	// Action is "deleted" or "truncated".
+	Action string `json:"action"`
+	// Freed is the bytes attributed to this item. For clones or hardlinks
+	// the physical count reflects attribution, not necessarily reclamation —
+	// see PruneReport.Notes.
+	Freed DiskSize `json:"freed"`
+	// Reason is a human-readable justification (e.g. "stopped 5d ago").
+	Reason string `json:"reason,omitempty"`
+}
+
+// SkippedItem is an entity the prune pass inspected but left alone, with a
+// short reason. Examples: running shed; stopped but too recent; lock held
+// by an in-flight conversion; malformed metadata.
+type SkippedItem struct {
+	Kind   string `json:"kind"`
+	Name   string `json:"name,omitempty"`
+	Path   string `json:"path,omitempty"`
+	Reason string `json:"reason"`
+}
+
+// PruneReportTotals summarizes what the prune pass did (or would do).
+type PruneReportTotals struct {
+	Freed DiskSize `json:"freed"`
+	Items int      `json:"items"`
+}
+
+// PruneReport is the payload returned by POST /api/system/prune.
+type PruneReport struct {
+	DryRun     bool              `json:"dry_run"`
+	ServerName string            `json:"server_name"`
+	Scope      []string          `json:"scope"`
+	Until      string            `json:"until"`
+	Items      []PrunedItem      `json:"items"`
+	Skipped    []SkippedItem     `json:"skipped,omitempty"`
+	Notes      []string          `json:"notes,omitempty"`
+	Totals     PruneReportTotals `json:"totals"`
+}
+
+// PruneReportOrError is one entry in a multi-server aggregated response.
+type PruneReportOrError struct {
+	ServerName string       `json:"server_name"`
+	Report     *PruneReport `json:"report,omitempty"`
+	Error      string       `json:"error,omitempty"`
+}
+
+// SystemPruneResponse is the client-side aggregation of per-server prune
+// results from `shed system prune --all`. Never returned by the API directly.
+type SystemPruneResponse struct {
+	Servers []PruneReportOrError `json:"servers"`
+}
+
 // CreateShedRequest is the request body for POST /api/sheds.
 type CreateShedRequest struct {
 	Name        string `json:"name"`

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -186,6 +186,90 @@ type PruneImagesResponse struct {
 	Deleted []ImageInfo `json:"deleted"`
 }
 
+// DiskSize captures both apparent (logical) and allocated (physical) bytes.
+// PhysicalBytes comes from stat.Blocks * 512. On APFS and other reflink-capable
+// filesystems, a file's st_blocks counts cloned-but-unmodified extents against
+// every referencing file, so summing PhysicalBytes across files that share
+// extents (via clonefile, FICLONE, or hardlinks) overcounts the actual on-disk
+// usage. This is accepted for v1 and surfaced in DiskUsage.Notes.
+type DiskSize struct {
+	LogicalBytes  int64 `json:"logical_bytes"`
+	PhysicalBytes int64 `json:"physical_bytes"`
+}
+
+// FileEntry describes a single file with its size and classification.
+type FileEntry struct {
+	Path string   `json:"path"`
+	Size DiskSize `json:"size"`
+	// Kind is one of: "rootfs" | "console_log" | "kernel" | "initrd" |
+	// "lock" | "tmp" | "source" | "metadata".
+	Kind string `json:"kind,omitempty"`
+}
+
+// ImageDiskEntry is the df view of a cached image variant, carrying both
+// logical and physical bytes. Kept separate from ImageInfo so /api/images
+// wire format stays stable.
+type ImageDiskEntry struct {
+	Name      string   `json:"name"`
+	Path      string   `json:"path"`
+	DockerRef string   `json:"docker_ref,omitempty"`
+	Size      DiskSize `json:"size"`
+	// IsBase is true for the _base-rootfs.ext4 cache entry.
+	IsBase bool `json:"is_base,omitempty"`
+}
+
+// ShedDiskEntry describes one shed's per-instance disk footprint.
+type ShedDiskEntry struct {
+	Name       string      `json:"name"`
+	Status     string      `json:"status"`
+	Image      string      `json:"image,omitempty"`
+	Rootfs     FileEntry   `json:"rootfs"`
+	ConsoleLog *FileEntry  `json:"console_log,omitempty"` // nil for Firecracker
+	OtherFiles []FileEntry `json:"other_files,omitempty"`
+	Total      DiskSize    `json:"total"`
+}
+
+// DiskUsageTotals aggregates bytes across df sections.
+type DiskUsageTotals struct {
+	Images  DiskSize `json:"images"` // includes kernel + initrd
+	Sheds   DiskSize `json:"sheds"`
+	Orphans DiskSize `json:"orphans"`
+	All     DiskSize `json:"all"`
+}
+
+// DiskUsage is the payload returned by GET /api/system/df.
+type DiskUsage struct {
+	ServerName  string    `json:"server_name"`
+	Backend     string    `json:"backend"` // "vz" | "firecracker" | "none"
+	GeneratedAt time.Time `json:"generated_at"`
+
+	Images []ImageDiskEntry `json:"images"`
+	Kernel *FileEntry       `json:"kernel,omitempty"`
+	Initrd *FileEntry       `json:"initrd,omitempty"` // VZ only
+
+	Sheds   []ShedDiskEntry `json:"sheds"`
+	Orphans []FileEntry     `json:"orphans"`
+
+	Totals DiskUsageTotals `json:"totals"`
+
+	// Notes carries advisory caveats (APFS overcount, hardlink double-count, etc.).
+	Notes []string `json:"notes,omitempty"`
+}
+
+// DiskUsageOrError is one entry in a multi-server SystemDFResponse.
+// Exactly one of Usage or Error is populated.
+type DiskUsageOrError struct {
+	ServerName string     `json:"server_name"`
+	Usage      *DiskUsage `json:"usage,omitempty"`
+	Error      string     `json:"error,omitempty"`
+}
+
+// SystemDFResponse is the client-side aggregation of per-server df results
+// produced by `shed system df --all`. Never returned by the API directly.
+type SystemDFResponse struct {
+	Servers []DiskUsageOrError `json:"servers"`
+}
+
 // CreateShedRequest is the request body for POST /api/sheds.
 type CreateShedRequest struct {
 	Name        string `json:"name"`

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -392,6 +392,7 @@ const (
 	ErrInvalidSessionName = "INVALID_SESSION_NAME"
 	ErrTmuxNotAvailable   = "TMUX_NOT_AVAILABLE"
 	ErrInvalidLocalDir    = "INVALID_LOCAL_DIR"
+	ErrInvalidRequest     = "INVALID_REQUEST"
 )
 
 // Backend type constants for Shed.Backend field.

--- a/internal/diskstat/diskstat.go
+++ b/internal/diskstat/diskstat.go
@@ -1,0 +1,41 @@
+// Package diskstat reports both logical (apparent) and physical (allocated)
+// byte counts for a single file. Physical bytes come from stat.Blocks * 512
+// (POSIX convention on darwin and linux alike).
+//
+// This package has no shed-internal dependencies; it must not import config
+// or backend. The rule mirrors vmimage's import-cycle constraint so diskstat
+// can be used by any package without creating a cycle.
+package diskstat
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// BlockSize is the POSIX block size for stat.Blocks accounting.
+// Both darwin and linux report st_blocks in 512-byte units regardless of
+// the filesystem's actual block size.
+const BlockSize = 512
+
+// Stat returns logical (apparent) and physical (allocated) bytes for path.
+// Follows symlinks. Logical bytes come from stat.Size; physical from
+// stat.Blocks * BlockSize.
+//
+// Returns an error if path does not exist or cannot be stat'd.
+func Stat(path string) (logical, physical int64, err error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, 0, fmt.Errorf("diskstat: %w", err)
+	}
+
+	logical = info.Size()
+
+	sys, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return logical, logical, errors.New("diskstat: Stat_t unavailable on this platform")
+	}
+	physical = int64(sys.Blocks) * BlockSize
+	return logical, physical, nil
+}

--- a/internal/diskstat/diskstat_test.go
+++ b/internal/diskstat/diskstat_test.go
@@ -1,0 +1,94 @@
+package diskstat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStat_DenseFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dense")
+
+	data := make([]byte, 64*1024) // 64 KB
+	for i := range data {
+		data[i] = byte(i)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	logical, physical, err := Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if logical != int64(len(data)) {
+		t.Errorf("logical = %d, want %d", logical, len(data))
+	}
+	// Physical should be >= logical for a dense file, allowing FS overhead.
+	if physical < logical {
+		t.Errorf("physical (%d) < logical (%d) for dense file", physical, logical)
+	}
+}
+
+func TestStat_SparseFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sparse")
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Create a 20 MiB sparse file with no actual data written.
+	// Some filesystems (e.g., ZFS-on-Linux, tmpfs) don't preserve sparseness
+	// via Truncate; skip the assertion if the kernel materialized it.
+	const sparseSize = 20 * 1024 * 1024
+	if err := f.Truncate(sparseSize); err != nil {
+		f.Close()
+		t.Fatalf("truncate: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	logical, physical, err := Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if logical != sparseSize {
+		t.Errorf("logical = %d, want %d", logical, sparseSize)
+	}
+	if physical >= logical {
+		t.Skipf("filesystem does not preserve sparseness (physical=%d, logical=%d)", physical, logical)
+	}
+}
+
+func TestStat_Missing(t *testing.T) {
+	_, _, err := Stat(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestStat_Symlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "link")
+
+	data := make([]byte, 8192)
+	if err := os.WriteFile(target, data, 0644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	// Stat follows symlinks — should report the target's size.
+	logical, _, err := Stat(link)
+	if err != nil {
+		t.Fatalf("Stat symlink: %v", err)
+	}
+	if logical != int64(len(data)) {
+		t.Errorf("logical via symlink = %d, want %d", logical, len(data))
+	}
+}

--- a/internal/firecracker/backend.go
+++ b/internal/firecracker/backend.go
@@ -204,3 +204,8 @@ func (b *FirecrackerBackend) PruneImages(_ context.Context, dryRun bool) ([]conf
 func (b *FirecrackerBackend) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 	return b.client.DiskUsage(ctx)
 }
+
+// Prune runs the disk cleanup pass. See backend.PruneOptions for semantics.
+func (b *FirecrackerBackend) Prune(ctx context.Context, opts backend.PruneOptions) (config.PruneReport, error) {
+	return b.client.Prune(ctx, opts)
+}

--- a/internal/firecracker/backend.go
+++ b/internal/firecracker/backend.go
@@ -199,3 +199,8 @@ func (b *FirecrackerBackend) DeleteImage(_ context.Context, name string) error {
 func (b *FirecrackerBackend) PruneImages(_ context.Context, dryRun bool) ([]config.ImageInfo, error) {
 	return b.client.PruneImages(dryRun)
 }
+
+// DiskUsage returns disk-usage information for the Firecracker server.
+func (b *FirecrackerBackend) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
+	return b.client.DiskUsage(ctx)
+}

--- a/internal/firecracker/image.go
+++ b/internal/firecracker/image.go
@@ -40,12 +40,23 @@ func (c *Client) PruneImages(dryRun bool) ([]config.ImageInfo, error) {
 
 // inUseImageNames returns image names referenced by existing Firecracker instances.
 func (c *Client) inUseImageNames() ([]string, error) {
+	return c.inUseImageNamesExcept(nil)
+}
+
+// inUseImageNamesExcept returns image names referenced by existing
+// Firecracker instances whose names are NOT in skipSheds. Used by Prune's
+// dry-run path to simulate the post-instance-delete state so image
+// candidates reflect the fleet after instance deletions.
+func (c *Client) inUseImageNamesExcept(skipSheds map[string]bool) ([]string, error) {
 	instances, err := ListInstances(c.cfg.InstanceDir)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("listing instances: %w", err)
 	}
 	var names []string
 	for _, inst := range instances {
+		if skipSheds[inst] {
+			continue
+		}
 		meta, err := LoadMetadata(c.cfg.InstanceDir, inst)
 		if err != nil {
 			return nil, fmt.Errorf("reading metadata for %s: %w", inst, err)

--- a/internal/firecracker/image.go
+++ b/internal/firecracker/image.go
@@ -5,6 +5,7 @@ package firecracker
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/charliek/shed/internal/config"
@@ -45,8 +46,13 @@ func (c *Client) inUseImageNames() ([]string, error) {
 
 // inUseImageNamesExcept returns image names referenced by existing
 // Firecracker instances whose names are NOT in skipSheds. Used by Prune's
-// dry-run path to simulate the post-instance-delete state so image
-// candidates reflect the fleet after instance deletions.
+// dry-run path to simulate the post-instance-delete state.
+//
+// Malformed metadata on a single instance is skip-and-warn rather than a
+// hard failure — matches ListSheds and keeps the prune path operable when
+// one shed's metadata got corrupted. The closure still returns only the
+// image references we could verify, so Manager.PruneImages' fail-closed
+// protection on the names it receives is intact.
 func (c *Client) inUseImageNamesExcept(skipSheds map[string]bool) ([]string, error) {
 	instances, err := ListInstances(c.cfg.InstanceDir)
 	if err != nil && !os.IsNotExist(err) {
@@ -59,7 +65,8 @@ func (c *Client) inUseImageNamesExcept(skipSheds map[string]bool) ([]string, err
 		}
 		meta, err := LoadMetadata(c.cfg.InstanceDir, inst)
 		if err != nil {
-			return nil, fmt.Errorf("reading metadata for %s: %w", inst, err)
+			log.Printf("Warning: inUseImageNames: skipping instance %q with invalid metadata: %v", inst, err)
+			continue
 		}
 		if meta.Image != "" {
 			names = append(names, meta.Image)

--- a/internal/firecracker/image.go
+++ b/internal/firecracker/image.go
@@ -5,7 +5,6 @@ package firecracker
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/charliek/shed/internal/config"
@@ -65,8 +64,13 @@ func (c *Client) inUseImageNamesExcept(skipSheds map[string]bool) ([]string, err
 		}
 		meta, err := LoadMetadata(c.cfg.InstanceDir, inst)
 		if err != nil {
-			log.Printf("Warning: inUseImageNames: skipping instance %q with invalid metadata: %v", inst, err)
-			continue
+			// Only tolerate the list-then-load race; all other errors
+			// (malformed JSON, I/O failure) must fail closed so we don't
+			// accidentally mark a still-referenced image as unused.
+			if errors.Is(err, ErrInstanceNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("reading metadata for %s: %w", inst, err)
 		}
 		if meta.Image != "" {
 			names = append(names, meta.Image)

--- a/internal/firecracker/rootfs.go
+++ b/internal/firecracker/rootfs.go
@@ -5,9 +5,11 @@ package firecracker
 
 import (
 	"fmt"
-	"io"
+	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/charliek/shed/internal/vmimage/clone"
 )
 
 // RootfsPath returns the path to the rootfs image for an instance.
@@ -15,40 +17,42 @@ func RootfsPath(instanceDir, name string) string {
 	return filepath.Join(instanceDir, name, "rootfs.ext4")
 }
 
-// CopyRootfs copies the base rootfs image to the instance directory.
+// CopyRootfs copies the base rootfs image to the instance directory,
+// preferring FICLONE (reflink) then copy_file_range and falling back to
+// io.Copy on older kernels or non-reflink filesystems. See the clone
+// package for strategy precedence.
+//
+// Both FICLONE and copy_file_range require dst to not already exist;
+// pre-clean any stale dst before invoking the chain.
 func CopyRootfs(baseRootfs, instanceDir, name string) (string, error) {
 	dst := RootfsPath(instanceDir, name)
 
-	// Ensure instance directory exists
 	dir := InstanceDir(instanceDir, name)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create instance directory: %w", err)
 	}
 
-	// Open source file
-	src, err := os.Open(baseRootfs)
-	if err != nil {
-		return "", fmt.Errorf("failed to open base rootfs: %w", err)
+	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("failed to clean stale rootfs: %w", err)
 	}
-	defer src.Close()
 
-	// Create destination file
-	dstFile, err := os.Create(dst)
+	strategy, err := clone.CloneFile(baseRootfs, dst)
 	if err != nil {
-		return "", fmt.Errorf("failed to create rootfs copy: %w", err)
-	}
-	defer dstFile.Close()
-
-	// Copy contents
-	if _, err := io.Copy(dstFile, src); err != nil {
-		os.Remove(dst) // Clean up on failure
+		_ = os.Remove(dst)
 		return "", fmt.Errorf("failed to copy rootfs: %w", err)
 	}
 
-	// Sync to ensure data is written
-	if err := dstFile.Sync(); err != nil {
-		os.Remove(dst)
-		return "", fmt.Errorf("failed to sync rootfs: %w", err)
+	var logical int64
+	if fi, statErr := os.Stat(dst); statErr == nil {
+		logical = fi.Size()
+	}
+	log.Printf("rootfs strategy=%s src=%s dst=%s logical_bytes=%d", strategy, baseRootfs, dst, logical)
+
+	// Sync on every path so crash recovery semantics stay uniform.
+	f, err := os.OpenFile(dst, os.O_RDWR, 0)
+	if err == nil {
+		_ = f.Sync()
+		f.Close()
 	}
 
 	return dst, nil

--- a/internal/firecracker/rootfs.go
+++ b/internal/firecracker/rootfs.go
@@ -38,6 +38,9 @@ func CopyRootfs(baseRootfs, instanceDir, name string) (string, error) {
 	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
 		return "", fmt.Errorf("failed to clean stale rootfs: %w", err)
 	}
+	if err := syncDir(dir); err != nil {
+		return "", fmt.Errorf("failed to sync instance directory after cleanup: %w", err)
+	}
 
 	strategy, err := clone.CloneFile(baseRootfs, dst)
 	if err != nil {
@@ -68,8 +71,23 @@ func CopyRootfs(baseRootfs, instanceDir, name string) (string, error) {
 		_ = os.Remove(dst)
 		return "", fmt.Errorf("failed to close rootfs after sync: %w", closeErr)
 	}
+	if err := syncDir(dir); err != nil {
+		_ = os.Remove(dst)
+		return "", fmt.Errorf("failed to sync instance directory: %w", err)
+	}
 
 	return dst, nil
+}
+
+// syncDir fsyncs a directory so pending create/unlink metadata is on
+// stable storage. See the matching helper in internal/vz/rootfs.go.
+func syncDir(path string) error {
+	d, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
 }
 
 // DeleteRootfs removes the rootfs image for an instance.

--- a/internal/firecracker/rootfs.go
+++ b/internal/firecracker/rootfs.go
@@ -24,6 +24,9 @@ func RootfsPath(instanceDir, name string) string {
 //
 // Both FICLONE and copy_file_range require dst to not already exist;
 // pre-clean any stale dst before invoking the chain.
+//
+// CONCURRENCY: single-writer-per-shed-name is assumed. See the matching
+// comment in internal/vz/rootfs.go for details on the TOCTOU window.
 func CopyRootfs(baseRootfs, instanceDir, name string) (string, error) {
 	dst := RootfsPath(instanceDir, name)
 
@@ -48,11 +51,22 @@ func CopyRootfs(baseRootfs, instanceDir, name string) (string, error) {
 	}
 	log.Printf("rootfs strategy=%s src=%s dst=%s logical_bytes=%d", strategy, baseRootfs, dst, logical)
 
-	// Sync on every path so crash recovery semantics stay uniform.
+	// Sync on every path so crash recovery semantics stay uniform, and
+	// surface delayed-writeback errors (ENOSPC, EIO) rather than silently
+	// booting a VM on broken storage.
 	f, err := os.OpenFile(dst, os.O_RDWR, 0)
-	if err == nil {
-		_ = f.Sync()
+	if err != nil {
+		_ = os.Remove(dst)
+		return "", fmt.Errorf("failed to reopen rootfs for sync: %w", err)
+	}
+	if syncErr := f.Sync(); syncErr != nil {
 		f.Close()
+		_ = os.Remove(dst)
+		return "", fmt.Errorf("failed to sync rootfs: %w", syncErr)
+	}
+	if closeErr := f.Close(); closeErr != nil {
+		_ = os.Remove(dst)
+		return "", fmt.Errorf("failed to close rootfs after sync: %w", closeErr)
 	}
 
 	return dst, nil

--- a/internal/firecracker/stub_nonlinux.go
+++ b/internal/firecracker/stub_nonlinux.go
@@ -116,3 +116,10 @@ func (b *FirecrackerBackend) DeleteImage(_ context.Context, _ string) error {
 func (b *FirecrackerBackend) PruneImages(_ context.Context, _ bool) ([]config.ImageInfo, error) {
 	return nil, nil
 }
+
+// DiskUsage returns an empty disk-usage report on non-linux platforms.
+// Read-only system queries never error on a non-native backend — they just
+// report "no local state," matching the ListImages precedent.
+func (b *FirecrackerBackend) DiskUsage(_ context.Context) (config.DiskUsage, error) {
+	return config.DiskUsage{Backend: "none"}, nil
+}

--- a/internal/firecracker/stub_nonlinux.go
+++ b/internal/firecracker/stub_nonlinux.go
@@ -123,3 +123,8 @@ func (b *FirecrackerBackend) PruneImages(_ context.Context, _ bool) ([]config.Im
 func (b *FirecrackerBackend) DiskUsage(_ context.Context) (config.DiskUsage, error) {
 	return config.DiskUsage{Backend: "none"}, nil
 }
+
+// Prune is a mutating operation; the non-native stub returns the sentinel.
+func (b *FirecrackerBackend) Prune(_ context.Context, _ backend.PruneOptions) (config.PruneReport, error) {
+	return config.PruneReport{}, fmt.Errorf("prune: %w", config.ErrNotSupportedSentinel)
+}

--- a/internal/firecracker/system.go
+++ b/internal/firecracker/system.go
@@ -1,0 +1,236 @@
+//go:build linux
+// +build linux
+
+package firecracker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/diskstat"
+	"github.com/charliek/shed/internal/vmimage"
+)
+
+// DiskUsage returns disk-usage information for everything the Firecracker
+// backend manages on the local server: image cache, per-instance rootfs
+// copies, kernel, and orphan sidecar files.
+//
+// Firecracker does not produce a per-instance console log (the SDK writes
+// logs to stderr), so ShedDiskEntry.ConsoleLog is always nil for FC sheds.
+func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
+	du := config.DiskUsage{
+		ServerName:  c.serverCfg.Name,
+		Backend:     "firecracker",
+		GeneratedAt: time.Now().UTC(),
+		Images:      []config.ImageDiskEntry{},
+		Sheds:       []config.ShedDiskEntry{},
+		Orphans:     []config.FileEntry{},
+	}
+
+	imagesDir := c.cfg.ImagesDir
+	if imagesDir != "" {
+		imgs, err := c.ListImages()
+		if err != nil {
+			return du, fmt.Errorf("listing images: %w", err)
+		}
+		for _, img := range imgs {
+			if !img.Cached || img.Path == "" {
+				continue
+			}
+			entry := config.ImageDiskEntry{
+				Name:      img.Name,
+				Path:      img.Path,
+				DockerRef: img.DockerRef,
+			}
+			entry.Size.LogicalBytes, entry.Size.PhysicalBytes, _ = diskstat.Stat(img.Path)
+			du.Images = append(du.Images, entry)
+		}
+
+		// _base is skipped by ListImages by design; stat it directly.
+		basePath := filepath.Join(imagesDir, vmimage.RootfsFilename("_base"))
+		if logical, physical, err := diskstat.Stat(basePath); err == nil {
+			baseRef := ""
+			if vmimage.IsDockerRef(c.cfg.BaseRootfs) {
+				baseRef = c.cfg.BaseRootfs
+			}
+			du.Images = append(du.Images, config.ImageDiskEntry{
+				Name:      "_base",
+				Path:      basePath,
+				DockerRef: baseRef,
+				Size:      config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
+				IsBase:    true,
+			})
+		}
+
+		orphans, err := findOrphans(imagesDir)
+		if err != nil {
+			return du, fmt.Errorf("scanning orphans: %w", err)
+		}
+		du.Orphans = orphans
+	}
+
+	// Kernel only — Firecracker has no initrd.
+	if c.cfg.KernelPath != "" {
+		if logical, physical, err := diskstat.Stat(c.cfg.KernelPath); err == nil {
+			du.Kernel = &config.FileEntry{
+				Path: c.cfg.KernelPath,
+				Size: config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
+				Kind: "kernel",
+			}
+		}
+	}
+
+	instanceDir := c.cfg.InstanceDir
+	if instanceDir != "" {
+		names, err := ListInstances(instanceDir)
+		if err != nil {
+			return du, fmt.Errorf("listing instances: %w", err)
+		}
+		for _, name := range names {
+			meta, err := LoadMetadata(instanceDir, name)
+			if err != nil {
+				continue
+			}
+			du.Sheds = append(du.Sheds, shedDiskEntryForFC(instanceDir, meta))
+		}
+	}
+
+	for _, img := range du.Images {
+		du.Totals.Images.LogicalBytes += img.Size.LogicalBytes
+		du.Totals.Images.PhysicalBytes += img.Size.PhysicalBytes
+	}
+	if du.Kernel != nil {
+		du.Totals.Images.LogicalBytes += du.Kernel.Size.LogicalBytes
+		du.Totals.Images.PhysicalBytes += du.Kernel.Size.PhysicalBytes
+	}
+	for _, shed := range du.Sheds {
+		du.Totals.Sheds.LogicalBytes += shed.Total.LogicalBytes
+		du.Totals.Sheds.PhysicalBytes += shed.Total.PhysicalBytes
+	}
+	for _, orph := range du.Orphans {
+		du.Totals.Orphans.LogicalBytes += orph.Size.LogicalBytes
+		du.Totals.Orphans.PhysicalBytes += orph.Size.PhysicalBytes
+	}
+	du.Totals.All.LogicalBytes = du.Totals.Images.LogicalBytes + du.Totals.Sheds.LogicalBytes + du.Totals.Orphans.LogicalBytes
+	du.Totals.All.PhysicalBytes = du.Totals.Images.PhysicalBytes + du.Totals.Sheds.PhysicalBytes + du.Totals.Orphans.PhysicalBytes
+
+	du.Notes = append(du.Notes,
+		"physical bytes may overcount shared extents (reflink clones, hardlinks)",
+	)
+
+	return du, nil
+}
+
+// shedDiskEntryForFC builds a ShedDiskEntry for a single Firecracker instance.
+// No ConsoleLog (FC writes to stderr, not a per-instance file).
+func shedDiskEntryForFC(instanceDir string, meta *Metadata) config.ShedDiskEntry {
+	entry := config.ShedDiskEntry{
+		Name:   meta.Name,
+		Status: meta.Status,
+		Image:  meta.Image,
+	}
+
+	rootfsPath := RootfsPath(instanceDir, meta.Name)
+	rootfsLogical, rootfsPhysical, _ := diskstat.Stat(rootfsPath)
+	entry.Rootfs = config.FileEntry{
+		Path: rootfsPath,
+		Size: config.DiskSize{LogicalBytes: rootfsLogical, PhysicalBytes: rootfsPhysical},
+		Kind: "rootfs",
+	}
+
+	metaPath := MetadataPath(instanceDir, meta.Name)
+	if logical, physical, err := diskstat.Stat(metaPath); err == nil {
+		entry.OtherFiles = append(entry.OtherFiles, config.FileEntry{
+			Path: metaPath,
+			Size: config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
+			Kind: "metadata",
+		})
+	}
+
+	entry.Total.LogicalBytes = entry.Rootfs.Size.LogicalBytes
+	entry.Total.PhysicalBytes = entry.Rootfs.Size.PhysicalBytes
+	for _, f := range entry.OtherFiles {
+		entry.Total.LogicalBytes += f.Size.LogicalBytes
+		entry.Total.PhysicalBytes += f.Size.PhysicalBytes
+	}
+
+	return entry
+}
+
+// findOrphans scans imagesDir for sidecar files (`.lock`, `.tmp*`, `.source`)
+// whose corresponding `{name}-rootfs.ext4` does not exist. Phase 1 reports;
+// Phase 2 adds flock + age checks before acting.
+func findOrphans(imagesDir string) ([]config.FileEntry, error) {
+	entries, err := os.ReadDir(imagesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	presentRootfs := make(map[string]bool)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(e.Name(), "-rootfs.ext4") {
+			presentRootfs[e.Name()] = true
+		}
+	}
+
+	var orphans []config.FileEntry
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		base, kind := classifySidecar(name)
+		if base == "" {
+			continue
+		}
+		if presentRootfs[base] {
+			continue
+		}
+		path := filepath.Join(imagesDir, name)
+		logical, physical, err := diskstat.Stat(path)
+		if err != nil {
+			continue
+		}
+		orphans = append(orphans, config.FileEntry{
+			Path: path,
+			Size: config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
+			Kind: kind,
+		})
+	}
+	return orphans, nil
+}
+
+// classifySidecar returns the parent rootfs filename and sidecar kind for a
+// filename, or ("", "") if the filename isn't a known sidecar.
+func classifySidecar(filename string) (baseRootfs, kind string) {
+	const suffix = "-rootfs.ext4"
+	idx := strings.Index(filename, suffix)
+	if idx < 0 {
+		return "", ""
+	}
+	after := filename[idx+len(suffix):]
+	if after == "" {
+		return "", ""
+	}
+	if after == ".lock" {
+		return filename[:idx+len(suffix)], "lock"
+	}
+	if after == ".source" {
+		return filename[:idx+len(suffix)], "source"
+	}
+	if after == ".tmp" || strings.HasPrefix(after, ".tmp.") {
+		return filename[:idx+len(suffix)], "tmp"
+	}
+	return "", ""
+}

--- a/internal/firecracker/system.go
+++ b/internal/firecracker/system.go
@@ -5,16 +5,26 @@ package firecracker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/diskstat"
 	"github.com/charliek/shed/internal/vmimage"
 )
+
+// Default tail size for log truncation (FC currently has no console.log,
+// so this exists only for future parity).
+const defaultLogTailBytes = 5 * 1024 * 1024
+
+// Skip very fresh .tmp files: a conversion writes to .tmp before rename,
+// so treating those as orphans would race.
+const tmpOrphanMinAge = time.Hour
 
 // DiskUsage returns disk-usage information for everything the Firecracker
 // backend manages on the local server: image cache, per-instance rootfs
@@ -233,4 +243,396 @@ func classifySidecar(filename string) (baseRootfs, kind string) {
 		return filename[:idx+len(suffix)], "tmp"
 	}
 	return "", ""
+}
+
+// Prune removes items selected by opts. See backend.PruneOptions for flag
+// semantics. Mirrors the VZ implementation except:
+//   - No console.log handling (FC has no per-instance console log).
+//   - DeleteShed also frees TAP devices and unregisters CID/IP.
+func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.PruneReport, error) {
+	opts = normalizePruneOptions(opts)
+
+	report := config.PruneReport{
+		DryRun:     opts.DryRun,
+		ServerName: c.serverCfg.Name,
+		Scope:      scopeFlags(opts),
+		Until:      opts.Until.String(),
+		Items:      []config.PrunedItem{},
+		Skipped:    []config.SkippedItem{},
+	}
+
+	mtimes := snapshotMetadataMtimes(c.cfg.InstanceDir)
+
+	var instanceCandidates []instanceCandidate
+	if opts.Instances {
+		cands, skipped, err := c.collectInstanceCandidates(ctx, mtimes, opts.Until)
+		if err != nil {
+			return report, err
+		}
+		instanceCandidates = cands
+		report.Skipped = append(report.Skipped, skipped...)
+	}
+
+	var orphanCandidates []orphanCandidate
+	if opts.Orphans {
+		cands, skipped := collectOrphanCandidates(c.cfg.ImagesDir)
+		orphanCandidates = cands
+		report.Skipped = append(report.Skipped, skipped...)
+	}
+
+	var imageCandidates []vmimage.ImageInfo
+	if opts.Images {
+		skipSet := make(map[string]bool, len(instanceCandidates))
+		for _, ic := range instanceCandidates {
+			skipSet[ic.name] = true
+		}
+		mgr := vmimage.NewManager(c.cfg)
+		cands, err := mgr.PruneImages(true, func() ([]string, error) {
+			return c.inUseImageNamesExcept(skipSet)
+		})
+		if err != nil {
+			return report, fmt.Errorf("dry-run image prune: %w", err)
+		}
+		imageCandidates = cands
+	}
+
+	for _, ic := range instanceCandidates {
+		report.Items = append(report.Items, ic.toPrunedItem(opts.DryRun))
+	}
+	for _, oc := range orphanCandidates {
+		report.Items = append(report.Items, oc.toPrunedItem(opts.DryRun))
+	}
+	for _, img := range imageCandidates {
+		report.Items = append(report.Items, imageToPrunedItem(img, opts.DryRun))
+	}
+
+	if opts.DryRun {
+		finalizeReport(&report)
+		return report, nil
+	}
+
+	report.Items = report.Items[:0]
+
+	for _, ic := range instanceCandidates {
+		if err := c.DeleteShed(ctx, ic.name, false); err != nil {
+			report.Skipped = append(report.Skipped, config.SkippedItem{
+				Kind: "instance", Name: ic.name,
+				Reason: fmt.Sprintf("delete failed: %v", err),
+			})
+			continue
+		}
+		report.Items = append(report.Items, ic.toPrunedItem(false))
+	}
+
+	if opts.Images {
+		mgr := vmimage.NewManager(c.cfg)
+		deleted, err := mgr.PruneImages(false, c.inUseImageNames)
+		if err != nil {
+			return report, fmt.Errorf("image prune: %w", err)
+		}
+		for _, img := range deleted {
+			report.Items = append(report.Items, imageToPrunedItem(img, false))
+		}
+	}
+
+	if opts.Orphans {
+		for _, oc := range orphanCandidates {
+			if ok := sweepOrphan(c.cfg.ImagesDir, oc); !ok {
+				report.Skipped = append(report.Skipped, config.SkippedItem{
+					Kind: oc.kind, Path: oc.path,
+					Reason: "lock now held or removal failed",
+				})
+				continue
+			}
+			report.Items = append(report.Items, oc.toPrunedItem(false))
+		}
+	}
+
+	if opts.Logs {
+		// Firecracker has no per-instance console.log; record a no-op skip
+		// for every shed so JSON consumers see the explicit result.
+		names, _ := ListInstances(c.cfg.InstanceDir)
+		for _, name := range names {
+			report.Skipped = append(report.Skipped, config.SkippedItem{
+				Kind: "console_log", Name: name,
+				Reason: "firecracker does not write a per-instance console log",
+			})
+		}
+	}
+
+	finalizeReport(&report)
+	return report, nil
+}
+
+func normalizePruneOptions(opts backend.PruneOptions) backend.PruneOptions {
+	if !opts.Images && !opts.Instances && !opts.Logs && !opts.Orphans {
+		opts.Images = true
+		opts.Instances = true
+		opts.Orphans = true
+	}
+	if opts.LogTailBytes == 0 {
+		opts.LogTailBytes = defaultLogTailBytes
+	}
+	return opts
+}
+
+func scopeFlags(opts backend.PruneOptions) []string {
+	var scope []string
+	if opts.Images {
+		scope = append(scope, "images")
+	}
+	if opts.Instances {
+		scope = append(scope, "instances")
+	}
+	if opts.Logs {
+		scope = append(scope, "logs")
+	}
+	if opts.Orphans {
+		scope = append(scope, "orphans")
+	}
+	return scope
+}
+
+// snapshotMetadataMtimes must run BEFORE ListSheds (since ListSheds can
+// refresh metadata mtime on stale-running→stopped detection).
+func snapshotMetadataMtimes(instanceDir string) map[string]time.Time {
+	mtimes := make(map[string]time.Time)
+	names, err := ListInstances(instanceDir)
+	if err != nil {
+		return mtimes
+	}
+	for _, name := range names {
+		fi, err := os.Stat(MetadataPath(instanceDir, name))
+		if err != nil {
+			continue
+		}
+		mtimes[name] = fi.ModTime()
+	}
+	return mtimes
+}
+
+type instanceCandidate struct {
+	name  string
+	image string
+	age   time.Duration
+	size  config.DiskSize
+}
+
+func (ic instanceCandidate) toPrunedItem(dry bool) config.PrunedItem {
+	reason := fmt.Sprintf("stopped %s", humanDuration(ic.age))
+	if !dry {
+		reason = fmt.Sprintf("deleted (stopped %s)", humanDuration(ic.age))
+	}
+	return config.PrunedItem{
+		Kind: "instance", Name: ic.name, Action: "deleted",
+		Freed: ic.size, Reason: reason,
+	}
+}
+
+func (c *Client) collectInstanceCandidates(ctx context.Context, mtimes map[string]time.Time, until time.Duration) ([]instanceCandidate, []config.SkippedItem, error) {
+	sheds, err := c.ListSheds(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing sheds: %w", err)
+	}
+	var cands []instanceCandidate
+	var skipped []config.SkippedItem
+	now := time.Now()
+	for _, shed := range sheds {
+		if shed.Status != config.StatusStopped {
+			skipped = append(skipped, config.SkippedItem{
+				Kind: "instance", Name: shed.Name,
+				Reason: "cannot prune " + shed.Status + " shed",
+			})
+			continue
+		}
+		mtime, ok := mtimes[shed.Name]
+		if !ok {
+			continue
+		}
+		age := now.Sub(mtime)
+		if until > 0 && age < until {
+			skipped = append(skipped, config.SkippedItem{
+				Kind: "instance", Name: shed.Name,
+				Reason: fmt.Sprintf("too recent (%s < %s)", humanDuration(age), humanDuration(until)),
+			})
+			continue
+		}
+		cands = append(cands, instanceCandidate{
+			name:  shed.Name,
+			image: shed.Image,
+			age:   age,
+			size:  instanceSize(c.cfg.InstanceDir, shed.Name),
+		})
+	}
+	return cands, skipped, nil
+}
+
+func instanceSize(instanceDir, name string) config.DiskSize {
+	var size config.DiskSize
+	dir := InstanceDir(instanceDir, name)
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		logical, physical, err := diskstat.Stat(path)
+		if err == nil {
+			size.LogicalBytes += logical
+			size.PhysicalBytes += physical
+		}
+		return nil
+	})
+	return size
+}
+
+type orphanCandidate struct {
+	path string
+	kind string
+	size config.DiskSize
+}
+
+func (oc orphanCandidate) toPrunedItem(dry bool) config.PrunedItem {
+	reason := ""
+	if dry {
+		reason = "orphan (no matching rootfs)"
+	}
+	return config.PrunedItem{
+		Kind: oc.kind, Path: oc.path, Action: "deleted",
+		Freed: oc.size, Reason: reason,
+	}
+}
+
+func collectOrphanCandidates(imagesDir string) ([]orphanCandidate, []config.SkippedItem) {
+	var candidates []orphanCandidate
+	var skipped []config.SkippedItem
+
+	entries, err := os.ReadDir(imagesDir)
+	if err != nil {
+		return nil, nil
+	}
+
+	presentRootfs := make(map[string]bool)
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), "-rootfs.ext4") {
+			presentRootfs[e.Name()] = true
+		}
+	}
+
+	now := time.Now()
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		base, kind := classifySidecar(name)
+		if base == "" || presentRootfs[base] {
+			continue
+		}
+		path := filepath.Join(imagesDir, name)
+		fi, err := e.Info()
+		if err != nil {
+			continue
+		}
+
+		if kind == "tmp" && now.Sub(fi.ModTime()) < tmpOrphanMinAge {
+			skipped = append(skipped, config.SkippedItem{
+				Kind: kind, Path: path,
+				Reason: fmt.Sprintf("too recent (%s < %s)", humanDuration(now.Sub(fi.ModTime())), humanDuration(tmpOrphanMinAge)),
+			})
+			continue
+		}
+
+		lockPath := filepath.Join(imagesDir, base+".lock")
+		release, held, err := vmimage.TryAcquireFileLock(lockPath)
+		if err != nil {
+			skipped = append(skipped, config.SkippedItem{
+				Kind: kind, Path: path,
+				Reason: fmt.Sprintf("lock probe failed: %v", err),
+			})
+			continue
+		}
+		if !held {
+			skipped = append(skipped, config.SkippedItem{
+				Kind: kind, Path: path,
+				Reason: "lock held (conversion in progress)",
+			})
+			continue
+		}
+		release()
+
+		logical, physical, _ := diskstat.Stat(path)
+		candidates = append(candidates, orphanCandidate{
+			path: path, kind: kind,
+			size: config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
+		})
+	}
+	return candidates, skipped
+}
+
+func sweepOrphan(imagesDir string, oc orphanCandidate) bool {
+	base := filepath.Base(oc.path)
+	rootfsBase, _ := classifySidecar(base)
+	if rootfsBase == "" {
+		return false
+	}
+	lockPath := filepath.Join(imagesDir, rootfsBase+".lock")
+	release, held, err := vmimage.TryAcquireFileLock(lockPath)
+	if err != nil || !held {
+		return false
+	}
+	defer release()
+
+	if oc.kind == "lock" {
+		// Leave the canonical .lock in place; see VZ sweepOrphan.
+		return true
+	}
+
+	if err := os.Remove(oc.path); err != nil {
+		return errors.Is(err, os.ErrNotExist)
+	}
+	return true
+}
+
+func imageToPrunedItem(img vmimage.ImageInfo, dry bool) config.PrunedItem {
+	size := config.DiskSize{LogicalBytes: img.SizeBytes}
+	if img.Path != "" {
+		if logical, physical, err := diskstat.Stat(img.Path); err == nil {
+			size.LogicalBytes = logical
+			size.PhysicalBytes = physical
+		}
+	}
+	reason := ""
+	if dry {
+		reason = "unreferenced image"
+	}
+	return config.PrunedItem{
+		Kind: "image", Name: img.Name, Path: img.Path, Action: "deleted",
+		Freed: size, Reason: reason,
+	}
+}
+
+func finalizeReport(r *config.PruneReport) {
+	for _, item := range r.Items {
+		r.Totals.Freed.LogicalBytes += item.Freed.LogicalBytes
+		r.Totals.Freed.PhysicalBytes += item.Freed.PhysicalBytes
+	}
+	r.Totals.Items = len(r.Items)
+	r.Notes = append(r.Notes,
+		"physical bytes are attributed (stat.Blocks*512); clonefile/FICLONE clones and hardlinks may report bytes that won't actually be reclaimed",
+	)
+}
+
+func humanDuration(d time.Duration) string {
+	if d < 0 {
+		d = -d
+	}
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int64(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int64(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int64(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int64(d.Hours()/24))
+	}
 }

--- a/internal/firecracker/system.go
+++ b/internal/firecracker/system.go
@@ -261,6 +261,7 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 		Skipped:    []config.SkippedItem{},
 	}
 
+	// Step 1: snapshot mtimes BEFORE ListSheds.
 	mtimes := snapshotMetadataMtimes(c.cfg.InstanceDir)
 
 	var instanceCandidates []instanceCandidate
@@ -273,15 +274,16 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 		report.Skipped = append(report.Skipped, skipped...)
 	}
 
+	// Empty ImagesDir guard (Codex #7) — os.ReadDir("") reads CWD.
 	var orphanCandidates []orphanCandidate
-	if opts.Orphans {
+	if opts.Orphans && c.cfg.ImagesDir != "" {
 		cands, skipped := collectOrphanCandidates(c.cfg.ImagesDir)
 		orphanCandidates = cands
 		report.Skipped = append(report.Skipped, skipped...)
 	}
 
 	var imageCandidates []vmimage.ImageInfo
-	if opts.Images {
+	if opts.Images && c.cfg.ImagesDir != "" {
 		skipSet := make(map[string]bool, len(instanceCandidates))
 		for _, ic := range instanceCandidates {
 			skipSet[ic.name] = true
@@ -296,6 +298,19 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 		imageCandidates = cands
 	}
 
+	// FC has no per-instance console.log; collect the skip reasons as
+	// candidates-that-will-be-skipped so dry-run reflects the real result.
+	var logSkips []config.SkippedItem
+	if opts.Logs {
+		names, _ := ListInstances(c.cfg.InstanceDir)
+		for _, name := range names {
+			logSkips = append(logSkips, config.SkippedItem{
+				Kind: "console_log", Name: name,
+				Reason: "firecracker does not write a per-instance console log",
+			})
+		}
+	}
+
 	for _, ic := range instanceCandidates {
 		report.Items = append(report.Items, ic.toPrunedItem(opts.DryRun))
 	}
@@ -305,6 +320,7 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 	for _, img := range imageCandidates {
 		report.Items = append(report.Items, imageToPrunedItem(img, opts.DryRun))
 	}
+	report.Skipped = append(report.Skipped, logSkips...)
 
 	if opts.DryRun {
 		finalizeReport(&report)
@@ -324,10 +340,11 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 		report.Items = append(report.Items, ic.toPrunedItem(false))
 	}
 
-	if opts.Images {
+	if opts.Images && c.cfg.ImagesDir != "" {
 		mgr := vmimage.NewManager(c.cfg)
 		deleted, err := mgr.PruneImages(false, c.inUseImageNames)
 		if err != nil {
+			finalizeReport(&report)
 			return report, fmt.Errorf("image prune: %w", err)
 		}
 		for _, img := range deleted {
@@ -345,18 +362,6 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 				continue
 			}
 			report.Items = append(report.Items, oc.toPrunedItem(false))
-		}
-	}
-
-	if opts.Logs {
-		// Firecracker has no per-instance console.log; record a no-op skip
-		// for every shed so JSON consumers see the explicit result.
-		names, _ := ListInstances(c.cfg.InstanceDir)
-		for _, name := range names {
-			report.Skipped = append(report.Skipped, config.SkippedItem{
-				Kind: "console_log", Name: name,
-				Reason: "firecracker does not write a per-instance console log",
-			})
 		}
 	}
 
@@ -533,6 +538,15 @@ func collectOrphanCandidates(imagesDir string) ([]orphanCandidate, []config.Skip
 			continue
 		}
 
+		// .lock orphans: preserved, reported as skipped (Codex #4).
+		if kind == "lock" {
+			skipped = append(skipped, config.SkippedItem{
+				Kind: kind, Path: path,
+				Reason: "lock file retained (inode-reuse race safety)",
+			})
+			continue
+		}
+
 		if kind == "tmp" && now.Sub(fi.ModTime()) < tmpOrphanMinAge {
 			skipped = append(skipped, config.SkippedItem{
 				Kind: kind, Path: path,
@@ -580,12 +594,7 @@ func sweepOrphan(imagesDir string, oc orphanCandidate) bool {
 		return false
 	}
 	defer release()
-
-	if oc.kind == "lock" {
-		// Leave the canonical .lock in place; see VZ sweepOrphan.
-		return true
-	}
-
+	// `.lock` orphans are filtered upstream; oc.kind is "tmp" or "source".
 	if err := os.Remove(oc.path); err != nil {
 		return errors.Is(err, os.ErrNotExist)
 	}

--- a/internal/firecracker/system_test.go
+++ b/internal/firecracker/system_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/vmimage"
 )
@@ -64,6 +65,38 @@ func TestDiskUsage_Empty_FC(t *testing.T) {
 	}
 	if du.Initrd != nil {
 		t.Errorf("Initrd must be nil on Firecracker, got %v", du.Initrd)
+	}
+}
+
+func TestPrune_FC_LogsSkippedWithReason(t *testing.T) {
+	client, _, instanceDir := newSystemTestClient(t)
+
+	// A stopped shed — exists just so `--logs` has something to iterate.
+	meta := testMetadata("some-shed")
+	meta.Status = config.StatusStopped
+	if err := meta.Save(instanceDir); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := client.Prune(context.Background(), backend.PruneOptions{Logs: true})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	// FC should have NO truncated console logs in Items...
+	for _, it := range report.Items {
+		if it.Kind == "console_log" {
+			t.Errorf("FC prune produced console_log Item %+v; FC has no console.log", it)
+		}
+	}
+	// ...and should have a skipped entry explaining why.
+	found := false
+	for _, s := range report.Skipped {
+		if s.Kind == "console_log" && s.Name == "some-shed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected skipped console_log entry for some-shed, got %+v", report.Skipped)
 	}
 }
 

--- a/internal/firecracker/system_test.go
+++ b/internal/firecracker/system_test.go
@@ -1,0 +1,116 @@
+//go:build linux
+
+package firecracker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/vmimage"
+)
+
+func newSystemTestClient(t *testing.T) (*Client, string, string) {
+	t.Helper()
+	imagesDir := t.TempDir()
+	instanceDir := t.TempDir()
+
+	cfg := &config.FirecrackerConfig{
+		ImagesDir:   imagesDir,
+		InstanceDir: instanceDir,
+		Images:      map[string]string{},
+		BaseRootfs:  "ghcr.io/example/base:v1",
+	}
+	serverCfg := &config.ServerConfig{Name: "test-fc"}
+
+	client := &Client{cfg: cfg, serverCfg: serverCfg}
+	return client, imagesDir, instanceDir
+}
+
+func TestClassifySidecar(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantBase string
+		wantKind string
+	}{
+		{"default-rootfs.ext4.lock", "default-rootfs.ext4", "lock"},
+		{"default-rootfs.ext4.source", "default-rootfs.ext4", "source"},
+		{"default-rootfs.ext4.tmp", "default-rootfs.ext4", "tmp"},
+		{"default-rootfs.ext4.tmp.12345", "default-rootfs.ext4", "tmp"},
+		{"default-rootfs.ext4", "", ""},
+		{"random.txt", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			base, kind := classifySidecar(tt.in)
+			if base != tt.wantBase || kind != tt.wantKind {
+				t.Errorf("classifySidecar(%q) = (%q, %q), want (%q, %q)",
+					tt.in, base, kind, tt.wantBase, tt.wantKind)
+			}
+		})
+	}
+}
+
+func TestDiskUsage_Empty_FC(t *testing.T) {
+	client, _, _ := newSystemTestClient(t)
+	du, err := client.DiskUsage(context.Background())
+	if err != nil {
+		t.Fatalf("DiskUsage: %v", err)
+	}
+	if du.Backend != "firecracker" {
+		t.Errorf("Backend = %q, want firecracker", du.Backend)
+	}
+	if du.Initrd != nil {
+		t.Errorf("Initrd must be nil on Firecracker, got %v", du.Initrd)
+	}
+}
+
+func TestDiskUsage_Populated_FC(t *testing.T) {
+	client, imagesDir, instanceDir := newSystemTestClient(t)
+
+	// _base and a variant.
+	if err := os.WriteFile(filepath.Join(imagesDir, vmimage.RootfsFilename("_base")), make([]byte, 4096), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(imagesDir, vmimage.RootfsFilename("default")), make([]byte, 8192), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// One stopped shed with rootfs — but NO console.log (FC has no console log file).
+	meta := testMetadata("api-dev")
+	meta.Image = "default"
+	meta.Status = config.StatusStopped
+	if err := meta.Save(instanceDir); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(instanceDir, "api-dev")
+	if err := os.WriteFile(filepath.Join(dir, "rootfs.ext4"), make([]byte, 4096), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	du, err := client.DiskUsage(context.Background())
+	if err != nil {
+		t.Fatalf("DiskUsage: %v", err)
+	}
+
+	names := map[string]bool{}
+	for _, img := range du.Images {
+		names[img.Name] = true
+	}
+	if !names["_base"] || !names["default"] {
+		t.Errorf("expected both _base and default; got %+v", names)
+	}
+
+	if len(du.Sheds) != 1 {
+		t.Fatalf("expected 1 shed, got %d", len(du.Sheds))
+	}
+	if du.Sheds[0].ConsoleLog != nil {
+		t.Errorf("FC shed must NOT have ConsoleLog, got %v", du.Sheds[0].ConsoleLog)
+	}
+
+	if du.Initrd != nil {
+		t.Errorf("FC DiskUsage must not populate Initrd, got %v", du.Initrd)
+	}
+}

--- a/internal/vmimage/clone/clone.go
+++ b/internal/vmimage/clone/clone.go
@@ -1,0 +1,166 @@
+// Package clone implements the fast-path file-copy strategy chain used by
+// CopyRootfs. The chain prefers reflink/clonefile primitives that share
+// disk extents (near-instant, near-zero physical cost) and transparently
+// falls back to full byte-by-byte copies when those aren't supported.
+//
+// Strategy precedence:
+//
+//	darwin: Clonefile -> io.Copy
+//	linux:  FICLONE   -> copy_file_range -> io.Copy
+//	other:  io.Copy
+//
+// This package has no shed-internal dependencies by design. Like
+// internal/diskstat, it may be consumed by any backend without creating an
+// import cycle through config or vmimage's lifecycle code.
+package clone
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+)
+
+// Strategy identifies which primitive produced the copy. Operators can
+// grep the info log emitted by CopyRootfs to confirm reflink is active.
+type Strategy int
+
+const (
+	// StrategyUnknown is the zero value, meaning no strategy attempted.
+	StrategyUnknown Strategy = iota
+	// StrategyClonefile: darwin unix.Clonefile (APFS extent sharing).
+	StrategyClonefile
+	// StrategyFICLONE: linux ioctl_ficlone (btrfs/xfs/ext4 reflink).
+	StrategyFICLONE
+	// StrategyCopyFileRange: linux copy_file_range(2) — in-kernel bulk copy,
+	// no reflink but still avoids userspace buffer shuffling.
+	StrategyCopyFileRange
+	// StrategyIOCopy: universal fallback — reads the source through userspace.
+	StrategyIOCopy
+)
+
+// String returns a lowercase name suitable for log lines (e.g. "clonefile").
+func (s Strategy) String() string {
+	switch s {
+	case StrategyClonefile:
+		return "clonefile"
+	case StrategyFICLONE:
+		return "ficlone"
+	case StrategyCopyFileRange:
+		return "copy_file_range"
+	case StrategyIOCopy:
+		return "io_copy"
+	default:
+		return "unknown"
+	}
+}
+
+// errNotSupported is returned by platform-specific helpers when the
+// primitive is unavailable on this build target or filesystem. Callers
+// treat it as a cue to try the next strategy.
+var errNotSupported = errors.New("clone: strategy not supported")
+
+// errShortCopy is a cross-platform sentinel referenced by isFallback.
+// The linux build sets a real value via clone_linux.go's init; other
+// builds leave it as a never-matched sentinel so errors.Is returns false.
+var errShortCopy = errors.New("clone: copy_file_range returned EOF before source exhausted")
+
+// isFallback reports whether err is a "try the next strategy" signal.
+// Fallback triggers are filesystem / kernel signals meaning the primitive
+// isn't supported HERE (ENOTSUP, EOPNOTSUPP, EXDEV, EINVAL, ENOTTY,
+// ENOSYS, and our own errNotSupported/errShortCopy sentinels). Real
+// errors (EIO, ENOSPC, EACCES, EPERM) propagate unchanged.
+func isFallback(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errNotSupported) || errors.Is(err, errShortCopy) {
+		return true
+	}
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+	// ENOTSUP and EOPNOTSUPP are the same errno on linux (95); listing
+	// both in the switch would duplicate the case. Check separately.
+	if errno == syscall.ENOTSUP || errno == syscall.EOPNOTSUPP {
+		return true
+	}
+	switch errno {
+	case syscall.EXDEV, syscall.EINVAL, syscall.ENOTTY, syscall.ENOSYS:
+		return true
+	}
+	return false
+}
+
+// forceFallback, when set via the ForceFallback test helper, disables all
+// platform-specific primitives so CloneFile exercises the io.Copy path.
+// Lives in this file (not a _test.go) so production callers can't see it.
+var forceFallback bool
+
+// ForceFallback is a test hook that disables clonefile / FICLONE /
+// copy_file_range for the duration of the returned function's caller.
+// Callers should defer the returned restore func.
+func ForceFallback(enable bool) (restore func()) {
+	prev := forceFallback
+	forceFallback = enable
+	return func() { forceFallback = prev }
+}
+
+// CloneFile copies src to dst using the fastest strategy available.
+// dst MUST NOT exist — Clonefile fails with EEXIST otherwise, and the
+// higher-level shed create flow already cleans up stale instance rootfs
+// files before calling in.
+//
+// Returns the strategy that produced the copy so callers can log it.
+func CloneFile(src, dst string) (Strategy, error) {
+	if src == "" || dst == "" {
+		return StrategyUnknown, errors.New("clone: src and dst must be non-empty")
+	}
+
+	if !forceFallback {
+		if s, err := tryPlatformClone(src, dst); err == nil {
+			return s, nil
+		} else if !isFallback(err) {
+			return StrategyUnknown, err
+		}
+	}
+
+	if !forceFallback {
+		if s, err := tryCopyFileRange(src, dst); err == nil {
+			return s, nil
+		} else if !isFallback(err) {
+			return StrategyUnknown, err
+		}
+	}
+
+	if err := ioCopy(src, dst); err != nil {
+		return StrategyUnknown, err
+	}
+	return StrategyIOCopy, nil
+}
+
+// ioCopy is the universal fallback. Creates dst and streams src through
+// userspace. Preserves source mode (0644 on base rootfs) via os.Create's
+// umask-masked 0666 — identical to the pre-clone CopyRootfs behavior.
+func ioCopy(src, dst string) error {
+	sf, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer sf.Close()
+
+	// O_EXCL: dst must not already exist, same contract as Clonefile.
+	df, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("create dst: %w", err)
+	}
+	defer df.Close()
+
+	if _, err := io.Copy(df, sf); err != nil {
+		_ = os.Remove(dst)
+		return fmt.Errorf("copy: %w", err)
+	}
+	return nil
+}

--- a/internal/vmimage/clone/clone.go
+++ b/internal/vmimage/clone/clone.go
@@ -144,6 +144,11 @@ func CloneFile(src, dst string) (Strategy, error) {
 // ioCopy is the universal fallback. Creates dst and streams src through
 // userspace. Preserves source mode (0644 on base rootfs) via os.Create's
 // umask-masked 0666 — identical to the pre-clone CopyRootfs behavior.
+//
+// Close errors are explicitly propagated: io.Copy can succeed while a
+// deferred flush on Close fails (late ENOSPC is the classic case).
+// Returning success there would leave a truncated rootfs treated as
+// valid, so we close explicitly and unlink on failure.
 func ioCopy(src, dst string) error {
 	sf, err := os.Open(src)
 	if err != nil {
@@ -156,11 +161,15 @@ func ioCopy(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("create dst: %w", err)
 	}
-	defer df.Close()
 
 	if _, err := io.Copy(df, sf); err != nil {
+		df.Close()
 		_ = os.Remove(dst)
 		return fmt.Errorf("copy: %w", err)
+	}
+	if err := df.Close(); err != nil {
+		_ = os.Remove(dst)
+		return fmt.Errorf("close dst: %w", err)
 	}
 	return nil
 }

--- a/internal/vmimage/clone/clone_darwin.go
+++ b/internal/vmimage/clone/clone_darwin.go
@@ -1,0 +1,25 @@
+//go:build darwin
+
+package clone
+
+import "golang.org/x/sys/unix"
+
+// tryPlatformClone calls Clonefile(2). APFS always supports it; non-APFS
+// volumes (exFAT, NFS) return ENOTSUP, which isFallback recognizes as a
+// "try the next strategy" cue.
+//
+// Clonefile REQUIRES dst to not exist (returns EEXIST otherwise). The
+// higher-level CopyRootfs caller guarantees this via os.Remove-then-clone.
+func tryPlatformClone(src, dst string) (Strategy, error) {
+	if err := unix.Clonefile(src, dst, 0); err != nil {
+		return StrategyUnknown, err
+	}
+	return StrategyClonefile, nil
+}
+
+// tryCopyFileRange is a no-op on darwin; the io.Copy fallback follows
+// Clonefile when it isn't supported. macOS doesn't expose copy_file_range
+// and has no equivalent in-kernel bulk copy.
+func tryCopyFileRange(src, dst string) (Strategy, error) {
+	return StrategyUnknown, errNotSupported
+}

--- a/internal/vmimage/clone/clone_darwin_test.go
+++ b/internal/vmimage/clone/clone_darwin_test.go
@@ -1,0 +1,33 @@
+//go:build darwin
+
+package clone
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCloneFile_Darwin_IsClonefile asserts that on darwin/APFS (the only
+// supported VZ configuration) the native strategyegy is selected. This catches
+// regressions where the build tag drifts or unix.Clonefile moves behind a
+// newer errno we haven't folded into isFallback.
+func TestCloneFile_Darwin_IsClonefile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	if err := os.WriteFile(src, []byte("hello world"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	strategy, err := CloneFile(src, dst)
+	if err != nil {
+		// ENOTSUP from a non-APFS tmpfs-like FS is the one legitimate
+		// reason to skip; any other error is a real failure.
+		t.Skipf("CloneFile failed on darwin (non-APFS tmp dir?): %v", err)
+	}
+	if strategy != StrategyClonefile {
+		t.Errorf("strategyegy = %v, want StrategyClonefile (run on APFS)", strategy)
+	}
+}

--- a/internal/vmimage/clone/clone_darwin_test.go
+++ b/internal/vmimage/clone/clone_darwin_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TestCloneFile_Darwin_IsClonefile asserts that on darwin/APFS (the only
-// supported VZ configuration) the native strategyegy is selected. This catches
+// supported VZ configuration) the native strategy is selected. This catches
 // regressions where the build tag drifts or unix.Clonefile moves behind a
 // newer errno we haven't folded into isFallback.
 func TestCloneFile_Darwin_IsClonefile(t *testing.T) {
@@ -23,11 +23,15 @@ func TestCloneFile_Darwin_IsClonefile(t *testing.T) {
 
 	strategy, err := CloneFile(src, dst)
 	if err != nil {
-		// ENOTSUP from a non-APFS tmpfs-like FS is the one legitimate
-		// reason to skip; any other error is a real failure.
-		t.Skipf("CloneFile failed on darwin (non-APFS tmp dir?): %v", err)
+		// Only skip when the filesystem doesn't support clonefile —
+		// any other error is a real regression that should fail the
+		// test rather than be hidden by t.Skip.
+		if isFallback(err) {
+			t.Skipf("CloneFile fallback on darwin (non-APFS tmp dir?): %v", err)
+		}
+		t.Fatalf("CloneFile failed on darwin: %v", err)
 	}
 	if strategy != StrategyClonefile {
-		t.Errorf("strategyegy = %v, want StrategyClonefile (run on APFS)", strategy)
+		t.Errorf("strategy = %v, want StrategyClonefile (run on APFS)", strategy)
 	}
 }

--- a/internal/vmimage/clone/clone_linux.go
+++ b/internal/vmimage/clone/clone_linux.go
@@ -1,0 +1,99 @@
+//go:build linux
+
+package clone
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// tryPlatformClone attempts FICLONE on Linux. Requires a reflink-capable
+// filesystem (btrfs, xfs with reflink=1, ext4 on kernel 6.7+ with
+// reflink=1). Returns an errno the caller's isFallback recognizes when
+// the FS doesn't support it, so CloneFile drops through to
+// copy_file_range.
+//
+// Unlike Clonefile on darwin, FICLONE needs an already-open empty dst
+// fd — the kernel clones extents into an existing inode rather than
+// creating one. We honor the "dst must not exist" contract with O_EXCL.
+func tryPlatformClone(src, dst string) (Strategy, error) {
+	srcF, err := os.Open(src)
+	if err != nil {
+		return StrategyUnknown, err
+	}
+	defer srcF.Close()
+
+	dstF, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		return StrategyUnknown, err
+	}
+	// Argument order is (destFd, srcFd) — dst first. Easy to flip; keep
+	// this comment present as a landmark.
+	if err := unix.IoctlFileClone(int(dstF.Fd()), int(srcF.Fd())); err != nil {
+		dstF.Close()
+		_ = os.Remove(dst) // clean the half-built dst before the next strategy
+		return StrategyUnknown, err
+	}
+	if err := dstF.Close(); err != nil {
+		return StrategyUnknown, err
+	}
+	return StrategyFICLONE, nil
+}
+
+// tryCopyFileRange uses copy_file_range(2), Linux's in-kernel bulk copy.
+// Not reflink (data is physically copied), but faster than userspace
+// io.Copy because no buffer shuffling happens. Works across any local
+// filesystem on kernel 5.3+.
+//
+// The kernel may return fewer bytes than requested; loop until EOF
+// (n == 0 && err == nil) and advance by the actual n each iteration.
+func tryCopyFileRange(src, dst string) (Strategy, error) {
+	srcF, err := os.Open(src)
+	if err != nil {
+		return StrategyUnknown, err
+	}
+	defer srcF.Close()
+
+	srcInfo, err := srcF.Stat()
+	if err != nil {
+		return StrategyUnknown, err
+	}
+
+	dstF, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		return StrategyUnknown, err
+	}
+	defer dstF.Close()
+
+	// Budget per call: whole file size, minus what's been copied already.
+	remaining := srcInfo.Size()
+	for remaining > 0 {
+		n, err := unix.CopyFileRange(int(srcF.Fd()), nil, int(dstF.Fd()), nil, int(remaining), 0)
+		if err != nil {
+			// First-call EINVAL/ENOSYS/EXDEV bubble up via isFallback so
+			// the outer chain tries io.Copy. A later-call error is real
+			// I/O failure — return it unadorned so the caller's fallback
+			// logic can decide.
+			_ = os.Remove(dst)
+			return StrategyUnknown, err
+		}
+		if n == 0 {
+			break // EOF
+		}
+		remaining -= int64(n)
+	}
+	if remaining > 0 {
+		// Kernel returned EOF before src was exhausted — extremely rare
+		// but possible if src was truncated mid-copy. Fall back to
+		// io.Copy to finish deterministically.
+		_ = os.Remove(dst)
+		return StrategyUnknown, errShortCopy
+	}
+	return StrategyCopyFileRange, nil
+}
+
+// Compile-time sentinel so io.Discard stays linked during bench builds;
+// some linters strip unused imports aggressively.
+var _ = io.Discard

--- a/internal/vmimage/clone/clone_linux.go
+++ b/internal/vmimage/clone/clone_linux.go
@@ -36,7 +36,12 @@ func tryPlatformClone(src, dst string) (Strategy, error) {
 		_ = os.Remove(dst) // clean the half-built dst before the next strategy
 		return StrategyUnknown, err
 	}
+	// IoctlFileClone succeeded: dst now contains a full clone. If Close
+	// fails we must still remove the dst — the caller's next strategy
+	// opens with O_EXCL and would otherwise fail with a stale dst left
+	// behind. (CodeRabbit review 1.3.)
 	if err := dstF.Close(); err != nil {
+		_ = os.Remove(dst)
 		return StrategyUnknown, err
 	}
 	return StrategyFICLONE, nil

--- a/internal/vmimage/clone/clone_linux_test.go
+++ b/internal/vmimage/clone/clone_linux_test.go
@@ -31,7 +31,7 @@ func TestCloneFile_Linux_Strategy(t *testing.T) {
 	// vary widely. The fallback chain is the guarantee, not the exact
 	// winner. We only fail if we got Unknown.
 	if strategy == StrategyUnknown {
-		t.Errorf("strategyegy = Unknown; want a concrete strategyegy")
+		t.Errorf("strategy = Unknown; want a concrete strategy")
 	}
 
 	got, err := os.ReadFile(dst)
@@ -71,7 +71,7 @@ func TestCloneFile_Linux_CopyFileRange_ShortCopyLoop(t *testing.T) {
 		t.Fatalf("CloneFile: %v", err)
 	}
 	if strategy == StrategyUnknown {
-		t.Fatalf("strategyegy = Unknown")
+		t.Fatalf("strategy = Unknown")
 	}
 
 	got, err := os.ReadFile(dst)
@@ -79,6 +79,6 @@ func TestCloneFile_Linux_CopyFileRange_ShortCopyLoop(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(got, data) {
-		t.Errorf("4 MiB clone dst mismatch (strategyegy=%s)", strategy)
+		t.Errorf("4 MiB clone dst mismatch (strategy=%s)", strategy)
 	}
 }

--- a/internal/vmimage/clone/clone_linux_test.go
+++ b/internal/vmimage/clone/clone_linux_test.go
@@ -1,0 +1,84 @@
+//go:build linux
+
+package clone
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCloneFile_Linux_Strategy confirms CloneFile picks FICLONE or
+// copy_file_range when available on this FS. On CI filesystems like
+// tmpfs/overlay that don't support FICLONE, copy_file_range is the
+// expected answer.
+func TestCloneFile_Linux_Strategy(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	data := []byte("hello world, from linux clone")
+	if err := os.WriteFile(src, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	strategy, err := CloneFile(src, dst)
+	if err != nil {
+		t.Fatalf("CloneFile: %v", err)
+	}
+	// Accept any of FICLONE / copy_file_range / io_copy — filesystems
+	// vary widely. The fallback chain is the guarantee, not the exact
+	// winner. We only fail if we got Unknown.
+	if strategy == StrategyUnknown {
+		t.Errorf("strategyegy = Unknown; want a concrete strategyegy")
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("dst content mismatch")
+	}
+}
+
+// TestCloneFile_Linux_CopyFileRange_ShortCopyLoop exercises
+// tryCopyFileRange with a large file so the kernel's internal chunking
+// guarantees multiple iterations of the copy loop.
+func TestCloneFile_Linux_CopyFileRange_ShortCopyLoop(t *testing.T) {
+	// Force FICLONE to fall through so we land on copy_file_range directly.
+	// An easy way is to use a filesystem that almost certainly doesn't
+	// support reflink (tmpfs via t.TempDir) — but we can't guarantee
+	// that, so the assertion tolerates io_copy too. The important check
+	// is content integrity across a file large enough to span multiple
+	// kernel calls (a few MiB is enough on most kernels).
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	const size = 4 * 1024 * 1024
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	if err := os.WriteFile(src, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	strategy, err := CloneFile(src, dst)
+	if err != nil {
+		t.Fatalf("CloneFile: %v", err)
+	}
+	if strategy == StrategyUnknown {
+		t.Fatalf("strategyegy = Unknown")
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("4 MiB clone dst mismatch (strategyegy=%s)", strategy)
+	}
+}

--- a/internal/vmimage/clone/clone_other.go
+++ b/internal/vmimage/clone/clone_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package clone
+
+// tryPlatformClone and tryCopyFileRange are no-ops on platforms with no
+// native extent-sharing primitive; the io.Copy fallback takes over.
+func tryPlatformClone(src, dst string) (Strategy, error) { return StrategyUnknown, errNotSupported }
+
+func tryCopyFileRange(src, dst string) (Strategy, error) { return StrategyUnknown, errNotSupported }

--- a/internal/vmimage/clone/clone_test.go
+++ b/internal/vmimage/clone/clone_test.go
@@ -22,9 +22,9 @@ func randomBytes(t *testing.T, n int) []byte {
 }
 
 func TestCloneFile_NativeStrategy(t *testing.T) {
-	// The platform strategyegy is whichever the build-tagged file selects.
+	// The platform strategy is whichever the build-tagged file selects.
 	// We only assert: (1) clone succeeds, (2) dst is byte-identical to src.
-	// The strategyegy identity is logged for operators, not gated on here.
+	// The strategy identity is logged for operators, not gated on here.
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src")
 	dst := filepath.Join(dir, "dst")
@@ -39,7 +39,7 @@ func TestCloneFile_NativeStrategy(t *testing.T) {
 		t.Fatalf("CloneFile: %v", err)
 	}
 	if strategy == StrategyUnknown {
-		t.Errorf("got StrategyUnknown; want a concrete strategyegy")
+		t.Errorf("got StrategyUnknown; want a concrete strategy")
 	}
 
 	got, err := os.ReadFile(dst)
@@ -54,7 +54,7 @@ func TestCloneFile_NativeStrategy(t *testing.T) {
 func TestCloneFile_Fallback_IOCopy(t *testing.T) {
 	// ForceFallback disables all platform primitives so we exercise the
 	// universal io.Copy path. This keeps the fallback regression-tested
-	// even on hosts where every native strategyegy happens to succeed.
+	// even on hosts where every native strategy happens to succeed.
 	restore := ForceFallback(true)
 	defer restore()
 
@@ -72,7 +72,7 @@ func TestCloneFile_Fallback_IOCopy(t *testing.T) {
 		t.Fatalf("CloneFile: %v", err)
 	}
 	if strategy != StrategyIOCopy {
-		t.Errorf("strategyegy = %v, want StrategyIOCopy", strategy)
+		t.Errorf("strategy = %v, want StrategyIOCopy", strategy)
 	}
 	got, err := os.ReadFile(dst)
 	if err != nil {

--- a/internal/vmimage/clone/clone_test.go
+++ b/internal/vmimage/clone/clone_test.go
@@ -1,0 +1,195 @@
+package clone
+
+import (
+	"bytes"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// randomBytes returns a byte slice of size n filled with cryptographically
+// random data. Used so we can prove dst matches src byte-for-byte even
+// when the platform path slices the copy through io.Copy.
+func randomBytes(t *testing.T, n int) []byte {
+	t.Helper()
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return b
+}
+
+func TestCloneFile_NativeStrategy(t *testing.T) {
+	// The platform strategyegy is whichever the build-tagged file selects.
+	// We only assert: (1) clone succeeds, (2) dst is byte-identical to src.
+	// The strategyegy identity is logged for operators, not gated on here.
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	data := randomBytes(t, 8192)
+	if err := os.WriteFile(src, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	strategy, err := CloneFile(src, dst)
+	if err != nil {
+		t.Fatalf("CloneFile: %v", err)
+	}
+	if strategy == StrategyUnknown {
+		t.Errorf("got StrategyUnknown; want a concrete strategyegy")
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("dst != src (dst len=%d, src len=%d)", len(got), len(data))
+	}
+}
+
+func TestCloneFile_Fallback_IOCopy(t *testing.T) {
+	// ForceFallback disables all platform primitives so we exercise the
+	// universal io.Copy path. This keeps the fallback regression-tested
+	// even on hosts where every native strategyegy happens to succeed.
+	restore := ForceFallback(true)
+	defer restore()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	data := randomBytes(t, 1<<20) // 1 MiB
+	if err := os.WriteFile(src, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	strategy, err := CloneFile(src, dst)
+	if err != nil {
+		t.Fatalf("CloneFile: %v", err)
+	}
+	if strategy != StrategyIOCopy {
+		t.Errorf("strategyegy = %v, want StrategyIOCopy", strategy)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("dst content mismatch after io.Copy fallback")
+	}
+}
+
+func TestCloneFile_EEXIST(t *testing.T) {
+	// Clonefile/FICLONE and our io.Copy fallback all use O_EXCL semantics.
+	// A pre-existing dst must produce an error, not silently overwrite.
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	if err := os.WriteFile(src, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("preexisting"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := CloneFile(src, dst)
+	if err == nil {
+		t.Fatalf("expected error for pre-existing dst, got nil")
+	}
+
+	// dst must still contain the original content (not the src data).
+	got, readErr := os.ReadFile(dst)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != "preexisting" {
+		t.Errorf("pre-existing dst was overwritten: got %q", got)
+	}
+}
+
+func TestCloneFile_EmptyPaths(t *testing.T) {
+	if _, err := CloneFile("", "/tmp/x"); err == nil {
+		t.Errorf("expected error for empty src")
+	}
+	if _, err := CloneFile("/tmp/x", ""); err == nil {
+		t.Errorf("expected error for empty dst")
+	}
+}
+
+func TestCloneFile_MissingSource(t *testing.T) {
+	dir := t.TempDir()
+	_, err := CloneFile(filepath.Join(dir, "nope"), filepath.Join(dir, "dst"))
+	if err == nil {
+		t.Fatal("expected error for missing source")
+	}
+}
+
+func TestStrategy_String(t *testing.T) {
+	cases := map[Strategy]string{
+		StrategyClonefile:     "clonefile",
+		StrategyFICLONE:       "ficlone",
+		StrategyCopyFileRange: "copy_file_range",
+		StrategyIOCopy:        "io_copy",
+		StrategyUnknown:       "unknown",
+		Strategy(99):          "unknown",
+	}
+	for s, want := range cases {
+		if got := s.String(); got != want {
+			t.Errorf("%d.String() = %q, want %q", int(s), got, want)
+		}
+	}
+}
+
+// TestCloneFile_ConcurrentSameDst verifies that two concurrent goroutines
+// calling CloneFile on the same dst don't both claim success. Exactly
+// one should win; the loser must see an EEXIST-class error and leave the
+// winner's data intact.
+//
+// This matters because the plan documents that higher-level shed-create
+// serialization is trusted, but the primitive itself must also be race-safe.
+func TestCloneFile_ConcurrentSameDst(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	data := randomBytes(t, 16384)
+	if err := os.WriteFile(src, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	results := make([]error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, err := CloneFile(src, dst)
+			results[idx] = err
+		}(i)
+	}
+	wg.Wait()
+
+	successes := 0
+	for _, err := range results {
+		if err == nil {
+			successes++
+		}
+	}
+	if successes != 1 {
+		t.Errorf("expected exactly one success, got %d (results: %+v)", successes, results)
+	}
+
+	// Winner's data must still be present and correct.
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("dst content corrupted by concurrent CloneFile")
+	}
+}

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -441,18 +441,21 @@ func TryAcquireFileLockBlocking(path string) (func(), error) {
 }
 
 // TryAcquireFileLock attempts a non-blocking exclusive flock on path.
-// Returns held=true with a release function if the lock was acquired;
-// held=false (with release=nil, err=nil) if another process holds it OR
-// the lock file does not exist. Other I/O errors are returned as err.
+// Return values:
+//   - held=true with a non-nil release if the lock was acquired.
+//   - held=true with a no-op release if the lock file does NOT exist
+//     ("nothing to contend with" — safe for dry-run probes since we
+//     never create the file as a side effect).
+//   - held=false with release=nil, err=nil if another process holds it.
+//   - Any other I/O error is returned as err with held=false.
 //
 // This is the "is a conversion running right now?" probe used by
 // orphan-sweep in `shed system prune`. If the lock is live we must NOT
 // touch the sibling sidecars.
 //
 // Unlike acquireFileLock (blocking path used by image conversion), this
-// does NOT create the lock file if it's absent. A missing lock file is
-// treated as "nothing to contend with" so dry-run prune can probe without
-// side effects (Codex review: dry-run must not mutate disk).
+// does NOT create the lock file if it's absent — required so dry-run
+// prune can probe without mutating disk.
 func TryAcquireFileLock(path string) (release func(), held bool, err error) {
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -432,3 +432,44 @@ func acquireFileLock(path string) (func(), error) {
 		// where concurrent processes can hold locks on different inodes.
 	}, nil
 }
+
+// TryAcquireFileLockBlocking takes an exclusive flock on path and blocks
+// until it's available. Use this from tests that need to simulate a
+// live conversion holding the lock.
+func TryAcquireFileLockBlocking(path string) (func(), error) {
+	return acquireFileLock(path)
+}
+
+// TryAcquireFileLock attempts a non-blocking exclusive flock on path.
+// Returns held=true with a release function if the lock was acquired;
+// held=false (with release=nil, err=nil) if another process holds it.
+// Other I/O errors are returned as err.
+//
+// This is the "is a conversion running right now?" probe used by
+// orphan-sweep in `shed system prune`. If the lock is live we must NOT
+// touch the sibling sidecars.
+func TryAcquireFileLock(path string) (release func(), held bool, err error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, false, err
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		f.Close()
+		// EWOULDBLOCK means someone else holds it — NOT an error.
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("failed to acquire lock: %w", err)
+	}
+
+	return func() {
+		syscall.Flock(int(f.Fd()), syscall.LOCK_UN) //nolint:errcheck
+		f.Close()
+		// Lock file intentionally not removed — see acquireFileLock.
+	}, true, nil
+}

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -442,19 +442,27 @@ func TryAcquireFileLockBlocking(path string) (func(), error) {
 
 // TryAcquireFileLock attempts a non-blocking exclusive flock on path.
 // Returns held=true with a release function if the lock was acquired;
-// held=false (with release=nil, err=nil) if another process holds it.
-// Other I/O errors are returned as err.
+// held=false (with release=nil, err=nil) if another process holds it OR
+// the lock file does not exist. Other I/O errors are returned as err.
 //
 // This is the "is a conversion running right now?" probe used by
 // orphan-sweep in `shed system prune`. If the lock is live we must NOT
 // touch the sibling sidecars.
+//
+// Unlike acquireFileLock (blocking path used by image conversion), this
+// does NOT create the lock file if it's absent. A missing lock file is
+// treated as "nothing to contend with" so dry-run prune can probe without
+// side effects (Codex review: dry-run must not mutate disk).
 func TryAcquireFileLock(path string) (release func(), held bool, err error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return nil, false, err
-	}
-
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// No lock file = no contending conversion. Caller may proceed
+			// without holding a lock. Returning held=false with nil err
+			// would be ambiguous; signal success via held=true and a
+			// no-op release so callers treat it uniformly.
+			return func() {}, true, nil
+		}
 		return nil, false, err
 	}
 

--- a/internal/vz/backend.go
+++ b/internal/vz/backend.go
@@ -204,3 +204,8 @@ func (b *VZBackend) DeleteImage(_ context.Context, name string) error {
 func (b *VZBackend) PruneImages(_ context.Context, dryRun bool) ([]config.ImageInfo, error) {
 	return b.client.PruneImages(dryRun)
 }
+
+// DiskUsage returns disk-usage information for the VZ server.
+func (b *VZBackend) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
+	return b.client.DiskUsage(ctx)
+}

--- a/internal/vz/backend.go
+++ b/internal/vz/backend.go
@@ -209,3 +209,8 @@ func (b *VZBackend) PruneImages(_ context.Context, dryRun bool) ([]config.ImageI
 func (b *VZBackend) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 	return b.client.DiskUsage(ctx)
 }
+
+// Prune runs the disk cleanup pass. See backend.PruneOptions for semantics.
+func (b *VZBackend) Prune(ctx context.Context, opts backend.PruneOptions) (config.PruneReport, error) {
+	return b.client.Prune(ctx, opts)
+}

--- a/internal/vz/image.go
+++ b/internal/vz/image.go
@@ -57,12 +57,23 @@ func (c *Client) PruneImages(dryRun bool) ([]config.ImageInfo, error) {
 
 // inUseImageNames returns image names referenced by existing VZ instances.
 func (c *Client) inUseImageNames() ([]string, error) {
+	return c.inUseImageNamesExcept(nil)
+}
+
+// inUseImageNamesExcept returns image names referenced by existing VZ
+// instances whose names are NOT in skipSheds. Used by Prune's dry-run path
+// to simulate the post-instance-delete state so image candidates reflect
+// the fleet after instance deletions.
+func (c *Client) inUseImageNamesExcept(skipSheds map[string]bool) ([]string, error) {
 	instances, err := ListInstances(c.cfg.InstanceDir)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 	var names []string
 	for _, inst := range instances {
+		if skipSheds[inst] {
+			continue
+		}
 		meta, err := LoadMetadata(c.cfg.InstanceDir, inst)
 		if err != nil {
 			return nil, err

--- a/internal/vz/image.go
+++ b/internal/vz/image.go
@@ -5,7 +5,6 @@ package vz
 import (
 	"context"
 	"errors"
-	"log"
 	"os"
 
 	"github.com/charliek/shed/internal/backend"
@@ -83,14 +82,16 @@ func (c *Client) inUseImageNamesExcept(skipSheds map[string]bool) ([]string, err
 		}
 		meta, err := LoadMetadata(c.cfg.InstanceDir, inst)
 		if err != nil {
-			// Don't let a single corrupt metadata.json block the whole
-			// prune path; log and move on. A malformed shed's image
-			// reference can't be confirmed, so its image becomes a
-			// potential prune candidate — which is the safe, user-visible
-			// behavior (the user can `shed delete --force` the broken
-			// shed and retry).
-			log.Printf("Warning: inUseImageNames: skipping instance %q with invalid metadata: %v", inst, err)
-			continue
+			// Only the race-condition case (instance removed between
+			// ListInstances and LoadMetadata) is safe to skip silently.
+			// Any other error (malformed JSON, I/O failure, permission
+			// denied) means we cannot confirm in-use images and must
+			// fail closed, not fail open — otherwise prune might
+			// reclaim an image that's actually referenced.
+			if errors.Is(err, ErrInstanceNotFound) {
+				continue
+			}
+			return nil, err
 		}
 		if meta.Image != "" {
 			names = append(names, meta.Image)

--- a/internal/vz/image.go
+++ b/internal/vz/image.go
@@ -5,6 +5,7 @@ package vz
 import (
 	"context"
 	"errors"
+	"log"
 	"os"
 
 	"github.com/charliek/shed/internal/backend"
@@ -64,6 +65,12 @@ func (c *Client) inUseImageNames() ([]string, error) {
 // instances whose names are NOT in skipSheds. Used by Prune's dry-run path
 // to simulate the post-instance-delete state so image candidates reflect
 // the fleet after instance deletions.
+//
+// Malformed metadata on a single instance is treated as "cannot confirm
+// image usage" — we skip-and-warn rather than failing the whole scan,
+// matching ListSheds' behavior. The upstream Manager.PruneImages still
+// fails-closed when its closure errors, so the protection is intact:
+// we only contribute names we could verify.
 func (c *Client) inUseImageNamesExcept(skipSheds map[string]bool) ([]string, error) {
 	instances, err := ListInstances(c.cfg.InstanceDir)
 	if err != nil && !os.IsNotExist(err) {
@@ -76,7 +83,14 @@ func (c *Client) inUseImageNamesExcept(skipSheds map[string]bool) ([]string, err
 		}
 		meta, err := LoadMetadata(c.cfg.InstanceDir, inst)
 		if err != nil {
-			return nil, err
+			// Don't let a single corrupt metadata.json block the whole
+			// prune path; log and move on. A malformed shed's image
+			// reference can't be confirmed, so its image becomes a
+			// potential prune candidate — which is the safe, user-visible
+			// behavior (the user can `shed delete --force` the broken
+			// shed and retry).
+			log.Printf("Warning: inUseImageNames: skipping instance %q with invalid metadata: %v", inst, err)
+			continue
 		}
 		if meta.Image != "" {
 			names = append(names, meta.Image)

--- a/internal/vz/rootfs.go
+++ b/internal/vz/rootfs.go
@@ -25,6 +25,17 @@ func RootfsPath(instanceDir, name string) string {
 // Pre-clean a stale dst: the kernel primitives (Clonefile / FICLONE)
 // both require dst to not exist. A prior failed create may have left
 // rootfs.ext4 behind; remove it first (ignoring "already gone").
+//
+// CONCURRENCY: this function assumes a single-writer-per-shed-name
+// contract. Higher-level code in CreateShed performs a LoadMetadata
+// existence check before calling in, but that check has a TOCTOU window
+// with the metadata Save. Two concurrent `shed create` calls for the
+// same name could both pass the existence check; the unconditional
+// os.Remove(dst) here would let the second caller delete the first
+// caller's newly-cloned rootfs. In practice the window is narrow
+// (microseconds to a few seconds) and shed names are user-supplied and
+// rarely raced. A per-name mutex would close the race at the cost of
+// serializing creates; out of scope for this change.
 func CopyRootfs(baseRootfs, instanceDir, name string) (string, error) {
 	dst := RootfsPath(instanceDir, name)
 
@@ -54,10 +65,23 @@ func CopyRootfs(baseRootfs, instanceDir, name string) (string, error) {
 	// durability until the next FS commit, and the negligible cost on a
 	// cloned inode isn't worth the "did the next create-then-crash lose
 	// the instance?" hazard.
+	//
+	// Delayed-writeback errors (ENOSPC, EIO) surface here — return the
+	// error with dst removed so the create aborts cleanly rather than
+	// silently booting a VM on broken storage.
 	f, err := os.OpenFile(dst, os.O_RDWR, 0)
-	if err == nil {
-		_ = f.Sync()
+	if err != nil {
+		_ = os.Remove(dst)
+		return "", fmt.Errorf("failed to reopen rootfs for sync: %w", err)
+	}
+	if syncErr := f.Sync(); syncErr != nil {
 		f.Close()
+		_ = os.Remove(dst)
+		return "", fmt.Errorf("failed to sync rootfs: %w", syncErr)
+	}
+	if closeErr := f.Close(); closeErr != nil {
+		_ = os.Remove(dst)
+		return "", fmt.Errorf("failed to close rootfs after sync: %w", closeErr)
 	}
 
 	return dst, nil

--- a/internal/vz/rootfs.go
+++ b/internal/vz/rootfs.go
@@ -47,6 +47,13 @@ func CopyRootfs(baseRootfs, instanceDir, name string) (string, error) {
 	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
 		return "", fmt.Errorf("failed to clean stale rootfs: %w", err)
 	}
+	// fsync the instance directory after the stale-file cleanup so the
+	// unlink is durable before we create the new inode. Without this,
+	// a crash between unlink and clonefile can leave the directory
+	// pointing at a file that's being replaced but not yet committed.
+	if err := syncDir(dir); err != nil {
+		return "", fmt.Errorf("failed to sync instance directory after cleanup: %w", err)
+	}
 
 	strategy, err := clone.CloneFile(baseRootfs, dst)
 	if err != nil {
@@ -83,8 +90,26 @@ func CopyRootfs(baseRootfs, instanceDir, name string) (string, error) {
 		_ = os.Remove(dst)
 		return "", fmt.Errorf("failed to close rootfs after sync: %w", closeErr)
 	}
+	// fsync the instance directory again so the rename/link that
+	// created the new rootfs entry is durable before we report success.
+	if err := syncDir(dir); err != nil {
+		_ = os.Remove(dst)
+		return "", fmt.Errorf("failed to sync instance directory: %w", err)
+	}
 
 	return dst, nil
+}
+
+// syncDir fsyncs a directory so the pending create/unlink metadata is
+// actually on stable storage. Cheap on macOS/APFS, cheap on ext4 with
+// journal=ordered; never wrong to do on the crash-recovery path.
+func syncDir(path string) error {
+	d, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
 }
 
 // DeleteRootfs removes the rootfs image for an instance.

--- a/internal/vz/rootfs.go
+++ b/internal/vz/rootfs.go
@@ -5,9 +5,11 @@ package vz
 
 import (
 	"fmt"
-	"io"
+	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/charliek/shed/internal/vmimage/clone"
 )
 
 // RootfsPath returns the path to the rootfs image for an instance.
@@ -15,40 +17,47 @@ func RootfsPath(instanceDir, name string) string {
 	return filepath.Join(instanceDir, name, "rootfs.ext4")
 }
 
-// CopyRootfs copies the base rootfs image to the instance directory.
+// CopyRootfs copies the base rootfs image to the instance directory,
+// preferring reflink/clonefile when available so `shed create` is near-
+// instant and near-zero physical cost. Falls back to io.Copy on older
+// kernels or non-reflink filesystems.
+//
+// Pre-clean a stale dst: the kernel primitives (Clonefile / FICLONE)
+// both require dst to not exist. A prior failed create may have left
+// rootfs.ext4 behind; remove it first (ignoring "already gone").
 func CopyRootfs(baseRootfs, instanceDir, name string) (string, error) {
 	dst := RootfsPath(instanceDir, name)
 
-	// Ensure instance directory exists
 	dir := InstanceDir(instanceDir, name)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create instance directory: %w", err)
 	}
 
-	// Open source file
-	src, err := os.Open(baseRootfs)
-	if err != nil {
-		return "", fmt.Errorf("failed to open base rootfs: %w", err)
+	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("failed to clean stale rootfs: %w", err)
 	}
-	defer src.Close()
 
-	// Create destination file
-	dstFile, err := os.Create(dst)
+	strategy, err := clone.CloneFile(baseRootfs, dst)
 	if err != nil {
-		return "", fmt.Errorf("failed to create rootfs copy: %w", err)
-	}
-	defer dstFile.Close()
-
-	// Copy contents
-	if _, err := io.Copy(dstFile, src); err != nil {
-		os.Remove(dst) // Clean up on failure
+		_ = os.Remove(dst)
 		return "", fmt.Errorf("failed to copy rootfs: %w", err)
 	}
 
-	// Sync to ensure data is written
-	if err := dstFile.Sync(); err != nil {
-		os.Remove(dst)
-		return "", fmt.Errorf("failed to sync rootfs: %w", err)
+	// Stable log line for operators: "rootfs strategy=clonefile src=... dst=... logical_bytes=..."
+	var logical int64
+	if fi, statErr := os.Stat(dst); statErr == nil {
+		logical = fi.Size()
+	}
+	log.Printf("rootfs strategy=%s src=%s dst=%s logical_bytes=%d", strategy, baseRootfs, dst, logical)
+
+	// Sync on every path. Clonefile/FICLONE don't guarantee metadata
+	// durability until the next FS commit, and the negligible cost on a
+	// cloned inode isn't worth the "did the next create-then-crash lose
+	// the instance?" hazard.
+	f, err := os.OpenFile(dst, os.O_RDWR, 0)
+	if err == nil {
+		_ = f.Sync()
+		f.Close()
 	}
 
 	return dst, nil

--- a/internal/vz/stub_nondarwin.go
+++ b/internal/vz/stub_nondarwin.go
@@ -123,3 +123,9 @@ func (b *VZBackend) PruneImages(_ context.Context, _ bool) ([]config.ImageInfo, 
 func (b *VZBackend) DiskUsage(_ context.Context) (config.DiskUsage, error) {
 	return config.DiskUsage{Backend: "none"}, nil
 }
+
+// Prune is a mutating operation; the non-native stub returns the sentinel
+// so callers get a clear "not supported" signal (matches DeleteImage).
+func (b *VZBackend) Prune(_ context.Context, _ backend.PruneOptions) (config.PruneReport, error) {
+	return config.PruneReport{}, fmt.Errorf("prune: %w", config.ErrNotSupportedSentinel)
+}

--- a/internal/vz/stub_nondarwin.go
+++ b/internal/vz/stub_nondarwin.go
@@ -116,3 +116,10 @@ func (b *VZBackend) DeleteImage(_ context.Context, _ string) error {
 func (b *VZBackend) PruneImages(_ context.Context, _ bool) ([]config.ImageInfo, error) {
 	return nil, nil
 }
+
+// DiskUsage returns an empty disk-usage report on non-darwin platforms.
+// Read-only system queries never error on a non-native backend — they just
+// report "no local state," matching the ListImages precedent.
+func (b *VZBackend) DiskUsage(_ context.Context) (config.DiskUsage, error) {
+	return config.DiskUsage{Backend: "none"}, nil
+}

--- a/internal/vz/system.go
+++ b/internal/vz/system.go
@@ -5,16 +5,25 @@ package vz
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/diskstat"
 	"github.com/charliek/shed/internal/vmimage"
 )
+
+// Default tail size for console.log truncation when opts.LogTailBytes is 0.
+const defaultLogTailBytes = 5 * 1024 * 1024
+
+// Default skip threshold for very fresh .tmp files: conversions write to a
+// .tmp before rename, so treating them as orphans would race.
+const tmpOrphanMinAge = time.Hour
 
 // consoleLogFilename is written by vm.go when launching vfkit. Kept here so
 // DiskUsage/Prune don't depend on the non-exported VM internals.
@@ -275,4 +284,523 @@ func classifySidecar(filename string) (baseRootfs, kind string) {
 		return filename[:idx+len(suffix)], "tmp"
 	}
 	return "", ""
+}
+
+// Prune removes items selected by opts. See backend.PruneOptions for flag
+// semantics and backend.Backend.Prune for contract.
+//
+// Internal ordering (plan-mandated):
+//  1. Snapshot mtimes of metadata.json files BEFORE calling ListSheds (since
+//     ListSheds's staleness re-check can refresh mtime and break age filters).
+//  2. Collect candidate instances, orphans, and images; image dry-run uses
+//     inUseImageNamesExcept(<stopped candidates>) to simulate post-delete.
+//  3. DryRun → return report with no mutation.
+//  4. Execute: delete instances first (so inUseImageNames excludes them
+//     naturally), then prune images, then sweep orphans (re-acquiring
+//     flock per file), then optionally truncate console.log on survivors.
+func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.PruneReport, error) {
+	opts = normalizePruneOptions(opts)
+
+	report := config.PruneReport{
+		DryRun:     opts.DryRun,
+		ServerName: c.serverCfg.Name,
+		Scope:      scopeFlags(opts),
+		Until:      opts.Until.String(),
+		Items:      []config.PrunedItem{},
+		Skipped:    []config.SkippedItem{},
+	}
+
+	// Step 1: snapshot mtimes BEFORE ListSheds.
+	mtimes := snapshotMetadataMtimes(c.cfg.InstanceDir)
+
+	// Step 2a: instance candidates.
+	var instanceCandidates []instanceCandidate
+	if opts.Instances {
+		cands, skipped, err := c.collectInstanceCandidates(ctx, mtimes, opts.Until)
+		if err != nil {
+			return report, err
+		}
+		instanceCandidates = cands
+		report.Skipped = append(report.Skipped, skipped...)
+	}
+
+	// Step 2b: orphan candidates.
+	var orphanCandidates []orphanCandidate
+	if opts.Orphans {
+		cands, skipped := collectOrphanCandidates(c.cfg.ImagesDir)
+		orphanCandidates = cands
+		report.Skipped = append(report.Skipped, skipped...)
+	}
+
+	// Step 2c: image candidates (dry-run, respects candidate deletions).
+	var imageCandidates []vmimage.ImageInfo
+	if opts.Images {
+		skipSet := make(map[string]bool, len(instanceCandidates))
+		for _, ic := range instanceCandidates {
+			skipSet[ic.name] = true
+		}
+		mgr := vmimage.NewManager(c.cfg)
+		cands, err := mgr.PruneImages(true, func() ([]string, error) {
+			return c.inUseImageNamesExcept(skipSet)
+		})
+		if err != nil {
+			return report, fmt.Errorf("dry-run image prune: %w", err)
+		}
+		imageCandidates = cands
+	}
+
+	// Populate candidate Items for dry-run display. On execute we'll
+	// rebuild with post-action Freed numbers — but for instances/orphans
+	// the pre-delete attributed bytes are exactly what we want to show.
+	for _, ic := range instanceCandidates {
+		report.Items = append(report.Items, ic.toPrunedItem(opts.DryRun))
+	}
+	for _, oc := range orphanCandidates {
+		report.Items = append(report.Items, oc.toPrunedItem(opts.DryRun))
+	}
+	for _, img := range imageCandidates {
+		report.Items = append(report.Items, imageToPrunedItem(img, opts.DryRun))
+	}
+
+	if opts.DryRun {
+		finalizeReport(&report)
+		return report, nil
+	}
+
+	// Step 3: execute. Reset items so we report only what ACTUALLY ran.
+	report.Items = report.Items[:0]
+
+	// 3a: delete candidate instances via DeleteShed (handles TAP/cred
+	// cleanup correctly and re-checks running state under its own lock).
+	deletedSheds := 0
+	for _, ic := range instanceCandidates {
+		if err := c.DeleteShed(ctx, ic.name, false); err != nil {
+			report.Skipped = append(report.Skipped, config.SkippedItem{
+				Kind: "instance", Name: ic.name,
+				Reason: fmt.Sprintf("delete failed: %v", err),
+			})
+			continue
+		}
+		report.Items = append(report.Items, ic.toPrunedItem(false))
+		deletedSheds++
+	}
+
+	// 3b: real image prune. ListInstances no longer sees deleted sheds,
+	// so the unmodified inUseImageNames closure returns the correct set.
+	if opts.Images {
+		mgr := vmimage.NewManager(c.cfg)
+		deleted, err := mgr.PruneImages(false, c.inUseImageNames)
+		if err != nil {
+			return report, fmt.Errorf("image prune: %w", err)
+		}
+		for _, img := range deleted {
+			report.Items = append(report.Items, imageToPrunedItem(img, false))
+		}
+	}
+
+	// 3c: sweep orphans — re-acquire flock for safety.
+	if opts.Orphans {
+		for _, oc := range orphanCandidates {
+			if ok := sweepOrphan(c.cfg.ImagesDir, oc); !ok {
+				report.Skipped = append(report.Skipped, config.SkippedItem{
+					Kind: oc.kind, Path: oc.path,
+					Reason: "lock now held or removal failed",
+				})
+				continue
+			}
+			report.Items = append(report.Items, oc.toPrunedItem(false))
+		}
+	}
+
+	// 3d: truncate console.log on surviving VZ sheds.
+	if opts.Logs {
+		truncated, skipped := c.truncateConsoleLogs(opts.LogTailBytes)
+		report.Items = append(report.Items, truncated...)
+		report.Skipped = append(report.Skipped, skipped...)
+	}
+
+	finalizeReport(&report)
+	return report, nil
+}
+
+// normalizePruneOptions applies defaults: empty scope → images+instances+
+// orphans; zero LogTailBytes → 5 MiB.
+func normalizePruneOptions(opts backend.PruneOptions) backend.PruneOptions {
+	if !opts.Images && !opts.Instances && !opts.Logs && !opts.Orphans {
+		opts.Images = true
+		opts.Instances = true
+		opts.Orphans = true
+	}
+	if opts.LogTailBytes == 0 {
+		opts.LogTailBytes = defaultLogTailBytes
+	}
+	return opts
+}
+
+// scopeFlags returns the list of active scope names for the report.
+func scopeFlags(opts backend.PruneOptions) []string {
+	var scope []string
+	if opts.Images {
+		scope = append(scope, "images")
+	}
+	if opts.Instances {
+		scope = append(scope, "instances")
+	}
+	if opts.Logs {
+		scope = append(scope, "logs")
+	}
+	if opts.Orphans {
+		scope = append(scope, "orphans")
+	}
+	return scope
+}
+
+// snapshotMetadataMtimes reads mtime(metadata.json) for every instance under
+// instanceDir. Must run BEFORE any call that might touch metadata (ListSheds,
+// GetShed) since those paths save on stale-running→stopped detection.
+func snapshotMetadataMtimes(instanceDir string) map[string]time.Time {
+	mtimes := make(map[string]time.Time)
+	names, err := ListInstances(instanceDir)
+	if err != nil {
+		return mtimes
+	}
+	for _, name := range names {
+		fi, err := os.Stat(MetadataPath(instanceDir, name))
+		if err != nil {
+			continue
+		}
+		mtimes[name] = fi.ModTime()
+	}
+	return mtimes
+}
+
+// instanceCandidate is a stopped shed that is eligible for prune.
+type instanceCandidate struct {
+	name  string
+	image string
+	age   time.Duration
+	size  config.DiskSize
+}
+
+func (ic instanceCandidate) toPrunedItem(dry bool) config.PrunedItem {
+	reason := fmt.Sprintf("stopped %s", humanDuration(ic.age))
+	if !dry {
+		reason = fmt.Sprintf("deleted (stopped %s)", humanDuration(ic.age))
+	}
+	return config.PrunedItem{
+		Kind: "instance", Name: ic.name, Action: "deleted",
+		Freed: ic.size, Reason: reason,
+	}
+}
+
+// collectInstanceCandidates returns stopped sheds whose mtime(metadata.json)
+// is older than until. Running sheds and too-recent stopped sheds land in
+// the skipped list. Malformed metadata is silently skipped (matches
+// ListSheds behavior).
+func (c *Client) collectInstanceCandidates(ctx context.Context, mtimes map[string]time.Time, until time.Duration) ([]instanceCandidate, []config.SkippedItem, error) {
+	sheds, err := c.ListSheds(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing sheds: %w", err)
+	}
+	var cands []instanceCandidate
+	var skipped []config.SkippedItem
+	now := time.Now()
+	for _, shed := range sheds {
+		if shed.Status != config.StatusStopped {
+			skipped = append(skipped, config.SkippedItem{
+				Kind: "instance", Name: shed.Name,
+				Reason: "cannot prune " + shed.Status + " shed",
+			})
+			continue
+		}
+		mtime, ok := mtimes[shed.Name]
+		if !ok {
+			// Metadata disappeared between snapshot and ListSheds; skip.
+			continue
+		}
+		age := now.Sub(mtime)
+		if until > 0 && age < until {
+			skipped = append(skipped, config.SkippedItem{
+				Kind: "instance", Name: shed.Name,
+				Reason: fmt.Sprintf("too recent (%s < %s)", humanDuration(age), humanDuration(until)),
+			})
+			continue
+		}
+		cands = append(cands, instanceCandidate{
+			name:  shed.Name,
+			image: shed.Image,
+			age:   age,
+			size:  instanceSize(c.cfg.InstanceDir, shed.Name),
+		})
+	}
+	return cands, skipped, nil
+}
+
+// instanceSize returns the attributed bytes for an instance directory
+// (rootfs + console.log + metadata + any other files). Measured before
+// deletion so the report shows what was reclaimed.
+func instanceSize(instanceDir, name string) config.DiskSize {
+	var size config.DiskSize
+	dir := InstanceDir(instanceDir, name)
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		logical, physical, err := diskstat.Stat(path)
+		if err == nil {
+			size.LogicalBytes += logical
+			size.PhysicalBytes += physical
+		}
+		return nil
+	})
+	return size
+}
+
+// orphanCandidate is a sidecar that's lost its parent rootfs AND has passed
+// flock + age checks.
+type orphanCandidate struct {
+	path string
+	kind string // "lock" | "tmp" | "source"
+	size config.DiskSize
+}
+
+func (oc orphanCandidate) toPrunedItem(dry bool) config.PrunedItem {
+	reason := ""
+	if dry {
+		reason = "orphan (no matching rootfs)"
+	}
+	return config.PrunedItem{
+		Kind: oc.kind, Path: oc.path, Action: "deleted",
+		Freed: oc.size, Reason: reason,
+	}
+}
+
+// collectOrphanCandidates scans imagesDir for sidecars whose parent rootfs
+// is absent, after verifying the canonical `.lock` is NOT held by a live
+// conversion and the file is not a very-fresh `.tmp`.
+func collectOrphanCandidates(imagesDir string) ([]orphanCandidate, []config.SkippedItem) {
+	var candidates []orphanCandidate
+	var skipped []config.SkippedItem
+
+	entries, err := os.ReadDir(imagesDir)
+	if err != nil {
+		return nil, nil
+	}
+
+	presentRootfs := make(map[string]bool)
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), "-rootfs.ext4") {
+			presentRootfs[e.Name()] = true
+		}
+	}
+
+	now := time.Now()
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		base, kind := classifySidecar(name)
+		if base == "" || presentRootfs[base] {
+			continue
+		}
+		path := filepath.Join(imagesDir, name)
+		fi, err := e.Info()
+		if err != nil {
+			continue
+		}
+
+		// .tmp files younger than tmpOrphanMinAge are almost certainly an
+		// in-flight EnsureImage. Skip with reason.
+		if kind == "tmp" && now.Sub(fi.ModTime()) < tmpOrphanMinAge {
+			skipped = append(skipped, config.SkippedItem{
+				Kind: kind, Path: path,
+				Reason: fmt.Sprintf("too recent (%s < %s)", humanDuration(now.Sub(fi.ModTime())), humanDuration(tmpOrphanMinAge)),
+			})
+			continue
+		}
+
+		// Confirm the canonical lock is NOT held. A conversion can write a
+		// .tmp before the ext4 exists, holding the .lock the whole time.
+		lockPath := filepath.Join(imagesDir, base+".lock")
+		release, held, err := vmimage.TryAcquireFileLock(lockPath)
+		if err != nil {
+			skipped = append(skipped, config.SkippedItem{
+				Kind: kind, Path: path,
+				Reason: fmt.Sprintf("lock probe failed: %v", err),
+			})
+			continue
+		}
+		if !held {
+			skipped = append(skipped, config.SkippedItem{
+				Kind: kind, Path: path,
+				Reason: "lock held (conversion in progress)",
+			})
+			continue
+		}
+		release()
+
+		logical, physical, _ := diskstat.Stat(path)
+		candidates = append(candidates, orphanCandidate{
+			path: path, kind: kind,
+			size: config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
+		})
+	}
+	return candidates, skipped
+}
+
+// sweepOrphan re-acquires the canonical flock and deletes the sidecar.
+// Returns false on any failure — the caller should record a SkippedItem.
+// Never removes the .lock file itself when that's the orphan (matches
+// Manager.DeleteImage convention: unlinking locks creates a race).
+func sweepOrphan(imagesDir string, oc orphanCandidate) bool {
+	base := filepath.Base(oc.path)
+	rootfsBase, _ := classifySidecar(base)
+	if rootfsBase == "" {
+		return false
+	}
+	lockPath := filepath.Join(imagesDir, rootfsBase+".lock")
+	release, held, err := vmimage.TryAcquireFileLock(lockPath)
+	if err != nil || !held {
+		return false
+	}
+	defer release()
+
+	if oc.kind == "lock" {
+		// The .lock IS the canonical lock — leave it in place to avoid
+		// the race documented in Manager.PruneImages. Treat the orphan
+		// as "handled" conceptually: the parent ext4 is gone, the lock
+		// is dormant, and the next conversion will flock+reuse the inode.
+		return true
+	}
+
+	if err := os.Remove(oc.path); err != nil {
+		// Treat "already gone" as success — another sweep beat us to it.
+		return errors.Is(err, os.ErrNotExist)
+	}
+	return true
+}
+
+// imageToPrunedItem wraps a vmimage.ImageInfo as a PrunedItem. Physical
+// bytes are pulled via diskstat so the report reflects the actual on-disk
+// footprint (ImageInfo only carries logical SizeBytes).
+func imageToPrunedItem(img vmimage.ImageInfo, dry bool) config.PrunedItem {
+	size := config.DiskSize{LogicalBytes: img.SizeBytes}
+	if img.Path != "" {
+		if logical, physical, err := diskstat.Stat(img.Path); err == nil {
+			size.LogicalBytes = logical
+			size.PhysicalBytes = physical
+		}
+	}
+	reason := ""
+	if dry {
+		reason = "unreferenced image"
+	}
+	return config.PrunedItem{
+		Kind: "image", Name: img.Name, Path: img.Path, Action: "deleted",
+		Freed: size, Reason: reason,
+	}
+}
+
+// truncateConsoleLogs shrinks each surviving VZ shed's console.log to its
+// last tailBytes. Uses ftruncate-in-place + rewrite-tail so vfkit's
+// O_APPEND fd keeps writing past the new EOF.
+//
+// Small lost-writes race: writes between our read-tail and our truncate
+// disappear. For a debug aid this is acceptable.
+func (c *Client) truncateConsoleLogs(tailBytes int64) ([]config.PrunedItem, []config.SkippedItem) {
+	var done []config.PrunedItem
+	var skipped []config.SkippedItem
+
+	names, err := ListInstances(c.cfg.InstanceDir)
+	if err != nil {
+		return nil, nil
+	}
+	for _, name := range names {
+		consolePath := filepath.Join(InstanceDir(c.cfg.InstanceDir, name), consoleLogFilename)
+		fi, err := os.Stat(consolePath)
+		if err != nil {
+			continue // no log — nothing to do (skip silently, not a candidate)
+		}
+		if fi.Size() <= tailBytes {
+			skipped = append(skipped, config.SkippedItem{
+				Kind: "console_log", Name: name, Path: consolePath,
+				Reason: fmt.Sprintf("size %d ≤ tail %d", fi.Size(), tailBytes),
+			})
+			continue
+		}
+
+		origSize := fi.Size()
+		if err := truncateConsoleLogInPlace(consolePath, origSize, tailBytes); err != nil {
+			skipped = append(skipped, config.SkippedItem{
+				Kind: "console_log", Name: name, Path: consolePath,
+				Reason: fmt.Sprintf("truncate failed: %v", err),
+			})
+			continue
+		}
+		freed := origSize - tailBytes
+		done = append(done, config.PrunedItem{
+			Kind: "console_log", Name: name, Path: consolePath,
+			Action: "truncated",
+			Freed:  config.DiskSize{LogicalBytes: freed, PhysicalBytes: freed},
+			Reason: fmt.Sprintf("kept last %d bytes", tailBytes),
+		})
+	}
+	return done, skipped
+}
+
+// truncateConsoleLogInPlace truncates path to 0 and rewrites the last
+// tailBytes of its original contents to the head. Preserves inode so
+// vfkit's O_APPEND fd continues appending past the rewritten tail.
+func truncateConsoleLogInPlace(path string, origSize, tailBytes int64) error {
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	tail := make([]byte, tailBytes)
+	if _, err := f.ReadAt(tail, origSize-tailBytes); err != nil {
+		return fmt.Errorf("read tail: %w", err)
+	}
+	if err := f.Truncate(0); err != nil {
+		return fmt.Errorf("ftruncate: %w", err)
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		return fmt.Errorf("seek: %w", err)
+	}
+	if _, err := f.Write(tail); err != nil {
+		return fmt.Errorf("write tail: %w", err)
+	}
+	return nil
+}
+
+// finalizeReport sums Freed across all items into Totals.
+func finalizeReport(r *config.PruneReport) {
+	for _, item := range r.Items {
+		r.Totals.Freed.LogicalBytes += item.Freed.LogicalBytes
+		r.Totals.Freed.PhysicalBytes += item.Freed.PhysicalBytes
+	}
+	r.Totals.Items = len(r.Items)
+	r.Notes = append(r.Notes,
+		"physical bytes are attributed (stat.Blocks*512); clonefile/FICLONE clones and hardlinks may report bytes that won't actually be reclaimed",
+	)
+}
+
+// humanDuration formats a duration for SkippedItem.Reason / PrunedItem.Reason.
+// Rounds to the nearest sensible unit: seconds, minutes, hours, or days.
+func humanDuration(d time.Duration) string {
+	if d < 0 {
+		d = -d
+	}
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int64(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int64(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int64(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int64(d.Hours()/24))
+	}
 }

--- a/internal/vz/system.go
+++ b/internal/vz/system.go
@@ -1,0 +1,278 @@
+//go:build darwin
+// +build darwin
+
+package vz
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/diskstat"
+	"github.com/charliek/shed/internal/vmimage"
+)
+
+// consoleLogFilename is written by vm.go when launching vfkit. Kept here so
+// DiskUsage/Prune don't depend on the non-exported VM internals.
+const consoleLogFilename = "console.log"
+
+// DiskUsage returns disk-usage information for everything the VZ backend
+// manages on the local server: image cache, per-instance rootfs copies and
+// console logs, kernel/initrd, and orphan sidecar files.
+func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
+	du := config.DiskUsage{
+		ServerName:  c.serverCfg.Name,
+		Backend:     "vz",
+		GeneratedAt: time.Now().UTC(),
+		Images:      []config.ImageDiskEntry{},
+		Sheds:       []config.ShedDiskEntry{},
+		Orphans:     []config.FileEntry{},
+	}
+
+	imagesDir := c.cfg.ImagesDir
+	if imagesDir != "" {
+		// Discovered variants and config-referenced images. `ListImages`
+		// intentionally skips `_base`, so we stat it directly below.
+		imgs, err := c.ListImages()
+		if err != nil {
+			return du, fmt.Errorf("listing images: %w", err)
+		}
+		for _, img := range imgs {
+			if !img.Cached || img.Path == "" {
+				continue
+			}
+			entry := config.ImageDiskEntry{
+				Name:      img.Name,
+				Path:      img.Path,
+				DockerRef: img.DockerRef,
+			}
+			entry.Size.LogicalBytes, entry.Size.PhysicalBytes, _ = diskstat.Stat(img.Path)
+			du.Images = append(du.Images, entry)
+		}
+
+		// _base is produced by the runtime when base_rootfs is a Docker ref,
+		// and is intentionally omitted from ListImages(). Stat it here.
+		basePath := filepath.Join(imagesDir, vmimage.RootfsFilename("_base"))
+		if logical, physical, err := diskstat.Stat(basePath); err == nil {
+			baseRef := ""
+			if vmimage.IsDockerRef(c.cfg.BaseRootfs) {
+				baseRef = c.cfg.BaseRootfs
+			}
+			du.Images = append(du.Images, config.ImageDiskEntry{
+				Name:      "_base",
+				Path:      basePath,
+				DockerRef: baseRef,
+				Size:      config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
+				IsBase:    true,
+			})
+		}
+
+		// Orphan sweep: sidecars (`.lock`, `.tmp*`, `.source`) whose parent
+		// `-rootfs.ext4` is missing. Phase 2 adds the flock + age-threshold
+		// checks before acting on these; Phase 1 only reports.
+		orphans, err := findOrphans(imagesDir)
+		if err != nil {
+			return du, fmt.Errorf("scanning orphans: %w", err)
+		}
+		du.Orphans = orphans
+	}
+
+	// Kernel + initrd
+	if c.cfg.KernelPath != "" {
+		if logical, physical, err := diskstat.Stat(c.cfg.KernelPath); err == nil {
+			du.Kernel = &config.FileEntry{
+				Path: c.cfg.KernelPath,
+				Size: config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
+				Kind: "kernel",
+			}
+		}
+	}
+	if c.cfg.InitrdPath != "" {
+		if logical, physical, err := diskstat.Stat(c.cfg.InitrdPath); err == nil {
+			du.Initrd = &config.FileEntry{
+				Path: c.cfg.InitrdPath,
+				Size: config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
+				Kind: "initrd",
+			}
+		}
+	}
+
+	// Per-instance disk usage. Use ListInstances (no staleness re-check) for
+	// reporting — we only want what's on disk now, regardless of agent state.
+	instanceDir := c.cfg.InstanceDir
+	if instanceDir != "" {
+		names, err := ListInstances(instanceDir)
+		if err != nil {
+			return du, fmt.Errorf("listing instances: %w", err)
+		}
+		for _, name := range names {
+			meta, err := LoadMetadata(instanceDir, name)
+			if err != nil {
+				// Skip malformed metadata; don't fail the whole df.
+				continue
+			}
+			du.Sheds = append(du.Sheds, shedDiskEntryForVZ(instanceDir, meta))
+		}
+	}
+
+	// Totals
+	for _, img := range du.Images {
+		du.Totals.Images.LogicalBytes += img.Size.LogicalBytes
+		du.Totals.Images.PhysicalBytes += img.Size.PhysicalBytes
+	}
+	if du.Kernel != nil {
+		du.Totals.Images.LogicalBytes += du.Kernel.Size.LogicalBytes
+		du.Totals.Images.PhysicalBytes += du.Kernel.Size.PhysicalBytes
+	}
+	if du.Initrd != nil {
+		du.Totals.Images.LogicalBytes += du.Initrd.Size.LogicalBytes
+		du.Totals.Images.PhysicalBytes += du.Initrd.Size.PhysicalBytes
+	}
+	for _, shed := range du.Sheds {
+		du.Totals.Sheds.LogicalBytes += shed.Total.LogicalBytes
+		du.Totals.Sheds.PhysicalBytes += shed.Total.PhysicalBytes
+	}
+	for _, orph := range du.Orphans {
+		du.Totals.Orphans.LogicalBytes += orph.Size.LogicalBytes
+		du.Totals.Orphans.PhysicalBytes += orph.Size.PhysicalBytes
+	}
+	du.Totals.All.LogicalBytes = du.Totals.Images.LogicalBytes + du.Totals.Sheds.LogicalBytes + du.Totals.Orphans.LogicalBytes
+	du.Totals.All.PhysicalBytes = du.Totals.Images.PhysicalBytes + du.Totals.Sheds.PhysicalBytes + du.Totals.Orphans.PhysicalBytes
+
+	du.Notes = append(du.Notes,
+		"physical bytes may overcount shared extents on APFS (clonefile) or hardlinks",
+	)
+
+	return du, nil
+}
+
+// shedDiskEntryForVZ builds a ShedDiskEntry for a single VZ instance.
+func shedDiskEntryForVZ(instanceDir string, meta *Metadata) config.ShedDiskEntry {
+	entry := config.ShedDiskEntry{
+		Name:   meta.Name,
+		Status: meta.Status,
+		Image:  meta.Image,
+	}
+
+	rootfsPath := RootfsPath(instanceDir, meta.Name)
+	rootfsLogical, rootfsPhysical, _ := diskstat.Stat(rootfsPath)
+	entry.Rootfs = config.FileEntry{
+		Path: rootfsPath,
+		Size: config.DiskSize{LogicalBytes: rootfsLogical, PhysicalBytes: rootfsPhysical},
+		Kind: "rootfs",
+	}
+
+	consolePath := filepath.Join(InstanceDir(instanceDir, meta.Name), consoleLogFilename)
+	if logical, physical, err := diskstat.Stat(consolePath); err == nil {
+		entry.ConsoleLog = &config.FileEntry{
+			Path: consolePath,
+			Size: config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
+			Kind: "console_log",
+		}
+	}
+
+	metaPath := MetadataPath(instanceDir, meta.Name)
+	if logical, physical, err := diskstat.Stat(metaPath); err == nil {
+		entry.OtherFiles = append(entry.OtherFiles, config.FileEntry{
+			Path: metaPath,
+			Size: config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
+			Kind: "metadata",
+		})
+	}
+
+	entry.Total.LogicalBytes = entry.Rootfs.Size.LogicalBytes
+	entry.Total.PhysicalBytes = entry.Rootfs.Size.PhysicalBytes
+	if entry.ConsoleLog != nil {
+		entry.Total.LogicalBytes += entry.ConsoleLog.Size.LogicalBytes
+		entry.Total.PhysicalBytes += entry.ConsoleLog.Size.PhysicalBytes
+	}
+	for _, f := range entry.OtherFiles {
+		entry.Total.LogicalBytes += f.Size.LogicalBytes
+		entry.Total.PhysicalBytes += f.Size.PhysicalBytes
+	}
+
+	return entry
+}
+
+// findOrphans scans imagesDir for sidecar files (`.lock`, `.tmp*`, `.source`)
+// whose corresponding `{name}-rootfs.ext4` does not exist. Phase 1 is
+// observational — Phase 2 adds flock / age checks before acting.
+func findOrphans(imagesDir string) ([]config.FileEntry, error) {
+	entries, err := os.ReadDir(imagesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// Build the set of base rootfs names present on disk.
+	presentRootfs := make(map[string]bool)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(e.Name(), "-rootfs.ext4") {
+			presentRootfs[e.Name()] = true
+		}
+	}
+
+	var orphans []config.FileEntry
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		base, kind := classifySidecar(name)
+		if base == "" {
+			continue
+		}
+		if presentRootfs[base] {
+			continue
+		}
+		path := filepath.Join(imagesDir, name)
+		logical, physical, err := diskstat.Stat(path)
+		if err != nil {
+			continue
+		}
+		orphans = append(orphans, config.FileEntry{
+			Path: path,
+			Size: config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
+			Kind: kind,
+		})
+	}
+	return orphans, nil
+}
+
+// classifySidecar returns the parent rootfs filename and the sidecar kind
+// for a filename. Returns ("", "") for anything that isn't a known sidecar.
+//
+// Recognized patterns (all relative to `{name}-rootfs.ext4`):
+//   - {name}-rootfs.ext4.lock
+//   - {name}-rootfs.ext4.source
+//   - {name}-rootfs.ext4.tmp   or   {name}-rootfs.ext4.tmp.{pid}
+func classifySidecar(filename string) (baseRootfs, kind string) {
+	const suffix = "-rootfs.ext4"
+	idx := strings.Index(filename, suffix)
+	if idx < 0 {
+		return "", ""
+	}
+	after := filename[idx+len(suffix):]
+	if after == "" {
+		return "", "" // the rootfs itself
+	}
+	if after == ".lock" {
+		return filename[:idx+len(suffix)], "lock"
+	}
+	if after == ".source" {
+		return filename[:idx+len(suffix)], "source"
+	}
+	if after == ".tmp" || strings.HasPrefix(after, ".tmp.") {
+		return filename[:idx+len(suffix)], "tmp"
+	}
+	return "", ""
+}

--- a/internal/vz/system.go
+++ b/internal/vz/system.go
@@ -310,7 +310,9 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 		Skipped:    []config.SkippedItem{},
 	}
 
-	// Step 1: snapshot mtimes BEFORE ListSheds.
+	// Step 1: snapshot mtimes BEFORE ListSheds. Plan-mandated: ListSheds
+	// can refresh mtime via its stale-running→stopped re-check, which would
+	// otherwise reset the age clock and confuse the age filter.
 	mtimes := snapshotMetadataMtimes(c.cfg.InstanceDir)
 
 	// Step 2a: instance candidates.
@@ -324,17 +326,20 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 		report.Skipped = append(report.Skipped, skipped...)
 	}
 
-	// Step 2b: orphan candidates.
+	// Step 2b: orphan candidates. Skipped: empty ImagesDir means there's
+	// no configured cache, and passing "" to os.ReadDir would scan the
+	// daemon's working directory (Codex review).
 	var orphanCandidates []orphanCandidate
-	if opts.Orphans {
+	if opts.Orphans && c.cfg.ImagesDir != "" {
 		cands, skipped := collectOrphanCandidates(c.cfg.ImagesDir)
 		orphanCandidates = cands
 		report.Skipped = append(report.Skipped, skipped...)
 	}
 
 	// Step 2c: image candidates (dry-run, respects candidate deletions).
+	// Same empty-ImagesDir guard for safety.
 	var imageCandidates []vmimage.ImageInfo
-	if opts.Images {
+	if opts.Images && c.cfg.ImagesDir != "" {
 		skipSet := make(map[string]bool, len(instanceCandidates))
 		for _, ic := range instanceCandidates {
 			skipSet[ic.name] = true
@@ -349,6 +354,15 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 		imageCandidates = cands
 	}
 
+	// Step 2d: log-truncation candidates. Critical: these must be
+	// collected during the candidate phase — NOT the execute phase — or
+	// the dry-run-first CLI flow sees zero candidates and exits before
+	// anything can be truncated. (Codex review #1.)
+	var logCandidates []logCandidate
+	if opts.Logs {
+		logCandidates = c.collectLogCandidates(opts.LogTailBytes)
+	}
+
 	// Populate candidate Items for dry-run display. On execute we'll
 	// rebuild with post-action Freed numbers — but for instances/orphans
 	// the pre-delete attributed bytes are exactly what we want to show.
@@ -361,6 +375,9 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 	for _, img := range imageCandidates {
 		report.Items = append(report.Items, imageToPrunedItem(img, opts.DryRun))
 	}
+	for _, lc := range logCandidates {
+		report.Items = append(report.Items, lc.toPrunedItem(opts.DryRun))
+	}
 
 	if opts.DryRun {
 		finalizeReport(&report)
@@ -372,7 +389,6 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 
 	// 3a: delete candidate instances via DeleteShed (handles TAP/cred
 	// cleanup correctly and re-checks running state under its own lock).
-	deletedSheds := 0
 	for _, ic := range instanceCandidates {
 		if err := c.DeleteShed(ctx, ic.name, false); err != nil {
 			report.Skipped = append(report.Skipped, config.SkippedItem{
@@ -382,15 +398,17 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 			continue
 		}
 		report.Items = append(report.Items, ic.toPrunedItem(false))
-		deletedSheds++
 	}
 
 	// 3b: real image prune. ListInstances no longer sees deleted sheds,
 	// so the unmodified inUseImageNames closure returns the correct set.
-	if opts.Images {
+	// On error we still return the report (with Items populated from 3a)
+	// so the client sees partial progress rather than a bare 500.
+	if opts.Images && c.cfg.ImagesDir != "" {
 		mgr := vmimage.NewManager(c.cfg)
 		deleted, err := mgr.PruneImages(false, c.inUseImageNames)
 		if err != nil {
+			finalizeReport(&report)
 			return report, fmt.Errorf("image prune: %w", err)
 		}
 		for _, img := range deleted {
@@ -414,9 +432,16 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 
 	// 3d: truncate console.log on surviving VZ sheds.
 	if opts.Logs {
-		truncated, skipped := c.truncateConsoleLogs(opts.LogTailBytes)
-		report.Items = append(report.Items, truncated...)
-		report.Skipped = append(report.Skipped, skipped...)
+		for _, lc := range logCandidates {
+			if err := truncateConsoleLogInPlace(lc.path, lc.origSize, opts.LogTailBytes); err != nil {
+				report.Skipped = append(report.Skipped, config.SkippedItem{
+					Kind: "console_log", Name: lc.shedName, Path: lc.path,
+					Reason: fmt.Sprintf("truncate failed: %v", err),
+				})
+				continue
+			}
+			report.Items = append(report.Items, lc.toPrunedItem(false))
+		}
 	}
 
 	finalizeReport(&report)
@@ -578,6 +603,11 @@ func (oc orphanCandidate) toPrunedItem(dry bool) config.PrunedItem {
 // collectOrphanCandidates scans imagesDir for sidecars whose parent rootfs
 // is absent, after verifying the canonical `.lock` is NOT held by a live
 // conversion and the file is not a very-fresh `.tmp`.
+//
+// `.lock` orphans are NEVER candidates — sweepOrphan refuses to remove them
+// to avoid the inode-reuse race (see Manager.PruneImages). Instead they're
+// reported as SkippedItem with reason "lock file retained" so the report
+// doesn't lie about what will/did happen. (Codex review #4.)
 func collectOrphanCandidates(imagesDir string) ([]orphanCandidate, []config.SkippedItem) {
 	var candidates []orphanCandidate
 	var skipped []config.SkippedItem
@@ -610,6 +640,16 @@ func collectOrphanCandidates(imagesDir string) ([]orphanCandidate, []config.Skip
 			continue
 		}
 
+		// .lock orphans: preserved, not deleted. Recorded as SkippedItem
+		// so the report accurately reflects the no-op.
+		if kind == "lock" {
+			skipped = append(skipped, config.SkippedItem{
+				Kind: kind, Path: path,
+				Reason: "lock file retained (inode-reuse race safety)",
+			})
+			continue
+		}
+
 		// .tmp files younger than tmpOrphanMinAge are almost certainly an
 		// in-flight EnsureImage. Skip with reason.
 		if kind == "tmp" && now.Sub(fi.ModTime()) < tmpOrphanMinAge {
@@ -620,8 +660,11 @@ func collectOrphanCandidates(imagesDir string) ([]orphanCandidate, []config.Skip
 			continue
 		}
 
-		// Confirm the canonical lock is NOT held. A conversion can write a
-		// .tmp before the ext4 exists, holding the .lock the whole time.
+		// Confirm the canonical lock is NOT held. A conversion can write
+		// a .tmp before the ext4 exists, holding the .lock the whole time.
+		// TryAcquireFileLock treats a missing .lock as "nothing to contend
+		// with" so we don't pollute the cache dir with new lock files
+		// during dry-run probes.
 		lockPath := filepath.Join(imagesDir, base+".lock")
 		release, held, err := vmimage.TryAcquireFileLock(lockPath)
 		if err != nil {
@@ -651,8 +694,8 @@ func collectOrphanCandidates(imagesDir string) ([]orphanCandidate, []config.Skip
 
 // sweepOrphan re-acquires the canonical flock and deletes the sidecar.
 // Returns false on any failure — the caller should record a SkippedItem.
-// Never removes the .lock file itself when that's the orphan (matches
-// Manager.DeleteImage convention: unlinking locks creates a race).
+// `.lock` orphans are filtered out upstream in collectOrphanCandidates so
+// by the time sweepOrphan runs, oc.kind is "tmp" or "source".
 func sweepOrphan(imagesDir string, oc orphanCandidate) bool {
 	base := filepath.Base(oc.path)
 	rootfsBase, _ := classifySidecar(base)
@@ -665,14 +708,6 @@ func sweepOrphan(imagesDir string, oc orphanCandidate) bool {
 		return false
 	}
 	defer release()
-
-	if oc.kind == "lock" {
-		// The .lock IS the canonical lock — leave it in place to avoid
-		// the race documented in Manager.PruneImages. Treat the orphan
-		// as "handled" conceptually: the parent ext4 is gone, the lock
-		// is dormant, and the next conversion will flock+reuse the inode.
-		return true
-	}
 
 	if err := os.Remove(oc.path); err != nil {
 		// Treat "already gone" as success — another sweep beat us to it.
@@ -702,51 +737,72 @@ func imageToPrunedItem(img vmimage.ImageInfo, dry bool) config.PrunedItem {
 	}
 }
 
-// truncateConsoleLogs shrinks each surviving VZ shed's console.log to its
-// last tailBytes. Uses ftruncate-in-place + rewrite-tail so vfkit's
-// O_APPEND fd keeps writing past the new EOF.
-//
-// Small lost-writes race: writes between our read-tail and our truncate
-// disappear. For a debug aid this is acceptable.
-func (c *Client) truncateConsoleLogs(tailBytes int64) ([]config.PrunedItem, []config.SkippedItem) {
-	var done []config.PrunedItem
-	var skipped []config.SkippedItem
+// logCandidate is a console.log file eligible for truncation. Captured
+// during the candidate phase so dry-run reports honor --logs, matching
+// how instance/orphan/image candidates flow.
+type logCandidate struct {
+	shedName  string
+	path      string
+	origSize  int64
+	tailBytes int64
+}
+
+func (lc logCandidate) toPrunedItem(dry bool) config.PrunedItem {
+	freed := lc.origSize - lc.tailBytes
+	reason := fmt.Sprintf("would keep last %s", humanBytes(lc.tailBytes))
+	if !dry {
+		reason = fmt.Sprintf("kept last %s", humanBytes(lc.tailBytes))
+	}
+	return config.PrunedItem{
+		Kind: "console_log", Name: lc.shedName, Path: lc.path,
+		Action: "truncated",
+		Freed:  config.DiskSize{LogicalBytes: freed, PhysicalBytes: freed},
+		Reason: reason,
+	}
+}
+
+// collectLogCandidates returns one logCandidate per VZ shed whose
+// console.log is larger than tailBytes. Pure read — no mutation — so
+// it's safe to run unconditionally during the candidate phase.
+func (c *Client) collectLogCandidates(tailBytes int64) []logCandidate {
+	var cands []logCandidate
 
 	names, err := ListInstances(c.cfg.InstanceDir)
 	if err != nil {
-		return nil, nil
+		return nil
 	}
 	for _, name := range names {
 		consolePath := filepath.Join(InstanceDir(c.cfg.InstanceDir, name), consoleLogFilename)
 		fi, err := os.Stat(consolePath)
 		if err != nil {
-			continue // no log — nothing to do (skip silently, not a candidate)
+			continue // no log — nothing to report
 		}
 		if fi.Size() <= tailBytes {
-			skipped = append(skipped, config.SkippedItem{
-				Kind: "console_log", Name: name, Path: consolePath,
-				Reason: fmt.Sprintf("size %d ≤ tail %d", fi.Size(), tailBytes),
-			})
-			continue
+			continue // already small enough; skip silently (don't clutter)
 		}
-
-		origSize := fi.Size()
-		if err := truncateConsoleLogInPlace(consolePath, origSize, tailBytes); err != nil {
-			skipped = append(skipped, config.SkippedItem{
-				Kind: "console_log", Name: name, Path: consolePath,
-				Reason: fmt.Sprintf("truncate failed: %v", err),
-			})
-			continue
-		}
-		freed := origSize - tailBytes
-		done = append(done, config.PrunedItem{
-			Kind: "console_log", Name: name, Path: consolePath,
-			Action: "truncated",
-			Freed:  config.DiskSize{LogicalBytes: freed, PhysicalBytes: freed},
-			Reason: fmt.Sprintf("kept last %d bytes", tailBytes),
+		cands = append(cands, logCandidate{
+			shedName:  name,
+			path:      consolePath,
+			origSize:  fi.Size(),
+			tailBytes: tailBytes,
 		})
 	}
-	return done, skipped
+	return cands
+}
+
+// humanBytes is a tiny helper for log reasons. Avoids pulling in the
+// CLI's formatSize (different package).
+func humanBytes(n int64) string {
+	const mb = 1024 * 1024
+	const kb = 1024
+	switch {
+	case n >= mb:
+		return fmt.Sprintf("%.1f MiB", float64(n)/float64(mb))
+	case n >= kb:
+		return fmt.Sprintf("%.1f KiB", float64(n)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
 }
 
 // truncateConsoleLogInPlace truncates path to 0 and rewrites the last

--- a/internal/vz/system_prune_test.go
+++ b/internal/vz/system_prune_test.go
@@ -163,12 +163,33 @@ func TestPrune_Instances_UntilZero_AnyAge(t *testing.T) {
 	}
 }
 
-func TestPrune_Instances_RunningNeverPruned(t *testing.T) {
+// TestPrune_MtimeSnapshotBeatsStalenessResave verifies the plan-mandated
+// ordering: mtime(metadata.json) is captured BEFORE ListSheds. ListSheds's
+// stale-running→stopped re-check rewrites metadata.json and would
+// otherwise bump mtime past the age threshold, making the shed ineligible
+// for pruning despite being old.
+//
+// We seed a "running" shed with no underlying vfkit process and an mtime
+// 30 days in the past. ListSheds flips the status to stopped and resaves
+// (mtime = now). The prune pass should still see the shed as a candidate
+// because the snapshot was taken first. Without the snapshot, the post-
+// resave mtime would make the shed look "too recent" against the 72h
+// threshold.
+//
+// NOTE: This test does NOT prove that a live running shed is never
+// pruned — that's a separate invariant upheld by `collectInstanceCandidates`
+// filtering on `Status == StatusStopped`. See TestPrune_Instances_AgeFilter
+// for the running-shed protection check (api-dev is running and lands in
+// Skipped, not Items). A fully process-level "is vfkit actually running"
+// test would require a vfkit fixture and is out of scope for unit tests.
+func TestPrune_MtimeSnapshotBeatsStalenessResave(t *testing.T) {
 	c, _, instanceDir := newPruneTestClient(t)
-	// Running shed, backdated way past the threshold.
+	// Seed a shed whose metadata.json claims "running" but no actual
+	// vfkit process backs it. ListSheds's staleness pass will flip it to
+	// stopped and resave metadata.
 	meta := &Metadata{
 		Version: MetadataVersion,
-		Name:    "running-shed",
+		Name:    "stale-running",
 		Status:  config.StatusRunning,
 		Backend: "vz",
 	}
@@ -176,7 +197,7 @@ func TestPrune_Instances_RunningNeverPruned(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 	past := time.Now().Add(-30 * 24 * time.Hour)
-	_ = os.Chtimes(MetadataPath(instanceDir, "running-shed"), past, past)
+	_ = os.Chtimes(MetadataPath(instanceDir, "stale-running"), past, past)
 
 	report, err := c.Prune(context.Background(), backend.PruneOptions{
 		Instances: true,
@@ -185,24 +206,14 @@ func TestPrune_Instances_RunningNeverPruned(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Prune: %v", err)
 	}
-	// Check the GetShed staleness pass: because we have no vfkit process
-	// running for this name, GetShed will flip status to "stopped" and
-	// resave metadata (which bumps mtime). The prune candidate collection
-	// uses the PRE-ListSheds mtime snapshot, so the shed appears as a
-	// candidate — but with an updated status of "stopped" from GetShed.
-	//
-	// This is exactly why the plan mandates the mtime snapshot happen
-	// BEFORE ListSheds. Assert the mechanic directly: the shed should
-	// now appear in Items as an instance delete (snapshot said it was
-	// old enough; ListSheds said it's stopped).
 	found := false
 	for _, it := range report.Items {
-		if it.Name == "running-shed" {
+		if it.Name == "stale-running" {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("expected running-shed (now stopped via stale-check) to prune thanks to mtime snapshot, got %v", report.Items)
+		t.Errorf("mtime snapshot must beat staleness resave — expected stale-running to be pruned despite ListSheds bumping mtime. Got items %+v", report.Items)
 	}
 }
 
@@ -450,4 +461,157 @@ func contains(haystack []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+// TestPrune_EmptyImagesDir_NoCWDScan (Codex #7 regression) verifies the
+// handler-level guard: when ImagesDir is blank, orphan and image sweep
+// must be skipped rather than scanning the process's current directory.
+func TestPrune_EmptyImagesDir_NoCWDScan(t *testing.T) {
+	c, _, instanceDir := newPruneTestClient(t)
+	c.cfg.ImagesDir = "" // no images dir configured
+
+	// A sibling file in CWD that would LOOK like an orphan if the code
+	// incorrectly scanned ".". The test's working dir is the vz package;
+	// drop a decoy into a temp dir we chdir into to verify no scan occurs
+	// even when there IS a matching file in cwd.
+	decoyDir := t.TempDir()
+	decoyPath := filepath.Join(decoyDir, "decoy-rootfs.ext4.tmp")
+	if err := os.WriteFile(decoyPath, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldCWD, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(oldCWD) })
+	if err := os.Chdir(decoyDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed a stopped shed so the instances path has something to do —
+	// that ensures the test isn't a trivial no-op.
+	seedStoppedShed(t, instanceDir, "old", "", 1024, 0, 5*24*time.Hour)
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{
+		Orphans:   true,
+		Instances: true,
+		Until:     72 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	// The decoy must not show up as a candidate or skipped.
+	for _, it := range report.Items {
+		if strings.Contains(it.Path, "decoy-rootfs.ext4.tmp") {
+			t.Errorf("empty ImagesDir leaked a CWD scan: item %+v", it)
+		}
+	}
+	for _, s := range report.Skipped {
+		if strings.Contains(s.Path, "decoy-rootfs.ext4.tmp") {
+			t.Errorf("empty ImagesDir leaked a CWD scan: skipped %+v", s)
+		}
+	}
+	// Instance path should still work.
+	if len(report.Items) == 0 {
+		t.Errorf("instance prune should still happen even with empty ImagesDir; got zero items")
+	}
+}
+
+// TestPrune_LockOrphan_IsSkippedNotDeleted (Codex #4 regression): a
+// `.lock` sidecar without its parent rootfs must be reported as a
+// SkippedItem with a clear reason, NOT as a PrunedItem (since sweepOrphan
+// never removes lock files).
+func TestPrune_LockOrphan_IsSkippedNotDeleted(t *testing.T) {
+	c, imagesDir, _ := newPruneTestClient(t)
+
+	// Orphan .lock — no parent rootfs, no concurrent conversion.
+	lockPath := filepath.Join(imagesDir, "dead-rootfs.ext4.lock")
+	if err := os.WriteFile(lockPath, []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	// Must NOT appear in Items.
+	for _, it := range report.Items {
+		if it.Path == lockPath {
+			t.Errorf(".lock orphan appeared in Items (should be Skipped only): %+v", it)
+		}
+	}
+	// Must appear in Skipped with "retained" reason.
+	found := false
+	for _, s := range report.Skipped {
+		if s.Path == lockPath && strings.Contains(s.Reason, "retained") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected .lock orphan skipped with 'retained' reason, got %+v", report.Skipped)
+	}
+	// File must still exist (never removed).
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Errorf(".lock orphan was removed: %v", err)
+	}
+}
+
+// TestPrune_Logs_DryRunShowsCandidates (Codex #1 regression): `--logs`
+// candidates must appear in the dry-run report so the CLI's dry-run-first
+// flow doesn't exit before truncation can happen.
+func TestPrune_Logs_DryRunShowsCandidates(t *testing.T) {
+	c, _, instanceDir := newPruneTestClient(t)
+
+	seedStoppedShed(t, instanceDir, "chatty", "", 0, 0, 0)
+	dir := InstanceDir(instanceDir, "chatty")
+	if err := os.WriteFile(filepath.Join(dir, consoleLogFilename), make([]byte, 10*1024*1024), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{
+		Logs:         true,
+		LogTailBytes: 4096,
+		DryRun:       true,
+	})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	found := false
+	for _, it := range report.Items {
+		if it.Kind == "console_log" && it.Name == "chatty" && it.Action == "truncated" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("dry-run with --logs should show the candidate; got items %+v", report.Items)
+	}
+	// Dry-run must NOT mutate the file.
+	fi, err := os.Stat(filepath.Join(dir, consoleLogFilename))
+	if err != nil || fi.Size() != 10*1024*1024 {
+		t.Errorf("dry-run mutated the console.log (size %d)", fi.Size())
+	}
+}
+
+// TestTryAcquireFileLock_NoCreate (Codex #3 regression): dry-run probe
+// must not create a new .lock file as a side effect.
+func TestTryAcquireFileLock_NoCreate(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "nonexistent.lock")
+
+	// Pre-check: no file present.
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("precondition: lock file should not exist, got err=%v", err)
+	}
+
+	release, held, err := vmimage.TryAcquireFileLock(lockPath)
+	if err != nil {
+		t.Fatalf("TryAcquireFileLock: %v", err)
+	}
+	if !held {
+		t.Errorf("held=false for nonexistent lock; should be treated as 'nothing to contend'")
+	}
+	if release != nil {
+		release()
+	}
+	// The probe must not have created the file.
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Errorf("TryAcquireFileLock created the lock file; it should be a no-op for missing locks")
+	}
 }

--- a/internal/vz/system_prune_test.go
+++ b/internal/vz/system_prune_test.go
@@ -1,0 +1,453 @@
+//go:build darwin
+
+package vz
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/vmimage"
+	"github.com/charliek/shed/internal/vmutil"
+)
+
+// newPruneTestClient builds a Client rooted in t.TempDir's and returns the
+// images and instance dirs so tests can seed fixtures directly.
+func newPruneTestClient(t *testing.T) (*Client, string, string) {
+	t.Helper()
+	imagesDir := t.TempDir()
+	instanceDir := t.TempDir()
+
+	cfg := &config.VZConfig{
+		ImagesDir:   imagesDir,
+		InstanceDir: instanceDir,
+		Images:      map[string]string{},
+		BaseRootfs:  "",
+	}
+	serverCfg := &config.ServerConfig{Name: "test-prune"}
+
+	// GetShed's stale-running→stopped branch touches credMgr.HealthTracker,
+	// so even pure "prune stopped shed" tests need a non-nil credMgr. The
+	// tracker itself may be nil — HealthTracker() returns nil safely, and
+	// the caller checks before use.
+	credMgr := vmutil.NewCredentialManager(nil, nil, "test", nil)
+	c := &Client{cfg: cfg, serverCfg: serverCfg, credMgr: credMgr}
+	return c, imagesDir, instanceDir
+}
+
+// seedStoppedShed creates a stopped-instance fixture with a rootfs and
+// (optionally) a console.log. Backdate sets metadata.json mtime so the age
+// filter sees it as "old enough."
+func seedStoppedShed(t *testing.T, instanceDir, name, image string, rootfsSize int, consoleSize int, age time.Duration) {
+	t.Helper()
+	meta := &Metadata{
+		Version: MetadataVersion,
+		Name:    name,
+		Status:  config.StatusStopped,
+		Backend: "vz",
+		Image:   image,
+	}
+	if err := meta.Save(instanceDir); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	dir := InstanceDir(instanceDir, name)
+	if rootfsSize > 0 {
+		if err := os.WriteFile(filepath.Join(dir, "rootfs.ext4"), make([]byte, rootfsSize), 0644); err != nil {
+			t.Fatalf("write rootfs: %v", err)
+		}
+	}
+	if consoleSize > 0 {
+		if err := os.WriteFile(filepath.Join(dir, consoleLogFilename), make([]byte, consoleSize), 0644); err != nil {
+			t.Fatalf("write console.log: %v", err)
+		}
+	}
+	if age > 0 {
+		past := time.Now().Add(-age)
+		if err := os.Chtimes(MetadataPath(instanceDir, name), past, past); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+	}
+}
+
+func TestPrune_DryRun_NoMutation(t *testing.T) {
+	c, _, instanceDir := newPruneTestClient(t)
+	seedStoppedShed(t, instanceDir, "old-shed", "default", 4096, 0, 5*24*time.Hour)
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{
+		Instances: true,
+		DryRun:    true,
+		Until:     72 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if !report.DryRun {
+		t.Errorf("expected DryRun=true in report")
+	}
+	if report.Totals.Items != 1 {
+		t.Fatalf("expected 1 candidate, got %d", report.Totals.Items)
+	}
+	// Critical: the shed must still exist on disk.
+	if _, err := os.Stat(InstanceDir(instanceDir, "old-shed")); err != nil {
+		t.Errorf("dry-run deleted the shed: %v", err)
+	}
+}
+
+func TestPrune_Instances_AgeFilter(t *testing.T) {
+	c, _, instanceDir := newPruneTestClient(t)
+	// 5 days old — should prune.
+	seedStoppedShed(t, instanceDir, "old-shed", "", 4096, 0, 5*24*time.Hour)
+	// 1 hour old — should be skipped.
+	seedStoppedShed(t, instanceDir, "recent-shed", "", 4096, 0, time.Hour)
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{
+		Instances: true,
+		Until:     72 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+
+	var deletedNames, skippedNames []string
+	for _, it := range report.Items {
+		if it.Kind == "instance" {
+			deletedNames = append(deletedNames, it.Name)
+		}
+	}
+	for _, s := range report.Skipped {
+		if s.Kind == "instance" {
+			skippedNames = append(skippedNames, s.Name)
+		}
+	}
+	if !contains(deletedNames, "old-shed") {
+		t.Errorf("expected old-shed deleted, got %v", deletedNames)
+	}
+	if !contains(skippedNames, "recent-shed") {
+		t.Errorf("expected recent-shed skipped, got %v", skippedNames)
+	}
+	// The deleted shed must actually be gone.
+	if _, err := os.Stat(InstanceDir(instanceDir, "old-shed")); !os.IsNotExist(err) {
+		t.Errorf("old-shed still exists after prune (err=%v)", err)
+	}
+	// The recent shed must be preserved.
+	if _, err := os.Stat(InstanceDir(instanceDir, "recent-shed")); err != nil {
+		t.Errorf("recent-shed was incorrectly deleted: %v", err)
+	}
+}
+
+func TestPrune_Instances_UntilZero_AnyAge(t *testing.T) {
+	c, _, instanceDir := newPruneTestClient(t)
+	// No backdating — just-created shed.
+	seedStoppedShed(t, instanceDir, "fresh-shed", "", 4096, 0, 0)
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{
+		Instances: true,
+		Until:     0, // any age
+	})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	found := false
+	for _, it := range report.Items {
+		if it.Name == "fresh-shed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected fresh-shed to be pruned with Until=0, got items %v", report.Items)
+	}
+}
+
+func TestPrune_Instances_RunningNeverPruned(t *testing.T) {
+	c, _, instanceDir := newPruneTestClient(t)
+	// Running shed, backdated way past the threshold.
+	meta := &Metadata{
+		Version: MetadataVersion,
+		Name:    "running-shed",
+		Status:  config.StatusRunning,
+		Backend: "vz",
+	}
+	if err := meta.Save(instanceDir); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	past := time.Now().Add(-30 * 24 * time.Hour)
+	_ = os.Chtimes(MetadataPath(instanceDir, "running-shed"), past, past)
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{
+		Instances: true,
+		Until:     72 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	// Check the GetShed staleness pass: because we have no vfkit process
+	// running for this name, GetShed will flip status to "stopped" and
+	// resave metadata (which bumps mtime). The prune candidate collection
+	// uses the PRE-ListSheds mtime snapshot, so the shed appears as a
+	// candidate — but with an updated status of "stopped" from GetShed.
+	//
+	// This is exactly why the plan mandates the mtime snapshot happen
+	// BEFORE ListSheds. Assert the mechanic directly: the shed should
+	// now appear in Items as an instance delete (snapshot said it was
+	// old enough; ListSheds said it's stopped).
+	found := false
+	for _, it := range report.Items {
+		if it.Name == "running-shed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected running-shed (now stopped via stale-check) to prune thanks to mtime snapshot, got %v", report.Items)
+	}
+}
+
+func TestPrune_Orphans_LockSkippedIfHeld(t *testing.T) {
+	c, imagesDir, _ := newPruneTestClient(t)
+
+	// A missing rootfs ("dead") with a .tmp sidecar that's old enough.
+	tmpPath := filepath.Join(imagesDir, "dead-rootfs.ext4.tmp")
+	if err := os.WriteFile(tmpPath, []byte("junk"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-2 * time.Hour)
+	_ = os.Chtimes(tmpPath, past, past)
+
+	// Hold the canonical lock in this process to simulate a live
+	// conversion. We use a blocking flock here because the prune path
+	// probes non-blocking and must see us.
+	lockPath := filepath.Join(imagesDir, "dead-rootfs.ext4.lock")
+	release, err := vmimage.TryAcquireFileLockBlocking(lockPath)
+	if err != nil {
+		t.Fatalf("test setup: acquire lock: %v", err)
+	}
+	defer release()
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{
+		Orphans: true,
+		Until:   72 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	// The .tmp must NOT appear in deleted items.
+	for _, it := range report.Items {
+		if it.Path == tmpPath {
+			t.Errorf("tmp orphan deleted despite lock held: %+v", it)
+		}
+	}
+	// It should appear in Skipped with "lock held" reason.
+	found := false
+	for _, s := range report.Skipped {
+		if strings.Contains(s.Path, "dead-rootfs.ext4.tmp") && strings.Contains(s.Reason, "lock held") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected tmp to be skipped with 'lock held', got %+v", report.Skipped)
+	}
+	// File must still exist.
+	if _, err := os.Stat(tmpPath); err != nil {
+		t.Errorf("tmp file was deleted: %v", err)
+	}
+}
+
+func TestPrune_Orphans_TmpTooRecent(t *testing.T) {
+	c, imagesDir, _ := newPruneTestClient(t)
+
+	// Fresh .tmp (< 1 hour old) — should be skipped regardless of lock state.
+	tmpPath := filepath.Join(imagesDir, "fresh-rootfs.ext4.tmp")
+	if err := os.WriteFile(tmpPath, []byte("junk"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	for _, it := range report.Items {
+		if it.Path == tmpPath {
+			t.Errorf("fresh .tmp deleted; should be skipped as too recent: %+v", it)
+		}
+	}
+	if _, err := os.Stat(tmpPath); err != nil {
+		t.Errorf("fresh .tmp was deleted: %v", err)
+	}
+}
+
+func TestPrune_Orphans_SourceWithoutRootfsDeleted(t *testing.T) {
+	c, imagesDir, _ := newPruneTestClient(t)
+
+	// An orphaned .source (old enough, no matching rootfs, no live lock).
+	srcPath := filepath.Join(imagesDir, "abandoned-rootfs.ext4.source")
+	if err := os.WriteFile(srcPath, []byte("ghcr.io/x/abandoned:v1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	found := false
+	for _, it := range report.Items {
+		if it.Path == srcPath && it.Kind == "source" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected .source orphan deleted, got items %+v", report.Items)
+	}
+	if _, err := os.Stat(srcPath); !os.IsNotExist(err) {
+		t.Errorf(".source still exists after prune (err=%v)", err)
+	}
+}
+
+func TestPrune_JSON_NoOp(t *testing.T) {
+	c, _, _ := newPruneTestClient(t)
+	// Empty state: scope defaults apply, nothing to do.
+	report, err := c.Prune(context.Background(), backend.PruneOptions{})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if report.Totals.Items != 0 {
+		t.Errorf("expected 0 items in empty state, got %d", report.Totals.Items)
+	}
+}
+
+func TestPrune_LogTruncation_PreservesTail(t *testing.T) {
+	c, _, instanceDir := newPruneTestClient(t)
+
+	// Seed a stopped shed with a large console.log.
+	seedStoppedShed(t, instanceDir, "chatty", "", 0, 0, 0)
+	dir := InstanceDir(instanceDir, "chatty")
+	const origSize = 10 * 1024 * 1024
+	content := make([]byte, origSize)
+	// Pattern so the tail is identifiable: last 1024 bytes = 'Z'.
+	for i := range content {
+		content[i] = 'A'
+	}
+	for i := origSize - 1024; i < origSize; i++ {
+		content[i] = 'Z'
+	}
+	if err := os.WriteFile(filepath.Join(dir, consoleLogFilename), content, 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	// Truncate to last 4 KiB.
+	const tail = 4096
+	_, err := c.Prune(context.Background(), backend.PruneOptions{
+		Logs:         true,
+		LogTailBytes: tail,
+	})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+
+	after, err := os.ReadFile(filepath.Join(dir, consoleLogFilename))
+	if err != nil {
+		t.Fatalf("read log after: %v", err)
+	}
+	if int64(len(after)) != tail {
+		t.Fatalf("after size = %d, want %d", len(after), tail)
+	}
+	// Last 1024 bytes must all be 'Z'.
+	for i := tail - 1024; i < tail; i++ {
+		if after[i] != 'Z' {
+			t.Fatalf("tail byte %d = %q, want 'Z' (truncation lost the tail)", i, after[i])
+		}
+	}
+}
+
+func TestPrune_InstancesBeforeImages_ReleasesImageRef(t *testing.T) {
+	c, imagesDir, instanceDir := newPruneTestClient(t)
+
+	// Create a cached image and a stopped shed that references it.
+	if err := os.WriteFile(filepath.Join(imagesDir, vmimage.RootfsFilename("tobereclaimed")), make([]byte, 8192), 0644); err != nil {
+		t.Fatal(err)
+	}
+	seedStoppedShed(t, instanceDir, "old-shed", "tobereclaimed", 4096, 0, 5*24*time.Hour)
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{
+		Images:    true,
+		Instances: true,
+		Until:     72 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+
+	var shedsDeleted, imagesDeleted []string
+	for _, it := range report.Items {
+		switch it.Kind {
+		case "instance":
+			shedsDeleted = append(shedsDeleted, it.Name)
+		case "image":
+			imagesDeleted = append(imagesDeleted, it.Name)
+		}
+	}
+	if !contains(shedsDeleted, "old-shed") {
+		t.Errorf("expected old-shed deleted, got %v", shedsDeleted)
+	}
+	if !contains(imagesDeleted, "tobereclaimed") {
+		t.Errorf("expected tobereclaimed image deleted after shed ref released, got %v", imagesDeleted)
+	}
+	// The image file should actually be gone.
+	if _, err := os.Stat(filepath.Join(imagesDir, vmimage.RootfsFilename("tobereclaimed"))); !os.IsNotExist(err) {
+		t.Errorf("image rootfs still exists after prune (err=%v)", err)
+	}
+}
+
+func TestPrune_MalformedMetadataSkipped(t *testing.T) {
+	c, _, instanceDir := newPruneTestClient(t)
+
+	// Broken metadata.json beside a valid candidate.
+	brokenDir := filepath.Join(instanceDir, "broken")
+	if err := os.MkdirAll(brokenDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(brokenDir, "metadata.json"), []byte("{not-json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-5 * 24 * time.Hour)
+	_ = os.Chtimes(filepath.Join(brokenDir, "metadata.json"), past, past)
+
+	seedStoppedShed(t, instanceDir, "good", "", 1024, 0, 5*24*time.Hour)
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{
+		Instances: true,
+		Until:     72 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Prune must not fail on malformed metadata: %v", err)
+	}
+	// The broken shed should NOT appear in Items.
+	for _, it := range report.Items {
+		if it.Name == "broken" {
+			t.Errorf("broken metadata appeared in Items: %+v", it)
+		}
+	}
+	// The good one must still be processed.
+	found := false
+	for _, it := range report.Items {
+		if it.Name == "good" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected good shed still pruned, got items %+v", report.Items)
+	}
+}
+
+// contains is a tiny slice helper used by tests.
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/vz/system_prune_test.go
+++ b/internal/vz/system_prune_test.go
@@ -584,7 +584,10 @@ func TestPrune_Logs_DryRunShowsCandidates(t *testing.T) {
 	}
 	// Dry-run must NOT mutate the file.
 	fi, err := os.Stat(filepath.Join(dir, consoleLogFilename))
-	if err != nil || fi.Size() != 10*1024*1024 {
+	if err != nil {
+		t.Fatalf("stat console.log after dry-run: %v", err)
+	}
+	if fi.Size() != 10*1024*1024 {
 		t.Errorf("dry-run mutated the console.log (size %d)", fi.Size())
 	}
 }

--- a/internal/vz/system_test.go
+++ b/internal/vz/system_test.go
@@ -1,0 +1,234 @@
+//go:build darwin
+
+package vz
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/vmimage"
+)
+
+func newSystemTestClient(t *testing.T) (*Client, string, string) {
+	t.Helper()
+	imagesDir := t.TempDir()
+	instanceDir := t.TempDir()
+
+	cfg := &config.VZConfig{
+		ImagesDir:   imagesDir,
+		InstanceDir: instanceDir,
+		Images:      map[string]string{},
+		BaseRootfs:  "ghcr.io/example/base:v1",
+	}
+	serverCfg := &config.ServerConfig{Name: "test-server"}
+
+	client := &Client{cfg: cfg, serverCfg: serverCfg}
+	return client, imagesDir, instanceDir
+}
+
+func TestClassifySidecar(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantBase string
+		wantKind string
+	}{
+		{"default-rootfs.ext4.lock", "default-rootfs.ext4", "lock"},
+		{"default-rootfs.ext4.source", "default-rootfs.ext4", "source"},
+		{"default-rootfs.ext4.tmp", "default-rootfs.ext4", "tmp"},
+		{"default-rootfs.ext4.tmp.12345", "default-rootfs.ext4", "tmp"},
+		{"default-rootfs.ext4", "", ""},       // the rootfs itself
+		{"random.txt", "", ""},                // unrelated
+		{"default-rootfs.ext4.weird", "", ""}, // unknown sidecar suffix
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			base, kind := classifySidecar(tt.in)
+			if base != tt.wantBase || kind != tt.wantKind {
+				t.Errorf("classifySidecar(%q) = (%q, %q), want (%q, %q)",
+					tt.in, base, kind, tt.wantBase, tt.wantKind)
+			}
+		})
+	}
+}
+
+func TestFindOrphans(t *testing.T) {
+	dir := t.TempDir()
+
+	// Live: rootfs present → lock/source/tmp are NOT orphans.
+	live := "live-rootfs.ext4"
+	if err := os.WriteFile(filepath.Join(dir, live), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, live+".lock"), []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, live+".source"), []byte("ref"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dead: no rootfs → lock/tmp/source ARE orphans.
+	dead := "dead-rootfs.ext4"
+	if err := os.WriteFile(filepath.Join(dir, dead+".lock"), []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, dead+".tmp"), []byte("junk"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, dead+".tmp.99999"), []byte("junk"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, dead+".source"), []byte("ref"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Noise: files that aren't sidecars must be ignored.
+	if err := os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := findOrphans(dir)
+	if err != nil {
+		t.Fatalf("findOrphans: %v", err)
+	}
+	if len(got) != 4 {
+		names := make([]string, len(got))
+		for i, f := range got {
+			names[i] = filepath.Base(f.Path)
+		}
+		t.Fatalf("got %d orphans %v, want 4 (dead .lock, .tmp, .tmp.99999, .source)", len(got), names)
+	}
+	// Classification spot-check.
+	for _, f := range got {
+		if filepath.Base(f.Path) == dead+".lock" && f.Kind != "lock" {
+			t.Errorf("dead.lock kind = %q, want lock", f.Kind)
+		}
+	}
+}
+
+func TestDiskUsage_Empty(t *testing.T) {
+	client, _, _ := newSystemTestClient(t)
+	du, err := client.DiskUsage(context.Background())
+	if err != nil {
+		t.Fatalf("DiskUsage: %v", err)
+	}
+	if du.Backend != "vz" {
+		t.Errorf("Backend = %q, want vz", du.Backend)
+	}
+	if du.ServerName != "test-server" {
+		t.Errorf("ServerName = %q, want test-server", du.ServerName)
+	}
+	if len(du.Images) != 0 || len(du.Sheds) != 0 || len(du.Orphans) != 0 {
+		t.Errorf("expected empty slices, got images=%d sheds=%d orphans=%d",
+			len(du.Images), len(du.Sheds), len(du.Orphans))
+	}
+	if du.Totals.All.LogicalBytes != 0 {
+		t.Errorf("expected zero total, got %d", du.Totals.All.LogicalBytes)
+	}
+}
+
+func TestDiskUsage_Populated(t *testing.T) {
+	client, imagesDir, instanceDir := newSystemTestClient(t)
+
+	// _base (discovered directly) + one variant (auto-discovered via ListImages).
+	basePath := filepath.Join(imagesDir, vmimage.RootfsFilename("_base"))
+	if err := os.WriteFile(basePath, make([]byte, 4096), 0644); err != nil {
+		t.Fatal(err)
+	}
+	variantPath := filepath.Join(imagesDir, vmimage.RootfsFilename("experimental"))
+	if err := os.WriteFile(variantPath, make([]byte, 8192), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// One stopped shed with a rootfs copy and a console.log.
+	dir := filepath.Join(instanceDir, "api-dev")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	meta := &Metadata{
+		Version: MetadataVersion,
+		Name:    "api-dev",
+		Status:  config.StatusStopped,
+		Backend: "vz",
+		Image:   "experimental",
+	}
+	if err := meta.Save(instanceDir); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "rootfs.ext4"), make([]byte, 4096), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "console.log"), make([]byte, 256), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A dead orphan sidecar.
+	if err := os.WriteFile(filepath.Join(imagesDir, "dead-rootfs.ext4.lock"), []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	du, err := client.DiskUsage(context.Background())
+	if err != nil {
+		t.Fatalf("DiskUsage: %v", err)
+	}
+
+	// Must include both _base and experimental.
+	names := map[string]bool{}
+	for _, img := range du.Images {
+		names[img.Name] = true
+	}
+	if !names["_base"] || !names["experimental"] {
+		t.Errorf("expected both _base and experimental; got images %+v", names)
+	}
+
+	if len(du.Sheds) != 1 || du.Sheds[0].Name != "api-dev" {
+		t.Fatalf("expected 1 shed named api-dev, got %+v", du.Sheds)
+	}
+	shed := du.Sheds[0]
+	if shed.ConsoleLog == nil {
+		t.Errorf("expected ConsoleLog to be set on VZ shed")
+	}
+	if shed.Rootfs.Size.LogicalBytes != 4096 {
+		t.Errorf("rootfs logical = %d, want 4096", shed.Rootfs.Size.LogicalBytes)
+	}
+
+	if len(du.Orphans) != 1 {
+		t.Errorf("expected 1 orphan, got %d", len(du.Orphans))
+	}
+
+	if du.Totals.All.LogicalBytes <= 0 {
+		t.Errorf("expected non-zero total, got %d", du.Totals.All.LogicalBytes)
+	}
+	// Images total should include at least _base + experimental (12288 bytes).
+	if du.Totals.Images.LogicalBytes < 12288 {
+		t.Errorf("images total = %d, want >= 12288", du.Totals.Images.LogicalBytes)
+	}
+	// Sheds total should include rootfs (4096) + console.log (256) at minimum.
+	if du.Totals.Sheds.LogicalBytes < 4096+256 {
+		t.Errorf("sheds total = %d, want >= 4352", du.Totals.Sheds.LogicalBytes)
+	}
+}
+
+func TestDiskUsage_MalformedMetadataSkipped(t *testing.T) {
+	client, _, instanceDir := newSystemTestClient(t)
+
+	// Create an instance directory with an invalid metadata file.
+	dir := filepath.Join(instanceDir, "broken")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte("{not-json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// DiskUsage should skip the broken instance rather than failing.
+	du, err := client.DiskUsage(context.Background())
+	if err != nil {
+		t.Fatalf("DiskUsage should not fail on malformed metadata: %v", err)
+	}
+	if len(du.Sheds) != 0 {
+		t.Errorf("expected 0 sheds after skipping broken, got %d", len(du.Sheds))
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
   - Reference:
       - CLI: reference/cli.md
       - Configuration: reference/configuration.md
+      - Disk Management: reference/disk-management.md
       - Tunnels: reference/tunnels.md
       - File Sync: reference/sync.md
       - Provisioning: reference/provisioning.md


### PR DESCRIPTION
## Summary

Delivers a disk-visibility and cleanup surface for shed servers plus a reflink-based fast path for `shed create`. Three phases, each landed as a separate commit, plus a fourth commit addressing Codex + CodeRabbit review findings.

- **`shed system df`** — read-only disk usage report: image cache, per-instance rootfs + console logs, kernel/initrd, orphan sidecars. Both logical and physical (`stat.Blocks * 512`) bytes. Supports `-v`, `--json`, `-s <server>`, `--all` with client-side fan-out.
- **`shed system prune`** — scoped cleanup via additive flags (`--images`, `--instances`, `--logs`, `--orphans`). Dry-run-first UX; `--force` skips confirmation; `--json` requires `--force` for the execute path. `--until 72h` default for stopped-instance age filter. `--all` fans out across configured servers.
- **Reflink `CopyRootfs`** — new `internal/vmimage/clone` package. `clonefile` on darwin/APFS → `io.Copy`; `FICLONE` on linux → `copy_file_range` → `io.Copy`. `shed create` on APFS now takes near-zero physical bytes and runs in sub-second wall-clock on warm caches.

## Commits

| # | Commit | What |
|---|--------|------|
| 1 | [0d2f227](../commit/0d2f227) | Add `shed system df` for disk-usage reporting |
| 2 | [2b63d61](../commit/2b63d61) | Add `shed system prune` for scoped disk cleanup |
| 3 | [ec68da4](../commit/ec68da4) | Reflink rootfs copies: `CopyRootfs` uses clonefile/FICLONE |
| 4 | [4499ada](../commit/4499ada) | Address Codex + CodeRabbit review findings |

## New API

- `GET /api/system/df` — disk usage payload with snake_case JSON throughout. `backend`, `images[]`, `kernel`, `initrd` (VZ only), `sheds[]`, `orphans[]`, `totals`, `notes`.
- `POST /api/system/prune?scope=...&dry_run=...&until=...&log_tail_bytes=...` — repeatable `scope=` query param (any of `images|instances|logs|orphans`). Returns a `PruneReport` listing `items[]`, `skipped[]`, `totals`, and `notes`. Invalid input → 400 with `INVALID_REQUEST` code. Partial mutations → 200 with a "partial failure" note.

## Plan-mandated invariants upheld

- **mtime snapshot runs BEFORE `ListSheds`**. `ListSheds`'s stale-running→stopped re-check rewrites `metadata.json` and would otherwise bump mtime past the age threshold. Covered by `TestPrune_MtimeSnapshotBeatsStalenessResave`.
- **Instances deleted before images**. `Client.DeleteShed` handles Firecracker TAP/CID/IP cleanup; after deletion, `inUseImageNames` naturally excludes them and `Manager.PruneImages` works correctly. Covered by `TestPrune_InstancesBeforeImages_ReleasesImageRef`.
- **Clonefile/FICLONE require dst not to exist**. `CopyRootfs` pre-cleans stale dst; each strategy uses `O_EXCL` so concurrent callers get clean `EEXIST` rather than corrupting a half-written file.
- **Always `Sync()` after copy**. Clonefile/FICLONE don't guarantee metadata durability across FS commits; delayed-writeback errors (`ENOSPC`, `EIO`) now propagate rather than silently booting a VM on broken storage.
- **Stable info log** per create: `rootfs strategy=<name> src=<path> dst=<path> logical_bytes=<n>`. Operators can grep it.

## Review fixes (commit 4)

Thirteen correctness / safety fixes from parallel Codex + CodeRabbit review:

- API default `until=72h` when omitted (was 0 = any age — would have deleted all stopped instances on a bare POST)
- Empty `ImagesDir` guard (prevented `os.ReadDir("")` from scanning daemon CWD)
- `--logs` candidates collected during candidate phase (was a no-op under dry-run-first UX)
- `TryAcquireFileLock` drops `O_CREATE` (dry-run probes no longer create lock files)
- `.lock` orphans reclassified as `SkippedItem` (report no longer lies about what was removed)
- `log_tail_bytes` capped at 64 MiB (prevents unbounded server allocation)
- `Sync/Open` errors in `CopyRootfs` now surface via dst cleanup + error return
- Prune returns `(report, err)` for partial failures → handler emits 200 with note
- Dedicated `INVALID_REQUEST` error code for 400 responses
- Malformed metadata in `inUseImageNamesExcept` is skip-and-warn
- Linux FICLONE close-failure symmetry (clean up half-built dst)
- Renamed `TestPrune_Instances_RunningNeverPruned` → `TestPrune_MtimeSnapshotBeatsStalenessResave`
- Documented `CopyRootfs` single-writer contract

Not addressed (refactors / low-priority, tracked for follow-up):
- ~350 lines duplicated between VZ and FC `system.go` (shared helper package)
- `formatSize` vs `formatBytes` unification
- Per-name mutex for `CopyRootfs` to fully close the pre-existing race window
- Cross-server shed cache-key collision

## Live verification

On macOS/APFS:
- `shed create reflink-demo` completes via clonefile; server logs `rootfs strategy=clonefile src=... dst=... logical_bytes=21474836480`.
- Post-create `stat -f "%z %b"` on instance rootfs vs base: identical logical size, blocks differ only by the VM's boot-time divergence (~6 MB of 20 GB).
- `shed system df --all` handles mixed online + 404 (older-server) responses without aborting; per-server errors surface in both text and `--json` output.
- `shed system prune --all --dry-run` enumerates candidates across every configured server.

## Test plan

- [x] `make check` green on darwin
- [x] `GOOS=linux go vet ./...` clean (Linux code paths exercised via build tags)
- [x] Unit tests at every layer: diskstat, fanout, VZ/FC DiskUsage+Prune, handler, CLI render, clone strategies
- [x] Platform-specific tests: clonefile on darwin, FICLONE + copy_file_range on linux
- [x] Regression tests for each review finding (default `until`, empty ImagesDir, `.lock` orphan, `--logs` dry-run, log-tail cap, error code)
- [x] Live smoke on VZ: create/delete, `df`, `prune --dry-run`, `--all` mixed-server scenario
- [ ] Firecracker live smoke (no Linux host available; FC tests compile under `GOOS=linux go vet` and share the same code paths as VZ aside from console-log handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `shed system df` (per-server and aggregated disk usage, verbose rows, JSON output).
  * Added `shed system prune` with additive scopes (--images, --instances, --logs, --orphans), dry-run preview, --until age filter, --log-tail-bytes, confirmation/--force, and multi-server mode.

* **API**
  * New endpoints: GET /api/system/df and POST /api/system/prune (structured dry-run/execute reports; longer prune timeout).

* **Documentation**
  * Expanded CLI/API docs and new Disk Management guide; updated disk-space guidance for reflink/clone behavior.

* **Tests**
  * Extensive unit and integration tests covering system commands, handlers, pruning, disk stats, and cloning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->