### PR TITLE
Fix machine-id collision via transient /run symlink

### DIFF
--- a/cmd/shed-firstboot/firstboot.go
+++ b/cmd/shed-firstboot/firstboot.go
@@ -2,8 +2,16 @@
 
 // Package main implements shed-firstboot, an early-boot oneshot that ensures
 // the guest's identity matches the shed name passed via kernel cmdline.
-// It runs before D-Bus, journald, sshd, and shed-agent so that machine-id
-// and SSH host keys are correct before any service caches them.
+// It runs before D-Bus, journald, sshd, and shed-agent so SSH host keys
+// and the hostname are correct before any service caches them.
+//
+// machine-id is intentionally NOT touched here: the rootfs Dockerfile
+// symlinks /etc/machine-id to /run/machine-id (transient tmpfs), so PID 1
+// generates a fresh value at every VM boot and nothing persists to disk.
+// Doing the regen at the firstboot layer would fight that mechanism (the
+// `systemd-machine-id-setup` command pulls from /var/lib/dbus/machine-id
+// when /etc/machine-id is empty, and the symlink chain handles the same
+// concern more cleanly via systemd's transient machine-id machinery).
 package main
 
 import (
@@ -19,23 +27,21 @@ import (
 
 // firstbootCfg lets tests override paths and the command runner.
 type firstbootCfg struct {
-	cmdlinePath   string
-	machineIDPath string
-	sshKeyGlob    string
-	hostnamePath  string
-	identityPath  string
-	runCommand    func(name string, args ...string) error
+	cmdlinePath  string
+	sshKeyGlob   string
+	hostnamePath string
+	identityPath string
+	runCommand   func(name string, args ...string) error
 }
 
 // defaultCfg is the production filesystem layout.
 func defaultCfg() firstbootCfg {
 	return firstbootCfg{
-		cmdlinePath:   "/proc/cmdline",
-		machineIDPath: "/etc/machine-id",
-		sshKeyGlob:    "/etc/ssh/ssh_host_*",
-		hostnamePath:  "/etc/hostname",
-		identityPath:  "/var/lib/shed/identity.json",
-		runCommand:    runRealCommand,
+		cmdlinePath:  "/proc/cmdline",
+		sshKeyGlob:   "/etc/ssh/ssh_host_*",
+		hostnamePath: "/etc/hostname",
+		identityPath: "/var/lib/shed/identity.json",
+		runCommand:   runRealCommand,
 	}
 }
 
@@ -105,22 +111,28 @@ func saveIdentity(path string, id *identity) error {
 	return nil
 }
 
-// regenerateIdentity wipes machine-id, removes existing SSH host keys, sets
-// the hostname, and re-derives the regenerated artifacts via systemd helpers.
-// Failures are returned per step; callers decide whether to abort or log.
+// regenerateIdentity sets the hostname, then removes and re-derives SSH host
+// keys. Hostname must be set BEFORE `ssh-keygen -A` so the new keys' comment
+// field reflects the spawned shed's name; otherwise `ssh-keygen` records the
+// source's hostname (still in /etc/hostname at this point) into every cloned
+// shed's keys. Failures are returned per step; callers decide whether to
+// abort or log.
+//
+// machine-id is intentionally NOT touched — the Dockerfile makes it transient
+// via a symlink to /run/machine-id, so PID 1 generates a fresh value per boot.
 func regenerateIdentity(cfg firstbootCfg, name string) error {
-	// machine-id: empty file makes systemd-machine-id-setup generate a fresh one.
-	if err := os.WriteFile(cfg.machineIDPath, nil, 0o444); err != nil {
-		return fmt.Errorf("clear machine-id: %w", err)
+	// Hostname BEFORE SSH key generation so the keys' comment matches.
+	// Avoid hostnamectl (requires running D-Bus, which is not yet up).
+	if err := os.WriteFile(cfg.hostnamePath, []byte(name+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write hostname: %w", err)
 	}
-	if err := cfg.runCommand("systemd-machine-id-setup"); err != nil {
-		// Fall back to dbus-uuidgen if the systemd helper is unavailable.
-		if err2 := cfg.runCommand("dbus-uuidgen", "--ensure="+cfg.machineIDPath); err2 != nil {
-			return fmt.Errorf("regen machine-id (systemd-machine-id-setup: %v; dbus-uuidgen: %w)", err, err2)
-		}
+	if err := cfg.runCommand("hostname", "-F", cfg.hostnamePath); err != nil {
+		return fmt.Errorf("apply hostname: %w", err)
 	}
 
-	// SSH host keys: remove existing, regenerate via ssh-keygen -A.
+	// SSH host keys: remove existing, regenerate via ssh-keygen -A. The
+	// hostname call above ensures the new keys' comment field carries the
+	// spawned shed's name rather than the source's.
 	matches, _ := filepath.Glob(cfg.sshKeyGlob)
 	for _, p := range matches {
 		if err := os.Remove(p); err != nil && !errors.Is(err, fs.ErrNotExist) {
@@ -129,14 +141,6 @@ func regenerateIdentity(cfg firstbootCfg, name string) error {
 	}
 	if err := cfg.runCommand("ssh-keygen", "-A"); err != nil {
 		return fmt.Errorf("regen ssh host keys: %w", err)
-	}
-
-	// Hostname: avoid hostnamectl (requires running D-Bus, which is not yet up).
-	if err := os.WriteFile(cfg.hostnamePath, []byte(name+"\n"), 0o644); err != nil {
-		return fmt.Errorf("write hostname: %w", err)
-	}
-	if err := cfg.runCommand("hostname", "-F", cfg.hostnamePath); err != nil {
-		return fmt.Errorf("apply hostname: %w", err)
 	}
 
 	return nil

--- a/cmd/shed-firstboot/firstboot_test.go
+++ b/cmd/shed-firstboot/firstboot_test.go
@@ -172,11 +172,6 @@ func TestRunFirstboot(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			machineIDPath := filepath.Join(tmp, "machine-id")
-			if err := os.WriteFile(machineIDPath, []byte("oldid"), 0o644); err != nil {
-				t.Fatal(err)
-			}
-
 			sshDir := filepath.Join(tmp, "ssh")
 			if err := os.MkdirAll(sshDir, 0o755); err != nil {
 				t.Fatal(err)
@@ -198,11 +193,10 @@ func TestRunFirstboot(t *testing.T) {
 			}
 
 			cfg := firstbootCfg{
-				cmdlinePath:   cmdlinePath,
-				machineIDPath: machineIDPath,
-				sshKeyGlob:    filepath.Join(sshDir, "ssh_host_*"),
-				hostnamePath:  hostnamePath,
-				identityPath:  identityPath,
+				cmdlinePath:  cmdlinePath,
+				sshKeyGlob:   filepath.Join(sshDir, "ssh_host_*"),
+				hostnamePath: hostnamePath,
+				identityPath: identityPath,
 				runCommand: func(name string, args ...string) error {
 					f.ranCommands = append(f.ranCommands, name)
 					return nil
@@ -233,16 +227,66 @@ func TestRunFirstboot(t *testing.T) {
 	}
 }
 
+// TestRegenerateIdentity_HostnameBeforeSSHKeygen asserts the order:
+// hostname must be set before `ssh-keygen -A` runs, otherwise the new SSH
+// host keys' comment field captures the source shed's hostname (which is
+// still in /etc/hostname at that point) instead of the spawn's. Caught
+// during the v0.4.1 live test on both backends — keys on cloned sheds
+// said `root@v041-base` instead of `root@v041-spawnN`.
+func TestRegenerateIdentity_HostnameBeforeSSHKeygen(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "ssh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "hostname"), []byte("oldhost\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var order []string
+	cfg := firstbootCfg{
+		sshKeyGlob:   filepath.Join(tmp, "ssh", "ssh_host_*"),
+		hostnamePath: filepath.Join(tmp, "hostname"),
+		identityPath: filepath.Join(tmp, "identity.json"),
+		runCommand: func(name string, args ...string) error {
+			order = append(order, name)
+			return nil
+		},
+	}
+
+	if err := regenerateIdentity(cfg, "newshed"); err != nil {
+		t.Fatalf("regenerateIdentity: %v", err)
+	}
+
+	hostnameIdx, sshKeygenIdx := -1, -1
+	for i, c := range order {
+		if c == "hostname" && hostnameIdx == -1 {
+			hostnameIdx = i
+		}
+		if c == "ssh-keygen" && sshKeygenIdx == -1 {
+			sshKeygenIdx = i
+		}
+	}
+	if hostnameIdx < 0 {
+		t.Fatalf("hostname command never ran (order: %v)", order)
+	}
+	if sshKeygenIdx < 0 {
+		t.Fatalf("ssh-keygen never ran (order: %v)", order)
+	}
+	if hostnameIdx >= sshKeygenIdx {
+		t.Errorf("hostname (idx %d) must run before ssh-keygen (idx %d); order: %v",
+			hostnameIdx, sshKeygenIdx, order)
+	}
+}
+
 func TestRunFirstboot_ErrorPaths(t *testing.T) {
 	t.Run("missing_cmdline_errors", func(t *testing.T) {
 		tmp := t.TempDir()
 		cfg := firstbootCfg{
-			cmdlinePath:   filepath.Join(tmp, "no-such-file"),
-			machineIDPath: filepath.Join(tmp, "machine-id"),
-			sshKeyGlob:    filepath.Join(tmp, "ssh_host_*"),
-			hostnamePath:  filepath.Join(tmp, "hostname"),
-			identityPath:  filepath.Join(tmp, "identity.json"),
-			runCommand:    func(string, ...string) error { return nil },
+			cmdlinePath:  filepath.Join(tmp, "no-such-file"),
+			sshKeyGlob:   filepath.Join(tmp, "ssh_host_*"),
+			hostnamePath: filepath.Join(tmp, "hostname"),
+			identityPath: filepath.Join(tmp, "identity.json"),
+			runCommand:   func(string, ...string) error { return nil },
 		}
 		err := runFirstboot(cfg)
 		if err == nil {
@@ -253,14 +297,12 @@ func TestRunFirstboot_ErrorPaths(t *testing.T) {
 	t.Run("regen_command_failure_propagates", func(t *testing.T) {
 		tmp := t.TempDir()
 		os.WriteFile(filepath.Join(tmp, "cmdline"), []byte("shed.name=err"), 0o644)
-		os.WriteFile(filepath.Join(tmp, "machine-id"), []byte(""), 0o644)
 		os.WriteFile(filepath.Join(tmp, "hostname"), []byte(""), 0o644)
 		cfg := firstbootCfg{
-			cmdlinePath:   filepath.Join(tmp, "cmdline"),
-			machineIDPath: filepath.Join(tmp, "machine-id"),
-			sshKeyGlob:    filepath.Join(tmp, "ssh_host_*"),
-			hostnamePath:  filepath.Join(tmp, "hostname"),
-			identityPath:  filepath.Join(tmp, "identity.json"),
+			cmdlinePath:  filepath.Join(tmp, "cmdline"),
+			sshKeyGlob:   filepath.Join(tmp, "ssh_host_*"),
+			hostnamePath: filepath.Join(tmp, "hostname"),
+			identityPath: filepath.Join(tmp, "identity.json"),
 			runCommand: func(name string, args ...string) error {
 				if name == "ssh-keygen" {
 					return errors.New("simulated failure")

--- a/cmd/shed-firstboot/firstboot_test.go
+++ b/cmd/shed-firstboot/firstboot_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -227,54 +228,75 @@ func TestRunFirstboot(t *testing.T) {
 	}
 }
 
-// TestRegenerateIdentity_HostnameBeforeSSHKeygen asserts the order:
-// hostname must be set before `ssh-keygen -A` runs, otherwise the new SSH
-// host keys' comment field captures the source shed's hostname (which is
-// still in /etc/hostname at that point) instead of the spawn's. Caught
-// during the v0.4.1 live test on both backends — keys on cloned sheds
-// said `root@v041-base` instead of `root@v041-spawnN`.
-func TestRegenerateIdentity_HostnameBeforeSSHKeygen(t *testing.T) {
-	tmp := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(tmp, "ssh"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(tmp, "hostname"), []byte("oldhost\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	var order []string
-	cfg := firstbootCfg{
-		sshKeyGlob:   filepath.Join(tmp, "ssh", "ssh_host_*"),
-		hostnamePath: filepath.Join(tmp, "hostname"),
-		identityPath: filepath.Join(tmp, "identity.json"),
-		runCommand: func(name string, args ...string) error {
-			order = append(order, name)
-			return nil
+// TestRegenerateIdentity_Calls asserts the exact argv and order of external
+// commands run during identity regeneration. Hostname must be set BEFORE
+// `ssh-keygen -A` so the new SSH host keys' comment field captures the spawn's
+// hostname rather than the source's (caught during v0.4.1 live test — keys on
+// cloned sheds said `root@v041-base` instead of `root@v041-spawnN`). Recording
+// full argv (not just the command name) prevents a regression where the
+// implementation switches to a different flag/path silently.
+func TestRegenerateIdentity_Calls(t *testing.T) {
+	tests := []struct {
+		name      string
+		shedName  string
+		wantCalls []string // exact argv strings, in order
+	}{
+		{
+			name:     "hostname_then_ssh_keygen_with_correct_argv",
+			shedName: "newshed",
+			wantCalls: []string{
+				"hostname -F %hostnamePath%",
+				"ssh-keygen -A",
+			},
 		},
 	}
 
-	if err := regenerateIdentity(cfg, "newshed"); err != nil {
-		t.Fatalf("regenerateIdentity: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(tmp, "ssh"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			hostnamePath := filepath.Join(tmp, "hostname")
+			if err := os.WriteFile(hostnamePath, []byte("oldhost\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
 
-	hostnameIdx, sshKeygenIdx := -1, -1
-	for i, c := range order {
-		if c == "hostname" && hostnameIdx == -1 {
-			hostnameIdx = i
-		}
-		if c == "ssh-keygen" && sshKeygenIdx == -1 {
-			sshKeygenIdx = i
-		}
-	}
-	if hostnameIdx < 0 {
-		t.Fatalf("hostname command never ran (order: %v)", order)
-	}
-	if sshKeygenIdx < 0 {
-		t.Fatalf("ssh-keygen never ran (order: %v)", order)
-	}
-	if hostnameIdx >= sshKeygenIdx {
-		t.Errorf("hostname (idx %d) must run before ssh-keygen (idx %d); order: %v",
-			hostnameIdx, sshKeygenIdx, order)
+			var calls []string
+			cfg := firstbootCfg{
+				sshKeyGlob:   filepath.Join(tmp, "ssh", "ssh_host_*"),
+				hostnamePath: hostnamePath,
+				identityPath: filepath.Join(tmp, "identity.json"),
+				runCommand: func(name string, args ...string) error {
+					if len(args) == 0 {
+						calls = append(calls, name)
+					} else {
+						calls = append(calls, name+" "+strings.Join(args, " "))
+					}
+					return nil
+				},
+			}
+
+			if err := regenerateIdentity(cfg, tt.shedName); err != nil {
+				t.Fatalf("regenerateIdentity: %v", err)
+			}
+
+			// Substitute %hostnamePath% in the expected argv so the test
+			// stays portable across t.TempDir's per-run paths.
+			want := make([]string, len(tt.wantCalls))
+			for i, c := range tt.wantCalls {
+				want[i] = strings.ReplaceAll(c, "%hostnamePath%", hostnamePath)
+			}
+
+			if len(calls) != len(want) {
+				t.Fatalf("call count = %d; want %d (got: %v)", len(calls), len(want), calls)
+			}
+			for i, w := range want {
+				if calls[i] != w {
+					t.Errorf("call[%d] = %q; want %q (full sequence: %v)", i, calls[i], w, calls)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/shed-firstboot/firstboot_test.go
+++ b/cmd/shed-firstboot/firstboot_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -233,20 +234,20 @@ func TestRunFirstboot(t *testing.T) {
 // `ssh-keygen -A` so the new SSH host keys' comment field captures the spawn's
 // hostname rather than the source's (caught during v0.4.1 live test — keys on
 // cloned sheds said `root@v041-base` instead of `root@v041-spawnN`). Recording
-// full argv (not just the command name) prevents a regression where the
-// implementation switches to a different flag/path silently.
+// full argv as []string preserves token boundaries so e.g. a switch from
+// `hostname -F /etc/hostname` to `hostname -F/etc/hostname` would still fail.
 func TestRegenerateIdentity_Calls(t *testing.T) {
 	tests := []struct {
 		name      string
 		shedName  string
-		wantCalls []string // exact argv strings, in order
+		wantCalls [][]string // exact argv tokens, in order
 	}{
 		{
 			name:     "hostname_then_ssh_keygen_with_correct_argv",
 			shedName: "newshed",
-			wantCalls: []string{
-				"hostname -F %hostnamePath%",
-				"ssh-keygen -A",
+			wantCalls: [][]string{
+				{"hostname", "-F", "%hostnamePath%"},
+				{"ssh-keygen", "-A"},
 			},
 		},
 	}
@@ -262,17 +263,14 @@ func TestRegenerateIdentity_Calls(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var calls []string
+			var calls [][]string
 			cfg := firstbootCfg{
 				sshKeyGlob:   filepath.Join(tmp, "ssh", "ssh_host_*"),
 				hostnamePath: hostnamePath,
 				identityPath: filepath.Join(tmp, "identity.json"),
 				runCommand: func(name string, args ...string) error {
-					if len(args) == 0 {
-						calls = append(calls, name)
-					} else {
-						calls = append(calls, name+" "+strings.Join(args, " "))
-					}
+					argv := append([]string{name}, args...)
+					calls = append(calls, argv)
 					return nil
 				},
 			}
@@ -281,19 +279,23 @@ func TestRegenerateIdentity_Calls(t *testing.T) {
 				t.Fatalf("regenerateIdentity: %v", err)
 			}
 
-			// Substitute %hostnamePath% in the expected argv so the test
-			// stays portable across t.TempDir's per-run paths.
-			want := make([]string, len(tt.wantCalls))
+			// Substitute %hostnamePath% in expected argv so the test stays
+			// portable across t.TempDir's per-run paths.
+			want := make([][]string, len(tt.wantCalls))
 			for i, c := range tt.wantCalls {
-				want[i] = strings.ReplaceAll(c, "%hostnamePath%", hostnamePath)
+				argv := make([]string, len(c))
+				for j, tok := range c {
+					argv[j] = strings.ReplaceAll(tok, "%hostnamePath%", hostnamePath)
+				}
+				want[i] = argv
 			}
 
 			if len(calls) != len(want) {
 				t.Fatalf("call count = %d; want %d (got: %v)", len(calls), len(want), calls)
 			}
 			for i, w := range want {
-				if calls[i] != w {
-					t.Errorf("call[%d] = %q; want %q (full sequence: %v)", i, calls[i], w, calls)
+				if !reflect.DeepEqual(calls[i], w) {
+					t.Errorf("call[%d] = %v; want %v (full sequence: %v)", i, calls[i], w, calls)
 				}
 			}
 		})

--- a/docs/reference/snapshots.md
+++ b/docs/reference/snapshots.md
@@ -47,11 +47,24 @@ shed create <new-name> --from-snapshot <snapshot-name> [--local-dir ...]
 ## Identity regeneration
 
 Each spawned shed gets a fresh `/etc/machine-id`, fresh SSH host keys, and the
-correct hostname. This is handled by a one-shot `shed-firstboot` service that
-runs early in boot — before D-Bus, journald, sshd, or `shed-agent` cache the
-old identity. The service is idempotent: it re-runs only when the recorded
-shed name in `/var/lib/shed/identity.json` does not match the
-`shed.name=<name>` value passed on the kernel cmdline.
+correct hostname.
+
+- **machine-id** is handled by the rootfs itself: `/etc/machine-id` is a
+  symlink to `/run/machine-id` (tmpfs), and `systemd-machine-id-commit.service`
+  is masked. PID 1 generates a fresh UUID into `/run/machine-id` at every VM
+  boot; nothing persists to disk. Each shed (fresh-create OR snapshot-spawn)
+  gets a unique machine-id, with no host-side ext4 manipulation required.
+  *Note:* this means `/etc/machine-id` regenerates on every boot of the same
+  shed, not just the first boot. For shed's ephemeral test-environment workflow
+  this is fine, but applications that key persistent state on machine-id and
+  expect it to be stable across reboots will see a regression.
+- **Hostname and SSH host keys** are handled by a one-shot `shed-firstboot`
+  service that runs early in boot — before D-Bus, journald, sshd, or
+  `shed-agent` cache identity. firstboot writes `/etc/hostname` from the
+  kernel cmdline `shed.name=<name>` value, then runs `ssh-keygen -A` so the
+  new keys' comment field carries the spawn's hostname. It records the name
+  in `/var/lib/shed/identity.json` and is idempotent — re-runs only when the
+  recorded name doesn't match the cmdline value.
 
 This makes `ssh known_hosts` and machine-id-based services work correctly
 across snapshot-spawned sheds.
@@ -112,14 +125,12 @@ overcount on-disk usage.
 
 ## Known caveats
 
-- **Early-boot journal may briefly show source's machine-id.** systemd PID 1
-  reads `/etc/machine-id` very early. On a cloned rootfs the file is
-  non-empty with the source shed's UUID until `shed-firstboot` regenerates
-  it. By the time firstboot runs, PID 1 has latched onto the source's value
-  in memory, so journald entries from the very first sysinit phase carry
-  the wrong machine-id. The persistent `/etc/machine-id` and
-  `/var/lib/dbus/machine-id` are correct after firstboot completes; this is
-  only an early-journal-staleness artifact, not a steady-state issue.
+- **machine-id is not stable across reboots of the same shed.** Because
+  `/etc/machine-id` is a tmpfs symlink (see "Identity regeneration"), every
+  VM boot generates a fresh value. This is the trade-off for unique-per-VM
+  identity without host-side ext4 manipulation. For applications that expect
+  a stable machine-id across reboots, recreate the shed instead of
+  stop+starting it.
 - **A snapshot create that crashes mid-write may leave an "invisible"
   directory.** If the host crashes between writing `rootfs.ext4` and the
   atomic rename of `snapshot.json`, the directory under `snapshots_dir`

--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -220,6 +220,22 @@ RUN SYSTEMD_OFFLINE=1 systemctl enable network-setup
 # Copy custom Firecracker kernel (extracted by shed during image conversion)
 COPY --from=kernel-builder /build/linux/vmlinux /boot/vmlinux
 
+# Make machine-id transient (lives in /run, never persists to disk).
+# Without this, dbus's postinst writes a value into /etc/machine-id at image
+# build time, baking a single UUID into the image — every shed (fresh or
+# snapshot-spawned) would inherit it. Symlinking /etc/machine-id to /run
+# makes systemd treat it as transient: PID 1 generates a fresh value into
+# /run/machine-id at every VM boot. /var/lib/dbus/machine-id is symlinked
+# to /etc/machine-id (the modern systemd convention) so dbus sees the same
+# value. systemd-machine-id-commit.service is masked so systemd doesn't try
+# to convert the symlink back to a real file when root is writable. Net
+# effect: every VM boot of every shed yields a unique machine-id, with
+# nothing persisted to disk and no host-side ext4 manipulation required.
+RUN rm -f /etc/machine-id /var/lib/dbus/machine-id && \
+    ln -sf /run/machine-id /etc/machine-id && \
+    ln -sf /etc/machine-id /var/lib/dbus/machine-id && \
+    ln -sf /dev/null /etc/systemd/system/systemd-machine-id-commit.service
+
 # Shell customization - colored prompt showing shed name, path, and git branch
 USER shed
 RUN cat >> /home/shed/.bashrc << 'PROMPT_EOF'

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -202,6 +202,22 @@ RUN mkdir -p /etc/systemd/network && \
 # the VM's enp0s1 interface to the VZ NAT gateway.
 RUN printf "net.ipv4.ip_forward=1\n" > /etc/sysctl.d/99-docker-forward.conf
 
+# Make machine-id transient (lives in /run, never persists to disk).
+# Without this, dbus's postinst writes a value into /etc/machine-id at image
+# build time, baking a single UUID into the image — every shed (fresh or
+# snapshot-spawned) would inherit it. Symlinking /etc/machine-id to /run
+# makes systemd treat it as transient: PID 1 generates a fresh value into
+# /run/machine-id at every VM boot. /var/lib/dbus/machine-id is symlinked
+# to /etc/machine-id (the modern systemd convention) so dbus sees the same
+# value. systemd-machine-id-commit.service is masked so systemd doesn't try
+# to convert the symlink back to a real file when root is writable. Net
+# effect: every VM boot of every shed yields a unique machine-id, with
+# nothing persisted to disk and no host-side ext4 manipulation required.
+RUN rm -f /etc/machine-id /var/lib/dbus/machine-id && \
+    ln -sf /run/machine-id /etc/machine-id && \
+    ln -sf /etc/machine-id /var/lib/dbus/machine-id && \
+    ln -sf /dev/null /etc/systemd/system/systemd-machine-id-commit.service
+
 # Shell customization - colored prompt showing shed name, path, and git branch
 USER shed
 RUN cat >> /home/shed/.bashrc << 'PROMPT_EOF'


### PR DESCRIPTION
## Summary

Fixes two follow-ups from v0.4.0/v0.4.1 testing:

- **Every shed had the same `/etc/machine-id`.** dbus's `postinst` calls `dbus-uuidgen --ensure=...` during the rootfs Docker build, which bakes one UUID into the image. Every shed (fresh-create AND snapshot-spawn) inherited it. Fixed by switching to systemd's "transient machine-id" pattern: `/etc/machine-id` is a symlink to `/run/machine-id` (tmpfs), `/var/lib/dbus/machine-id` symlinks to `/etc/machine-id`, and `systemd-machine-id-commit.service` is masked so systemd doesn't try to convert the symlink back to a regular file. PID 1 generates a fresh UUID into `/run/machine-id` on every VM boot; nothing persists to disk.
- **`shed-firstboot` set hostname AFTER `ssh-keygen -A`.** Result: SSH host keys' comment field on cloned sheds said `root@<source-name>` instead of `root@<spawn-name>`. Reordered to set hostname first.

## How the machine-id fix works

```
/etc/machine-id              -> /run/machine-id          (tmpfs)
/var/lib/dbus/machine-id     -> /etc/machine-id          (modern systemd convention)
/etc/systemd/system/systemd-machine-id-commit.service -> /dev/null  (masked)
```

- Boot: PID 1 reads `/etc/machine-id` → resolves to `/run/machine-id` → empty (tmpfs is fresh) → systemd generates a new random UUID → writes to `/run/machine-id` → reads return that value for the rest of the boot.
- The on-disk file is never touched (it's just a symlink). The commit service that would normally replace the symlink with a regular file is masked.
- Net: each VM boot of each shed yields a unique machine-id; `rootfs.ext4` carries only the symlink in its filesystem, never a UUID. Snapshot+spawn inherits the symlink, not a value.

`shed-firstboot` no longer touches machine-id at all (the previous `truncate + systemd-machine-id-setup` flow was actually broken — `systemd-machine-id-setup` falls back to `/var/lib/dbus/machine-id` when `/etc/machine-id` is empty, which had the source's value baked in). It now just handles hostname (set BEFORE ssh-keygen) and SSH host keys.

## Trade-off

machine-id regenerates on every VM boot of the same shed, not just first boot. For shed's ephemeral test-environment workflow this is fine. Documented in `docs/reference/snapshots.md` as a known caveat for anyone keying persistent state on machine-id.

## Validation

- **Linux (Firecracker, mini2):** patched the cached `_base-rootfs.ext4` in-place to mimic the Dockerfile change, then ran the full snapshot lifecycle. Two fresh sheds → distinct machine-ids. snapshot + 2 spawns → each spawn has a distinct machine-id different from each other and from the source. On-disk `/etc/machine-id` is a symlink (Type: symlink, Size: 15) — no UUID persisted.
- **macOS (VZ, this Mac):** built `make vz-rootfs-base` from this branch's Dockerfile, pointed a test config at the local file, ran the same lifecycle. Same results: unique fresh machine-ids, unique spawn machine-ids, SSH key comments now show `root@<spawn-name>` correctly.
- `make check` clean; firstboot tests updated to match the new flow.

## Files changed

- `vz/Dockerfile`, `firecracker/Dockerfile` — three-line block adding the symlink + mask
- `cmd/shed-firstboot/firstboot.go` — drop machine-id handling; hostname-before-ssh-keygen ordering preserved
- `cmd/shed-firstboot/firstboot_test.go` — match new firstbootCfg shape; new `TestRegenerateIdentity_HostnameBeforeSSHKeygen` (added during v0.4.1 follow-up work, kept here)
- `docs/reference/snapshots.md` — describe transient machine-id and the per-boot regeneration trade-off

## Test plan

- [x] `make check` clean
- [x] In-place validation on mini2 (Firecracker) — fresh + snapshot uniqueness, on-disk inspection
- [x] Local rootfs build + test on Mac (VZ) — fresh + snapshot uniqueness, SSH key comments correct
- [ ] CI green
- [ ] Bot review pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Machine ID is now transient and regenerated per VM boot (no persistent ID baked into images).

* **Bug Fixes**
  * Hostname is applied before SSH host keys are generated to ensure correct key metadata.

* **Documentation**
  * Updated identity regeneration docs and caveats: IDs may differ across reboots.

* **Tests**
  * Added test ensuring identity setup commands run in the correct sequence.

* **Chores**
  * Build images adjusted to make machine-ID transient at boot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->