### PR TITLE
Snapshot feature follow-up cleanups

### DIFF
--- a/cmd/shed/system.go
+++ b/cmd/shed/system.go
@@ -222,8 +222,13 @@ func renderDF(w io.Writer, du config.DiskUsage, verbose bool) {
 		}
 	}
 
-	// Per-snapshot FILES count is one rootfs + one snapshot.json per snapshot.
-	snapshotFiles := len(du.Snapshots) * 2
+	// Per-snapshot FILES count is one rootfs plus any sidecar files (typically
+	// snapshot.json). Mirrors the per-shed shedFiles accumulation above.
+	snapshotFiles := 0
+	for _, s := range du.Snapshots {
+		snapshotFiles++ // rootfs
+		snapshotFiles += len(s.OtherFiles)
+	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "CATEGORY\tFILES\tLOGICAL\tPHYSICAL")
@@ -365,8 +370,10 @@ func countFiles(du *config.DiskUsage) int {
 		}
 		n += len(s.OtherFiles)
 	}
-	// Each snapshot is rootfs.ext4 + snapshot.json.
-	n += len(du.Snapshots) * 2
+	for _, s := range du.Snapshots {
+		n++ // rootfs
+		n += len(s.OtherFiles)
+	}
 	return n
 }
 

--- a/cmd/shed/system_test.go
+++ b/cmd/shed/system_test.go
@@ -180,6 +180,31 @@ func TestCountFiles(t *testing.T) {
 	}
 }
 
+func TestCountFiles_SnapshotOtherFiles(t *testing.T) {
+	du := sampleDiskUsage()
+	du.Snapshots = []config.SnapshotDiskEntry{
+		{
+			Name:   "snap-no-meta",
+			Rootfs: config.FileEntry{Path: "/tmp/r1", Size: config.DiskSize{LogicalBytes: 1024}, Kind: "rootfs"},
+			Total:  config.DiskSize{LogicalBytes: 1024},
+		},
+		{
+			Name:   "snap-with-meta",
+			Rootfs: config.FileEntry{Path: "/tmp/r2", Size: config.DiskSize{LogicalBytes: 2048}, Kind: "rootfs"},
+			OtherFiles: []config.FileEntry{
+				{Path: "/tmp/r2/snapshot.json", Size: config.DiskSize{LogicalBytes: 256, PhysicalBytes: 4096}, Kind: "metadata"},
+			},
+			Total: config.DiskSize{LogicalBytes: 2048 + 256, PhysicalBytes: 4096},
+		},
+	}
+	// Base from the existing fixture is 8 (see TestCountFiles); plus 2 snapshot
+	// rootfs + 1 metadata sidecar = 11.
+	got := countFiles(&du)
+	if got != 11 {
+		t.Errorf("countFiles = %d, want 11", got)
+	}
+}
+
 func samplePruneReport(dry bool) config.PruneReport {
 	return config.PruneReport{
 		DryRun:     dry,

--- a/internal/api/connect.go
+++ b/internal/api/connect.go
@@ -56,7 +56,7 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Upgrade", "shed-tcp")
 	w.WriteHeader(http.StatusSwitchingProtocols)
 
-	clientConn, _, err := hj.Hijack()
+	clientConn, bufrw, err := hj.Hijack()
 	if err != nil {
 		vmConn.Close()
 		log.Printf("Connect API: hijack failed for %s:%d: %v", shedName, port, err)
@@ -65,8 +65,14 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("Connect API: tunnel %s:%d established", shedName, port)
 
+	// The HTTP server's bufio.Reader may have read past the request headers
+	// into the body before Hijack returned. Wrap clientConn with BufferedConn
+	// so BidirectionalCopy reads those buffered bytes first; otherwise they
+	// are stranded in bufrw and lost. Mirrors internal/tunnels/connect.go.
+	bufferedClient := &vmutil.BufferedConn{Conn: clientConn, Reader: bufrw.Reader}
+
 	// Bidirectional proxy.
-	vmutil.BidirectionalCopy(clientConn, vmConn)
+	vmutil.BidirectionalCopy(bufferedClient, vmConn)
 	clientConn.Close()
 	vmConn.Close()
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -83,16 +83,11 @@ func (s *Server) handleCreateShed(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// from_snapshot is mutually exclusive with image and repo (snapshot rootfs is the source of truth).
+	// from_snapshot name validation. The mutual-exclusion check (vs image/repo) is enforced
+	// in the backend via ErrInvalidShedRequestSentinel, which mapBackendError translates to
+	// 400 INVALID_REQUEST. Name validation stays here because backends only catch a bad name
+	// later (in loadSnapshot) without surfacing a 400.
 	if req.FromSnapshot != "" {
-		if req.Image != "" {
-			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "from_snapshot and image are mutually exclusive")
-			return
-		}
-		if req.Repo != "" {
-			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "from_snapshot and repo are mutually exclusive")
-			return
-		}
 		if err := config.ValidateSnapshotName(req.FromSnapshot); err != nil {
 			writeError(w, http.StatusBadRequest, config.ErrInvalidSnapshotName, err.Error())
 			return
@@ -422,6 +417,9 @@ func mapBackendError(err error) (int, string, string) {
 	}
 	if errors.Is(err, config.ErrSnapshotBackendMismatchSentinel) {
 		return http.StatusBadRequest, config.ErrSnapshotBackendMismatch, err.Error()
+	}
+	if errors.Is(err, config.ErrInvalidShedRequestSentinel) {
+		return http.StatusBadRequest, config.ErrInvalidRequest, err.Error()
 	}
 
 	// Fallback to string matching for errors without sentinels

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -83,13 +83,18 @@ func (s *Server) handleCreateShed(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// from_snapshot name validation. The mutual-exclusion check (vs image/repo) is enforced
-	// in the backend via ErrInvalidShedRequestSentinel, which mapBackendError translates to
-	// 400 INVALID_REQUEST. Name validation stays here because backends only catch a bad name
-	// later (in loadSnapshot) without surfacing a 400.
+	// from_snapshot validation runs BEFORE either the SSE branch or the
+	// backend call: handleCreateShedSSE writes "200 OK" before the backend
+	// runs, so a backend-only sentinel would surface as a streamed error
+	// instead of the 400 INVALID_REQUEST clients expect.
 	if req.FromSnapshot != "" {
 		if err := config.ValidateSnapshotName(req.FromSnapshot); err != nil {
 			writeError(w, http.StatusBadRequest, config.ErrInvalidSnapshotName, err.Error())
+			return
+		}
+		if req.Image != "" || req.Repo != "" {
+			writeError(w, http.StatusBadRequest, config.ErrInvalidRequest,
+				"invalid create-shed request: --from-snapshot cannot be combined with --image or --repo")
 			return
 		}
 	}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -163,6 +163,7 @@ func TestMapBackendError_SentinelErrors(t *testing.T) {
 		{"not running", fmt.Errorf("%w: mydev", config.ErrShedNotRunningSentinel), http.StatusConflict, config.ErrShedAlreadyStopped},
 		{"image not found", fmt.Errorf("%w", config.ErrImageNotFoundSentinel), http.StatusNotFound, config.ErrImageNotFound},
 		{"image in use", fmt.Errorf("%w", config.ErrImageInUseSentinel), http.StatusConflict, config.ErrImageInUse},
+		{"invalid shed request", fmt.Errorf("%w: --from-snapshot cannot be combined with --image or --repo", config.ErrInvalidShedRequestSentinel), http.StatusBadRequest, config.ErrInvalidRequest},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/api/snapshot_handlers_test.go
+++ b/internal/api/snapshot_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,10 @@ import (
 
 // snapshotFakeBackend is a minimal backend.Backend that exercises only the
 // snapshot-related routes. Other methods panic so accidental coupling shows up.
+//
+// CreateShed is overridable via createShedFn for tests that need to exercise
+// the API handler's create path (e.g., the from-snapshot mutual-exclusion case
+// after the API-layer mutex check moved to the backend sentinel).
 type snapshotFakeBackend struct {
 	listResp     []config.Snapshot
 	listErr      error
@@ -25,11 +30,15 @@ type snapshotFakeBackend struct {
 	getErr       error
 	deleteErr    error
 	createCalled config.SnapshotCreateRequest
+	createShedFn func(context.Context, config.CreateShedRequest) (*config.Shed, error)
 }
 
 func (f *snapshotFakeBackend) Type() backend.Type { return backend.TypeVZ }
 func (f *snapshotFakeBackend) Close() error       { return nil }
-func (f *snapshotFakeBackend) CreateShed(_ context.Context, _ config.CreateShedRequest) (*config.Shed, error) {
+func (f *snapshotFakeBackend) CreateShed(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error) {
+	if f.createShedFn != nil {
+		return f.createShedFn(ctx, req)
+	}
 	panic("unexpected")
 }
 func (f *snapshotFakeBackend) GetShed(_ context.Context, _ string) (*config.Shed, error) {
@@ -277,7 +286,11 @@ func TestHandleCreateShed_FromSnapshotMutualExclusion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			be := &snapshotFakeBackend{}
+			be := &snapshotFakeBackend{
+				createShedFn: func(_ context.Context, _ config.CreateShedRequest) (*config.Shed, error) {
+					return nil, fmt.Errorf("%w: --from-snapshot cannot be combined with --image or --repo", config.ErrInvalidShedRequestSentinel)
+				},
+			}
 			srv := NewServer(be, &config.ServerConfig{Name: "t", DefaultBackend: config.BackendVZ}, "", nil, nil)
 			r := httptest.NewRequest(http.MethodPost, "/api/sheds", bytes.NewBufferString(tt.body))
 			w := httptest.NewRecorder()

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -450,11 +450,14 @@ type SnapshotCreateResponse struct {
 }
 
 // SnapshotDiskEntry describes one snapshot's disk footprint for `shed system df`.
+// OtherFiles holds metadata sidecars (snapshot.json) so callers can sum the
+// total footprint without hardcoding a per-snapshot file count.
 type SnapshotDiskEntry struct {
-	Name       string    `json:"name"`
-	SourceShed string    `json:"source_shed,omitempty"`
-	Rootfs     FileEntry `json:"rootfs"`
-	Total      DiskSize  `json:"total"`
+	Name       string      `json:"name"`
+	SourceShed string      `json:"source_shed,omitempty"`
+	Rootfs     FileEntry   `json:"rootfs"`
+	OtherFiles []FileEntry `json:"other_files,omitempty"`
+	Total      DiskSize    `json:"total"`
 }
 
 // APIError represents an error response from the API.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -51,6 +51,12 @@ var (
 
 	// ErrSnapshotBackendMismatchSentinel is returned when spawning a snapshot on the wrong backend.
 	ErrSnapshotBackendMismatchSentinel = errors.New("snapshot backend does not match target")
+
+	// ErrInvalidShedRequestSentinel is the catch-all sentinel for CreateShedRequest
+	// field-level validation that maps to HTTP 400 INVALID_REQUEST. Add new
+	// field-conflict cases (e.g., --from-snapshot combined with --image or --repo)
+	// under this sentinel rather than minting per-conflict sentinels.
+	ErrInvalidShedRequestSentinel = errors.New("invalid create-shed request")
 )
 
 // shedNameRegex validates shed names: lowercase alphanumeric and hyphens, starting with a letter.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -240,7 +240,7 @@ type FileEntry struct {
 	Path string   `json:"path"`
 	Size DiskSize `json:"size"`
 	// Kind is one of: "rootfs" | "console_log" | "kernel" | "initrd" |
-	// "lock" | "tmp" | "source" | "metadata".
+	// "lock" | "tmp" | "source" | "metadata" | "snapshot_orphan".
 	Kind string `json:"kind,omitempty"`
 }
 
@@ -314,7 +314,7 @@ type SystemDFResponse struct {
 // by `shed system prune`.
 type PrunedItem struct {
 	// Kind is one of: "image" | "rootfs" | "console_log" | "metadata" |
-	// "instance" | "lock" | "tmp" | "source".
+	// "instance" | "lock" | "tmp" | "source" | "snapshot_orphan".
 	Kind string `json:"kind"`
 	Path string `json:"path,omitempty"`
 	// Name is the shed or image name when applicable.

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -395,7 +395,7 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 
 	if req.FromSnapshot != "" {
 		if req.Image != "" || req.Repo != "" {
-			return nil, fmt.Errorf("--from-snapshot is mutually exclusive with --image and --repo")
+			return nil, fmt.Errorf("%w: --from-snapshot cannot be combined with --image or --repo", config.ErrInvalidShedRequestSentinel)
 		}
 	}
 

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/lockmap"
 	"github.com/charliek/shed/internal/plugin"
 	"github.com/charliek/shed/internal/vmimage"
 	"github.com/charliek/shed/internal/vmutil"
@@ -34,19 +35,17 @@ type Client struct {
 	usedIPs   map[string]string      // IP -> name
 	p9Servers map[string][]*P9Server // name -> active 9P servers for this VM
 
-	// createLocks serializes CreateShed calls by shed name to close the
-	// TOCTOU between the already-exists check and the final meta.Save.
-	// Two racing `shed create` calls for the same name would otherwise
-	// both pass the existence check and the second caller's CopyRootfs
-	// would os.Remove the first caller's just-cloned rootfs. createMu
-	// guards the map; each value is locked across a single CreateShed.
-	createMu    sync.Mutex
-	createLocks map[string]*sync.Mutex
+	// shedLocks serializes per-shed-name lifecycle operations. Originally
+	// added for CreateShed-vs-CreateShed TOCTOU but the lock has broadened
+	// to cover any operation that mutates a shed's on-disk state (Create,
+	// Start, Stop, Delete, and CreateSnapshot of this shed as source).
+	// Value type so the zero-value Client{} works in tests.
+	shedLocks lockmap.NamedMutexMap
 
-	// snapshotLocks serializes CreateSnapshot/DeleteSnapshot calls by
-	// snapshot name. Distinct keyspace from createLocks.
-	snapshotMu    sync.Mutex
-	snapshotLocks map[string]*sync.Mutex
+	// snapshotLocks serializes CreateSnapshot/DeleteSnapshot/CreateShed-
+	// from-snapshot calls by snapshot name. Distinct keyspace from
+	// shedLocks (snapshot names vs shed names).
+	snapshotLocks lockmap.NamedMutexMap
 
 	// Credential sync
 	credMgr *vmutil.CredentialManager
@@ -60,16 +59,14 @@ func NewClient(cfg *config.FirecrackerConfig, serverCfg *config.ServerConfig, br
 	}
 
 	client := &Client{
-		cfg:           cfg,
-		serverCfg:     serverCfg,
-		netMgr:        netMgr,
-		vms:           make(map[string]*VM),
-		usedCIDs:      make(map[uint32]string),
-		usedIPs:       make(map[string]string),
-		p9Servers:     make(map[string][]*P9Server),
-		createLocks:   make(map[string]*sync.Mutex),
-		snapshotLocks: make(map[string]*sync.Mutex),
-		credMgr:       vmutil.NewCredentialManager(serverCfg, bridge, string(config.BackendFirecracker), vmutil.NewHealthTracker()),
+		cfg:       cfg,
+		serverCfg: serverCfg,
+		netMgr:    netMgr,
+		vms:       make(map[string]*VM),
+		usedCIDs:  make(map[uint32]string),
+		usedIPs:   make(map[string]string),
+		p9Servers: make(map[string][]*P9Server),
+		credMgr:   vmutil.NewCredentialManager(serverCfg, bridge, string(config.BackendFirecracker), vmutil.NewHealthTracker()),
 	}
 
 	// Load existing instances to populate CID and IP maps
@@ -113,22 +110,8 @@ func (c *Client) loadExistingInstances() error {
 // Lock-order rule: when both locks are needed (snapshot create or
 // from-snapshot spawn), acquire snapshotLock BEFORE createLock to avoid
 // AB-BA deadlock with other code paths.
-//
-// The per-name mutex is leaked on first use — bounded by the number of
-// distinct shed names ever created in this process, which is negligible.
 func (c *Client) acquireCreateLock(name string) func() {
-	c.createMu.Lock()
-	if c.createLocks == nil {
-		c.createLocks = make(map[string]*sync.Mutex)
-	}
-	mu, ok := c.createLocks[name]
-	if !ok {
-		mu = &sync.Mutex{}
-		c.createLocks[name] = mu
-	}
-	c.createMu.Unlock()
-	mu.Lock()
-	return mu.Unlock
+	return c.shedLocks.Acquire(name)
 }
 
 // Close closes the client and releases resources.

--- a/internal/firecracker/client_test.go
+++ b/internal/firecracker/client_test.go
@@ -6,6 +6,7 @@ package firecracker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -583,5 +584,28 @@ func TestMetadataLocalDir_RoundTrip(t *testing.T) {
 
 	if localDir != "/tmp/test-project" {
 		t.Errorf("local_dir in JSON = %q, want %q", localDir, "/tmp/test-project")
+	}
+}
+
+func TestCreateShedFromSnapshotMutualExclusionWrapsSentinel(t *testing.T) {
+	c := &Client{}
+
+	tests := []struct {
+		name string
+		req  config.CreateShedRequest
+	}{
+		{"with_image", config.CreateShedRequest{Name: "n", FromSnapshot: "snap1", Image: "default"}},
+		{"with_repo", config.CreateShedRequest{Name: "n", FromSnapshot: "snap1", Repo: "git@github.com:o/r.git"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := c.CreateShed(context.Background(), tt.req)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !errors.Is(err, config.ErrInvalidShedRequestSentinel) {
+				t.Fatalf("error %v does not wrap ErrInvalidShedRequestSentinel", err)
+			}
+		})
 	}
 }

--- a/internal/firecracker/snapshot.go
+++ b/internal/firecracker/snapshot.go
@@ -175,12 +175,21 @@ func (c *Client) CreateSnapshot(ctx context.Context, req config.SnapshotCreateRe
 	}
 
 	// Drop a `.creating` marker so `shed system prune --orphans` won't sweep
-	// this dir if the host crashes mid-create. Removed on every exit path.
+	// this dir if the host crashes mid-create. Fail-closed: if we can't make
+	// the marker durable before the long-running clone, abort rather than
+	// proceed with no crash protection. fsync the parent dir so the marker
+	// dentry is on stable storage before returning from the write.
 	markerPath := filepath.Join(dir, systemprune.SnapshotCreatingMarker)
-	if mf, err := os.Create(markerPath); err == nil {
-		_ = mf.Close()
-		defer os.Remove(markerPath)
+	if err := os.WriteFile(markerPath, nil, 0o600); err != nil {
+		os.RemoveAll(dir)
+		return nil, fmt.Errorf("failed to create snapshot marker: %w", err)
 	}
+	if err := syncDir(dir); err != nil {
+		_ = os.Remove(markerPath)
+		os.RemoveAll(dir)
+		return nil, fmt.Errorf("failed to sync snapshot marker: %w", err)
+	}
+	defer os.Remove(markerPath)
 
 	dstRootfs := SnapshotRootfsPath(c.cfg.SnapshotsDir, req.Name)
 	if err := os.Remove(dstRootfs); err != nil && !os.IsNotExist(err) {

--- a/internal/firecracker/snapshot.go
+++ b/internal/firecracker/snapshot.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/systemprune"
 	"github.com/charliek/shed/internal/vmimage/clone"
 )
 
@@ -171,6 +172,14 @@ func (c *Client) CreateSnapshot(ctx context.Context, req config.SnapshotCreateRe
 	dir := SnapshotDir(c.cfg.SnapshotsDir, req.Name)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create snapshot directory: %w", err)
+	}
+
+	// Drop a `.creating` marker so `shed system prune --orphans` won't sweep
+	// this dir if the host crashes mid-create. Removed on every exit path.
+	markerPath := filepath.Join(dir, systemprune.SnapshotCreatingMarker)
+	if mf, err := os.Create(markerPath); err == nil {
+		_ = mf.Close()
+		defer os.Remove(markerPath)
 	}
 
 	dstRootfs := SnapshotRootfsPath(c.cfg.SnapshotsDir, req.Name)

--- a/internal/firecracker/snapshot.go
+++ b/internal/firecracker/snapshot.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/charliek/shed/internal/backend"
@@ -128,19 +127,12 @@ func listSnapshotNames(snapshotsDir string) ([]string, error) {
 
 // acquireSnapshotLock returns an unlock closure after taking the per-name
 // snapshot mutex. Mirrors acquireCreateLock in the snapshot keyspace.
+//
+// Lock-order rule: when both locks are needed (snapshot create or
+// from-snapshot spawn), acquire snapshotLock BEFORE the source shed's
+// createLock to avoid AB-BA deadlock.
 func (c *Client) acquireSnapshotLock(name string) func() {
-	c.snapshotMu.Lock()
-	if c.snapshotLocks == nil {
-		c.snapshotLocks = make(map[string]*sync.Mutex)
-	}
-	mu, ok := c.snapshotLocks[name]
-	if !ok {
-		mu = &sync.Mutex{}
-		c.snapshotLocks[name] = mu
-	}
-	c.snapshotMu.Unlock()
-	mu.Lock()
-	return mu.Unlock
+	return c.snapshotLocks.Acquire(name)
 }
 
 // CreateSnapshot captures a stopped shed's rootfs as a named, immutable artifact.

--- a/internal/firecracker/system.go
+++ b/internal/firecracker/system.go
@@ -75,6 +75,14 @@ func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 		du.Orphans = orphans
 	}
 
+	if c.cfg.SnapshotsDir != "" {
+		snapOrphans, err := systemprune.FindSnapshotOrphans(c.cfg.SnapshotsDir)
+		if err != nil {
+			return du, fmt.Errorf("scanning snapshot orphans: %w", err)
+		}
+		du.Orphans = append(du.Orphans, snapOrphans...)
+	}
+
 	// Kernel only — Firecracker has no initrd.
 	if c.cfg.KernelPath != "" {
 		if logical, physical, err := diskstat.Stat(c.cfg.KernelPath); err == nil {
@@ -247,6 +255,13 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 		report.Skipped = append(report.Skipped, skipped...)
 	}
 
+	var snapshotOrphanCandidates []systemprune.SnapshotOrphanCandidate
+	if opts.Orphans && c.cfg.SnapshotsDir != "" {
+		cands, skipped := systemprune.CollectSnapshotOrphanCandidates(c.cfg.SnapshotsDir)
+		snapshotOrphanCandidates = cands
+		report.Skipped = append(report.Skipped, skipped...)
+	}
+
 	var imageCandidates []vmimage.ImageInfo
 	if opts.Images && c.cfg.ImagesDir != "" {
 		skipSet := make(map[string]bool, len(instanceCandidates))
@@ -281,6 +296,9 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 	}
 	for _, oc := range orphanCandidates {
 		report.Items = append(report.Items, oc.ToPrunedItem(opts.DryRun))
+	}
+	for _, sc := range snapshotOrphanCandidates {
+		report.Items = append(report.Items, sc.ToPrunedItems(opts.DryRun)...)
 	}
 	for _, img := range imageCandidates {
 		report.Items = append(report.Items, systemprune.ImageToPrunedItem(img, opts.DryRun))
@@ -327,6 +345,16 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 				continue
 			}
 			report.Items = append(report.Items, oc.ToPrunedItem(false))
+		}
+		for _, sc := range snapshotOrphanCandidates {
+			if ok := systemprune.SweepSnapshotOrphan(sc); !ok {
+				report.Skipped = append(report.Skipped, config.SkippedItem{
+					Kind: "snapshot_orphan", Path: sc.Dir,
+					Reason: "removal failed",
+				})
+				continue
+			}
+			report.Items = append(report.Items, sc.ToPrunedItems(false)...)
 		}
 	}
 

--- a/internal/firecracker/system.go
+++ b/internal/firecracker/system.go
@@ -124,6 +124,16 @@ func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 				},
 				Total: config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
 			}
+			meta := SnapshotMetadataPath(c.cfg.SnapshotsDir, name)
+			if metaLogical, metaPhysical, err := diskstat.Stat(meta); err == nil {
+				entry.OtherFiles = append(entry.OtherFiles, config.FileEntry{
+					Path: meta,
+					Size: config.DiskSize{LogicalBytes: metaLogical, PhysicalBytes: metaPhysical},
+					Kind: "metadata",
+				})
+				entry.Total.LogicalBytes += metaLogical
+				entry.Total.PhysicalBytes += metaPhysical
+			}
 			du.Snapshots = append(du.Snapshots, entry)
 		}
 	}
@@ -156,7 +166,7 @@ func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 	)
 	if len(du.Snapshots) > 0 {
 		du.Notes = append(du.Notes,
-			"snapshots and sheds spawned from them share extents via reflink — physical bytes count those extents under both",
+			"rootfs extents are shared via reflink between a snapshot and sheds spawned from it — physical bytes count those extents under both; metadata files are unique per snapshot",
 		)
 	}
 

--- a/internal/firecracker/system_prune_test.go
+++ b/internal/firecracker/system_prune_test.go
@@ -1,0 +1,132 @@
+//go:build linux
+
+package firecracker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/config"
+)
+
+// newPruneTestClient builds a Client backed by a temp config so the
+// snapshot-orphan path can be exercised without spinning up a real VM.
+func newPruneTestClient(t *testing.T) (*Client, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	cfg := testFirecrackerConfig(tmp)
+	cfg.ImagesDir = filepath.Join(tmp, "images")
+	cfg.SnapshotsDir = filepath.Join(tmp, "snapshots")
+	if err := os.MkdirAll(cfg.SnapshotsDir, 0o755); err != nil {
+		t.Fatalf("mkdir snapshots: %v", err)
+	}
+	c := &Client{cfg: cfg, serverCfg: &config.ServerConfig{Name: "test-prune"}}
+	return c, cfg.SnapshotsDir
+}
+
+func TestPrune_SnapshotOrphans_PartialDirRemoved(t *testing.T) {
+	c, snapshotsDir := newPruneTestClient(t)
+
+	dir := filepath.Join(snapshotsDir, "halfwritten")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rootfs := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(rootfs, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+
+	hasRootfs, hasDir := false, false
+	for _, it := range report.Items {
+		if it.Path == rootfs && it.Kind == "snapshot_orphan" {
+			hasRootfs = true
+		}
+		if it.Path == dir && it.Kind == "snapshot_orphan" {
+			hasDir = true
+		}
+	}
+	if !hasRootfs {
+		t.Errorf("expected snapshot rootfs reported as snapshot_orphan, got %+v", report.Items)
+	}
+	if !hasDir {
+		t.Errorf("expected snapshot dir reported as snapshot_orphan, got %+v", report.Items)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("snapshot orphan dir still exists after prune (err=%v)", err)
+	}
+}
+
+func TestPrune_SnapshotOrphans_FreshCreatingMarkerSkipped(t *testing.T) {
+	c, snapshotsDir := newPruneTestClient(t)
+
+	dir := filepath.Join(snapshotsDir, "inflight")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "rootfs.ext4"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".creating"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+
+	for _, it := range report.Items {
+		if strings.HasPrefix(it.Path, dir) {
+			t.Fatalf("inflight snapshot dir was touched: %+v", it)
+		}
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("inflight dir was deleted: %v", err)
+	}
+
+	hasSkip := false
+	for _, sk := range report.Skipped {
+		if sk.Path == dir && sk.Kind == "snapshot_orphan" {
+			hasSkip = true
+		}
+	}
+	if !hasSkip {
+		t.Errorf("expected SkippedItem for inflight snapshot, got %+v", report.Skipped)
+	}
+}
+
+func TestPrune_SnapshotOrphans_DryRunNoMutation(t *testing.T) {
+	c, snapshotsDir := newPruneTestClient(t)
+
+	dir := filepath.Join(snapshotsDir, "halfwritten")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rootfs := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(rootfs, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true, DryRun: true})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if !report.DryRun {
+		t.Errorf("expected DryRun=true")
+	}
+	if _, err := os.Stat(rootfs); err != nil {
+		t.Errorf("dry run deleted rootfs: %v", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("dry run deleted dir: %v", err)
+	}
+}

--- a/internal/firecracker/system_prune_test.go
+++ b/internal/firecracker/system_prune_test.go
@@ -28,105 +28,98 @@ func newPruneTestClient(t *testing.T) (*Client, string) {
 	return c, cfg.SnapshotsDir
 }
 
-func TestPrune_SnapshotOrphans_PartialDirRemoved(t *testing.T) {
-	c, snapshotsDir := newPruneTestClient(t)
-
-	dir := filepath.Join(snapshotsDir, "halfwritten")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	rootfs := filepath.Join(dir, "rootfs.ext4")
-	if err := os.WriteFile(rootfs, []byte("data"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true})
-	if err != nil {
-		t.Fatalf("Prune: %v", err)
-	}
-
-	hasRootfs, hasDir := false, false
-	for _, it := range report.Items {
-		if it.Path == rootfs && it.Kind == "snapshot_orphan" {
-			hasRootfs = true
-		}
-		if it.Path == dir && it.Kind == "snapshot_orphan" {
-			hasDir = true
-		}
-	}
-	if !hasRootfs {
-		t.Errorf("expected snapshot rootfs reported as snapshot_orphan, got %+v", report.Items)
-	}
-	if !hasDir {
-		t.Errorf("expected snapshot dir reported as snapshot_orphan, got %+v", report.Items)
-	}
-	if _, err := os.Stat(dir); !os.IsNotExist(err) {
-		t.Errorf("snapshot orphan dir still exists after prune (err=%v)", err)
-	}
-}
-
-func TestPrune_SnapshotOrphans_FreshCreatingMarkerSkipped(t *testing.T) {
-	c, snapshotsDir := newPruneTestClient(t)
-
-	dir := filepath.Join(snapshotsDir, "inflight")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "rootfs.ext4"), []byte("data"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, ".creating"), nil, 0o600); err != nil {
-		t.Fatal(err)
+// TestPrune_SnapshotOrphans covers all three snapshot-orphan paths in one
+// table-driven harness. Setup writes a partial snapshot dir; flags toggle
+// the `.creating` marker and DryRun. Assertions cover both the
+// PruneReport shape and the on-disk state after Prune returns.
+func TestPrune_SnapshotOrphans(t *testing.T) {
+	tests := []struct {
+		name              string
+		writeMarker       bool
+		dryRun            bool
+		wantItems         bool // expect snapshot_orphan entries in report.Items
+		wantSkipped       bool // expect snapshot_orphan SkippedItem
+		wantDirRemoved    bool // expect the partial dir to be gone after Prune
+		wantRootfsRemoved bool // expect the rootfs file to be gone after Prune
+	}{
+		{
+			name:              "partial dir removed",
+			wantItems:         true,
+			wantDirRemoved:    true,
+			wantRootfsRemoved: true,
+		},
+		{
+			name:        "fresh creating marker is skipped",
+			writeMarker: true,
+			wantSkipped: true,
+		},
+		{
+			name:      "dry-run does not mutate disk",
+			dryRun:    true,
+			wantItems: true,
+		},
 	}
 
-	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true})
-	if err != nil {
-		t.Fatalf("Prune: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, snapshotsDir := newPruneTestClient(t)
 
-	for _, it := range report.Items {
-		if strings.HasPrefix(it.Path, dir) {
-			t.Fatalf("inflight snapshot dir was touched: %+v", it)
-		}
-	}
-	if _, err := os.Stat(dir); err != nil {
-		t.Errorf("inflight dir was deleted: %v", err)
-	}
+			dir := filepath.Join(snapshotsDir, "halfwritten")
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			rootfs := filepath.Join(dir, "rootfs.ext4")
+			if err := os.WriteFile(rootfs, []byte("data"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if tt.writeMarker {
+				if err := os.WriteFile(filepath.Join(dir, ".creating"), nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	hasSkip := false
-	for _, sk := range report.Skipped {
-		if sk.Path == dir && sk.Kind == "snapshot_orphan" {
-			hasSkip = true
-		}
-	}
-	if !hasSkip {
-		t.Errorf("expected SkippedItem for inflight snapshot, got %+v", report.Skipped)
-	}
-}
+			report, err := c.Prune(context.Background(), backend.PruneOptions{
+				Orphans: true,
+				DryRun:  tt.dryRun,
+			})
+			if err != nil {
+				t.Fatalf("Prune: %v", err)
+			}
+			if report.DryRun != tt.dryRun {
+				t.Errorf("report.DryRun = %v; want %v", report.DryRun, tt.dryRun)
+			}
 
-func TestPrune_SnapshotOrphans_DryRunNoMutation(t *testing.T) {
-	c, snapshotsDir := newPruneTestClient(t)
+			hasItems := false
+			for _, it := range report.Items {
+				if strings.HasPrefix(it.Path, dir) && it.Kind == "snapshot_orphan" {
+					hasItems = true
+				}
+			}
+			if hasItems != tt.wantItems {
+				t.Errorf("snapshot_orphan items present = %v; want %v (items=%+v)", hasItems, tt.wantItems, report.Items)
+			}
 
-	dir := filepath.Join(snapshotsDir, "halfwritten")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	rootfs := filepath.Join(dir, "rootfs.ext4")
-	if err := os.WriteFile(rootfs, []byte("data"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+			hasSkipped := false
+			for _, sk := range report.Skipped {
+				if sk.Path == dir && sk.Kind == "snapshot_orphan" {
+					hasSkipped = true
+				}
+			}
+			if hasSkipped != tt.wantSkipped {
+				t.Errorf("snapshot_orphan skipped present = %v; want %v (skipped=%+v)", hasSkipped, tt.wantSkipped, report.Skipped)
+			}
 
-	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true, DryRun: true})
-	if err != nil {
-		t.Fatalf("Prune: %v", err)
-	}
-	if !report.DryRun {
-		t.Errorf("expected DryRun=true")
-	}
-	if _, err := os.Stat(rootfs); err != nil {
-		t.Errorf("dry run deleted rootfs: %v", err)
-	}
-	if _, err := os.Stat(dir); err != nil {
-		t.Errorf("dry run deleted dir: %v", err)
+			_, dirStatErr := os.Stat(dir)
+			dirGone := os.IsNotExist(dirStatErr)
+			if dirGone != tt.wantDirRemoved {
+				t.Errorf("dir removed = %v; want %v (stat err=%v)", dirGone, tt.wantDirRemoved, dirStatErr)
+			}
+
+			_, rootfsStatErr := os.Stat(rootfs)
+			rootfsGone := os.IsNotExist(rootfsStatErr)
+			if rootfsGone != tt.wantRootfsRemoved {
+				t.Errorf("rootfs removed = %v; want %v (stat err=%v)", rootfsGone, tt.wantRootfsRemoved, rootfsStatErr)
+			}
+		})
 	}
 }

--- a/internal/lockmap/lockmap.go
+++ b/internal/lockmap/lockmap.go
@@ -1,0 +1,43 @@
+// Package lockmap provides per-name mutex serialization.
+package lockmap
+
+import "sync"
+
+// NamedMutexMap serializes operations keyed by name. Each name gets its own
+// sync.Mutex; a single guard mutex protects the underlying map. The per-name
+// mutex is leaked on first use — bounded by the number of distinct names ever
+// seen in this process, which is effectively negligible for shed.
+//
+// The zero value is ready to use; New() is offered for callers that prefer
+// explicit construction.
+type NamedMutexMap struct {
+	guard sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+// New returns a ready-to-use NamedMutexMap. Equivalent to using the zero value.
+func New() *NamedMutexMap {
+	return &NamedMutexMap{}
+}
+
+// Acquire takes the per-name mutex and returns an unlock closure. Callers
+// MUST defer the returned closure.
+//
+// Lock-order rule when callers hold multiple NamedMutexMaps: the rule is
+// documented at the type level by the embedding caller (see e.g.
+// internal/vz/client.go's acquireSnapshotLock vs acquireCreateLock comments).
+// AB-BA deadlock between distinct NamedMutexMaps is the caller's responsibility.
+func (m *NamedMutexMap) Acquire(name string) func() {
+	m.guard.Lock()
+	if m.locks == nil {
+		m.locks = make(map[string]*sync.Mutex)
+	}
+	mu, ok := m.locks[name]
+	if !ok {
+		mu = &sync.Mutex{}
+		m.locks[name] = mu
+	}
+	m.guard.Unlock()
+	mu.Lock()
+	return mu.Unlock
+}

--- a/internal/lockmap/lockmap_test.go
+++ b/internal/lockmap/lockmap_test.go
@@ -1,0 +1,117 @@
+package lockmap
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAcquireSerializesSameName(t *testing.T) {
+	tests := []struct {
+		name        string
+		firstName   string
+		secondName  string
+		shouldBlock bool
+	}{
+		{"same name serializes", "snap", "snap", true},
+		{"different names do not block", "a", "b", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := New()
+			release1 := m.Acquire(tt.firstName)
+
+			acquired := make(chan struct{})
+			go func() {
+				release2 := m.Acquire(tt.secondName)
+				close(acquired)
+				release2()
+			}()
+
+			if tt.shouldBlock {
+				select {
+				case <-acquired:
+					release1()
+					t.Fatal("second Acquire should have blocked")
+				case <-time.After(100 * time.Millisecond):
+					// expected: still blocked
+				}
+				release1()
+				select {
+				case <-acquired:
+					// expected: unblocked after release
+				case <-time.After(time.Second):
+					t.Fatal("second Acquire did not proceed after release")
+				}
+			} else {
+				defer release1()
+				select {
+				case <-acquired:
+					// expected: parallel acquire
+				case <-time.After(500 * time.Millisecond):
+					t.Fatal("Acquire for different names must not block")
+				}
+			}
+		})
+	}
+}
+
+func TestZeroValueReady(t *testing.T) {
+	// A zero-value NamedMutexMap must be usable without calling New().
+	var m NamedMutexMap
+	release := m.Acquire("x")
+	release()
+}
+
+func TestUnlockClosureReleases(t *testing.T) {
+	m := New()
+	release := m.Acquire("x")
+	release()
+
+	// Should be able to acquire again immediately.
+	done := make(chan struct{})
+	go func() {
+		r2 := m.Acquire("x")
+		r2()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("re-acquire after unlock blocked")
+	}
+}
+
+func TestTwoMapsConsistentOrderNoDeadlock(t *testing.T) {
+	a := New()
+	b := New()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		ra := a.Acquire("k")
+		rb := b.Acquire("k")
+		rb()
+		ra()
+	}()
+	go func() {
+		defer wg.Done()
+		ra := a.Acquire("k")
+		rb := b.Acquire("k")
+		rb()
+		ra()
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("consistent-order acquires deadlocked")
+	}
+}

--- a/internal/systemprune/snapshot_orphans.go
+++ b/internal/systemprune/snapshot_orphans.go
@@ -1,0 +1,205 @@
+package systemprune
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/diskstat"
+)
+
+// SnapshotCreatingMarker is the filename written into a snapshot directory
+// while CreateSnapshot is in flight. Its presence (and a recent mtime) tells
+// the orphan scanner to leave the directory alone.
+const SnapshotCreatingMarker = ".creating"
+
+// SnapshotCreatingMaxAge bounds how long a `.creating` marker is honored
+// before the directory is treated as crash residue. A correct CreateSnapshot
+// completes well under this threshold; anything older is taken to mean the
+// process was killed mid-create and the partial dir should be reclaimable.
+const SnapshotCreatingMaxAge = 24 * time.Hour
+
+// snapshotMetadataFilename is the JSON sidecar each completed snapshot dir holds.
+// Duplicated here (rather than imported) to keep internal/systemprune dep-free.
+const snapshotMetadataFilename = "snapshot.json"
+
+// SnapshotOrphanCandidate is a snapshot directory whose snapshot.json is
+// missing AND whose `.creating` marker is absent or stale. The whole dir is
+// orphan; Files holds each enumerated entry inside so Prune can remove them
+// individually before rmdir-ing the parent.
+type SnapshotOrphanCandidate struct {
+	Dir   string
+	Files []config.FileEntry
+	// Total is the sum of Files sizes; convenient for the PrunedItem.Freed
+	// emitted by ToPrunedItem.
+	Total config.DiskSize
+}
+
+// ToPrunedItems renders the candidate as one PrunedItem per enumerated file
+// plus a final entry for the empty-dir rmdir. Reason text differs from the
+// image-orphan path because the cause is "snapshot.json absent" rather than
+// "no matching rootfs."
+func (c SnapshotOrphanCandidate) ToPrunedItems(dry bool) []config.PrunedItem {
+	reason := ""
+	if dry {
+		reason = "snapshot directory missing snapshot.json"
+	}
+	items := make([]config.PrunedItem, 0, len(c.Files)+1)
+	for _, f := range c.Files {
+		items = append(items, config.PrunedItem{
+			Kind:   "snapshot_orphan",
+			Path:   f.Path,
+			Action: "deleted",
+			Freed:  f.Size,
+			Reason: reason,
+		})
+	}
+	items = append(items, config.PrunedItem{
+		Kind:   "snapshot_orphan",
+		Path:   c.Dir,
+		Action: "deleted",
+		Freed:  config.DiskSize{},
+		Reason: reason,
+	})
+	return items
+}
+
+// FindSnapshotOrphans scans snapshotsDir for subdirectories missing their
+// snapshot.json sidecar. Pure observation — used by DiskUsage to surface
+// orphans in `shed system df`. CollectSnapshotOrphanCandidates adds the
+// `.creating`-marker check used by Prune.
+func FindSnapshotOrphans(snapshotsDir string) ([]config.FileEntry, error) {
+	if snapshotsDir == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(snapshotsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var orphans []config.FileEntry
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(snapshotsDir, e.Name())
+		if _, err := os.Stat(filepath.Join(dir, snapshotMetadataFilename)); err == nil {
+			continue
+		}
+		files, err := walkSnapshotDir(dir)
+		if err != nil {
+			continue
+		}
+		orphans = append(orphans, files...)
+	}
+	return orphans, nil
+}
+
+// CollectSnapshotOrphanCandidates returns snapshot dirs ready to delete, plus
+// SkippedItems for partial dirs that are protected by a recent `.creating`
+// marker (an in-flight CreateSnapshot). Mirrors CollectOrphanCandidates' shape.
+func CollectSnapshotOrphanCandidates(snapshotsDir string) ([]SnapshotOrphanCandidate, []config.SkippedItem) {
+	if snapshotsDir == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(snapshotsDir)
+	if err != nil {
+		return nil, nil
+	}
+
+	var candidates []SnapshotOrphanCandidate
+	var skipped []config.SkippedItem
+	now := time.Now()
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(snapshotsDir, e.Name())
+		if _, err := os.Stat(filepath.Join(dir, snapshotMetadataFilename)); err == nil {
+			continue
+		}
+
+		markerPath := filepath.Join(dir, SnapshotCreatingMarker)
+		if fi, err := os.Stat(markerPath); err == nil {
+			age := now.Sub(fi.ModTime())
+			if age < SnapshotCreatingMaxAge {
+				skipped = append(skipped, config.SkippedItem{
+					Kind:   "snapshot_orphan",
+					Path:   dir,
+					Reason: fmt.Sprintf("create in flight (.creating marker, age %s)", HumanDuration(age)),
+				})
+				continue
+			}
+		}
+
+		files, err := walkSnapshotDir(dir)
+		if err != nil {
+			skipped = append(skipped, config.SkippedItem{
+				Kind:   "snapshot_orphan",
+				Path:   dir,
+				Reason: fmt.Sprintf("walk failed: %v", err),
+			})
+			continue
+		}
+		var total config.DiskSize
+		for _, f := range files {
+			total.LogicalBytes += f.Size.LogicalBytes
+			total.PhysicalBytes += f.Size.PhysicalBytes
+		}
+		candidates = append(candidates, SnapshotOrphanCandidate{Dir: dir, Files: files, Total: total})
+	}
+	return candidates, skipped
+}
+
+// SweepSnapshotOrphan removes every file in the candidate directory and then
+// rmdirs the directory itself. Returns false if any step fails — caller is
+// expected to record a SkippedItem and surface the failure.
+func SweepSnapshotOrphan(c SnapshotOrphanCandidate) bool {
+	for _, f := range c.Files {
+		if err := os.Remove(f.Path); err != nil && !os.IsNotExist(err) {
+			return false
+		}
+	}
+	if err := os.Remove(c.Dir); err != nil && !os.IsNotExist(err) {
+		// Some leftover (e.g., new file appeared mid-sweep) — bail rather than
+		// recursively delete and risk eating an in-flight create.
+		return false
+	}
+	return true
+}
+
+// walkSnapshotDir returns each regular file inside dir as a FileEntry with
+// Kind="snapshot_orphan" and a diskstat.Stat-derived size. Uses
+// filepath.WalkDir to enumerate any depth (snapshots are typically flat but
+// the contract is "every file under dir").
+func walkSnapshotDir(dir string) ([]config.FileEntry, error) {
+	var out []config.FileEntry
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		logical, physical, err := diskstat.Stat(path)
+		if err != nil {
+			return nil // skip unreadable files; the dir delete will fail loudly
+		}
+		out = append(out, config.FileEntry{
+			Path: path,
+			Size: config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
+			Kind: "snapshot_orphan",
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/systemprune/snapshot_orphans.go
+++ b/internal/systemprune/snapshot_orphans.go
@@ -145,7 +145,8 @@ func CollectSnapshotOrphanCandidates(snapshotsDir string) ([]SnapshotOrphanCandi
 		}
 
 		markerPath := filepath.Join(dir, SnapshotCreatingMarker)
-		if fi, err := os.Stat(markerPath); err == nil {
+		fi, markerErr := os.Stat(markerPath)
+		if markerErr == nil {
 			age := now.Sub(fi.ModTime())
 			if age < SnapshotCreatingMaxAge {
 				skipped = append(skipped, config.SkippedItem{
@@ -155,6 +156,16 @@ func CollectSnapshotOrphanCandidates(snapshotsDir string) ([]SnapshotOrphanCandi
 				})
 				continue
 			}
+		} else if !os.IsNotExist(markerErr) {
+			// Permission/transient I/O error stat'ing the marker: fail closed.
+			// Treating "stat failed" as "marker absent" would let an in-flight
+			// create be enqueued for deletion.
+			skipped = append(skipped, config.SkippedItem{
+				Kind:   "snapshot_orphan",
+				Path:   dir,
+				Reason: fmt.Sprintf("stat %s failed: %v", SnapshotCreatingMarker, markerErr),
+			})
+			continue
 		}
 
 		files, err := walkSnapshotDir(dir)

--- a/internal/systemprune/snapshot_orphans.go
+++ b/internal/systemprune/snapshot_orphans.go
@@ -88,7 +88,14 @@ func FindSnapshotOrphans(snapshotsDir string) ([]config.FileEntry, error) {
 			continue
 		}
 		dir := filepath.Join(snapshotsDir, e.Name())
-		if _, err := os.Stat(filepath.Join(dir, snapshotMetadataFilename)); err == nil {
+		_, statErr := os.Stat(filepath.Join(dir, snapshotMetadataFilename))
+		if statErr == nil {
+			continue
+		}
+		// Only IsNotExist means "metadata is genuinely missing." A permission
+		// or transient I/O error must NOT misclassify a healthy snapshot as
+		// orphan — skip and let the next scan retry.
+		if !os.IsNotExist(statErr) {
 			continue
 		}
 		files, err := walkSnapshotDir(dir)
@@ -121,7 +128,19 @@ func CollectSnapshotOrphanCandidates(snapshotsDir string) ([]SnapshotOrphanCandi
 			continue
 		}
 		dir := filepath.Join(snapshotsDir, e.Name())
-		if _, err := os.Stat(filepath.Join(dir, snapshotMetadataFilename)); err == nil {
+		_, statErr := os.Stat(filepath.Join(dir, snapshotMetadataFilename))
+		if statErr == nil {
+			continue
+		}
+		// Permission or transient I/O failure must NOT be treated as "missing
+		// metadata" — that path leads to deletion of healthy snapshots. Surface
+		// it as a SkippedItem instead.
+		if !os.IsNotExist(statErr) {
+			skipped = append(skipped, config.SkippedItem{
+				Kind:   "snapshot_orphan",
+				Path:   dir,
+				Reason: fmt.Sprintf("stat snapshot.json failed: %v", statErr),
+			})
 			continue
 		}
 

--- a/internal/systemprune/snapshot_orphans_test.go
+++ b/internal/systemprune/snapshot_orphans_test.go
@@ -1,0 +1,172 @@
+package systemprune
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+)
+
+// snapshotFixture builds a snapshotsDir under t.TempDir() with the requested
+// per-snapshot contents and returns the dir path.
+func snapshotFixture(t *testing.T, snaps map[string]map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for name, files := range snaps {
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		for fname, content := range files {
+			if err := os.WriteFile(filepath.Join(dir, fname), []byte(content), 0o644); err != nil {
+				t.Fatalf("write %s: %v", fname, err)
+			}
+		}
+	}
+	return root
+}
+
+func TestFindSnapshotOrphans(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T) string
+		wantPaths []string // file paths (relative to snapshotsDir) expected in result
+	}{
+		{
+			name: "complete snapshot is not flagged",
+			setup: func(t *testing.T) string {
+				return snapshotFixture(t, map[string]map[string]string{
+					"complete": {"snapshot.json": "{}", "rootfs.ext4": "data"},
+				})
+			},
+			wantPaths: nil,
+		},
+		{
+			name: "rootfs without metadata is flagged",
+			setup: func(t *testing.T) string {
+				return snapshotFixture(t, map[string]map[string]string{
+					"partial": {"rootfs.ext4": "data"},
+				})
+			},
+			wantPaths: []string{"partial/rootfs.ext4"},
+		},
+		{
+			name: "rootfs plus tmp metadata is flagged on both files",
+			setup: func(t *testing.T) string {
+				return snapshotFixture(t, map[string]map[string]string{
+					"partial": {
+						"rootfs.ext4":            "data",
+						".snapshot-XYZ.json.tmp": "{}",
+					},
+				})
+			},
+			wantPaths: []string{"partial/.snapshot-XYZ.json.tmp", "partial/rootfs.ext4"},
+		},
+		{
+			name: "fresh .creating marker still observed (FindSnapshotOrphans is pure)",
+			setup: func(t *testing.T) string {
+				root := snapshotFixture(t, map[string]map[string]string{
+					"inflight": {
+						"rootfs.ext4": "data",
+						".creating":   "",
+					},
+				})
+				return root
+			},
+			// FindSnapshotOrphans is the df-side observer; it reports
+			// every partial dir (including the marker file). The
+			// .creating-marker check belongs to the prune-side
+			// CollectSnapshotOrphanCandidates path.
+			wantPaths: []string{"inflight/.creating", "inflight/rootfs.ext4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := tt.setup(t)
+			got, err := FindSnapshotOrphans(root)
+			if err != nil {
+				t.Fatalf("FindSnapshotOrphans: %v", err)
+			}
+
+			gotPaths := make([]string, 0, len(got))
+			for _, f := range got {
+				rel, _ := filepath.Rel(root, f.Path)
+				gotPaths = append(gotPaths, filepath.ToSlash(rel))
+				if f.Kind != "snapshot_orphan" {
+					t.Errorf("Kind = %q; want snapshot_orphan", f.Kind)
+				}
+			}
+			sort.Strings(gotPaths)
+			sort.Strings(tt.wantPaths)
+			if !equalStringSlice(gotPaths, tt.wantPaths) {
+				t.Errorf("paths = %v; want %v", gotPaths, tt.wantPaths)
+			}
+		})
+	}
+}
+
+func TestCollectSnapshotOrphanCandidates_CreatingMarker(t *testing.T) {
+	tests := []struct {
+		name           string
+		markerAge      time.Duration // how old to make the .creating marker
+		wantCandidates int           // expected candidate count for the inflight dir
+		wantSkipped    int           // expected skipped count
+	}{
+		{name: "fresh marker protects the dir", markerAge: 30 * time.Second, wantCandidates: 0, wantSkipped: 1},
+		{name: "stale marker (>24h) is treated as orphan", markerAge: 25 * time.Hour, wantCandidates: 1, wantSkipped: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := snapshotFixture(t, map[string]map[string]string{
+				"inflight": {
+					"rootfs.ext4": "data",
+					".creating":   "",
+				},
+			})
+			markerPath := filepath.Join(root, "inflight", ".creating")
+			ts := time.Now().Add(-tt.markerAge)
+			if err := os.Chtimes(markerPath, ts, ts); err != nil {
+				t.Fatalf("chtimes: %v", err)
+			}
+
+			cands, skipped := CollectSnapshotOrphanCandidates(root)
+			if len(cands) != tt.wantCandidates {
+				t.Errorf("candidates = %d; want %d (cands=%+v)", len(cands), tt.wantCandidates, cands)
+			}
+			if len(skipped) != tt.wantSkipped {
+				t.Errorf("skipped = %d; want %d (skipped=%+v)", len(skipped), tt.wantSkipped, skipped)
+			}
+		})
+	}
+}
+
+func TestSweepSnapshotOrphan_RemovesFilesAndDir(t *testing.T) {
+	root := snapshotFixture(t, map[string]map[string]string{
+		"partial": {"rootfs.ext4": "data", ".snapshot-XYZ.json.tmp": "{}"},
+	})
+	cands, _ := CollectSnapshotOrphanCandidates(root)
+	if len(cands) != 1 {
+		t.Fatalf("candidates = %d; want 1", len(cands))
+	}
+	if !SweepSnapshotOrphan(cands[0]) {
+		t.Fatal("SweepSnapshotOrphan returned false")
+	}
+	if _, err := os.Stat(filepath.Join(root, "partial")); !os.IsNotExist(err) {
+		t.Errorf("partial dir still present (err=%v)", err)
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/lockmap"
 	"github.com/charliek/shed/internal/plugin"
 	"github.com/charliek/shed/internal/vmutil"
 )
@@ -30,20 +31,17 @@ type Client struct {
 	mu  sync.Mutex
 	vms map[string]*VM // name -> VM
 
-	// createLocks serializes CreateShed calls by shed name to close the
-	// TOCTOU between the already-exists check and the final meta.Save.
-	// Two racing `shed create` calls for the same name would otherwise
-	// both pass the existence check and the second caller's CopyRootfs
-	// would os.Remove the first caller's just-cloned rootfs. createMu
-	// guards the map; each value is locked across a single CreateShed.
-	createMu    sync.Mutex
-	createLocks map[string]*sync.Mutex
+	// shedLocks serializes per-shed-name lifecycle operations. Originally
+	// added for CreateShed-vs-CreateShed TOCTOU but the lock has broadened
+	// to cover any operation that mutates a shed's on-disk state (Create,
+	// Start, Stop, Delete, and CreateSnapshot of this shed as source).
+	// Value type so the zero-value Client{} works in tests.
+	shedLocks lockmap.NamedMutexMap
 
-	// snapshotLocks serializes CreateSnapshot/DeleteSnapshot calls by
-	// snapshot name. Distinct keyspace from createLocks (snapshot names
-	// vs shed names). Same mutex-map-leak tradeoff documented above.
-	snapshotMu    sync.Mutex
-	snapshotLocks map[string]*sync.Mutex
+	// snapshotLocks serializes CreateSnapshot/DeleteSnapshot/CreateShed-
+	// from-snapshot calls by snapshot name. Distinct keyspace from
+	// shedLocks (snapshot names vs shed names).
+	snapshotLocks lockmap.NamedMutexMap
 
 	credMgr *vmutil.CredentialManager
 }
@@ -55,12 +53,10 @@ func NewClient(cfg *config.VZConfig, serverCfg *config.ServerConfig, bridge *plu
 	}
 
 	client := &Client{
-		cfg:           cfg,
-		serverCfg:     serverCfg,
-		vms:           make(map[string]*VM),
-		createLocks:   make(map[string]*sync.Mutex),
-		snapshotLocks: make(map[string]*sync.Mutex),
-		credMgr:       vmutil.NewCredentialManager(serverCfg, bridge, string(config.BackendVZ), vmutil.NewHealthTracker()),
+		cfg:       cfg,
+		serverCfg: serverCfg,
+		vms:       make(map[string]*VM),
+		credMgr:   vmutil.NewCredentialManager(serverCfg, bridge, string(config.BackendVZ), vmutil.NewHealthTracker()),
 	}
 
 	return client, nil
@@ -78,22 +74,8 @@ func NewClient(cfg *config.VZConfig, serverCfg *config.ServerConfig, bridge *plu
 // Lock-order rule: when both locks are needed (snapshot create or
 // from-snapshot spawn), acquire snapshotLock BEFORE createLock to avoid
 // AB-BA deadlock with other code paths.
-//
-// The per-name mutex is leaked on first use — bounded by the number of
-// distinct shed names ever created in this process, which is negligible.
 func (c *Client) acquireCreateLock(name string) func() {
-	c.createMu.Lock()
-	if c.createLocks == nil {
-		c.createLocks = make(map[string]*sync.Mutex)
-	}
-	mu, ok := c.createLocks[name]
-	if !ok {
-		mu = &sync.Mutex{}
-		c.createLocks[name] = mu
-	}
-	c.createMu.Unlock()
-	mu.Lock()
-	return mu.Unlock
+	return c.shedLocks.Acquire(name)
 }
 
 // Close closes the client and releases resources.

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -116,7 +116,7 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 
 	if req.FromSnapshot != "" {
 		if req.Image != "" || req.Repo != "" {
-			return nil, fmt.Errorf("--from-snapshot is mutually exclusive with --image and --repo")
+			return nil, fmt.Errorf("%w: --from-snapshot cannot be combined with --image or --repo", config.ErrInvalidShedRequestSentinel)
 		}
 	}
 

--- a/internal/vz/client_test.go
+++ b/internal/vz/client_test.go
@@ -5,6 +5,7 @@ package vz
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -516,5 +517,32 @@ func TestCreateShedValidatesResources(t *testing.T) {
 	}
 	if _, statErr := os.Stat(InstanceDir(tmpDir, "too-little-memory")); !os.IsNotExist(statErr) {
 		t.Fatalf("instance dir should not exist for invalid memory request, stat err: %v", statErr)
+	}
+}
+
+func TestCreateShedFromSnapshotMutualExclusionWrapsSentinel(t *testing.T) {
+	client := &Client{
+		cfg:     &config.VZConfig{InstanceDir: t.TempDir()},
+		vms:     make(map[string]*VM),
+		credMgr: newTestCredMgr(),
+	}
+
+	tests := []struct {
+		name string
+		req  config.CreateShedRequest
+	}{
+		{"with_image", config.CreateShedRequest{Name: "n", FromSnapshot: "snap1", Image: "default"}},
+		{"with_repo", config.CreateShedRequest{Name: "n", FromSnapshot: "snap1", Repo: "git@github.com:o/r.git"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.CreateShed(context.Background(), tt.req)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !errors.Is(err, config.ErrInvalidShedRequestSentinel) {
+				t.Fatalf("error %v does not wrap ErrInvalidShedRequestSentinel", err)
+			}
+		})
 	}
 }

--- a/internal/vz/snapshot.go
+++ b/internal/vz/snapshot.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/charliek/shed/internal/backend"
@@ -131,20 +130,12 @@ func listSnapshotNames(snapshotsDir string) ([]string, error) {
 
 // acquireSnapshotLock returns an unlock closure after taking the per-name
 // snapshot mutex. Mirrors acquireCreateLock for the snapshot keyspace.
-// Per-name mutex bound by number of distinct snapshot names ever used.
+//
+// Lock-order rule: when both locks are needed (snapshot create or
+// from-snapshot spawn), acquire snapshotLock BEFORE the source shed's
+// createLock to avoid AB-BA deadlock.
 func (c *Client) acquireSnapshotLock(name string) func() {
-	c.snapshotMu.Lock()
-	if c.snapshotLocks == nil {
-		c.snapshotLocks = make(map[string]*sync.Mutex)
-	}
-	mu, ok := c.snapshotLocks[name]
-	if !ok {
-		mu = &sync.Mutex{}
-		c.snapshotLocks[name] = mu
-	}
-	c.snapshotMu.Unlock()
-	mu.Lock()
-	return mu.Unlock
+	return c.snapshotLocks.Acquire(name)
 }
 
 // CreateSnapshot captures a stopped shed's rootfs as a named, immutable artifact.

--- a/internal/vz/snapshot.go
+++ b/internal/vz/snapshot.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/systemprune"
 	"github.com/charliek/shed/internal/vmimage/clone"
 )
 
@@ -177,6 +178,14 @@ func (c *Client) CreateSnapshot(ctx context.Context, req config.SnapshotCreateRe
 	dir := SnapshotDir(c.cfg.SnapshotsDir, req.Name)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create snapshot directory: %w", err)
+	}
+
+	// Drop a `.creating` marker so `shed system prune --orphans` won't sweep
+	// this dir if the host crashes mid-create. Removed on every exit path.
+	markerPath := filepath.Join(dir, systemprune.SnapshotCreatingMarker)
+	if mf, err := os.Create(markerPath); err == nil {
+		_ = mf.Close()
+		defer os.Remove(markerPath)
 	}
 
 	dstRootfs := SnapshotRootfsPath(c.cfg.SnapshotsDir, req.Name)

--- a/internal/vz/snapshot.go
+++ b/internal/vz/snapshot.go
@@ -181,12 +181,21 @@ func (c *Client) CreateSnapshot(ctx context.Context, req config.SnapshotCreateRe
 	}
 
 	// Drop a `.creating` marker so `shed system prune --orphans` won't sweep
-	// this dir if the host crashes mid-create. Removed on every exit path.
+	// this dir if the host crashes mid-create. Fail-closed: if we can't make
+	// the marker durable before the long-running clone, abort rather than
+	// proceed with no crash protection. fsync the parent dir so the marker
+	// dentry is on stable storage before returning from the write.
 	markerPath := filepath.Join(dir, systemprune.SnapshotCreatingMarker)
-	if mf, err := os.Create(markerPath); err == nil {
-		_ = mf.Close()
-		defer os.Remove(markerPath)
+	if err := os.WriteFile(markerPath, nil, 0o600); err != nil {
+		os.RemoveAll(dir)
+		return nil, fmt.Errorf("failed to create snapshot marker: %w", err)
 	}
+	if err := syncDir(dir); err != nil {
+		_ = os.Remove(markerPath)
+		os.RemoveAll(dir)
+		return nil, fmt.Errorf("failed to sync snapshot marker: %w", err)
+	}
+	defer os.Remove(markerPath)
 
 	dstRootfs := SnapshotRootfsPath(c.cfg.SnapshotsDir, req.Name)
 	if err := os.Remove(dstRootfs); err != nil && !os.IsNotExist(err) {

--- a/internal/vz/system.go
+++ b/internal/vz/system.go
@@ -80,6 +80,14 @@ func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 		du.Orphans = orphans
 	}
 
+	if c.cfg.SnapshotsDir != "" {
+		snapOrphans, err := systemprune.FindSnapshotOrphans(c.cfg.SnapshotsDir)
+		if err != nil {
+			return du, fmt.Errorf("scanning snapshot orphans: %w", err)
+		}
+		du.Orphans = append(du.Orphans, snapOrphans...)
+	}
+
 	// Kernel + initrd
 	if c.cfg.KernelPath != "" {
 		if logical, physical, err := diskstat.Stat(c.cfg.KernelPath); err == nil {
@@ -294,6 +302,14 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 		report.Skipped = append(report.Skipped, skipped...)
 	}
 
+	// Step 2b': snapshot orphan candidates (partial snapshot dirs).
+	var snapshotOrphanCandidates []systemprune.SnapshotOrphanCandidate
+	if opts.Orphans && c.cfg.SnapshotsDir != "" {
+		cands, skipped := systemprune.CollectSnapshotOrphanCandidates(c.cfg.SnapshotsDir)
+		snapshotOrphanCandidates = cands
+		report.Skipped = append(report.Skipped, skipped...)
+	}
+
 	// Step 2c: image candidates (dry-run, respects candidate deletions).
 	// Same empty-ImagesDir guard for safety.
 	var imageCandidates []vmimage.ImageInfo
@@ -329,6 +345,9 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 	}
 	for _, oc := range orphanCandidates {
 		report.Items = append(report.Items, oc.ToPrunedItem(opts.DryRun))
+	}
+	for _, sc := range snapshotOrphanCandidates {
+		report.Items = append(report.Items, sc.ToPrunedItems(opts.DryRun)...)
 	}
 	for _, img := range imageCandidates {
 		report.Items = append(report.Items, systemprune.ImageToPrunedItem(img, opts.DryRun))
@@ -385,6 +404,16 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 				continue
 			}
 			report.Items = append(report.Items, oc.ToPrunedItem(false))
+		}
+		for _, sc := range snapshotOrphanCandidates {
+			if ok := systemprune.SweepSnapshotOrphan(sc); !ok {
+				report.Skipped = append(report.Skipped, config.SkippedItem{
+					Kind: "snapshot_orphan", Path: sc.Dir,
+					Reason: "removal failed",
+				})
+				continue
+			}
+			report.Items = append(report.Items, sc.ToPrunedItems(false)...)
 		}
 	}
 

--- a/internal/vz/system.go
+++ b/internal/vz/system.go
@@ -141,6 +141,16 @@ func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 				},
 				Total: config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
 			}
+			meta := SnapshotMetadataPath(c.cfg.SnapshotsDir, name)
+			if metaLogical, metaPhysical, err := diskstat.Stat(meta); err == nil {
+				entry.OtherFiles = append(entry.OtherFiles, config.FileEntry{
+					Path: meta,
+					Size: config.DiskSize{LogicalBytes: metaLogical, PhysicalBytes: metaPhysical},
+					Kind: "metadata",
+				})
+				entry.Total.LogicalBytes += metaLogical
+				entry.Total.PhysicalBytes += metaPhysical
+			}
 			du.Snapshots = append(du.Snapshots, entry)
 		}
 	}
@@ -178,7 +188,7 @@ func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 	)
 	if len(du.Snapshots) > 0 {
 		du.Notes = append(du.Notes,
-			"snapshots and sheds spawned from them share extents via reflink — physical bytes count those extents under both",
+			"rootfs extents are shared via reflink between a snapshot and sheds spawned from it — physical bytes count those extents under both; metadata files are unique per snapshot",
 		)
 	}
 

--- a/internal/vz/system_prune_test.go
+++ b/internal/vz/system_prune_test.go
@@ -628,107 +628,98 @@ func TestTryAcquireFileLock_NoCreate(t *testing.T) {
 	}
 }
 
-func TestPrune_SnapshotOrphans_PartialDirRemoved(t *testing.T) {
-	c, snapshotsDir := newPruneTestClientWithSnapshots(t)
-
-	// Partial snapshot: rootfs.ext4 present, snapshot.json missing, no marker.
-	dir := filepath.Join(snapshotsDir, "halfwritten")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	rootfs := filepath.Join(dir, "rootfs.ext4")
-	if err := os.WriteFile(rootfs, []byte("data"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true})
-	if err != nil {
-		t.Fatalf("Prune: %v", err)
-	}
-
-	hasRootfs, hasDir := false, false
-	for _, it := range report.Items {
-		if it.Path == rootfs && it.Kind == "snapshot_orphan" {
-			hasRootfs = true
-		}
-		if it.Path == dir && it.Kind == "snapshot_orphan" {
-			hasDir = true
-		}
-	}
-	if !hasRootfs {
-		t.Errorf("expected snapshot rootfs reported as snapshot_orphan, got %+v", report.Items)
-	}
-	if !hasDir {
-		t.Errorf("expected snapshot dir reported as snapshot_orphan, got %+v", report.Items)
-	}
-	if _, err := os.Stat(dir); !os.IsNotExist(err) {
-		t.Errorf("snapshot orphan dir still exists after prune (err=%v)", err)
-	}
-}
-
-func TestPrune_SnapshotOrphans_FreshCreatingMarkerSkipped(t *testing.T) {
-	c, snapshotsDir := newPruneTestClientWithSnapshots(t)
-
-	dir := filepath.Join(snapshotsDir, "inflight")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "rootfs.ext4"), []byte("data"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, ".creating"), nil, 0o600); err != nil {
-		t.Fatal(err)
+// TestPrune_SnapshotOrphans covers all three snapshot-orphan paths in one
+// table-driven harness. Setup writes a partial snapshot dir; flags toggle
+// the `.creating` marker and DryRun. Assertions cover both the
+// PruneReport shape and the on-disk state after Prune returns.
+func TestPrune_SnapshotOrphans(t *testing.T) {
+	tests := []struct {
+		name              string
+		writeMarker       bool
+		dryRun            bool
+		wantItems         bool // expect snapshot_orphan entries in report.Items
+		wantSkipped       bool // expect snapshot_orphan SkippedItem
+		wantDirRemoved    bool // expect the partial dir to be gone after Prune
+		wantRootfsRemoved bool // expect the rootfs file to be gone after Prune
+	}{
+		{
+			name:              "partial dir removed",
+			wantItems:         true,
+			wantDirRemoved:    true,
+			wantRootfsRemoved: true,
+		},
+		{
+			name:        "fresh creating marker is skipped",
+			writeMarker: true,
+			wantSkipped: true,
+		},
+		{
+			name:      "dry-run does not mutate disk",
+			dryRun:    true,
+			wantItems: true,
+		},
 	}
 
-	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true})
-	if err != nil {
-		t.Fatalf("Prune: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, snapshotsDir := newPruneTestClientWithSnapshots(t)
 
-	for _, it := range report.Items {
-		if strings.HasPrefix(it.Path, dir) {
-			t.Fatalf("inflight snapshot dir was touched: %+v", it)
-		}
-	}
-	if _, err := os.Stat(dir); err != nil {
-		t.Errorf("inflight dir was deleted: %v", err)
-	}
+			dir := filepath.Join(snapshotsDir, "halfwritten")
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			rootfs := filepath.Join(dir, "rootfs.ext4")
+			if err := os.WriteFile(rootfs, []byte("data"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if tt.writeMarker {
+				if err := os.WriteFile(filepath.Join(dir, ".creating"), nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	// And the skipped list should mention the dir.
-	hasSkip := false
-	for _, sk := range report.Skipped {
-		if sk.Path == dir && sk.Kind == "snapshot_orphan" {
-			hasSkip = true
-		}
-	}
-	if !hasSkip {
-		t.Errorf("expected SkippedItem for inflight snapshot, got %+v", report.Skipped)
-	}
-}
+			report, err := c.Prune(context.Background(), backend.PruneOptions{
+				Orphans: true,
+				DryRun:  tt.dryRun,
+			})
+			if err != nil {
+				t.Fatalf("Prune: %v", err)
+			}
+			if report.DryRun != tt.dryRun {
+				t.Errorf("report.DryRun = %v; want %v", report.DryRun, tt.dryRun)
+			}
 
-func TestPrune_SnapshotOrphans_DryRunNoMutation(t *testing.T) {
-	c, snapshotsDir := newPruneTestClientWithSnapshots(t)
+			hasItems := false
+			for _, it := range report.Items {
+				if strings.HasPrefix(it.Path, dir) && it.Kind == "snapshot_orphan" {
+					hasItems = true
+				}
+			}
+			if hasItems != tt.wantItems {
+				t.Errorf("snapshot_orphan items present = %v; want %v (items=%+v)", hasItems, tt.wantItems, report.Items)
+			}
 
-	dir := filepath.Join(snapshotsDir, "halfwritten")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	rootfs := filepath.Join(dir, "rootfs.ext4")
-	if err := os.WriteFile(rootfs, []byte("data"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+			hasSkipped := false
+			for _, sk := range report.Skipped {
+				if sk.Path == dir && sk.Kind == "snapshot_orphan" {
+					hasSkipped = true
+				}
+			}
+			if hasSkipped != tt.wantSkipped {
+				t.Errorf("snapshot_orphan skipped present = %v; want %v (skipped=%+v)", hasSkipped, tt.wantSkipped, report.Skipped)
+			}
 
-	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true, DryRun: true})
-	if err != nil {
-		t.Fatalf("Prune: %v", err)
-	}
-	if !report.DryRun {
-		t.Errorf("expected DryRun=true")
-	}
-	if _, err := os.Stat(rootfs); err != nil {
-		t.Errorf("dry run deleted rootfs: %v", err)
-	}
-	if _, err := os.Stat(dir); err != nil {
-		t.Errorf("dry run deleted dir: %v", err)
+			_, dirStatErr := os.Stat(dir)
+			dirGone := os.IsNotExist(dirStatErr)
+			if dirGone != tt.wantDirRemoved {
+				t.Errorf("dir removed = %v; want %v (stat err=%v)", dirGone, tt.wantDirRemoved, dirStatErr)
+			}
+
+			_, rootfsStatErr := os.Stat(rootfs)
+			rootfsGone := os.IsNotExist(rootfsStatErr)
+			if rootfsGone != tt.wantRootfsRemoved {
+				t.Errorf("rootfs removed = %v; want %v (stat err=%v)", rootfsGone, tt.wantRootfsRemoved, rootfsStatErr)
+			}
+		})
 	}
 }

--- a/internal/vz/system_prune_test.go
+++ b/internal/vz/system_prune_test.go
@@ -40,6 +40,15 @@ func newPruneTestClient(t *testing.T) (*Client, string, string) {
 	return c, imagesDir, instanceDir
 }
 
+// newPruneTestClientWithSnapshots is like newPruneTestClient but also seeds a
+// SnapshotsDir on the config so the snapshot-orphan path is exercised.
+func newPruneTestClientWithSnapshots(t *testing.T) (*Client, string) {
+	t.Helper()
+	c, _, _ := newPruneTestClient(t)
+	c.cfg.SnapshotsDir = t.TempDir()
+	return c, c.cfg.SnapshotsDir
+}
+
 // seedStoppedShed creates a stopped-instance fixture with a rootfs and
 // (optionally) a console.log. Backdate sets metadata.json mtime so the age
 // filter sees it as "old enough."
@@ -616,5 +625,110 @@ func TestTryAcquireFileLock_NoCreate(t *testing.T) {
 	// The probe must not have created the file.
 	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
 		t.Errorf("TryAcquireFileLock created the lock file; it should be a no-op for missing locks")
+	}
+}
+
+func TestPrune_SnapshotOrphans_PartialDirRemoved(t *testing.T) {
+	c, snapshotsDir := newPruneTestClientWithSnapshots(t)
+
+	// Partial snapshot: rootfs.ext4 present, snapshot.json missing, no marker.
+	dir := filepath.Join(snapshotsDir, "halfwritten")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rootfs := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(rootfs, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+
+	hasRootfs, hasDir := false, false
+	for _, it := range report.Items {
+		if it.Path == rootfs && it.Kind == "snapshot_orphan" {
+			hasRootfs = true
+		}
+		if it.Path == dir && it.Kind == "snapshot_orphan" {
+			hasDir = true
+		}
+	}
+	if !hasRootfs {
+		t.Errorf("expected snapshot rootfs reported as snapshot_orphan, got %+v", report.Items)
+	}
+	if !hasDir {
+		t.Errorf("expected snapshot dir reported as snapshot_orphan, got %+v", report.Items)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("snapshot orphan dir still exists after prune (err=%v)", err)
+	}
+}
+
+func TestPrune_SnapshotOrphans_FreshCreatingMarkerSkipped(t *testing.T) {
+	c, snapshotsDir := newPruneTestClientWithSnapshots(t)
+
+	dir := filepath.Join(snapshotsDir, "inflight")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "rootfs.ext4"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".creating"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+
+	for _, it := range report.Items {
+		if strings.HasPrefix(it.Path, dir) {
+			t.Fatalf("inflight snapshot dir was touched: %+v", it)
+		}
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("inflight dir was deleted: %v", err)
+	}
+
+	// And the skipped list should mention the dir.
+	hasSkip := false
+	for _, sk := range report.Skipped {
+		if sk.Path == dir && sk.Kind == "snapshot_orphan" {
+			hasSkip = true
+		}
+	}
+	if !hasSkip {
+		t.Errorf("expected SkippedItem for inflight snapshot, got %+v", report.Skipped)
+	}
+}
+
+func TestPrune_SnapshotOrphans_DryRunNoMutation(t *testing.T) {
+	c, snapshotsDir := newPruneTestClientWithSnapshots(t)
+
+	dir := filepath.Join(snapshotsDir, "halfwritten")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rootfs := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(rootfs, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := c.Prune(context.Background(), backend.PruneOptions{Orphans: true, DryRun: true})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if !report.DryRun {
+		t.Errorf("expected DryRun=true")
+	}
+	if _, err := os.Stat(rootfs); err != nil {
+		t.Errorf("dry run deleted rootfs: %v", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("dry run deleted dir: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Five small follow-ups deferred during the snapshot/clone work (v0.4.0 → v0.4.2), each its own commit so the PR can bisect cleanly:

- **Item 4 — sentinel for `--from-snapshot` mutex** (`fffc8d1`): `ErrInvalidShedRequestSentinel` routes the backend's mutual-exclusion error through `mapBackendError` as 400 INVALID_REQUEST. Removes the redundant API-handler check; keeps the snapshot-name validation since backends do not surface a 400 for it.
- **Item 2 — `snapshot.json` in `shed system df` totals** (`bcbcf6e`): `SnapshotDiskEntry.OtherFiles` mirrors `ShedDiskEntry`. CLI counts now sum `rootfs + OtherFiles` instead of hardcoded `len(snapshots) * 2`. Reflink note reworded.
- **Item 3 — `internal/lockmap`** (`2f4654f`): consolidates four duplicated per-name mutex maps. Zero-value-safe so existing `Client{}` zero-value tests continue to pass. `createLocks` → `shedLocks` rename matches the broader semantics.
- **Item 1 — snapshot orphan cleanup** (`7b8fd4d`): `shed system prune --orphans` now reclaims partial snapshot dirs that `shed snapshot list` cannot see. Race-safe via a `.creating` marker dropped at the start of `CreateSnapshot` and removed via `defer`; stale markers (>24h) are treated as crash residue. Adds `internal/firecracker/system_prune_test.go` (FC had no prune coverage before).
- **Item 5 — `TestHandleConnectSuccess` flake fix** (`24a7c92`): `handleConnect` now wraps the hijacked `clientConn` with `vmutil.BufferedConn` so any bytes the http server pre-buffered are not stranded. Mirrors the existing pattern in `internal/tunnels/connect.go`. Most recent CI repro: run 24969968123 (2026-04-26).

`make check` passes after each commit individually.

## Test plan

- [ ] CI green on this PR (especially `TestHandleConnectSuccess`)
- [ ] Manual on local Mac VZ: create a shed, snapshot it, simulate a partial dir by removing `snapshot.json` — verify `shed snapshot list` ignores it, `shed system df` shows it, `shed system prune --orphans --dry-run` lists it, `shed system prune --orphans` removes both files and the dir
- [ ] Race check: `touch <snapshotsDir>/<other>/.creating` plus a `rootfs.ext4` — verify `shed system prune --orphans` does NOT remove `<other>`
- [ ] API: `curl -X POST .../api/sheds -d '{"name":"x","from_snapshot":"foo","image":"bar"}'` returns 400 INVALID_REQUEST
- [ ] API: `curl -X POST .../api/sheds -d '{"name":"x","from_snapshot":"BAD NAME"}'` still returns 400 (validates the kept name-check after the mutex check moved to the backend)
- [ ] Mirror the manual checks on a Linux Firecracker host

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshot orphan detection and safe cleanup via system prune --orphans.
  * In-progress snapshots are marked and protected from removal.
  * Disk usage now includes per-snapshot metadata files alongside rootfs.

* **Bug Fixes**
  * Corrected snapshot file counting to match actual per-snapshot files.
  * Validation for combining --from-snapshot with --image/--repo now returns proper invalid-request errors (HTTP 400).

* **Tests**
  * Expanded tests covering snapshot orphaning, pruning, disk accounting, and error mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->