### PR TITLE
Fix silent clone failures and missing known_hosts in shed VMs

### DIFF
--- a/configs/server.example.yaml
+++ b/configs/server.example.yaml
@@ -62,6 +62,14 @@ log_level: info
 #     - ssh-agent
 #     - aws-credentials
 
+# Git behaviour for in-VM clones
+# extra_known_hosts: lines appended to ~/.ssh/known_hosts before `git clone`
+# runs over SSH. GitHub's published host keys are always included; this list
+# extends them. Generate entries with `ssh-keyscan <host>` on a trusted machine.
+# git:
+#   extra_known_hosts:
+#     - "gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf"
+
 # --- VZ Backend (macOS Apple Silicon) ---
 # vz:
 #   vfkit_path: vfkit

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -83,6 +83,7 @@ log_level: info
 | `env_file` | string | - | Path to environment variables file |
 | `log_level` | string | `info` | Logging level (debug, info, warn, error) |
 | `extensions` | object | `{}` | Extensions to activate in VMs (see [Extensions](extensions.md)) |
+| `git` | object | - | Git behaviour for in-VM clones (see [Git](#git)) |
 | `firecracker` | object | - | Firecracker-specific configuration (see below) |
 | `vz` | object | - | VZ-specific configuration (see below) |
 
@@ -169,6 +170,31 @@ extensions:
 ```
 
 See [Extensions](extensions.md) for the full guide on the message bus, manifests, SDK, and health reporting.
+
+## Git
+
+When a shed is created with a `repo` over SSH (e.g., `charliek/sltstodo` or `git@github.com:org/repo.git`), the server seeds the in-VM `~/.ssh/known_hosts` before invoking `git clone`. Without this, OpenSSH defaults to `StrictHostKeyChecking=yes` and rejects the connection with `Host key verification failed`.
+
+GitHub's published host keys (ED25519, ECDSA, RSA) are baked into the server binary and are always included. To trust additional hosts (GitLab, GitHub Enterprise, self-hosted Gitea, etc.), add their `known_hosts` lines to `git.extra_known_hosts`:
+
+```yaml
+git:
+  extra_known_hosts:
+    - "gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf"
+    - "my-gitea.internal ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI..."
+```
+
+Each entry must be a syntactically valid `known_hosts` line: `<host> <key-type> <base64-key>`. The server validates this at startup and refuses to start if any entry is malformed.
+
+**Generating entries:** Run `ssh-keyscan <host>` on a trusted machine and paste the output. For example:
+
+```bash
+ssh-keyscan gitlab.com 2>/dev/null
+```
+
+The `git.extra_known_hosts` list is *additive* — it extends the built-in defaults, never replaces them. Only SSH-form clone URLs (`git@host:path`, `ssh://...`) consult `known_hosts`; HTTPS clones skip this step entirely.
+
+**Key rotation:** If GitHub or another host rotates its keys, you can extend the trust list via `extra_known_hosts` immediately without waiting for a shed release. The default GitHub keys ship with the server binary and are updated in releases.
 
 ## Firecracker Configuration
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -173,7 +173,7 @@ See [Extensions](extensions.md) for the full guide on the message bus, manifests
 
 ## Git
 
-When a shed is created with a `repo` over SSH (e.g., `charliek/sltstodo` or `git@github.com:org/repo.git`), the server seeds the in-VM `~/.ssh/known_hosts` before invoking `git clone`. Without this, OpenSSH defaults to `StrictHostKeyChecking=yes` and rejects the connection with `Host key verification failed`.
+When a shed is created with a `repo` whose URL uses SSH (e.g., `git@github.com:org/repo.git` or `ssh://git@host/path`), the server seeds the in-VM `~/.ssh/known_hosts` before invoking `git clone`. Without this, OpenSSH defaults to `StrictHostKeyChecking=yes` and rejects the connection with `Host key verification failed`. The `owner/repo` shorthand is expanded to `git@github.com:owner/repo.git`, so it goes through the same SSH path.
 
 GitHub's published host keys (ED25519, ECDSA, RSA) are baked into the server binary and are always included. To trust additional hosts (GitLab, GitHub Enterprise, self-hosted Gitea, etc.), add their `known_hosts` lines to `git.extra_known_hosts`:
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -283,7 +283,9 @@ func TestCreateShed_SSE_SurfacesProgressAndWarning(t *testing.T) {
 	be := &createShedFakeBackend{
 		createFn: func(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error) {
 			backend.Progress(ctx, "repo", "Cloning repository...")
-			backend.ProgressWarning(ctx, "repo", "Failed to clone repository: boom")
+			// Match the production sanitized message from vz/firecracker
+			// client.go — no URL, no wrapped err.
+			backend.ProgressWarning(ctx, "repo", "Failed to clone repository (see server logs for details)")
 			return &config.Shed{Name: req.Name, Status: config.StatusRunning, Repo: req.Repo}, nil
 		},
 	}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
 )
 
@@ -175,5 +178,150 @@ func TestMapBackendError_SentinelErrors(t *testing.T) {
 				t.Errorf("errCode = %q, want %q", errCode, tt.wantErr)
 			}
 		})
+	}
+}
+
+// createShedFakeBackend stubs only what handleCreateShedSSE touches.
+// CreateShed runs the configured fn so tests can emit progress/warning events
+// before returning a result.
+type createShedFakeBackend struct {
+	createFn func(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error)
+}
+
+func (f *createShedFakeBackend) Type() backend.Type { return backend.TypeVZ }
+func (f *createShedFakeBackend) Close() error       { return nil }
+func (f *createShedFakeBackend) CreateShed(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error) {
+	return f.createFn(ctx, req)
+}
+func (f *createShedFakeBackend) GetShed(_ context.Context, _ string) (*config.Shed, error) {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) ListSheds(_ context.Context) ([]config.Shed, error) {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) DeleteShed(_ context.Context, _ string, _ bool) error {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) StartShed(_ context.Context, _ string) (*config.Shed, error) {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) StopShed(_ context.Context, _ string) (*config.Shed, error) {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) ListSessions(_ context.Context, _ string) ([]config.Session, error) {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) KillSession(_ context.Context, _, _ string) error {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) Exec(_ context.Context, _ string, _ backend.ExecOptions) error {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) GetNetworkEndpoint(_ context.Context, _ string) (string, error) {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) DialService(_ context.Context, _ string, _ uint16) (net.Conn, error) {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) ListImages(_ context.Context) ([]config.ImageInfo, error) {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) DeleteImage(_ context.Context, _ string) error {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) PruneImages(_ context.Context, _ bool) ([]config.ImageInfo, error) {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) DiskUsage(_ context.Context) (config.DiskUsage, error) {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) Prune(_ context.Context, _ backend.PruneOptions) (config.PruneReport, error) {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) ListSnapshots(_ context.Context) ([]config.Snapshot, error) {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) CreateSnapshot(_ context.Context, _ config.SnapshotCreateRequest) (*config.Snapshot, error) {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) GetSnapshot(_ context.Context, _ string) (*config.Snapshot, error) {
+	panic("unexpected")
+}
+func (f *createShedFakeBackend) DeleteSnapshot(_ context.Context, _ string) error {
+	panic("unexpected")
+}
+
+// parseSSEEvents parses an SSE stream body into a list of (event, data) pairs.
+// Handles only the simple "event:\ndata:\n\n" framing used by the API.
+func parseSSEEvents(t *testing.T, body string) []struct{ Event, Data string } {
+	t.Helper()
+	var events []struct{ Event, Data string }
+	for _, block := range strings.Split(body, "\n\n") {
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+		var evt, data string
+		for _, line := range strings.Split(block, "\n") {
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				evt = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				data = strings.TrimPrefix(line, "data: ")
+			}
+		}
+		events = append(events, struct{ Event, Data string }{evt, data})
+	}
+	return events
+}
+
+// TestCreateShed_SSE_SurfacesProgressAndWarning verifies that ProgressWarning
+// events emitted by the backend during CreateShed reach the SSE stream as
+// progress events with warning=true. Regression test for issue #84 — clone
+// failures used to be journald-only.
+func TestCreateShed_SSE_SurfacesProgressAndWarning(t *testing.T) {
+	be := &createShedFakeBackend{
+		createFn: func(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error) {
+			backend.Progress(ctx, "repo", "Cloning repository...")
+			backend.ProgressWarning(ctx, "repo", "Failed to clone git@example.com:x/y.git: boom")
+			return &config.Shed{Name: req.Name, Status: config.StatusRunning, Repo: req.Repo}, nil
+		},
+	}
+	srv := NewServer(be, &config.ServerConfig{Name: "test-server"}, "", nil, nil)
+
+	body, _ := json.Marshal(config.CreateShedRequest{Name: "myshed", Repo: "git@example.com:x/y.git"})
+	r := httptest.NewRequest(http.MethodPost, "/api/sheds", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Accept", "text/event-stream")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 (body: %s)", w.Code, w.Body.String())
+	}
+
+	events := parseSSEEvents(t, w.Body.String())
+
+	// Find the warning event and assert its payload carries warning=true.
+	var sawWarning, sawComplete bool
+	for _, e := range events {
+		if e.Event == "progress" && strings.Contains(e.Data, `"warning":true`) {
+			sawWarning = true
+			if !strings.Contains(e.Data, `"phase":"repo"`) {
+				t.Errorf("warning event missing repo phase: %s", e.Data)
+			}
+			if !strings.Contains(e.Data, "Failed to clone") {
+				t.Errorf("warning event missing failure message: %s", e.Data)
+			}
+		}
+		if e.Event == "complete" {
+			sawComplete = true
+		}
+	}
+	if !sawWarning {
+		t.Errorf("no progress event with warning=true found in stream:\n%s", w.Body.String())
+	}
+	if !sawComplete {
+		t.Errorf("no complete event found in stream:\n%s", w.Body.String())
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -283,7 +283,7 @@ func TestCreateShed_SSE_SurfacesProgressAndWarning(t *testing.T) {
 	be := &createShedFakeBackend{
 		createFn: func(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error) {
 			backend.Progress(ctx, "repo", "Cloning repository...")
-			backend.ProgressWarning(ctx, "repo", "Failed to clone git@example.com:x/y.git: boom")
+			backend.ProgressWarning(ctx, "repo", "Failed to clone repository: boom")
 			return &config.Shed{Name: req.Name, Status: config.StatusRunning, Repo: req.Repo}, nil
 		},
 	}
@@ -310,8 +310,14 @@ func TestCreateShed_SSE_SurfacesProgressAndWarning(t *testing.T) {
 			if !strings.Contains(e.Data, `"phase":"repo"`) {
 				t.Errorf("warning event missing repo phase: %s", e.Data)
 			}
-			if !strings.Contains(e.Data, "Failed to clone") {
+			if !strings.Contains(e.Data, "Failed to clone repository") {
 				t.Errorf("warning event missing failure message: %s", e.Data)
+			}
+			// SSE warning must NOT leak the repo URL — backends sanitize
+			// it because URLs can carry credentials. (See vz/firecracker
+			// client.go for the production message.)
+			if strings.Contains(e.Data, "git@") || strings.Contains(e.Data, "://") {
+				t.Errorf("warning event must not include repo URL: %s", e.Data)
 			}
 		}
 		if e.Event == "complete" {

--- a/internal/config/repo.go
+++ b/internal/config/repo.go
@@ -34,6 +34,22 @@ func ExpandRepoShorthand(repo string) string {
 	return repo
 }
 
+// IsSSHRepoURL reports whether a repo URL uses SSH transport.
+// Matches both `git@host:path` (SCP-like) and `ssh://...` schemes.
+// HTTPS, git://, http://, and empty strings return false.
+func IsSSHRepoURL(repo string) bool {
+	if repo == "" {
+		return false
+	}
+	if strings.HasPrefix(repo, "ssh://") {
+		return true
+	}
+	if strings.HasPrefix(repo, "git@") {
+		return gitSSHRegex.MatchString(repo)
+	}
+	return false
+}
+
 // ValidateGitRepoURL validates that a git repository URL is well-formed.
 // Accepts https://, git://, ssh://, and git@host:path formats.
 func ValidateGitRepoURL(repoURL string) error {

--- a/internal/config/repo.go
+++ b/internal/config/repo.go
@@ -34,6 +34,26 @@ func ExpandRepoShorthand(repo string) string {
 	return repo
 }
 
+// SanitizeRepoURL returns repo with the password component removed from the
+// URL's userinfo, if any. The username is preserved (it's informational, not
+// a secret). SSH-form URLs (git@host:path) and shorthand pass through
+// unchanged. Use this when logging URLs to avoid leaking embedded credentials
+// from forms like `https://user:password@host/repo.git`.
+func SanitizeRepoURL(repo string) string {
+	if repo == "" || strings.HasPrefix(repo, "git@") {
+		return repo
+	}
+	u, err := url.Parse(repo)
+	if err != nil || u.User == nil {
+		return repo
+	}
+	if _, hasPassword := u.User.Password(); !hasPassword {
+		return repo
+	}
+	u.User = url.User(u.User.Username())
+	return u.String()
+}
+
 // IsSSHRepoURL reports whether a repo URL uses SSH transport.
 // Matches both `git@host:path` (SCP-like) and `ssh://...` schemes.
 // HTTPS, git://, http://, and empty strings return false.

--- a/internal/config/repo_test.go
+++ b/internal/config/repo_test.go
@@ -31,6 +31,31 @@ func TestExpandRepoShorthand(t *testing.T) {
 	}
 }
 
+func TestSanitizeRepoURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "git@ unchanged", input: "git@github.com:charliek/prox.git", want: "git@github.com:charliek/prox.git"},
+		{name: "ssh:// with username unchanged", input: "ssh://git@host/path", want: "ssh://git@host/path"},
+		{name: "https no userinfo unchanged", input: "https://github.com/charliek/prox.git", want: "https://github.com/charliek/prox.git"},
+		{name: "https with username only unchanged", input: "https://user@host/repo.git", want: "https://user@host/repo.git"},
+		{name: "https with password stripped", input: "https://user:pw@host/repo.git", want: "https://user@host/repo.git"},
+		{name: "https with empty password stripped", input: "https://user:@host/repo.git", want: "https://user@host/repo.git"},
+		{name: "malformed url passes through", input: "not a url", want: "not a url"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeRepoURL(tt.input)
+			if got != tt.want {
+				t.Errorf("SanitizeRepoURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsSSHRepoURL(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/config/repo_test.go
+++ b/internal/config/repo_test.go
@@ -31,6 +31,35 @@ func TestExpandRepoShorthand(t *testing.T) {
 	}
 }
 
+func TestIsSSHRepoURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "empty", input: "", want: false},
+		{name: "git@ form", input: "git@github.com:charliek/prox.git", want: true},
+		{name: "git@ no .git", input: "git@github.com:charliek/prox", want: true},
+		{name: "ssh:// scheme", input: "ssh://git@github.com/charliek/prox.git", want: true},
+		{name: "ssh:// no user", input: "ssh://example.com/repo", want: true},
+		{name: "https rejected", input: "https://github.com/charliek/prox.git", want: false},
+		{name: "http rejected", input: "http://github.com/charliek/prox.git", want: false},
+		{name: "git:// rejected", input: "git://github.com/charliek/prox.git", want: false},
+		{name: "shorthand rejected", input: "charliek/prox", want: false},
+		{name: "garbage rejected", input: "not a url", want: false},
+		{name: "malformed git@ rejected", input: "git@:bad", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsSSHRepoURL(tt.input)
+			if got != tt.want {
+				t.Errorf("IsSSHRepoURL(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidateGitRepoURL(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -48,6 +48,10 @@ type ServerConfig struct {
 	// Extensions configures which extensions the agent should enable in VMs.
 	Extensions *ExtensionsConfig `yaml:"extensions,omitempty"`
 
+	// Git configures git-related behaviour for in-VM clones, including
+	// the SSH known_hosts content seeded before `git clone` runs.
+	Git *GitConfig `yaml:"git,omitempty"`
+
 	// Loaded environment variables (not from YAML)
 	EnvVars map[string]string `yaml:"-"`
 }
@@ -74,6 +78,49 @@ func (e *ExtensionsConfig) Validate() error {
 		// max 128 chars, rejects "system:" prefix).
 		if err := validateExtensionNamespace(ns); err != nil {
 			return fmt.Errorf("invalid extension namespace %q: %w", ns, err)
+		}
+	}
+	return nil
+}
+
+// GitConfig configures git behaviour for in-VM clones.
+type GitConfig struct {
+	// ExtraKnownHosts contains additional lines to append to the in-VM
+	// ~/.ssh/known_hosts before `git clone` runs over SSH. Each entry must be
+	// a valid known_hosts line (e.g., "github.com ssh-ed25519 AAAAC3..."),
+	// typically obtained by running `ssh-keyscan <host>` on a trusted machine.
+	// Built-in defaults (currently GitHub's published host keys) are always
+	// included; this list extends them.
+	ExtraKnownHosts []string `yaml:"extra_known_hosts,omitempty"`
+}
+
+// knownHostsKeyTypes lists the SSH key-type tokens accepted in known_hosts
+// lines. Used by GitConfig.Validate to reject obviously-malformed entries
+// at server startup rather than silently shipping garbage to the VM.
+var knownHostsKeyTypes = map[string]bool{
+	"ssh-rsa":             true,
+	"ssh-ed25519":         true,
+	"ssh-dss":             true,
+	"ecdsa-sha2-nistp256": true,
+	"ecdsa-sha2-nistp384": true,
+	"ecdsa-sha2-nistp521": true,
+}
+
+// Validate checks that each extra_known_hosts entry is a syntactically valid
+// known_hosts line. The check is deliberately simple — it catches typos and
+// obvious garbage but does not try to parse the base64 key material.
+func (g *GitConfig) Validate() error {
+	for i, line := range g.ExtraKnownHosts {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			return fmt.Errorf("extra_known_hosts[%d]: line must not be empty", i)
+		}
+		fields := strings.Fields(trimmed)
+		if len(fields) < 3 {
+			return fmt.Errorf("extra_known_hosts[%d]: expected at least 3 fields (host, key-type, base64-key), got %d", i, len(fields))
+		}
+		if !knownHostsKeyTypes[fields[1]] {
+			return fmt.Errorf("extra_known_hosts[%d]: unrecognized key type %q (expected one of ssh-rsa, ssh-ed25519, ssh-dss, ecdsa-sha2-nistp256/384/521)", i, fields[1])
 		}
 	}
 	return nil
@@ -866,6 +913,13 @@ func (c *ServerConfig) Validate() error {
 	if c.Extensions != nil {
 		if err := c.Extensions.Validate(); err != nil {
 			return fmt.Errorf("extensions config: %w", err)
+		}
+	}
+
+	// Validate git config if present
+	if c.Git != nil {
+		if err := c.Git.Validate(); err != nil {
+			return fmt.Errorf("git config: %w", err)
 		}
 	}
 

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -82,3 +82,86 @@ func TestExtensionsConfigValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestGitConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *GitConfig
+		wantErr bool
+	}{
+		{
+			name:    "nil extras is valid",
+			config:  &GitConfig{ExtraKnownHosts: nil},
+			wantErr: false,
+		},
+		{
+			name:    "empty extras is valid",
+			config:  &GitConfig{ExtraKnownHosts: []string{}},
+			wantErr: false,
+		},
+		{
+			name: "valid ed25519 line",
+			config: &GitConfig{ExtraKnownHosts: []string{
+				"gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf",
+			}},
+			wantErr: false,
+		},
+		{
+			name: "valid ecdsa line",
+			config: &GitConfig{ExtraKnownHosts: []string{
+				"example.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTY=",
+			}},
+			wantErr: false,
+		},
+		{
+			name: "valid rsa line with trailing comment",
+			config: &GitConfig{ExtraKnownHosts: []string{
+				"my-gitea.internal ssh-rsa AAAAB3NzaC1yc2E= operator@laptop",
+			}},
+			wantErr: false,
+		},
+		{
+			name:    "empty line rejected",
+			config:  &GitConfig{ExtraKnownHosts: []string{""}},
+			wantErr: true,
+		},
+		{
+			name:    "whitespace-only line rejected",
+			config:  &GitConfig{ExtraKnownHosts: []string{"   "}},
+			wantErr: true,
+		},
+		{
+			name:    "single field rejected",
+			config:  &GitConfig{ExtraKnownHosts: []string{"github.com"}},
+			wantErr: true,
+		},
+		{
+			name:    "two fields rejected",
+			config:  &GitConfig{ExtraKnownHosts: []string{"github.com ssh-ed25519"}},
+			wantErr: true,
+		},
+		{
+			name: "unknown key type rejected",
+			config: &GitConfig{ExtraKnownHosts: []string{
+				"github.com ssh-magic AAAAB3NzaC1y",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "garbage rejected",
+			config: &GitConfig{ExtraKnownHosts: []string{
+				"this is not a known_hosts line",
+			}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -603,7 +603,10 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		backend.Progress(ctx, "repo", "Cloning repository...")
 		if err := vmutil.CloneRepo(ctx, agent, c.serverCfg, req.Repo); err != nil {
 			log.Printf("Warning: failed to clone repo %s: %v", req.Repo, err)
-			backend.ProgressWarning(ctx, "repo", fmt.Sprintf("Failed to clone %s: %v", req.Repo, err))
+			// Don't include req.Repo in the SSE message — it can contain
+			// credentials (e.g., https://user:pw@host/...). Detail stays in
+			// the server log.
+			backend.ProgressWarning(ctx, "repo", fmt.Sprintf("Failed to clone repository: %v", err))
 		} else {
 			backend.Progress(ctx, "repo", "Repository cloned")
 		}

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -602,7 +602,7 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 	if req.Repo != "" && req.LocalDir == "" && req.FromSnapshot == "" {
 		backend.Progress(ctx, "repo", "Cloning repository...")
 		if err := vmutil.CloneRepo(ctx, agent, c.serverCfg, req.Repo); err != nil {
-			log.Printf("Warning: failed to clone repo %s: %v", req.Repo, err)
+			log.Printf("Warning: failed to clone repo %s: %v", config.SanitizeRepoURL(req.Repo), err)
 			// Generic SSE message by design: req.Repo can carry credentials
 			// (e.g., https://user:pw@host/...) and the wrapped err from
 			// git/ssh may include the URL too. Full detail is in the server

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -603,10 +603,11 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		backend.Progress(ctx, "repo", "Cloning repository...")
 		if err := vmutil.CloneRepo(ctx, agent, c.serverCfg, req.Repo); err != nil {
 			log.Printf("Warning: failed to clone repo %s: %v", req.Repo, err)
-			// Don't include req.Repo in the SSE message — it can contain
-			// credentials (e.g., https://user:pw@host/...). Detail stays in
-			// the server log.
-			backend.ProgressWarning(ctx, "repo", fmt.Sprintf("Failed to clone repository: %v", err))
+			// Generic SSE message by design: req.Repo can carry credentials
+			// (e.g., https://user:pw@host/...) and the wrapped err from
+			// git/ssh may include the URL too. Full detail is in the server
+			// log above; SSE consumers get a stable, sanitized signal.
+			backend.ProgressWarning(ctx, "repo", "Failed to clone repository (see server logs for details)")
 		} else {
 			backend.Progress(ctx, "repo", "Repository cloned")
 		}

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -603,6 +603,9 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		backend.Progress(ctx, "repo", "Cloning repository...")
 		if err := vmutil.CloneRepo(ctx, agent, c.serverCfg, req.Repo); err != nil {
 			log.Printf("Warning: failed to clone repo %s: %v", req.Repo, err)
+			backend.ProgressWarning(ctx, "repo", fmt.Sprintf("Failed to clone %s: %v", req.Repo, err))
+		} else {
+			backend.Progress(ctx, "repo", "Repository cloned")
 		}
 	}
 

--- a/internal/vmutil/known_hosts.go
+++ b/internal/vmutil/known_hosts.go
@@ -1,0 +1,55 @@
+package vmutil
+
+import (
+	"strings"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+// defaultKnownHosts is GitHub's published SSH host keys, copy-pasted from
+// https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
+//
+// These are baked in so a freshly-created shed can clone github.com over SSH
+// without any operator configuration. PR #58 removed the bind-mount that
+// previously supplied the user's ~/.ssh/known_hosts; this constant replaces
+// the GitHub portion of that lost trust state.
+//
+// If GitHub rotates host keys (last rotation: March 2023), update this
+// constant and ship a release. Operators can also add or override entries via
+// ServerConfig.Git.ExtraKnownHosts without waiting for a release.
+const defaultKnownHosts = `github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+`
+
+// BuildKnownHosts returns the full known_hosts content to seed into a shed
+// before `git clone` runs. The output combines built-in defaults with any
+// operator-supplied extras and always ends with a trailing newline.
+//
+// Duplicate lines are removed only on exact match — OpenSSH happily accepts
+// multiple entries for the same host (any-match-wins semantics), so we don't
+// try to be smart about host or key-type collisions.
+func BuildKnownHosts(cfg *config.ServerConfig) string {
+	var b strings.Builder
+	seen := make(map[string]bool)
+
+	add := func(line string) {
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" || seen[line] {
+			return
+		}
+		seen[line] = true
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+
+	for _, line := range strings.Split(defaultKnownHosts, "\n") {
+		add(line)
+	}
+	if cfg != nil && cfg.Git != nil {
+		for _, line := range cfg.Git.ExtraKnownHosts {
+			add(line)
+		}
+	}
+	return b.String()
+}

--- a/internal/vmutil/known_hosts_test.go
+++ b/internal/vmutil/known_hosts_test.go
@@ -1,0 +1,68 @@
+package vmutil
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+func TestBuildKnownHosts_NilConfig(t *testing.T) {
+	got := BuildKnownHosts(nil)
+	if !strings.Contains(got, "github.com ssh-ed25519") {
+		t.Errorf("expected GitHub ed25519 default in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "github.com ecdsa-sha2-nistp256") {
+		t.Errorf("expected GitHub ecdsa default in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "github.com ssh-rsa") {
+		t.Errorf("expected GitHub rsa default in output, got:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("expected trailing newline, got:\n%q", got)
+	}
+}
+
+func TestBuildKnownHosts_NilGit(t *testing.T) {
+	got := BuildKnownHosts(&config.ServerConfig{Name: "test"})
+	if !strings.Contains(got, "github.com ssh-ed25519") {
+		t.Errorf("expected GitHub default in output even when Git is nil")
+	}
+}
+
+func TestBuildKnownHosts_AppendsExtras(t *testing.T) {
+	extra := "gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf"
+	cfg := &config.ServerConfig{
+		Git: &config.GitConfig{ExtraKnownHosts: []string{extra}},
+	}
+	got := BuildKnownHosts(cfg)
+	if !strings.Contains(got, "github.com ssh-ed25519") {
+		t.Errorf("expected GitHub default to remain")
+	}
+	if !strings.Contains(got, extra) {
+		t.Errorf("expected operator extra in output, got:\n%s", got)
+	}
+}
+
+func TestBuildKnownHosts_DeduplicatesExactMatch(t *testing.T) {
+	dup := "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+	cfg := &config.ServerConfig{
+		Git: &config.GitConfig{ExtraKnownHosts: []string{dup, dup}},
+	}
+	got := BuildKnownHosts(cfg)
+	if n := strings.Count(got, dup); n != 1 {
+		t.Errorf("expected dup line to appear exactly once, found %d times in:\n%s", n, got)
+	}
+}
+
+func TestBuildKnownHosts_TrimsCRLF(t *testing.T) {
+	cfg := &config.ServerConfig{
+		Git: &config.GitConfig{ExtraKnownHosts: []string{
+			"gitlab.com ssh-ed25519 AAAAC3...\r\n",
+		}},
+	}
+	got := BuildKnownHosts(cfg)
+	if strings.Contains(got, "\r") {
+		t.Errorf("output must not contain carriage returns, got:\n%q", got)
+	}
+}

--- a/internal/vmutil/repo.go
+++ b/internal/vmutil/repo.go
@@ -12,7 +12,18 @@ import (
 )
 
 // CloneRepo clones a git repository into the VM's workspace.
+//
+// For SSH-form URLs (git@host:path or ssh://...), the in-VM
+// ~/.ssh/known_hosts is seeded first so OpenSSH can verify the remote host
+// key. Built-in defaults cover GitHub; extras come from
+// ServerConfig.Git.ExtraKnownHosts.
 func CloneRepo(ctx context.Context, agent *AgentClient, serverCfg *config.ServerConfig, repo string) error {
+	if config.IsSSHRepoURL(repo) {
+		if err := WriteKnownHosts(ctx, agent, BuildKnownHosts(serverCfg)); err != nil {
+			return fmt.Errorf("failed to seed known_hosts: %w", err)
+		}
+	}
+
 	env := BuildEnvForGit(serverCfg)
 
 	var output strings.Builder
@@ -30,6 +41,24 @@ func CloneRepo(ctx context.Context, agent *AgentClient, serverCfg *config.Server
 	}
 
 	return nil
+}
+
+// WriteKnownHosts writes content into the in-VM ~/.ssh/known_hosts file via
+// the agent. The file is created with mode 0600 (umask 077) and owned by
+// whatever user the agent runs commands as (the `shed` user — see
+// cmd/shed-agent/server.go).
+//
+// Overwrites any existing file. ~/.ssh is pre-created in the VM image so we
+// don't need to mkdir it here.
+func WriteKnownHosts(ctx context.Context, agent *AgentClient, content string) error {
+	opts := backend.ExecOptions{
+		Cmd:    []string{"sh", "-c", "umask 077 && cat > ~/.ssh/known_hosts"},
+		Stdin:  io.NopCloser(strings.NewReader(content)),
+		Stdout: NopWriteCloser(io.Discard),
+		Stderr: NopWriteCloser(io.Discard),
+		TTY:    false,
+	}
+	return agent.Exec(ctx, opts)
 }
 
 // BuildEnvForGit builds environment variables for git operations from server config.

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -247,7 +247,7 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 	if req.Repo != "" && req.LocalDir == "" && req.FromSnapshot == "" {
 		backend.Progress(ctx, "repo", "Cloning repository...")
 		if err := vmutil.CloneRepo(ctx, agent, c.serverCfg, req.Repo); err != nil {
-			log.Printf("Warning: failed to clone repo %s: %v", req.Repo, err)
+			log.Printf("Warning: failed to clone repo %s: %v", config.SanitizeRepoURL(req.Repo), err)
 			// Generic SSE message by design: req.Repo can carry credentials
 			// (e.g., https://user:pw@host/...) and the wrapped err from
 			// git/ssh may include the URL too. Full detail is in the server

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -248,6 +248,9 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		backend.Progress(ctx, "repo", "Cloning repository...")
 		if err := vmutil.CloneRepo(ctx, agent, c.serverCfg, req.Repo); err != nil {
 			log.Printf("Warning: failed to clone repo %s: %v", req.Repo, err)
+			backend.ProgressWarning(ctx, "repo", fmt.Sprintf("Failed to clone %s: %v", req.Repo, err))
+		} else {
+			backend.Progress(ctx, "repo", "Repository cloned")
 		}
 	}
 

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -248,10 +248,11 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		backend.Progress(ctx, "repo", "Cloning repository...")
 		if err := vmutil.CloneRepo(ctx, agent, c.serverCfg, req.Repo); err != nil {
 			log.Printf("Warning: failed to clone repo %s: %v", req.Repo, err)
-			// Don't include req.Repo in the SSE message — it can contain
-			// credentials (e.g., https://user:pw@host/...). Detail stays in
-			// the server log.
-			backend.ProgressWarning(ctx, "repo", fmt.Sprintf("Failed to clone repository: %v", err))
+			// Generic SSE message by design: req.Repo can carry credentials
+			// (e.g., https://user:pw@host/...) and the wrapped err from
+			// git/ssh may include the URL too. Full detail is in the server
+			// log above; SSE consumers get a stable, sanitized signal.
+			backend.ProgressWarning(ctx, "repo", "Failed to clone repository (see server logs for details)")
 		} else {
 			backend.Progress(ctx, "repo", "Repository cloned")
 		}

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -248,7 +248,10 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		backend.Progress(ctx, "repo", "Cloning repository...")
 		if err := vmutil.CloneRepo(ctx, agent, c.serverCfg, req.Repo); err != nil {
 			log.Printf("Warning: failed to clone repo %s: %v", req.Repo, err)
-			backend.ProgressWarning(ctx, "repo", fmt.Sprintf("Failed to clone %s: %v", req.Repo, err))
+			// Don't include req.Repo in the SSE message — it can contain
+			// credentials (e.g., https://user:pw@host/...). Detail stays in
+			// the server log.
+			backend.ProgressWarning(ctx, "repo", fmt.Sprintf("Failed to clone repository: %v", err))
 		} else {
 			backend.Progress(ctx, "repo", "Repository cloned")
 		}


### PR DESCRIPTION
## Summary

Fixes two related bugs that together caused `POST /api/sheds` with a `repo` field to silently produce a shed with an empty `/workspace`.

- **#84** — `git clone` failures inside the VM were logged to journald via `log.Printf` but never reached the SSE stream. The API client saw `event: complete` while `/workspace` was actually empty. Now surfaced as a `progress` event with `warning: true`.
- **#85** — PR #58 removed the `git_ssh` credential mount that previously supplied `~/.ssh/known_hosts`. The shed-extensions ssh-agent forwarding replaces *keys* but the agent protocol carries no host trust, so SSH clones failed with `Host key verification failed` before key auth ran. The server now seeds `~/.ssh/known_hosts` via the agent before invoking `git clone` for SSH-form URLs.

## Changes (one commit per concern)

1. **Surface clone outcome in SSE stream** — replace swallowed `log.Printf` with `backend.ProgressWarning`; add a `Repository cloned` success event so the `repo` phase always has a terminal event regardless of outcome.
2. **Add `git.extra_known_hosts` server config + SSH host-key defaults** — new optional `GitConfig` block on `ServerConfig` with validation that rejects malformed lines at startup. Built-in defaults bake in GitHub's published host keys (ed25519, ecdsa, rsa) so the common case works with no operator config.
3. **Seed in-VM `~/.ssh/known_hosts` before SSH `git clone`** — when the URL is SSH-form (`git@host:path` or `ssh://...`), `vmutil.WriteKnownHosts` writes the composed file via the agent (`umask 077`, owned `shed:shed`). HTTPS / git:// / http:// URLs skip this step.
4. **Documentation** — `docs/reference/configuration.md` gets a new ## Git section explaining the rationale, default behaviour, and how to extend the trust list. `configs/server.example.yaml` gets a commented example block.

## Design notes

- A failed clone does **not** fail shed creation. The shed itself is healthy; the user can clone manually after fixing the underlying problem. A `warning: true` SSE event matches the existing schema and is non-breaking for clients.
- Host trust is operator-controlled in server config and applied at clone time via the agent — no VM image rebuild needed. This respects PR #58's "no per-file credential mounts" architecture while restoring the lost trust state.
- OpenSSH's known_hosts uses any-match-wins semantics for multiple lines per host, so operator extras are purely additive — no need for a `disable_default_hosts` flag.
- `IsSSHRepoURL` lives in `internal/config/repo.go` next to the existing `gitSSHRegex` to keep URL classification in one place.

## Test plan

- [x] Unit tests added: `TestCreateShed_SSE_SurfacesProgressAndWarning`, `TestGitConfigValidate`, `TestBuildKnownHosts_*`, `TestIsSSHRepoURL`.
- [x] `make check` passes (build + tests + golangci-lint clean).
- [x] **End-to-end on local Firecracker (charliek/pop-os):**
  - HTTPS clone → SSE stream emits `Cloning repository...` then `Repository cloned`, `/workspace` populated, no `~/.ssh/known_hosts` written (correct — HTTPS skips the new code).
  - SSH clone (`charliek/sltstodo` shorthand) → `~/.ssh/known_hosts` written with mode `0600`, owned `shed:shed`, containing all three GitHub default keys plus the configured `gitlab.com` extra. Clone failed (no SSH auth in test config) and the SSE stream surfaced the failure as `{"phase":"repo","message":"Failed to clone …","warning":true}` followed by `complete`.
  - Malformed `extra_known_hosts: ["this is not a known_hosts line"]` → `shed-server` refused to start with `git config: extra_known_hosts[0]: unrecognized key type "is" (expected one of ssh-rsa, ssh-ed25519, ssh-dss, ecdsa-sha2-nistp256/384/521)`.

## Out of scope

- HTTPS / token-based git auth (no known_hosts needed).
- VM image rebuilds — the runtime fix avoids them.
- Issue #84 option B (waiting for ssh-agent extension `ExtHostConnected`) — the e2e test confirmed extension readiness wasn't the actual blocker; #85 was.
- Self-hosted-host trust *defaults* — operators add entries via `extra_known_hosts`. A `keyscan_at_startup` mode could be added later if demand emerges.

Closes #84, closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VMs now seed a built-in GitHub known_hosts set and optionally appended operator-provided known_hosts before SSH-based git clones; SSH detection added to trigger this.

* **Documentation**
  * Configuration docs updated with Git settings, extra_known_hosts usage, validation rules, and GitHub defaults.

* **Bug Fixes / Privacy**
  * Clone progress/warning messages sanitized to avoid leaking repo URLs.

* **Tests**
  * Added tests for known_hosts building, SSH-URL detection, validation, and SSE progress streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->