### PR TITLE
docs: refresh CLI/API/config/images for overlay-FS storage model

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ shed create my-project --repo git@github.com:user/repo.git
 
 # Or mount a local directory as the workspace
 shed create my-project --local-dir ~/projects/my-project
+
+# With a larger writable upper (default 5G; range 1G–100G)
+shed create big-project --image experimental --upper-size 20G
 ```
 
 ### 4. Connect
@@ -149,6 +152,7 @@ shed create <name> [--repo URL]  # Create a new shed (or --local-dir PATH)
 shed list                        # List all sheds on the current server
 shed start <name>                # Start a stopped shed
 shed stop <name>                 # Stop a running shed
+shed reset <name>                # Wipe and recreate the per-shed writable upper
 shed delete <name> [--force]     # Delete a shed
 
 # Connection & Execution

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -19,12 +19,20 @@ The `shed-server` exposes a REST API for managing sheds.
 | DELETE | `/api/sheds/{name}` | Delete a shed |
 | POST | `/api/sheds/{name}/start` | Start a shed |
 | POST | `/api/sheds/{name}/stop` | Stop a shed |
+| POST | `/api/sheds/{name}/reset` | Wipe and recreate the shed's writable upper layer |
 | GET | `/api/sheds/{name}/sessions` | List tmux sessions in shed |
 | DELETE | `/api/sheds/{name}/sessions/{session}` | Kill a tmux session |
 | GET | `/api/sessions` | List all sessions across sheds |
+| GET | `/api/snapshots` | List snapshots |
+| POST | `/api/snapshots` | Create a snapshot from a stopped shed |
+| GET | `/api/snapshots/{name}` | Get snapshot details |
+| DELETE | `/api/snapshots/{name}` | Delete a snapshot |
 | GET | `/api/images` | List available image variants |
-| DELETE | `/api/images/{name}` | Delete a cached image |
-| POST | `/api/images/prune` | Prune unused cached images |
+| GET | `/api/images/inspect/{name}` | Inspect a tag or digest (manifest + info) |
+| POST | `/api/images/tag` | Point a new tag at an existing digest |
+| POST | `/api/images/pull` | Pull a Docker reference into the blob store |
+| DELETE | `/api/images/{name}` | Delete a tag (blob preserved for `prune`) |
+| POST | `/api/images/prune` | Reclaim unreferenced blobs |
 | GET | `/api/system/df` | Disk usage report (image cache, sheds, orphans) |
 | POST | `/api/system/prune` | Scoped disk cleanup (dry-run, images/instances/logs/orphans) |
 | GET | `/api/sheds/{name}/connect/{port}` | TCP tunnel via HTTP upgrade |
@@ -117,6 +125,9 @@ Creates a new shed.
 | `local_dir` | No | null | Absolute path to host directory to mount as workspace (mutually exclusive with `repo`) |
 | `cpus` | No | Backend default | Number of vCPUs |
 | `memory_mb` | No | Backend default | Memory in MB |
+| `from_snapshot` | No | null | Snapshot name to spawn from (mutually exclusive with `image` and `repo`). Provisioning is skipped because the snapshot is already provisioned. |
+| `upper_size_bytes` | No | Server default | Per-shed overlay upper size in bytes. Range-validated 1 GiB – 100 GiB. When omitted, the per-backend `upper_size_default` config value applies. |
+| `no_provision` | No | `false` | Skip provisioning hooks (repo clone, install hook, first-time auto-sync). |
 
 **Response (201 Created):**
 
@@ -164,13 +175,14 @@ Without the `Accept: text/event-stream` header, the endpoint behaves synchronous
 
 **Errors:**
 
-| Code | Description |
-|------|-------------|
-| 400 | Invalid name format |
-| 400 | Invalid repository URL |
-| 400 | Invalid local directory path |
-| 409 | Shed already exists |
-| 500 | Backend or clone failure |
+| Code | Error | Description |
+|------|-------|-------------|
+| 400 | `INVALID_SHED_NAME` | Invalid name format |
+| 400 | `INVALID_REPO_URL` | Invalid repository URL |
+| 400 | `INVALID_LOCAL_DIR` | Invalid local directory path |
+| 400 | `INVALID_REQUEST` | No `image` specified and `base_rootfs` is not configured on the chosen backend, or `upper_size_bytes` is outside the 1–100 GiB range, or `from_snapshot` was passed together with `image`/`repo`. |
+| 409 | `SHED_ALREADY_EXISTS` | Shed already exists |
+| 500 | `CLONE_FAILED` / `BACKEND_ERROR` | Backend or clone failure |
 
 ### GET /api/sheds/{name}
 
@@ -248,6 +260,127 @@ Stops a running shed.
 | 404 | Shed not found |
 | 409 | Shed already stopped |
 
+### POST /api/sheds/{name}/reset
+
+Wipes and recreates the shed's per-shed writable overlay upper. The shared
+lower image is untouched; `/workspace` (mounted outside the overlay) is
+unaffected. The shed must be stopped first.
+
+**Response (200 OK):** the (still-stopped) Shed object, same shape as
+`GET /api/sheds/{name}`.
+
+**Errors:**
+
+| Code | Error | Description |
+|------|-------|-------------|
+| 404 | `SHED_NOT_FOUND` | Shed does not exist |
+| 409 | `SHED_NOT_STOPPED` | Shed must be stopped before reset |
+
+## Snapshots
+
+### GET /api/snapshots
+
+Lists all snapshots managed by this server. Each snapshot's `lower_cached`
+field is recomputed at read time from the local blob store; it is never
+persisted to `snapshot.json`.
+
+**Response (200 OK):**
+
+```json
+{
+  "snapshots": [
+    {
+      "version": 2,
+      "name": "post-migration",
+      "backend": "vz",
+      "source_shed": "api-dev",
+      "source_image": "experimental",
+      "size_bytes": 5368709120,
+      "created_at": "2026-05-10T12:00:00Z",
+      "lower_digest": "sha256:abc123...",
+      "lower_cached": true
+    }
+  ]
+}
+```
+
+### POST /api/snapshots
+
+Creates a snapshot from a stopped shed. Backend-emitted warnings (e.g., the
+source used `--local-dir`, so workspace contents are not captured) are
+returned alongside the snapshot rather than failing the request.
+
+**Request:**
+
+```json
+{
+  "name": "post-migration",
+  "source_shed": "api-dev",
+  "comment": "after the schema bump"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Snapshot name (alphanumeric + hyphens) |
+| `source_shed` | Yes | Source shed name. Must be stopped. |
+| `comment` | No | Free-form note attached to the snapshot |
+
+**Response (201 Created):**
+
+```json
+{
+  "snapshot": {
+    "version": 2,
+    "name": "post-migration",
+    "backend": "vz",
+    "source_shed": "api-dev",
+    "lower_digest": "sha256:abc123...",
+    "lower_cached": true,
+    "size_bytes": 5368709120,
+    "created_at": "2026-05-10T12:00:00Z"
+  },
+  "warnings": [
+    "source shed used --local-dir; workspace contents are not captured in the snapshot"
+  ]
+}
+```
+
+**Errors:**
+
+| Code | Error | Description |
+|------|-------|-------------|
+| 400 | `INVALID_SNAPSHOT_NAME` / `INVALID_SHED_NAME` | Name validation failed |
+| 404 | `SHED_NOT_FOUND` | Source shed does not exist |
+| 409 | `SNAPSHOT_ALREADY_EXISTS` | A snapshot with that name already exists |
+| 409 | `SNAPSHOT_SOURCE_RUNNING` | Source shed is running; stop it before snapshotting |
+
+### GET /api/snapshots/{name}
+
+Returns a single snapshot. Shape matches the list entries above (with
+`lower_cached` recomputed at read time).
+
+**Errors:**
+
+| Code | Error | Description |
+|------|-------|-------------|
+| 404 | `SNAPSHOT_NOT_FOUND` | Snapshot does not exist |
+
+### DELETE /api/snapshots/{name}
+
+Removes a snapshot. Sheds spawned from this snapshot remain independent —
+each has its own writable upper and metadata. Deleting a snapshot whose
+`lower_digest` is no longer referenced by any other shed or snapshot makes
+that digest a candidate for `shed image prune`.
+
+**Response (204 No Content)**
+
+**Errors:**
+
+| Code | Error | Description |
+|------|-------|-------------|
+| 404 | `SNAPSHOT_NOT_FOUND` | Snapshot does not exist |
+
 ## Session Management
 
 ### GET /api/sheds/{name}/sessions
@@ -321,7 +454,8 @@ Lists all tmux sessions across all running sheds.
 
 ### GET /api/images
 
-Returns available image variants across all backends.
+Returns available image variants across all backends. Each entry is an
+`ImageInfo`: tag-or-dangling-digest plus content-addressed metadata.
 
 **Response:**
 
@@ -330,18 +464,22 @@ Returns available image variants across all backends.
   "images": [
     {
       "name": "base",
-      "path": "/Users/user/Library/Application Support/shed/vz/base-rootfs.ext4",
-      "docker_ref": "ghcr.io/charliek/shed-vz-base:{version}",
+      "path": "/var/lib/shed/vz/blobs/sha256/abc123.../rootfs.ext4",
+      "docker_ref": "ghcr.io/charliek/shed-vz-base:v0.5.0",
       "size_bytes": 2147483648,
       "source": "config",
-      "cached": true
+      "cached": true,
+      "digest": "sha256:abc123...",
+      "tag": "base",
+      "in_use": true
     },
     {
-      "name": "custom",
-      "path": "/Users/user/Library/Application Support/shed/vz/custom-rootfs.ext4",
-      "size_bytes": 3221225472,
-      "source": "discovered",
-      "cached": true
+      "name": "sha256:ff8800...",
+      "path": "/var/lib/shed/vz/blobs/sha256/ff8800.../rootfs.ext4",
+      "size_bytes": 2147483648,
+      "source": "dangling",
+      "cached": true,
+      "digest": "sha256:ff8800..."
     }
   ]
 }
@@ -349,29 +487,144 @@ Returns available image variants across all backends.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `name` | string | Image variant name |
-| `path` | string | Local ext4 file path (empty if not cached) |
+| `name` | string | Tag name, or `sha256:...` for dangling blobs |
+| `path` | string | Blob rootfs path (empty if not cached) |
 | `docker_ref` | string | Docker image reference (empty for local-only images) |
 | `size_bytes` | int | File size in bytes (0 if not cached) |
-| `source` | string | `config` (from server config) or `discovered` (found in images_dir) |
-| `cached` | bool | Whether the ext4 file exists locally |
+| `source` | string | `config` (from server config), `discovered` (in blob store), or `dangling` (blob with no tag) |
+| `cached` | bool | Whether the underlying blob exists locally |
+| `digest` | string | Content digest (`sha256:...`) of the blob; empty when the image is uncached |
+| `tag` | string | Tag name pointing at this blob; empty for dangling entries |
+| `in_use` | bool | True when any existing shed or snapshot pins this digest |
 
-### DELETE /api/images/{name}
+### GET /api/images/inspect/{name}
 
-Deletes a cached image by name. Removes the ext4 rootfs and source sidecar files but preserves the lock file.
+Returns the full manifest plus `ImageInfo` for a tag or digest. `{name}`
+accepts either a tag (`experimental`) or a `sha256:...` digest (full or
+truncated).
+
+**Response (200 OK):**
+
+```json
+{
+  "image": {
+    "name": "experimental",
+    "path": "/var/lib/shed/vz/blobs/sha256/abc123.../rootfs.ext4",
+    "docker_ref": "ghcr.io/charliek/shed-vz-experimental:v0.5.0",
+    "size_bytes": 3700000000,
+    "source": "config",
+    "cached": true,
+    "digest": "sha256:abc123...",
+    "tag": "experimental",
+    "in_use": false
+  },
+  "manifest": {
+    "schema_version": 1,
+    "digest": "sha256:abc123...",
+    "backend": "vz",
+    "arch": "arm64",
+    "source_ref": "ghcr.io/charliek/shed-vz-experimental:v0.5.0",
+    "source_ref_digest": "sha256:def456...",
+    "shed_ext_version": "v0.3.1",
+    "kernel_size": 8388608,
+    "initrd_size": 102400,
+    "rootfs_logical_size": 21474836480,
+    "rootfs_physical_size": 3700000000,
+    "created_at": "2026-05-01T08:00:00Z"
+  }
+}
+```
+
+**Errors:**
+
+| Code | Error | Description |
+|------|-------|-------------|
+| 404 | `IMAGE_NOT_FOUND` | Tag/digest does not resolve to a cached blob |
+
+### POST /api/images/tag
+
+Points a new tag at the digest held by another tag (or a digest passed
+directly). Equivalent to `docker tag`.
+
+**Request:**
+
+```json
+{
+  "source": "experimental",
+  "target": "stable"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `source` | Yes | Tag name or `sha256:...` digest of an existing blob |
+| `target` | Yes | New tag name (must be a valid image name) |
 
 **Response (204 No Content)**
 
 **Errors:**
 
-| Code | Description |
-|------|-------------|
-| 404 | Image not found |
-| 409 | Image is referenced by config |
+| Code | Error | Description |
+|------|-------|-------------|
+| 400 | `INVALID_REQUEST` | Missing fields or invalid target name |
+| 404 | `IMAGE_NOT_FOUND` | Source tag/digest not found |
+
+### POST /api/images/pull
+
+Pulls a Docker reference, converts it to ext4, installs it under the blob
+store, and advances a tag. Returns the resulting digest.
+
+**Request:**
+
+```json
+{
+  "docker_ref": "ghcr.io/charliek/shed-vz-experimental:v0.5.0",
+  "tag": "experimental"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `docker_ref` | Yes | Docker registry reference to pull |
+| `tag` | Yes | Tag to advance to the resulting digest |
+
+**Response (200 OK):**
+
+```json
+{
+  "tag": "experimental",
+  "digest": "sha256:abc123..."
+}
+```
+
+**Errors:**
+
+| Code | Error | Description |
+|------|-------|-------------|
+| 400 | `INVALID_REQUEST` | Missing `docker_ref`/`tag` or invalid tag name |
+| 500 | `BACKEND_ERROR` | Pull or ext4 conversion failed |
+
+### DELETE /api/images/{name}
+
+Removes the tag (Docker model). The underlying blob is preserved and is
+reclaimed only by `POST /api/images/prune` once it has zero protective
+references. Config-managed tags cannot be removed via this endpoint —
+adjust server config instead.
+
+**Response (204 No Content)**
+
+**Errors:**
+
+| Code | Error | Description |
+|------|-------|-------------|
+| 404 | `IMAGE_NOT_FOUND` | Tag does not exist |
+| 409 | `IMAGE_IN_USE` | Tag is config-managed |
 
 ### POST /api/images/prune
 
-Removes cached images not referenced by config or any existing shed.
+Reclaims blobs that no shed or snapshot pins by digest. Tags do **not**
+protect blobs — only `lower_digest` references on instance `metadata.json`
+and snapshot `snapshot.json` do.
 
 **Query Parameters:**
 
@@ -385,17 +638,26 @@ Removes cached images not referenced by config or any existing shed.
 {
   "deleted": [
     {
-      "name": "old-variant",
-      "path": "/Users/user/Library/Application Support/shed/vz/old-variant-rootfs.ext4",
-      "docker_ref": "ghcr.io/example/old:v1",
+      "name": "sha256:ff8800...",
+      "path": "/var/lib/shed/vz/blobs/sha256/ff8800.../rootfs.ext4",
       "size_bytes": 2147483648,
-      "cached": true
+      "source": "dangling",
+      "cached": true,
+      "digest": "sha256:ff8800...",
+      "in_use": false
     }
   ]
 }
 ```
 
-The `deleted` array contains the images that were removed (or would be removed if `dry_run=true`).
+The `deleted` array contains the blobs that were removed (or would be removed
+if `dry_run=true`).
+
+**Fail-closed on malformed metadata:** prune aborts when any instance's
+`metadata.json` cannot be parsed for `lower_digest`. The error names the
+broken shed and its directory — fix or remove the broken instance before
+retrying. Lenient read paths (`GET /api/sheds`, `GET /api/images`,
+`GET /api/system/df`) warn-and-skip on the same fault.
 
 ## System
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -84,6 +84,7 @@ shed create <name> [flags]
 | `--backend` | | Server default | Backend to use: `firecracker` or `vz` |
 | `--cpus` | | Server default | Number of vCPUs |
 | `--memory` | | Server default | Memory in MB |
+| `--upper-size` | | Server default (`5G`) | Logical size of the per-shed writable overlay upper layer (e.g. `1G`, `5G`, `10G`, `100G`). Validated range: 1–100 GiB. The overlay grows copy-on-write, so this is the maximum, not the on-disk physical bytes. |
 | `--local-dir` | | None | Mount a local host directory as the workspace (mutually exclusive with `--repo`) |
 | `--no-provision` | | `false` | Skip provisioning hooks |
 | `--sync-profile` | | `default` | Profile to sync after creation |
@@ -203,7 +204,12 @@ Lists snapshots on the current server.
 shed snapshot info <snapshot-name>
 ```
 
-Shows snapshot metadata, including provenance and size.
+Shows snapshot metadata, including provenance and size. The output includes a
+`Lower digest: sha256:... (cached)` line — the digest of the lower image the
+snapshot was captured against. If that blob is no longer in the local image
+store, the status reads `(MISSING — pull or rebuild the image before
+spawning)` and a warning block points at the original image tag. See
+[Snapshots → Missing lower digest](snapshots.md#missing-lower-digest).
 
 ### shed snapshot delete
 
@@ -224,6 +230,45 @@ Spawns a new shed from a snapshot. `--from-snapshot` is mutually exclusive
 with `--image` and `--repo` (the snapshot rootfs is the source of truth).
 `--local-dir`, `--cpus`, and `--memory` remain valid since they describe
 runtime configuration, not rootfs source.
+
+If the snapshot's pinned `lower_digest` is no longer cached, the command
+fails fast with `BACKEND_ERROR: snapshot ... references lower digest
+sha256:... which is no longer cached; pull the original image (<tag>)
+first`. See [Snapshots → Missing lower digest](snapshots.md#missing-lower-digest).
+
+## Reset
+
+### shed reset
+
+Wipes and recreates a stopped shed's per-shed writable upper layer.
+
+```bash
+shed reset <name> [flags]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--force` | `-f` | `false` | Skip confirmation prompt |
+
+The lower image (shared, read-only) and `/workspace` (mounted post-boot from
+outside the overlay) are unaffected — only the writable upper is deleted and
+re-created empty. This is the equivalent of "throw away anything I wrote
+inside the VM and start fresh from the same image."
+
+The shed must be stopped. Otherwise the API returns `SHED_NOT_STOPPED` (HTTP
+409). When using `--json`, `--force` is required.
+
+Common uses:
+
+- Recovering from the upper-corruption panic (`shed-initramfs PANIC: ... no
+  ext4 magic at offset 1080 ...`) emitted by the in-guest initramfs.
+- Throwing away accumulated experiment state without losing `/workspace`.
+
+**Example:**
+
+```bash
+shed reset my-broken-shed --force
+```
 
 ## Image Management
 
@@ -386,6 +431,8 @@ shed image prune [flags]
 | `--dry-run` | | `false` | List candidates without deleting |
 
 A blob is preserved only if its digest is referenced by an existing shed's `metadata.json` (`lower_digest`) or a snapshot's `snapshot.json` (`lower_digest`). Tags are informational and do not protect blobs. After bumping image refs in server config and re-running `shed-server pull-images`, the previous digests typically become dangling and `shed image prune` reclaims them.
+
+**Fail-closed on malformed metadata:** `image prune` aborts (returns an error naming the broken shed and its directory) if any instance's `metadata.json` cannot be parsed for `lower_digest` — pruning while a refcount source is unreadable could orphan a digest still in use. Fix or `rm -rf` the broken instance directory before re-running. Lenient read paths (`shed list`, `shed image ls`, `shed system df`) warn-and-skip on the same fault.
 
 **Note:** When using `--json`, the `--force` flag is required.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -229,10 +229,11 @@ Replace `{version}` with the version matching your `shed` binary — run `shed v
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `kernel_path` | string | `{images_dir}/vmlinux` | Path to Linux kernel image (auto-populated from published images) |
-| `base_rootfs` | string | - | Path or Docker ref for base rootfs (used when no `--image` specified) |
+| `kernel_path` | string | `""` | Optional. Path to a Linux kernel image (auto-populated by published-image pulls). The Phase B initramfs prefers the kernel embedded in the image blob (`{images_dir}/blobs/sha256/<digest>/kernel`); this path is the fallback for legacy blobs that lack an embedded kernel. |
+| `base_rootfs` | string | `""` | Optional. Path or Docker ref for the default rootfs. Only consulted when `shed create` runs without `--image`. Empty is fine if every create passes `--image` explicitly; otherwise `shed create` errors with `INVALID_REQUEST: no --image specified and no base_rootfs configured`. |
 | `images` | map | - | Named image variants (ext4 paths or Docker refs) |
-| `images_dir` | string | `/var/lib/shed/firecracker/images` | Directory for converted/discovered ext4 images |
+| `images_dir` | string | `/var/lib/shed/firecracker/images` | Directory for converted/discovered ext4 images and the content-addressed blob store |
+| `upper_size_default` | string | `5G` | Default logical size of the per-shed writable overlay upper layer when `shed create --upper-size` is omitted. Validated to the range 1–100 GiB. |
 | `instance_dir` | string | - | Directory for VM instances |
 | `socket_dir` | string | - | Directory for API/vsock sockets |
 | `default_cpus` | int | `2` | Default vCPUs per VM |
@@ -246,6 +247,12 @@ Replace `{version}` with the version matching your `shed` binary — run `shed v
 | `bridge_name` | string | `shed-br0` | Linux bridge name |
 | `bridge_cidr` | string | `172.30.0.1/24` | Bridge network CIDR |
 | `tap_prefix` | string | `shed-tap` | TAP device name prefix |
+
+Path-existence validation only fires when **all** configured image sources
+are local paths. When `base_rootfs` (or any `images:` entry) is a Docker
+ref, the path-existence check is skipped because the file is created on
+first pull. `kernel_path` is still required to point at a real file when
+set non-empty.
 
 See [Firecracker Setup](../getting-started/fc-setup.md) for setup details.
 
@@ -283,11 +290,12 @@ vz:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `vfkit_path` | string | `vfkit` | Path to vfkit binary |
-| `kernel_path` | string | - | Path to decompressed Linux kernel |
-| `initrd_path` | string | - | Path to initial RAM disk image |
-| `base_rootfs` | string | - | Default rootfs ext4 path or Docker image reference (used when `--image` is not specified) |
+| `kernel_path` | string | `""` | Optional. Path to a decompressed Linux kernel (auto-populated by published-image pulls). Phase B prefers the kernel embedded in the image blob; this is the fallback for legacy blobs that lack an embedded kernel. |
+| `initrd_path` | string | `""` | Optional. Path to an initial RAM disk image. The shed-overlay initramfs lives inside the image blob, so this field is only consulted for legacy blobs. |
+| `base_rootfs` | string | `""` | Optional. Path or Docker ref for the default rootfs. Only consulted when `shed create` runs without `--image`. Empty is fine if every create passes `--image` explicitly; otherwise `shed create` errors with `INVALID_REQUEST: no --image specified and no base_rootfs configured`. |
 | `images` | map | - | Named image variants mapping variant name to rootfs path or Docker image reference (see [Image Variants](images.md)) |
-| `images_dir` | string | `~/Library/Application Support/shed/vz/` | Directory for converted/auto-discovered ext4 images |
+| `images_dir` | string | `~/Library/Application Support/shed/vz/` | Directory for converted/auto-discovered ext4 images and the content-addressed blob store |
+| `upper_size_default` | string | `5G` | Default logical size of the per-shed writable overlay upper layer when `shed create --upper-size` is omitted. Validated to the range 1–100 GiB. |
 | `instance_dir` | string | - | Directory for VM instances |
 | `socket_dir` | string | - | Directory for vsock Unix sockets (must not contain spaces) |
 | `default_cpus` | int | `2` | Default vCPUs per VM |

--- a/docs/reference/disk-management.md
+++ b/docs/reference/disk-management.md
@@ -1,6 +1,6 @@
 # Disk Management
 
-Shed stores cached VM images, per-shed rootfs copies, and (on VZ) console logs on each server. This page explains what lives on disk, how to measure it, and how to reclaim space safely.
+Shed stores cached VM image blobs (the shared lower layers), per-shed writable upper layers, instance metadata, and (on VZ) console logs on each server. This page explains what lives on disk, how to measure it, and how to reclaim space safely.
 
 The three tools involved:
 

--- a/docs/reference/disk-management.md
+++ b/docs/reference/disk-management.md
@@ -6,9 +6,9 @@ The three tools involved:
 
 - `shed system df` — read-only disk usage report.
 - `shed system prune` — scoped cleanup with a dry-run-first UX.
-- Reflink / clonefile on `shed create` — new sheds share extents with the base image on reflink-capable filesystems, so per-shed disk cost starts at near-zero.
+- The overlay-in-guest storage model — each shed allocates only a sparse writable upper (default 5 GB), while the read-only lower image is shared across every shed pinning the same digest.
 
-Full flag references live in the [CLI reference](cli.md#system-disk-usage); full API schemas live in the [HTTP API reference](api.md#system). This page focuses on workflows and the reflink behavior that affects every `shed create`. The on-disk layout itself is covered in [Storage Model](storage-model.md).
+Full flag references live in the [CLI reference](cli.md#system-disk-usage); full API schemas live in the [HTTP API reference](api.md#system). This page focuses on workflows. The on-disk layout itself is covered in [Storage Model](storage-model.md).
 
 ## What lives on disk
 
@@ -19,7 +19,8 @@ Each server stores four kinds of data in its backend directory:
 | Image blobs | `~/Library/Application Support/shed/vz/blobs/sha256/<digest>/` | `/var/lib/shed/firecracker/images/blobs/sha256/<digest>/` | `shed image build`, `shed image pull`, or `shed-server pull-images` | `shed image prune` (when no shed/snapshot pins the digest) |
 | Tags | `~/Library/Application Support/shed/vz/tags/<tag>.json` | `/var/lib/shed/firecracker/images/tags/<tag>.json` | Same as above | `shed image rm <tag>` |
 | Kernel / initrd (per blob) | Stored alongside `rootfs.ext4` inside each blob directory | Same | First conversion of an image | Removed with the blob |
-| Per-shed rootfs | `~/Library/Application Support/shed/vz/instances/{name}/rootfs.ext4` | `/var/lib/shed/firecracker/instances/{name}/rootfs.ext4` | `shed create` (shares extents with the blob's rootfs when possible) | `shed delete` or `shed system prune --instances` |
+| Per-shed writable upper | `~/Library/Application Support/shed/vz/uppers/{name}/upper.ext4` | `/var/lib/shed/firecracker/uppers/{name}/upper.ext4` | `shed create` (sparse, default 5 GB; lower image is shared read-only via overlayfs inside the guest) | `shed delete`, `shed reset`, or `shed system prune --instances` |
+| Per-shed metadata | `~/Library/Application Support/shed/vz/instances/{name}/metadata.json` | `/var/lib/shed/firecracker/instances/{name}/metadata.json` | `shed create` | `shed delete` or `shed system prune --instances` |
 | VZ console log | `~/Library/Application Support/shed/vz/instances/{name}/console.log` | _(Firecracker has none — SDK writes to stderr)_ | VM boot | `shed system prune --logs` (truncates to last N bytes) |
 | Orphan sidecars | `*.tmp` from a crashed install staging dir | Same | Partial or crashed image conversions | `shed system prune --orphans` |
 
@@ -76,15 +77,15 @@ $ shed system prune
 SERVER: prod-mac (dry-run) --until 72h0m0s scope=images+instances+orphans
 
 IMAGES (2, 40.0 GB)
-NAME          PATH                                                                          LOGICAL  PHYSICAL
-base          /Users/alice/Library/Application Support/shed/vz/base-rootfs.ext4             20.0 GB  1.9 GB
-experimental  /Users/alice/Library/Application Support/shed/vz/experimental-rootfs.ext4     20.0 GB  3.2 GB
+NAME          PATH                                                                                       LOGICAL  PHYSICAL
+base          /Users/alice/Library/Application Support/shed/vz/blobs/sha256/abc123.../rootfs.ext4        20.0 GB  1.9 GB
+experimental  /Users/alice/Library/Application Support/shed/vz/blobs/sha256/def456.../rootfs.ext4        20.0 GB  3.2 GB
 
 SKIPPED (3)
-KIND      NAME/PATH                                                                 REASON
-instance  api-dev                                                                   cannot prune running shed
-instance  api-test                                                                  too recent (3h < 72h)
-lock      /Users/alice/Library/Application Support/shed/vz/foo-rootfs.ext4.lock     lock file retained (inode-reuse race safety)
+KIND      NAME/PATH                                                                            REASON
+instance  api-dev                                                                              cannot prune running shed
+instance  api-test                                                                             too recent (3h < 72h)
+lock      /Users/alice/Library/Application Support/shed/vz/blobs/sha256/abc123.../rootfs.ext4.lock  lock file retained (inode-reuse race safety)
 
 TOTAL TO FREE: 40.0 GB logical / 5.1 GB physical (2 items)
 

--- a/docs/reference/fc-operations.md
+++ b/docs/reference/fc-operations.md
@@ -158,7 +158,10 @@ Example output:
   "tap_device": "shed-tap-0",
   "cpus": 2,
   "memory_mb": 4096,
-  "rootfs_path": "/var/lib/shed/firecracker/instances/myproject/rootfs.ext4"
+  "rootfs_path": "/var/lib/shed/firecracker/uppers/myproject/upper.ext4",
+  "upper_path": "/var/lib/shed/firecracker/uppers/myproject/upper.ext4",
+  "upper_size_bytes": 5368709120,
+  "lower_digest": "sha256:abc123..."
 }
 ```
 
@@ -222,47 +225,65 @@ shed exec myproject -- curl -I https://google.com
 
 ### VM Disk Layout
 
-Each VM has its own rootfs derived from the base image:
+Each VM mounts an overlayfs stack in-guest: the shared, read-only lower
+image (the content-addressed blob) plus a per-shed writable upper.
 
 ```text
-/var/lib/shed/firecracker/instances/myproject/
-├── metadata.json    # VM configuration and state
-└── rootfs.ext4      # VM's root filesystem (reflink of base when supported)
+/var/lib/shed/firecracker/
+├── images/blobs/sha256/<digest>/   # Shared lower images (read-only)
+│   ├── rootfs.ext4                 # The lower layer mounted in every shed pinning this digest
+│   ├── kernel                      # Kernel (preferred by Phase B initramfs)
+│   ├── initrd                      # Initial RAM disk
+│   └── manifest.json
+├── uppers/myproject/upper.ext4     # Per-shed sparse writable layer (default 5 GB)
+└── instances/myproject/
+    └── metadata.json               # VM configuration and pinned lower_digest
 
-/var/run/shed/firecracker/  # Runtime sockets (when VM is running)
-├── myproject.sock   # Firecracker API socket
-└── myproject.vsock  # vsock UDS for guest communication
+/var/run/shed/firecracker/          # Runtime sockets (when VM is running)
+├── myproject.sock                  # Firecracker API socket
+└── myproject.vsock                 # vsock UDS for guest communication
 ```
 
-On reflink-capable filesystems (btrfs, xfs with reflink, ext4 with `reflink=1` on kernel 6.7+), the per-shed rootfs shares extents with `_base` and adds near-zero physical bytes at create time; writes diverge copy-on-write. On non-reflink ext4 the rootfs is materialized as a full copy (~2–5 GB). See [Disk Management](disk-management.md) for the strategy chain, how to check reflink support, and how to measure per-shed cost.
+Per-shed disk cost is the writable upper alone — a sparse file (default 5 GB,
+configurable via `shed create --upper-size`). The lower image is shared across
+every shed pinning the same digest, both on disk and in the host page cache,
+so host filesystem reflink support is no longer load-bearing for per-shed
+cost. See [Storage Model](storage-model.md) for the overlay-in-guest design
+and [Disk Management](disk-management.md) for measurement and reclamation.
 
 ### Expanding Disk Space
 
-To resize a VM's rootfs:
+To give a shed more writable headroom, recreate it with a larger upper. The
+writable upper is sized at create time and cannot be resized in place — the
+lower image is read-only and shared:
 
 ```bash
-# Stop the VM first
+# Stop, snapshot if you need to keep state, then recreate with a bigger upper
 shed stop myproject
-
-# Resize the image
-sudo truncate -s 40G /var/lib/shed/firecracker/instances/myproject/rootfs.ext4
-sudo e2fsck -f /var/lib/shed/firecracker/instances/myproject/rootfs.ext4
-sudo resize2fs /var/lib/shed/firecracker/instances/myproject/rootfs.ext4
-
-# Start the VM
-shed start myproject
+shed snapshot create myproject pre-resize
+shed delete myproject --keep-volume
+shed create myproject --from-snapshot pre-resize --upper-size 20G
 ```
+
+To wipe accumulated upper-layer writes without resizing, use `shed reset` —
+it deletes and re-creates the upper at its current size while leaving
+`/workspace` and the lower untouched.
 
 ### Backing Up a VM
 
+The writable upper plus `metadata.json` is what's per-shed. `/workspace`
+lives outside the overlay (volume- or virtiofs-backed) and is the typical
+backup target.
+
 ```bash
-# Stop the VM
+# Snapshot the upper as a named snapshot
 shed stop myproject
+shed snapshot create myproject backup-2026-05-17
 
-# Copy the instance directory
-cp -r /var/lib/shed/firecracker/instances/myproject /backup/myproject-backup
-
-# Restart
+# Or copy the raw upper + metadata
+shed stop myproject
+sudo cp -r /var/lib/shed/firecracker/uppers/myproject /backup/upper-myproject
+sudo cp /var/lib/shed/firecracker/instances/myproject/metadata.json /backup/myproject.json
 shed start myproject
 ```
 

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -380,7 +380,11 @@ The common end-to-end flow when bumping image refs (for example, moving config f
         brew services restart shed
         ```
 
-4. Pull the new images. If `base_rootfs` shares a ref with a variant, `_base-rootfs.ext4` is hardlinked to the variant (no extra disk, no extra pull).
+4. Pull the new images. Each pull lands a new blob under
+   `blobs/sha256/<digest>/` and advances the tag (`tags/<tag>.json`) to
+   the new digest. When `base_rootfs` shares a Docker ref with a variant,
+   the same blob backs both `_base` and the variant tag — no duplicate
+   blob, no second pull.
    ```bash
    sudo shed-server pull-images
    ```
@@ -395,12 +399,19 @@ The common end-to-end flow when bumping image refs (for example, moving config f
    ```bash
    shed image ls
    du -sh <images_dir>      # blobs + tags + kernel
-   du -sh <instances_dir>   # running shed rootfs copies
+   du -sh <instances_dir>   # per-shed metadata + (VZ) console.log
+   du -sh <uppers_dir>      # per-shed writable upper layers
    ```
 
 ## Disk Space
 
-Each variant is a 20 GB sparse ext4 image; actual usage is typically 2–5 GB depending on what the variant installed. Per-shed rootfs copies start out sharing extents with `_base` on reflink-capable filesystems (APFS, btrfs, xfs-reflink, ext4 with `reflink=1`) and grow copy-on-write as the VM writes. On non-reflink filesystems the rootfs is materialized as a full copy.
+Each variant is a 20 GB sparse ext4 image; actual physical usage is
+typically 2–5 GB depending on what the variant installed. Per-shed cost is
+the writable upper layer alone (sparse, default 5 GB, configurable via
+`shed create --upper-size`) — not a copy of the rootfs. The lower image
+(the cached blob) is shared read-only across every shed pinning the same
+digest, both on disk and in the host page cache. See
+[Storage Model](storage-model.md) for the overlay-in-guest design.
 
 To measure usage, use `shed system df`:
 
@@ -409,13 +420,21 @@ shed system df
 shed system df -v
 ```
 
-See [Disk Management](disk-management.md) for the full reflink strategy chain, the APFS extent-sharing caveat, how to check reflink support on Linux, and how to reclaim space with `shed system prune`.
+See [Disk Management](disk-management.md) for how to measure and reclaim
+space with `shed system df` / `shed system prune`, plus the APFS
+extent-sharing caveat that affects physical-byte reporting.
 
 ## Requirements
 
 Image conversion requires Docker with privileged container support. The ext4 creation step uses a privileged Docker container for loop mounting.
 
-For VZ images, the kernel and initrd are automatically extracted alongside the rootfs during conversion. Both `shed image build --from` and the auto-pull on `shed create` handle this — no manual kernel extraction is needed.
+For VZ images, the kernel and initrd are extracted from the source image
+and written into the blob directory alongside the rootfs
+(`{images_dir}/blobs/sha256/<digest>/{kernel,initrd}`). Phase B's
+in-guest initramfs prefers these embedded files over the legacy
+`kernel_path`/`initrd_path` config values. Both `shed image build --from`
+and the auto-pull on `shed create` handle this — no manual extraction is
+needed.
 
 ## Building from Source
 

--- a/docs/reference/snapshots.md
+++ b/docs/reference/snapshots.md
@@ -132,6 +132,33 @@ FICLONE), the snapshot's stored upper and any spawned shed's upper
 share extents until they diverge. `shed system df` notes this so you
 don't overcount on-disk usage.
 
+### Missing lower digest
+
+A snapshot only **pins** its source's `lower_digest` — it doesn't carry a
+copy of the lower bytes. `shed image prune` refuses to delete a digest a
+snapshot pins, so in normal operation the lower stays available. If an
+operator removes a blob directory by hand (or moves the image store between
+hosts), the pin's protection is bypassed and the lower may go missing.
+
+`shed snapshot info` warns when this happens:
+
+```text
+Lower digest:   sha256:abc123... (MISSING — pull or rebuild the image before spawning)
+
+Warning: this snapshot's lower image is no longer cached.
+  shed create --from-snapshot <snap> will fail until you pull/rebuild <tag>.
+```
+
+`shed create --from-snapshot` then fails fast with
+`BACKEND_ERROR: snapshot ... references lower digest sha256:... which is no
+longer cached; pull the original image (<tag>) first`. Recover by pulling
+the original image:
+
+```bash
+shed image pull <docker-ref> -t <tag>
+shed create my-new-shed --from-snapshot <snap>
+```
+
 ## Out of scope
 
 - Live (memory state) snapshots — Tier 1 captures rootfs only.


### PR DESCRIPTION
## Summary

Phase A (#87) shipped the content-addressed image lifecycle and overlay-in-guest boot. This PR refreshes the reference docs to match the code on `main` — no stale claims, no missing features, no incorrect "required" markers.

A pre-edit audit found 12 substantive gaps across 6 doc files (missing `shed reset`, missing `--upper-size`, four missing API endpoints, several missing error codes, three config fields incorrectly marked required, and two files still describing the pre-Phase-B reflink cost model). All 12 are fixed.

## Coverage checklist

### Tier 1 — Critical (incorrect or actively misleading)
- [x] `docs/reference/cli.md` — add `shed reset` (new H2), `shed create --upper-size`, MISSING-lower note on `snapshot info`, fail-closed note on `image prune`.
- [x] `docs/reference/api.md` — add `/api/sheds/{name}/reset`, snapshot endpoints + `SNAPSHOT_SOURCE_RUNNING`, `/api/images/{tag,pull,inspect}`, `upper_size_bytes` + `from_snapshot` on `POST /api/sheds`, the new `ImageInfo` fields (`digest`, `tag`, `in_use`), and a corrected DELETE prose.
- [x] `docs/reference/configuration.md` — mark `base_rootfs`, `kernel_path`, `initrd_path` optional; add `upper_size_default` for both backends.
- [x] `docs/reference/images.md` — rewrite the Disk Space section (kill the reflink cost model, document writable-upper cost); document the in-blob kernel/initrd.
- [x] `docs/reference/disk-management.md` — fix the per-shed row to point at `uppers/{name}/upper.ext4`; update the sample prune output to show blob paths.
- [x] `docs/reference/fc-operations.md` — rewrite the VM Disk Layout tree, Expanding Disk Space, and Backing Up a VM for the overlay model.

### Tier 2 — High (missing/important but not actively wrong)
- [x] `docs/reference/snapshots.md` — add a Missing lower digest subsection.
- [x] `README.md` — add `shed reset` to the CLI quick-list and an `--upper-size` example.

### Tier 3 — Polish
- [x] Cross-link audit: no `reflink`/`clonefile` language remains outside historical context; no `*-rootfs.ext4` legacy paths remain in user-facing prose (intermediates that the build scripts emit are still mentioned, since the scripts still write them).
- [x] `docs/reference/vz-operations.md` — confirmed clean (no stale language to fix).

## Plan corrections

Two factual claims in the source plan were wrong against the code on `main` and the docs follow the code:
- `POST /api/images/pull` does **not** stream SSE — only `POST /api/sheds` does. Documented as a synchronous JSON endpoint.
- `ImageTagRequest` body fields are `source`/`target`, not `src`/`new`.

## Test plan

- [x] `uv run mkdocs build --strict` — clean (only pre-existing `discovery/` nav warnings).
- [x] `grep -r "shed reset" docs/ README.md` — appears in cli.md (new H2), README.md, disk-management.md, fc-operations.md.
- [x] `grep -r "upper-size\|upper_size" docs/ README.md` — appears in cli.md flag table, api.md, configuration.md (both backends), images.md, disk-management.md, fc-operations.md, README.md.
- [x] `grep -rE "/api/images/(tag|pull|inspect)|/api/sheds/.*reset|/api/snapshots"` — appears in api.md endpoint table + per-endpoint sections.
- [ ] Render docs locally with `make docs-serve` and skim each modified page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added `shed reset` docs (behavior, stopped requirement, --force)
  * Documented `--upper-size` for `shed create` (1–100 GiB, default 5 GiB) and recreating uppers to resize
  * Revised storage model and disk/layout guidance (sparse per-shed uppers, shared lower blobs)
  * Expanded API/CLI refs (new endpoints/fields, images/prune semantics, error codes)
  * Snapshot guidance for missing lower digests and fail-fast behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->