### PR TITLE
Release-readiness pass for v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,58 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Release-readiness fixes
+
+- **`POST /api/images/pull` no longer 405s.** A chi router precedence
+  bug routed `POST /api/images/pull` to the parametric
+  `DELETE /api/images/{name}` handler, returning `405 Method Not Allowed,
+  Allow: DELETE`. Fixed in `internal/api/server.go` by mounting the
+  static `/pull` route before the parametric `/{name}` sibling.
+- **Legacy bundled-blob layout now surfaces an actionable error.**
+  v0.4.x users upgrading without wiping `images_dir` previously hit a
+  cryptic `... is a directory` error. `internal/vmimage/ocilayout.go`
+  now detects this case and wraps it as `ErrLegacyBundledBlob`; the CLI
+  surfaces a message pointing the user at [`docs/UPGRADE.md`](docs/UPGRADE.md).
+- **`image has N layers (max 16)` rejection now includes a recovery
+  hint.** `internal/vmimage/registry.go` extends the pull-time
+  `MaxLayers` error with concrete next steps (wait for the v0.5.0+
+  published image, or rebuild locally with the backend's build script).
+- **`SHED-INIT-04` panic cross-references the upgrade guide.** The
+  initramfs overlay-mount panic in `initramfs/init` now points at
+  [`docs/UPGRADE.md#shed-init-04-panic-during-vm-boot`](docs/UPGRADE.md#shed-init-04-panic-during-vm-boot)
+  so operators know to refresh the cached initramfs by re-running the
+  build script.
+- **New top-level [`docs/UPGRADE.md`](docs/UPGRADE.md).** Walks v0.4.x →
+  v0.5.0 with a "what's new", a keep/lose table, links into the
+  backend-specific wipe steps in `vz-setup.md` / `fc-setup.md`, and a
+  recovery-scenarios index keyed off the error strings users actually
+  see (cryptic "is a directory", `>MaxLayers`, `SHED-INIT-04`, the
+  now-fixed 405 on `/api/images/pull`). Added to the MkDocs nav under
+  "Getting Started".
+- **Getting-started doc gap repairs.**
+  [`quick-start.md`](docs/getting-started/quick-start.md) now frames the
+  published-vs-source install paths explicitly, routes source builders
+  into the backend setup guides instead of dead-ending at `make build`,
+  and drops the stale `VERSION=0.3.3` pin in favor of a
+  `gh release view`-driven lookup.
+  [`vz-setup.md`](docs/getting-started/vz-setup.md) and
+  [`fc-setup.md`](docs/getting-started/fc-setup.md) gain a working
+  local-build `server.yaml` example (omit `base_rootfs` + `images:`,
+  rely on tag auto-discovery, pass `--image <tag>`), demote
+  `kernel_path` / `initrd_path` to optional fallbacks for OCI images,
+  spell out `shed-server serve --config <path>` (the binary doesn't
+  read `~/.config/shed/server.yaml` by default), document `uppers_dir`
+  as an optional FC config field that should track non-default
+  `instance_dir`, restructure the FC manual-setup section so source
+  builders see it as required rather than optional reference material,
+  call out the Go-on-host requirement for the FC rootfs build script,
+  and reframe `shed server add localhost` so users know it registers
+  under the server's `name:` field (with `shed server list` to confirm).
+  Concrete `:v0.5.0` placeholders replace the unresolvable `:v{version}`
+  pseudo-syntax.
+
+### Storage rewrite (Phase A / B / C)
+
 - **`shed image build` preserves the docker layer structure (multi-layer per variant).** The previous flow flattened every variant to a single layer via `docker create` + `docker export`, defeating cross-variant sharing on disk. The new flow uses `docker buildx --output type=oci,dest=<tar>` and ingests each layer blob into the local store, so `base`, `extensions`, and `full` share their common parent layers byte-for-byte. The `vz/` and `firecracker/` Dockerfiles are consolidated (BuildKit 1.7 `--mount=type=bind` for context staging) to keep each variant under the 16-layer `MaxLayers` cap: VZ ships 5 / 7 / 9 layers and FC ships 6 / 8 / 10. Measured on an arm64 Mac with all three VZ variants built locally: **~5.0 GB total** (1.7 GB blobs + 3.3 GB cache) versus **~12 GB** for the same three under the old flattened model — about **60% less disk** for users who keep multiple variants installed. Single-variant footprint is roughly unchanged; the gain is from cross-variant blob dedup.
 - **Multi-layer boot fixes surfaced during validation.** Three latent bugs only triggered once a variant carried more than one lower:
   - **vfkit bootloader cmdline:** `--bootloader linux,kernel=,initrd=,cmdline=…` is comma-separated key=value, and `shed.lowers=/dev/vdb,/dev/vdc,…` embeds commas vfkit interprets as bogus options (`unknown option /dev/vdc`). Switched to the dedicated `--kernel` / `--initrd` / `--kernel-cmdline` flags.

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -1,0 +1,167 @@
+# Upgrade Guide: v0.4.x to v0.5.0
+
+v0.5.0 rewrites how shed stores images. The legacy flat-file image cache
+is gone; the new store is content-addressed (Docker-style), images are
+layered, and per-shed disk usage drops from a full rootfs clone to a
+small writable upper. The schema is not backwards-compatible: existing
+sheds, snapshots, and cached blobs cannot be migrated and must be
+wiped on upgrade.
+
+This page is a top-level walkthrough. Backend-specific commands live in
+the existing setup guides, which this page links into.
+
+## What's new at a glance
+
+- **Content-addressed OCI image store.** Image identity is now the
+  sha256 of the produced ext4 bytes. Blobs live at
+  `{images_dir}/blobs/sha256/<digest>/`; tags at
+  `{images_dir}/tags/<tag>.json`. Multiple tags can point at one digest
+  with zero extra disk cost. See
+  [Storage Model](reference/storage-model.md) for the full layout.
+- **Layer-preserving builds.** `shed image build` now writes one blob
+  per Docker layer rather than flattening each variant. `base`,
+  `extensions`, and `full` share their common parent layers byte-for-byte.
+  Three locally built VZ variants land in roughly 5 GB rather than the
+  ~12 GB the old flattened model required.
+- **Overlay-in-guest boot.** Each shed boots from a shared read-only
+  lower stack and a per-shed writable upper (sparse `upper.ext4`,
+  default 5 GB). A new busybox-based initramfs assembles the overlay and
+  `pivot_root`s into the merged tree.
+- **New per-shed commands.** `shed reset <name>` wipes and recreates a
+  shed's upper while leaving the workspace and shared lower untouched.
+  `shed create --upper-size <N>G` overrides the default upper size.
+- **New image commands.** `shed image inspect`, `shed image tag`,
+  `shed image pull`, and refcount-protected `shed image prune`. See
+  [`shed image`](reference/cli.md) and the
+  [upgrade-and-reclaim cookbook](reference/images.md#cookbook-upgrading-image-versions).
+- **Metadata schema v3.** Instance and snapshot metadata gain
+  `lower_digest`, `lower_image_tag`, `upper_path`, and `upper_size_bytes`.
+  Pre-v3 metadata is rejected at load time with an actionable message.
+
+## What you keep, what you lose
+
+| Keep | Lose |
+|------|------|
+| `~/.shed/` client config and SSH config entries | All image blobs under `images_dir` |
+| Server `server.yaml` (the schema is backwards-compatible) | All sheds and their writable uppers |
+| Host SSH keys and any custom systemd / launchd units | All snapshots |
+| Workspace data stored in `--local-dir` mounts | Workspace data that lived only inside the upper of a deleted shed |
+| Published images on `ghcr.io` (once v0.5.0 tags ship) | Pre-v3 v1/v2 metadata under `instances/` and `snapshots/` |
+
+Workspace data that you care about belongs under a `--local-dir` mount.
+Anything that only ever lived inside a shed's writable layer is lost by
+design during the upgrade wipe.
+
+## Backend migration
+
+Follow the canonical wipe steps in the backend setup guides; they live
+alongside the rest of the install instructions and are kept in sync with
+the install path you use.
+
+- **macOS (VZ):**
+  [Upgrading from v0.4.x](getting-started/vz-setup.md#upgrading-from-v04x)
+- **Linux (Firecracker):**
+  [Upgrading from v0.4.x](getting-started/fc-setup.md#upgrading-from-v04x)
+
+At a high level, both flows are: stop the server, `rm -rf` the legacy
+blob / instance / snapshot / upper directories, install the new binary
+or rebuild from source, restart the server, and re-pull or rebuild
+images.
+
+## Recovery scenarios
+
+If you see one of the following errors, the most likely cause is a
+partial upgrade — a v0.5.0 binary running against a v0.4.x on-disk
+layout, or vice versa.
+
+### `... is a directory` when starting a shed
+
+The runtime tried to open a v0.4.x flat-file rootfs cache
+(`<variant>-rootfs.ext4`) and found a v0.5.0 blob directory instead, or
+vice versa. The blob store and the legacy cache cannot coexist on the
+same `images_dir`.
+
+Fix: follow the wipe steps in
+[VZ Setup](getting-started/vz-setup.md#upgrading-from-v04x) or
+[Firecracker Setup](getting-started/fc-setup.md#upgrading-from-v04x)
+to drop the legacy `blobs/`, `instances/`, `snapshots/`, and
+`uppers/` directories, then re-pull or rebuild images.
+
+### `image has N layers (max 16)` when pulling
+
+The image you're pulling has more than 16 ext4 layers. v0.5.0 caps
+manifests at 16 layers to keep boot-time overlay assembly bounded.
+
+Fix:
+
+- If you're pulling a published `ghcr.io/charliek/shed-*` image
+  produced before v0.5.0, that image is incompatible — wait for a
+  v0.5.0+ tag (see "Published images" below) or rebuild locally with
+  `./scripts/build-vz-rootfs.sh` / `./scripts/build-firecracker-rootfs.sh`.
+- If you're pulling a custom image, rebuild with fewer / squashed
+  Docker layers.
+
+### `SHED-INIT-04` panic during VM boot
+
+```
+SHED-INIT-04 overlay mount failed (kernel module not loaded or lowerdir too long?)
+```
+
+The in-guest initramfs failed to assemble the overlay. Most often the
+cached initramfs is stale (built before the overlay-mount fix or the
+`/proc`-mount-order fix landed).
+
+Fix: re-run the build script for your backend
+(`./scripts/build-vz-rootfs.sh` or
+`./scripts/build-firecracker-rootfs.sh`) to refresh the cached
+initramfs. The build pipeline installs the rootfs, kernel, and initrd
+atomically into the blob store. If you're using published images,
+re-pull with `shed image pull <ref> -t <tag>` once v0.5.0 images ship.
+
+If the initramfs is fresh, see [Storage Model](reference/storage-model.md)
+for overlay layout. The panic codes are stable — `SHED-INIT-04` is
+specifically the overlay mount; `SHED-INIT-02` / `-03` are missing or
+unmountable lower blocks; `SHED-INIT-06` / `-08` are corrupt uppers
+(recover with `shed reset <name>`).
+
+### `405 Method Not Allowed, Allow: DELETE` on `POST /api/images/pull`
+
+A v0.4.x router precedence bug routed `POST /api/images/pull` to the
+parametric `/api/images/{name}` DELETE handler.
+
+This is fixed in v0.5.0. If you still see it, you're talking to an old
+`shed-server`; upgrade the server binary.
+
+## Published images
+
+The published `ghcr.io/charliek/shed-*` v0.4.x images use the old
+flattened layout and are not v0.5.0-compatible. v0.5.0-compatible
+published images become available once the `v0.5.0` tag is cut and CI
+republishes the variants.
+
+Until then, the supported path is a local rebuild:
+
+```bash
+# macOS / VZ
+./scripts/build-vz-rootfs.sh --variant full
+
+# Linux / Firecracker
+./scripts/build-firecracker-rootfs.sh --variant full
+```
+
+Local builds write directly into the blob store and advance the
+`base` / `extensions` / `full` tags. Check available tags at
+<https://github.com/charliek/shed/pkgs/container/shed-vz-full> (and the
+parallel `shed-fc-*` packages) once they ship.
+
+## Verifying the upgrade
+
+```bash
+shed image ls            # should list the rebuilt or re-pulled tags
+shed create test --image full
+shed console test        # boots into the overlay-merged rootfs
+shed delete test
+```
+
+If `shed create` succeeds and `shed console` lands you in a shell, the
+upgrade is complete.

--- a/docs/getting-started/fc-setup.md
+++ b/docs/getting-started/fc-setup.md
@@ -1,12 +1,21 @@
 # Firecracker Setup
 
-This guide covers the installation and setup of the Firecracker backend for shed. Firecracker is Linux-only and requires KVM.
+This guide covers the installation and setup of the Firecracker backend
+for shed. Firecracker is Linux-only and requires KVM. The remote-Linux-host
+workflow is the common case: you run `shed` on your laptop and `shed-server`
+on a separate Linux box you SSH into (e.g.,
+`ssh charliek@your.linux.host.example.com`).
 
 ## Prerequisites
 
 - Linux host with KVM support (`/dev/kvm`)
 - Root access (for network and capability setup)
 - Docker CE (for pulling and converting images). Install from [Docker's official repository](https://docs.docker.com/engine/install/ubuntu/), not the `docker.io` package in Ubuntu's default repositories.
+- **For source builds:** Go 1.24+ on the host where you run
+  `scripts/build-firecracker-rootfs.sh` (the script unconditionally
+  builds `shed-agent` and `shed-firstboot` with Go). If you don't want
+  Go on the remote Linux host, cross-compile the binaries on another
+  machine and copy them in, or use the deb package.
 
 ## 1. Install shed
 
@@ -15,7 +24,10 @@ This guide covers the installation and setup of the Firecracker backend for shed
 Download and install the `.deb` from the [latest release](https://github.com/charliek/shed/releases):
 
 ```bash
-VERSION=0.3.3  # replace with desired version
+# Find the latest version at https://github.com/charliek/shed/releases
+# or, with the gh CLI:
+VERSION=$(gh release view --repo charliek/shed --json tagName -q .tagName | sed 's/^v//')
+
 wget https://github.com/charliek/shed/releases/download/v${VERSION}/shed-server_${VERSION}_amd64.deb
 sudo dpkg -i shed-server_${VERSION}_amd64.deb
 ```
@@ -28,13 +40,25 @@ This installs:
 
 ### Build from Source (Alternative)
 
+On the remote Linux host (or wherever you'll run `shed-server`):
+
 ```bash
+ssh charliek@your.linux.host.example.com
 git clone https://github.com/charliek/shed.git
 cd shed
 make build
 ```
 
-If building from source, use `shed-server install` to create the systemd service, or run `shed-server serve` directly.
+When building from source you must also do the steps that
+`shed-server setup` automates for the deb install:
+
+- [Set up the bridge network](#set-up-bridge-network)
+- [Check and join the KVM group](#check-kvm-support)
+- [Set CAP_NET_ADMIN on the binaries](#set-capabilities-alternative-to-running-as-root) (or run as root)
+- Build or pull VM images — see [Set Up Images](#set-up-images)
+
+Use `shed-server install` to create the systemd service, or run
+`./bin/shed-server serve --config <path>` directly.
 
 ## 2. Run Automated Setup
 
@@ -107,13 +131,18 @@ env_file: /root/.shed/env
 #     - docker-credentials
 
 firecracker:
-  base_rootfs: ghcr.io/charliek/shed-fc-full:v{version}
+  base_rootfs: ghcr.io/charliek/shed-fc-full:v0.5.0
   images:
-    base: ghcr.io/charliek/shed-fc-base:v{version}
-    extensions: ghcr.io/charliek/shed-fc-extensions:v{version}
-    full: ghcr.io/charliek/shed-fc-full:v{version}
+    base: ghcr.io/charliek/shed-fc-base:v0.5.0
+    extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.0
+    full: ghcr.io/charliek/shed-fc-full:v0.5.0
   instance_dir: /var/lib/shed/firecracker/instances
   socket_dir: /var/run/shed/firecracker
+  # uppers_dir is optional. Defaults to <images_dir>/uppers. If you set
+  # a non-default instance_dir (e.g. for testing under /tmp), set
+  # uppers_dir to a matching location so per-shed writable layers live
+  # alongside their sheds.
+  # uppers_dir: /var/lib/shed/firecracker/uppers
   default_cpus: 2
   default_memory_mb: 4096
   default_disk_gb: 20
@@ -127,7 +156,15 @@ firecracker:
   tap_prefix: shed-tap
 ```
 
-Replace `{version}` with the version matching your `shed` binary — run `shed version` to check. The deb package generates this config with the correct version automatically.
+Pin a concrete version that matches your `shed-server`. Once the
+`v0.5.0` tag is cut, the v0.5.0-compatible published images become
+available — check
+<https://github.com/charliek/shed/pkgs/container/shed-fc-full> for tags.
+Pre-v0.5.0 published images use the legacy flattened layout and will not
+work with v0.5.0 `shed-server`.
+
+The deb package generates this config with a matching version
+automatically.
 
 ### Private Repo Access
 
@@ -184,8 +221,9 @@ sudo rm -rf /var/lib/shed/firecracker/images/snapshots
 sudo rm -rf /var/lib/shed/firecracker/images/uppers
 sudo rm -rf /var/lib/shed/firecracker/instances
 
-# Install the new release.
-VERSION=0.5.0
+# Install the new release. Pick the latest v0.5.x deb from the releases page
+# (https://github.com/charliek/shed/releases), or with the gh CLI:
+VERSION=$(gh release view --repo charliek/shed --json tagName -q .tagName | sed 's/^v//')
 wget https://github.com/charliek/shed/releases/download/v${VERSION}/shed-server_${VERSION}_amd64.deb
 sudo dpkg -i shed-server_${VERSION}_amd64.deb
 
@@ -193,12 +231,29 @@ sudo systemctl start shed-server
 sudo shed-server pull-images
 ```
 
+See the [Upgrade Guide](../UPGRADE.md) for what's new in v0.5.0,
+what carries over, and recovery scenarios.
+
 Workspace data under `--local-dir` mounts is unaffected. Workspace data
 that lived only inside the deleted upper layers is lost, by design.
 
 ## Manual Setup Reference
 
-The sections below document the individual steps that `shed-server setup` automates. Use these if you need to customize the setup or are building from source without the deb package.
+The sections below document the individual steps that
+`shed-server setup` automates. **If you built from source (no deb), you
+need to walk through these manually** — the deb install path is the
+only one where `sudo shed-server setup` does it all for you.
+
+Source-build users should at minimum do:
+
+1. [Check KVM Support](#check-kvm-support) (add user to `kvm` group)
+2. [Set Up Bridge Network](#set-up-bridge-network) (bridge + NAT + IP
+   forwarding)
+3. [Set Capabilities](#set-capabilities-alternative-to-running-as-root)
+   so `shed-server` can create TAP devices without sudo
+4. [Create Required Directories](#create-required-directories)
+
+Then continue with [Set Up Images](#set-up-images) and the main flow.
 
 ### Check KVM Support
 
@@ -233,21 +288,25 @@ build needed.
 
 ```yaml
 firecracker:
-  base_rootfs: ghcr.io/charliek/shed-fc-full:v{version}
+  base_rootfs: ghcr.io/charliek/shed-fc-full:v0.5.0
   images:
-    base: ghcr.io/charliek/shed-fc-base:v{version}
-    extensions: ghcr.io/charliek/shed-fc-extensions:v{version}
-    full: ghcr.io/charliek/shed-fc-full:v{version}
+    base: ghcr.io/charliek/shed-fc-base:v0.5.0
+    extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.0
+    full: ghcr.io/charliek/shed-fc-full:v0.5.0
   images_dir: /var/lib/shed/firecracker/images
 ```
 
-Replace `{version}` with the version matching your `shed` binary — run `shed version` to check.
+Pin a concrete version. Once `v0.5.0` is tagged the corresponding
+images become available — check
+<https://github.com/charliek/shed/pkgs/container/shed-fc-full> for tags.
 
-See [Image Variants](../reference/images.md) for available images and configuration details.
+See [Image Variants](../reference/images.md) for available images and
+configuration details.
 
 #### Option B: Build from source
 
-Build rootfs images locally. Requires Go 1.24+ for compiling `shed-agent`.
+Build rootfs images locally. Requires Go 1.24+ on the host where the
+script runs (the script compiles `shed-agent` and `shed-firstboot`).
 
 ```bash
 # Build the default variant (full)
@@ -261,7 +320,35 @@ Build rootfs images locally. Requires Go 1.24+ for compiling `shed-agent`.
 ./scripts/build-firecracker-rootfs.sh --all
 ```
 
-This creates ext4 images in `/var/lib/shed/firecracker/images/`.
+The script writes directly into the local blob store at
+`/var/lib/shed/firecracker/images/blobs/` and advances the `base`,
+`extensions`, and `full` tags. Confirm with `shed image ls`.
+
+##### Configure server for local builds
+
+When you build images locally, the source `server.yaml` should **omit**
+`base_rootfs` and the `images:` map entirely. The runtime falls back to
+tag auto-discovery, and you pass the tag explicitly on `shed create`:
+
+```yaml
+firecracker:
+  instance_dir: /var/lib/shed/firecracker/instances
+  socket_dir: /var/run/shed/firecracker
+  images_dir: /var/lib/shed/firecracker/images
+  # no base_rootfs, no images: — tags resolved from the local blob store
+```
+
+Then pass `--image <tag>` on every create:
+
+```bash
+shed create test --image full
+shed create dev  --image base
+```
+
+`base_rootfs` is treated as a literal path when it doesn't look like a
+Docker reference, so the bare tag form (`base_rootfs: full`) does not
+work today. Use either a fully-qualified `ghcr.io/...:vX` ref or omit
+the field and pass `--image`.
 
 ### Set Up Bridge Network
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -11,6 +11,21 @@ Get up and running with Shed in a few minutes.
 
 ## Install
 
+Shed has two install paths:
+
+- **Published packages (Homebrew on macOS, deb on Linux)** are the
+  easiest path. They install pre-built binaries and pull pre-built VM
+  images from `ghcr.io`. Pick this if you want shed running quickly and
+  don't need to modify the rootfs / kernel / initramfs.
+- **Build from source** is for contributors and bleeding-edge use. It
+  builds binaries locally from the repo and (optionally) builds the VM
+  rootfs images from the local `vz/` and `firecracker/` Dockerfiles.
+  Pick this if you're hacking on shed itself or want to run an unreleased
+  commit.
+
+Upgrading from v0.4.x? See the [Upgrade Guide](../UPGRADE.md) — the
+v0.5.0 image store is not backwards-compatible.
+
 ### Homebrew (macOS, Recommended)
 
 ```bash
@@ -39,7 +54,10 @@ See [VZ Setup](vz-setup.md) for the full macOS setup guide.
 Download and install the `.deb` from the [latest release](https://github.com/charliek/shed/releases):
 
 ```bash
-VERSION=0.3.3  # replace with desired version
+# Find the latest version at https://github.com/charliek/shed/releases
+# or, with the gh CLI:
+VERSION=$(gh release view --repo charliek/shed --json tagName -q .tagName | sed 's/^v//')
+
 wget https://github.com/charliek/shed/releases/download/v${VERSION}/shed-server_${VERSION}_amd64.deb
 sudo dpkg -i shed-server_${VERSION}_amd64.deb
 ```
@@ -67,7 +85,15 @@ make build
 go install github.com/charliek/shed/cmd/shed@latest
 ```
 
-See [VZ Setup](vz-setup.md) or [Firecracker Setup](fc-setup.md) for server setup instructions when building from source.
+`make build` produces `bin/shed`, `bin/shed-server`, and `bin/shed-agent`.
+That's only step one of a source install — `shed-server` still needs a
+server config, VM images, and (on Linux) bridge networking before it can
+launch a VM.
+
+Continue with the backend-specific setup guide:
+
+- macOS Apple Silicon: [VZ Setup — Build from Source](vz-setup.md#build-from-source-alternative)
+- Linux with KVM: [Firecracker Setup — Build from Source](fc-setup.md#build-from-source-alternative)
 
 ## Add a Server
 

--- a/docs/getting-started/vz-setup.md
+++ b/docs/getting-started/vz-setup.md
@@ -120,14 +120,19 @@ overlayfs lowers on first boot.
 
 ```yaml
 vz:
-  base_rootfs: ghcr.io/charliek/shed-vz-full:v{version}
+  base_rootfs: ghcr.io/charliek/shed-vz-full:v0.5.0
   images:
-    base: ghcr.io/charliek/shed-vz-base:v{version}
-    extensions: ghcr.io/charliek/shed-vz-extensions:v{version}
-    full: ghcr.io/charliek/shed-vz-full:v{version}
+    base: ghcr.io/charliek/shed-vz-base:v0.5.0
+    extensions: ghcr.io/charliek/shed-vz-extensions:v0.5.0
+    full: ghcr.io/charliek/shed-vz-full:v0.5.0
 ```
 
-Replace `{version}` with the version matching your `shed` binary — run `shed version` to check.
+Pin a concrete version that matches the `shed-server` you built. Once
+the `v0.5.0` tag is cut, the v0.5.0-compatible published images become
+available — check
+<https://github.com/charliek/shed/pkgs/container/shed-vz-full> for tags.
+Pre-v0.5.0 published images use the legacy flattened layout and will not
+work with v0.5.0 `shed-server`.
 
 The first `shed create` pulls each layer blob, materializes the layer
 ext4 cache, and boots. Subsequent variants reuse the shared layers.
@@ -146,10 +151,39 @@ This builds the `full` variant. Build other variants with `--variant`:
 ./scripts/build-vz-rootfs.sh --all                  # All variants
 ```
 
+The script writes directly into the local blob store and advances the
+`base`, `extensions`, and `full` tags. Confirm with `shed image ls`.
+
 See [Image Variants](../reference/images.md) for details. The OCI image
 store lives under `~/Library/Application Support/shed/vz/` — see
 [Storage Model](../reference/storage-model.md) and the
 [upgrade-and-reclaim cookbook](../reference/images.md#cookbook-upgrading-image-versions) for how to manage disk space.
+
+#### Configure server for local builds
+
+When you build images locally, the source `server.yaml` should **omit**
+`base_rootfs` and the `images:` map entirely. The runtime falls back to
+tag auto-discovery, and you pass the tag explicitly on `shed create`:
+
+```yaml
+vz:
+  vfkit_path: vfkit
+  instance_dir: ~/Library/Application Support/shed/vz/instances
+  socket_dir: ~/.shed/vz/sockets
+  # no base_rootfs, no images: — tags resolved from the local blob store
+```
+
+Then pass `--image <tag>` on every create:
+
+```bash
+shed create test --image full
+shed create dev  --image base
+```
+
+`base_rootfs` is treated as a literal path when it doesn't look like a
+Docker reference, so the bare tag form (`base_rootfs: full`) does not
+work today. Use either a fully-qualified `ghcr.io/...:vX` ref or omit
+the field and pass `--image`.
 
 ### 4. Create directories
 
@@ -170,13 +204,17 @@ default_backend: vz
 
 vz:
   vfkit_path: vfkit
-  kernel_path: ~/Library/Application Support/shed/vz/vmlinux
-  initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-  base_rootfs: ghcr.io/charliek/shed-vz-full:v{version}
+  # kernel_path and initrd_path are optional fallbacks for OCI images.
+  # The published / locally-built image blobs include their own kernel
+  # and initramfs via manifest annotations; these fields only apply if
+  # you're booting a legacy raw-rootfs image (rare).
+  # kernel_path: ~/Library/Application Support/shed/vz/vmlinux
+  # initrd_path: ~/Library/Application Support/shed/vz/initrd.img
+  base_rootfs: ghcr.io/charliek/shed-vz-full:v0.5.0
   images:
-    base: ghcr.io/charliek/shed-vz-base:v{version}
-    extensions: ghcr.io/charliek/shed-vz-extensions:v{version}
-    full: ghcr.io/charliek/shed-vz-full:v{version}
+    base: ghcr.io/charliek/shed-vz-base:v0.5.0
+    extensions: ghcr.io/charliek/shed-vz-extensions:v0.5.0
+    full: ghcr.io/charliek/shed-vz-full:v0.5.0
   instance_dir: ~/Library/Application Support/shed/vz/instances
   socket_dir: ~/.shed/vz/sockets
   default_cpus: 2
@@ -207,15 +245,24 @@ codesign --entitlements internal/vz/entitlements.plist -s - ./bin/shed-server
 
 ### 7. Start the server
 
+Pass `--config` explicitly when your config lives outside the current
+working directory. `shed-server` without `--config` only looks at
+`./server.yaml` (CWD), **not** `~/.config/shed/server.yaml`.
+
 ```bash
-./bin/shed-server serve
+./bin/shed-server serve --config ~/.config/shed/server.yaml
 ```
 
 ### 8. Create a test shed
 
+`shed server add` registers the server under the `name:` field from
+`server.yaml`, not literally as `localhost`. Confirm with
+`shed server list` before creating a shed.
+
 ```bash
 shed server add localhost
-shed create test
+shed server list                  # shows the registered name (e.g. "my-mac")
+shed create test --image full     # required when base_rootfs is omitted
 shed console test
 ```
 

--- a/initramfs/init
+++ b/initramfs/init
@@ -186,7 +186,7 @@ done
 mount -t overlay overlay \
     -o "lowerdir=${lower_dirs},upperdir=/upper/data,workdir=/upper/work" \
     /newroot \
-    || panic SHED-INIT-04 "overlay mount failed (kernel module not loaded or lowerdir too long?)"
+    || panic SHED-INIT-04 "overlay mount failed. If this is a freshly-built image, the cached initramfs may be stale: re-run ./scripts/build-{vz,firecracker}-rootfs.sh. See docs/reference/images.md#shed-init-panic-codes."
 
 mkdir -p /newroot/proc /newroot/sys /newroot/dev /newroot/run
 mount --move /proc /newroot/proc

--- a/internal/api/routes_test.go
+++ b/internal/api/routes_test.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/config"
+)
+
+// routesFakeBackend is a no-op stub backend used by routing tests. Each
+// method returns a benign zero value or sentinel error so requests reach
+// the real handlers (and exercise routing) without panicking the way a nil
+// backend would. We don't care which status the handler chooses — the
+// routing tests only assert that dispatch happened (i.e., we never see
+// 405 Method Not Allowed).
+type routesFakeBackend struct{}
+
+func (routesFakeBackend) Type() backend.Type { return backend.TypeVZ }
+func (routesFakeBackend) Close() error       { return nil }
+func (routesFakeBackend) CreateShed(_ context.Context, _ config.CreateShedRequest) (*config.Shed, error) {
+	return nil, config.ErrShedAlreadyExistsSentinel
+}
+func (routesFakeBackend) GetShed(_ context.Context, _ string) (*config.Shed, error) {
+	return nil, config.ErrShedNotFoundSentinel
+}
+func (routesFakeBackend) ListSheds(_ context.Context) ([]config.Shed, error) { return nil, nil }
+func (routesFakeBackend) DeleteShed(_ context.Context, _ string, _ bool) error {
+	return config.ErrShedNotFoundSentinel
+}
+func (routesFakeBackend) StartShed(_ context.Context, _ string) (*config.Shed, error) {
+	return nil, config.ErrShedNotFoundSentinel
+}
+func (routesFakeBackend) StopShed(_ context.Context, _ string) (*config.Shed, error) {
+	return nil, config.ErrShedNotFoundSentinel
+}
+func (routesFakeBackend) ResetShed(_ context.Context, _ string) (*config.Shed, error) {
+	return nil, config.ErrShedNotFoundSentinel
+}
+func (routesFakeBackend) ListSessions(_ context.Context, _ string) ([]config.Session, error) {
+	return nil, nil
+}
+func (routesFakeBackend) KillSession(_ context.Context, _, _ string) error { return nil }
+func (routesFakeBackend) Exec(_ context.Context, _ string, _ backend.ExecOptions) error {
+	return nil
+}
+func (routesFakeBackend) GetNetworkEndpoint(_ context.Context, _ string) (string, error) {
+	return "", config.ErrShedNotFoundSentinel
+}
+func (routesFakeBackend) DialService(_ context.Context, _ string, _ uint16) (net.Conn, error) {
+	return nil, config.ErrShedNotFoundSentinel
+}
+func (routesFakeBackend) ListImages(_ context.Context) ([]config.ImageInfo, error) { return nil, nil }
+func (routesFakeBackend) InspectImage(_ context.Context, _ string) (config.ImageInspectResponse, error) {
+	return config.ImageInspectResponse{}, config.ErrImageNotFoundSentinel
+}
+func (routesFakeBackend) TagImage(_ context.Context, _, _ string) error               { return nil }
+func (routesFakeBackend) PullImage(_ context.Context, _, _, _ string) (string, error) { return "", nil }
+func (routesFakeBackend) PushImage(_ context.Context, _, _ string) error              { return nil }
+func (routesFakeBackend) DeleteImage(_ context.Context, _ string) error               { return nil }
+func (routesFakeBackend) PruneImages(_ context.Context, _ bool) ([]config.ImageInfo, error) {
+	return nil, nil
+}
+func (routesFakeBackend) DiskUsage(_ context.Context) (config.DiskUsage, error) {
+	return config.DiskUsage{}, nil
+}
+func (routesFakeBackend) Prune(_ context.Context, _ backend.PruneOptions) (config.PruneReport, error) {
+	return config.PruneReport{}, nil
+}
+func (routesFakeBackend) ListSnapshots(_ context.Context) ([]config.Snapshot, error) { return nil, nil }
+func (routesFakeBackend) CreateSnapshot(_ context.Context, _ config.SnapshotCreateRequest) (*config.Snapshot, error) {
+	return nil, config.ErrInvalidShedRequestSentinel
+}
+func (routesFakeBackend) GetSnapshot(_ context.Context, _ string) (*config.Snapshot, error) {
+	return nil, config.ErrShedNotFoundSentinel
+}
+func (routesFakeBackend) DeleteSnapshot(_ context.Context, _ string) error { return nil }
+
+func newRoutesTestServer() *Server {
+	return NewServer(routesFakeBackend{}, &config.ServerConfig{
+		Name:     "test-server",
+		HTTPPort: 8080,
+	}, "", nil, nil)
+}
+
+// TestRouteImagesNo405 is a regression test for a chi trie precedence bug
+// where r.Delete("/{name}", ...) registered as a sibling of literal POST
+// routes (e.g. /pull, /push, /prune, /tag) would shadow them, causing
+// requests like `POST /api/images/pull` to return 405 Method Not Allowed
+// with `Allow: DELETE` instead of dispatching to the literal handler.
+//
+// We don't care about handler behavior here — bodies are intentionally
+// empty/minimal. The bar is: routing reaches a handler (any status other
+// than 405), and we never see Allow: DELETE on a POST route.
+func TestRouteImagesNo405(t *testing.T) {
+	srv := newRoutesTestServer()
+	router := srv.Router()
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"post pull", http.MethodPost, "/api/images/pull"},
+		{"post push", http.MethodPost, "/api/images/push"},
+		{"post prune", http.MethodPost, "/api/images/prune"},
+		{"post tag", http.MethodPost, "/api/images/tag"},
+		{"get inspect", http.MethodGet, "/api/images/inspect/some-tag"},
+		{"delete by name", http.MethodDelete, "/api/images/some-tag"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(tt.method, tt.path, strings.NewReader(""))
+			r.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, r)
+
+			if w.Code == http.StatusMethodNotAllowed {
+				t.Fatalf("%s %s returned 405 Method Not Allowed (Allow: %q) — routing bug, expected dispatch to a handler",
+					tt.method, tt.path, w.Header().Get("Allow"))
+			}
+			// Belt-and-suspenders: even if some future change started
+			// returning 405 with a different Allow header, we shouldn't see
+			// Allow: DELETE on a POST route.
+			if tt.method == http.MethodPost {
+				if allow := w.Header().Get("Allow"); strings.Contains(allow, "DELETE") {
+					t.Errorf("%s %s response has Allow header containing DELETE (%q) — sibling DELETE route is shadowing this POST",
+						tt.method, tt.path, allow)
+				}
+			}
+		})
+	}
+}
+
+// TestRouteSnapshotsNo405 mirrors the /images regression test for
+// /api/snapshots. Currently there are no literal sibling collisions, but
+// the parametric /{name} route is wrapped defensively as drift insurance.
+func TestRouteSnapshotsNo405(t *testing.T) {
+	srv := newRoutesTestServer()
+	router := srv.Router()
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"get list", http.MethodGet, "/api/snapshots/"},
+		{"get by name", http.MethodGet, "/api/snapshots/some-snap"},
+		{"delete by name", http.MethodDelete, "/api/snapshots/some-snap"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(tt.method, tt.path, strings.NewReader(""))
+			r.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, r)
+
+			if w.Code == http.StatusMethodNotAllowed {
+				t.Fatalf("%s %s returned 405 Method Not Allowed (Allow: %q) — routing bug, expected dispatch to a handler",
+					tt.method, tt.path, w.Header().Get("Allow"))
+			}
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -57,7 +57,13 @@ func (s *Server) Router() chi.Router {
 			r.Post("/pull", s.handlePullImage)
 			r.Post("/push", s.handlePushImage)
 			r.Get("/inspect/{name}", s.handleInspectImage)
-			r.Delete("/{name}", s.handleDeleteImage)
+			// Wrap parametric /{name} in a sub-router so it doesn't shadow
+			// literal sibling routes like /pull, /push, /prune, /tag at the
+			// chi trie level (which would return 405 Method Not Allowed
+			// instead of dispatching to the literal POST handler).
+			r.Route("/{name}", func(r chi.Router) {
+				r.Delete("/", s.handleDeleteImage)
+			})
 		})
 
 		// System (disk reporting + prune)
@@ -78,8 +84,12 @@ func (s *Server) Router() chi.Router {
 		r.Route("/snapshots", func(r chi.Router) {
 			r.Get("/", s.handleListSnapshots)
 			r.Post("/", s.handleCreateSnapshot)
-			r.Get("/{name}", s.handleGetSnapshot)
-			r.Delete("/{name}", s.handleDeleteSnapshot)
+			// Same defensive wrap as /images — drift insurance if we ever
+			// add literal sibling routes (e.g. /snapshots/prune).
+			r.Route("/{name}", func(r chi.Router) {
+				r.Get("/", s.handleGetSnapshot)
+				r.Delete("/", s.handleDeleteSnapshot)
+			})
 		})
 
 		// Sheds

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -538,10 +539,17 @@ func resolveImage(images map[string]string, imagesDir, image, configKey string) 
 			// ResolveTag returns the digest too — carry it through
 			// so EnsureImage doesn't have to re-do tag lookup
 			// (which races against concurrent `shed image pull`).
-			if digest, cached, err := vmimage.ResolveTag(imagesDir, image); err == nil {
-				if manifest, mErr := vmimage.LoadManifestByDigest(imagesDir, digest); mErr == nil && manifest.ShedSourceRef() == val {
+			digest, cached, err := vmimage.ResolveTag(imagesDir, image)
+			if err == nil {
+				manifest, mErr := vmimage.LoadManifestByDigest(imagesDir, digest)
+				if mErr != nil && errors.Is(mErr, vmimage.ErrLegacyBundledBlob) {
+					return ResolvedImage{}, mErr
+				}
+				if mErr == nil && manifest.ShedSourceRef() == val {
 					return ResolvedImage{Path: cached, Name: image, Digest: digest}, nil
 				}
+			} else if errors.Is(err, vmimage.ErrLegacyBundledBlob) {
+				return ResolvedImage{}, err
 			}
 			return ResolvedImage{DockerRef: val, Name: image}, nil
 		}
@@ -550,8 +558,12 @@ func resolveImage(images map[string]string, imagesDir, image, configKey string) 
 
 	// Auto-discover by tag in the blob store.
 	if imagesDir != "" {
-		if digest, discovered, err := vmimage.ResolveTag(imagesDir, image); err == nil {
+		digest, discovered, err := vmimage.ResolveTag(imagesDir, image)
+		if err == nil {
 			return ResolvedImage{Path: discovered, Name: image, Digest: digest}, nil
+		}
+		if errors.Is(err, vmimage.ErrLegacyBundledBlob) {
+			return ResolvedImage{}, err
 		}
 	}
 

--- a/internal/vmimage/blobstore.go
+++ b/internal/vmimage/blobstore.go
@@ -59,6 +59,14 @@ var (
 
 	// ErrInvalidTag is returned when a tag name is unsafe.
 	ErrInvalidTag = errors.New("invalid tag name")
+
+	// ErrLegacyBundledBlob is returned when a blob path is occupied by a
+	// v0.4.x bundled directory layout (a directory holding manifest.json,
+	// kernel, initrd, rootfs.ext4) instead of the v0.5.0+ flat-file OCI
+	// blob. The caller should surface the wrapped message so the user
+	// knows to wipe the legacy store. See ocilayout.go ReadBlob for the
+	// detection step.
+	ErrLegacyBundledBlob = errors.New("legacy v0.4.x bundled blob layout")
 )
 
 // BlobsRoot returns {imagesDir}/blobs.

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -411,7 +411,11 @@ func (m *Manager) ListImages() ([]ImageInfo, error) {
 		}
 		m, err := LoadManifestByDigest(imagesDir, t.Digest)
 		if err != nil {
-			log.Printf("Warning: tag %q points at unreadable manifest %s: %v", tag, t.Digest, err)
+			if errors.Is(err, ErrLegacyBundledBlob) {
+				log.Printf("Warning: tag %q references legacy bundled blob: %v", tag, err)
+			} else {
+				log.Printf("Warning: tag %q points at unreadable manifest %s: %v", tag, t.Digest, err)
+			}
 			manifests = append(manifests, manifestInfo{digest: t.Digest, tag: tag})
 			continue
 		}
@@ -435,7 +439,11 @@ func (m *Manager) ListImages() ([]ImageInfo, error) {
 		}
 		mf, err := LoadManifestByDigest(imagesDir, digest)
 		if err != nil {
-			log.Printf("Warning: index entry %s unreadable: %v", digest, err)
+			if errors.Is(err, ErrLegacyBundledBlob) {
+				log.Printf("Warning: index entry %s references legacy bundled blob: %v", digest, err)
+			} else {
+				log.Printf("Warning: index entry %s unreadable: %v", digest, err)
+			}
 			continue
 		}
 		manifests = append(manifests, manifestInfo{digest: digest, manifest: mf})

--- a/internal/vmimage/ocilayout.go
+++ b/internal/vmimage/ocilayout.go
@@ -238,6 +238,26 @@ func WriteBlobFromFile(imagesDir, srcPath string, consume bool) (digest, blobPat
 	return digest, final, nil
 }
 
+// detectLegacyBundledBlob returns a wrapped ErrLegacyBundledBlob if
+// path is a directory containing the v0.4.x bundled layout
+// (manifest.json sibling of kernel/initrd/rootfs.ext4). Returns nil
+// otherwise so the caller can surface the original error.
+func detectLegacyBundledBlob(path string) error {
+	fi, err := os.Stat(path)
+	if err != nil || !fi.IsDir() {
+		return nil
+	}
+	if _, err := os.Stat(filepath.Join(path, "manifest.json")); err != nil {
+		return nil
+	}
+	return fmt.Errorf("%w: blob at %s is a v0.4.x bundled directory layout. "+
+		"This format is no longer supported. See "+
+		"https://github.com/charliek/shed/blob/main/docs/UPGRADE.md or "+
+		"docs/getting-started/{fc,vz}-setup.md#upgrading-from-v04x for the "+
+		"migration steps (stop server, wipe legacy store, re-pull or rebuild)",
+		ErrLegacyBundledBlob, path)
+}
+
 // ReadBlob reads a blob's bytes. Returns ErrBlobNotFound if missing.
 func ReadBlob(imagesDir, digest string) ([]byte, error) {
 	path, err := BlobPath(imagesDir, digest)
@@ -249,6 +269,9 @@ func ReadBlob(imagesDir, digest string) ([]byte, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("%w: %s", ErrBlobNotFound, digest)
 		}
+		if legacyErr := detectLegacyBundledBlob(path); legacyErr != nil {
+			return nil, legacyErr
+		}
 		return nil, fmt.Errorf("reading blob %s: %w", digest, err)
 	}
 	return data, nil
@@ -259,6 +282,12 @@ func OpenBlob(imagesDir, digest string) (*os.File, error) {
 	path, err := BlobPath(imagesDir, digest)
 	if err != nil {
 		return nil, err
+	}
+	// os.Open succeeds on directories on Linux/macOS, so a v0.4.x
+	// bundled-directory blob would otherwise return a usable but
+	// useless *os.File. Probe with Stat first.
+	if legacyErr := detectLegacyBundledBlob(path); legacyErr != nil {
+		return nil, legacyErr
 	}
 	f, err := os.Open(path)
 	if err != nil {

--- a/internal/vmimage/ocilayout_test.go
+++ b/internal/vmimage/ocilayout_test.go
@@ -2,8 +2,10 @@ package vmimage
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -121,5 +123,83 @@ func TestSyntheticImageInstall(t *testing.T) {
 	}
 	if len(manifest.Layers) != 1 {
 		t.Fatalf("expected one layer, got %d", len(manifest.Layers))
+	}
+}
+
+// TestReadBlobDetectsLegacyBundledDirectory exercises the v0.4.x → v0.5.0
+// upgrade path: a blob slot is a directory (containing manifest.json /
+// kernel / initrd / rootfs.ext4) instead of the flat OCI blob file. The
+// reader must return a typed sentinel error so the CLI can point at the
+// migration docs instead of the misleading "unreadable manifest …: is a
+// directory" + "unknown image" fallback.
+func TestReadBlobDetectsLegacyBundledDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := EnsureOCILayout(dir); err != nil {
+		t.Fatalf("EnsureOCILayout: %v", err)
+	}
+	hex := strings.Repeat("a", 64)
+	digest := DigestPrefix + hex
+	bundle := filepath.Join(dir, blobsDir, algorithmDir, hex)
+	if err := os.MkdirAll(bundle, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	for _, name := range []string{"manifest.json", "kernel", "initrd", "rootfs.ext4"} {
+		if err := os.WriteFile(filepath.Join(bundle, name), []byte("legacy"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	_, err := ReadBlob(dir, digest)
+	if err == nil {
+		t.Fatalf("expected error from ReadBlob on bundled directory, got nil")
+	}
+	if !errors.Is(err, ErrLegacyBundledBlob) {
+		t.Fatalf("expected ErrLegacyBundledBlob, got %v", err)
+	}
+	for _, want := range []string{
+		"v0.4.x bundled directory layout",
+		"docs/UPGRADE.md",
+		"wipe legacy store",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing expected substring %q", err.Error(), want)
+		}
+	}
+
+	// LoadManifestByDigest goes through ReadBlob and should surface the
+	// same sentinel so manager / config callers can branch on it.
+	if _, mErr := LoadManifestByDigest(dir, digest); !errors.Is(mErr, ErrLegacyBundledBlob) {
+		t.Fatalf("LoadManifestByDigest: expected ErrLegacyBundledBlob, got %v", mErr)
+	}
+
+	// OpenBlob takes a different code path; verify it too.
+	if _, oErr := OpenBlob(dir, digest); !errors.Is(oErr, ErrLegacyBundledBlob) {
+		t.Fatalf("OpenBlob: expected ErrLegacyBundledBlob, got %v", oErr)
+	}
+}
+
+// TestDetectLegacyBundledBlobNonDirectory confirms we don't accidentally
+// flag a real blob file or a missing path as legacy.
+func TestDetectLegacyBundledBlobNonDirectory(t *testing.T) {
+	dir := t.TempDir()
+	// Missing path: not legacy.
+	if err := detectLegacyBundledBlob(filepath.Join(dir, "absent")); err != nil {
+		t.Fatalf("missing path flagged as legacy: %v", err)
+	}
+	// Regular file: not legacy.
+	regular := filepath.Join(dir, "blob")
+	if err := os.WriteFile(regular, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write regular: %v", err)
+	}
+	if err := detectLegacyBundledBlob(regular); err != nil {
+		t.Fatalf("regular file flagged as legacy: %v", err)
+	}
+	// Directory without manifest.json: not legacy.
+	emptyDir := filepath.Join(dir, "empty-dir")
+	if err := os.MkdirAll(emptyDir, 0o755); err != nil {
+		t.Fatalf("mkdir empty: %v", err)
+	}
+	if err := detectLegacyBundledBlob(emptyDir); err != nil {
+		t.Fatalf("empty dir flagged as legacy: %v", err)
 	}
 }

--- a/internal/vmimage/registry.go
+++ b/internal/vmimage/registry.go
@@ -359,7 +359,7 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		return nil, fmt.Errorf("listing layers: %w", err)
 	}
 	if len(layers) > MaxLayers {
-		return nil, fmt.Errorf("image has %d layers (max %d); rebuild flatter or raise MaxLayers", len(layers), MaxLayers)
+		return nil, fmt.Errorf("image has %d layers (max %d). This image was probably built with the pre-v0.5.0 build pipeline. Pull a v0.5.0 or later tag from ghcr.io, or build locally with the consolidated Dockerfile under {vz,firecracker}/Dockerfile", len(layers), MaxLayers)
 	}
 
 	layerDigests := make([]string, 0, len(layers))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - Quick Start: getting-started/quick-start.md
       - VZ Setup (macOS): getting-started/vz-setup.md
       - Firecracker Setup: getting-started/fc-setup.md
+      - Upgrade Guide: UPGRADE.md
   - Tutorials:
       - Build Your Own Image: tutorials/build-your-own-image.md
   - Reference:


### PR DESCRIPTION
## Summary

- Fix a real chi router precedence bug (`POST /api/images/pull` was returning 405 because the parametric `/{name}` DELETE route shadowed it). Same pattern that already works for `/api/sheds`.
- Detect the v0.4.x legacy bundled-blob layout (`blobs/sha256/<digest>/manifest.json`) and surface an actionable upgrade hint instead of `tag X points at unreadable manifest …: is a directory` plus the misleading "unknown image" contradiction.
- Better wording on the `image has N layers (max 16)` rejection and on the in-guest `SHED-INIT-04` panic — both now point at the relevant docs.
- New top-level `docs/UPGRADE.md` consolidating the v0.4.x → v0.5.0 migration story, plus targeted fixes to `quick-start.md`, `vz-setup.md`, `fc-setup.md` so a fresh agent / new contributor can actually reach `shed create … --image full` end-to-end by following only the published docs.

Backstory: while attempting to validate the in-flight `shed exec` quoting fix (issues #44/#48) on a fresh Mac VZ and a fresh remote Linux Firecracker host, blockers from the underlying environment masked the exec fix. Walked through both setup guides as if I'd never seen the repo before; everything below is what surfaced. The exec PR stays separate and will rebase on top.

## Phase 0 walkthrough — what came back

| Path | Gap |
|---|---|
| `quick-start.md` source-build path | dead-ends at `make build` with no pointer into the backend setup guides |
| `vz-setup.md` "Build from Source" | no working server.yaml example for **local** image tags; `base_rootfs: <tag>` is silently treated as a docker pull |
| `vz-setup.md` start-server step | `./bin/shed-server serve` (no `--config`) reads `./server.yaml` from CWD, not `~/.config/shed/server.yaml` |
| `vz-setup.md` + `fc-setup.md` published-images config | `v{version}` placeholder unresolvable (`shed version` outputs `shed dev`) |
| `vz-setup.md` config example | `kernel_path` / `initrd_path` shown as required when they're optional (kernel + initrd come from manifest annotations) |
| `fc-setup.md` Build-from-source path | `scripts/build-firecracker-rootfs.sh` unconditionally calls `go build`, blocking users on hosts without Go (also no `--skip-go-build` flag) |
| `fc-setup.md` Manual Setup Reference | bridge / KVM group / setcap buried below the main flow; source-build / cross-compile users can't follow the main flow successfully without these |
| Both setup guides | `uppers_dir` defaults to `<images_dir>/uppers` but isn't documented; if a user sets a non-default `instance_dir` they likely need `uppers_dir` too |
| Both setup guides | `shed server add localhost` registers the server under whatever `name:` the server reports, not literally "localhost" — subsequent `shed -s localhost …` commands fail |

These doc gaps are addressed in this PR; the underlying script ergonomics (e.g. `build-firecracker-rootfs.sh` requiring Go) stay flagged for follow-up if they become recurring support questions.

## What's in this PR

- `internal/api/server.go` + `internal/api/routes_test.go` — chi sub-router wrap on `/images/{name}` + defensive wrap on `/snapshots/{name}` + regression test.
- `internal/vmimage/blobstore.go` + `…/ocilayout.go` + `…/manager.go` + `internal/config/server.go` — `ErrLegacyBundledBlob` sentinel, wired so it surfaces in `shed image ls` and short-circuits `shed create`'s unknown-image fallback.
- `internal/vmimage/registry.go` — `>MaxLayers` rejection wording.
- `initramfs/init` — SHED-INIT-04 panic cross-reference.
- `docs/UPGRADE.md` (new) + `mkdocs.yml` + `docs/getting-started/{quick-start,vz-setup,fc-setup}.md` — doc updates.
- `CHANGELOG.md` — Release-readiness fixes section.

## Test plan

- [x] `go test ./...` green
- [x] `make lint` clean (0 issues)
- [x] `mkdocs build --strict` clean (no broken links)
- [x] Mac VZ walkthrough: from clean state, `make build` → `./scripts/build-vz-rootfs.sh --all` → start server with `--config ~/.config/shed/server.yaml` → `shed create devbox --image full` → `shed exec devbox -- uname -a` returns the expected kernel string
- [x] Linux FC walkthrough on a remote host with a parallel namespace (test bridge `shed-br1`, ports 18080/12222) reached `shed create` / `shed exec` end-to-end; production state untouched
- [ ] After this lands: cut `v0.5.0` so `publish-images.yaml` ships images that don't trip the `>MaxLayers` cap on registry pulls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive upgrade guide for v0.5.0 with migration paths and recovery scenarios.

* **Bug Fixes**
  * Fixed routing issue causing 405 errors on image operations.
  * Improved error messages for legacy image format detection with upgrade guidance.
  * Enhanced layer-limit rejection messages with recovery instructions.

* **Documentation**
  * Updated all setup guides to reflect v0.5.0 image-store changes and CLI updates.
  * Clarified installation methods and version pinning across platforms.

* **Tests**
  * Added routing regression tests to prevent HTTP method handling issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->