### PR TITLE
shed image build: pick platform from --target prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Release-readiness fixes
 
+- **`shed image build` picks the right `--platform` for the target backend.**
+  Previously the CLI inferred the platform purely from `runtime.GOOS`, so
+  invoking `shed image build --target shed-vz-*` from a Linux runner (e.g.,
+  the `ubuntu-24.04-arm` GitHub Actions runner used by the publish workflow)
+  silently flipped to `linux/amd64`, which then crashed the per-layer ext4
+  materialization step with `exec format error`. The CLI now inspects
+  `--target shed-vz-*` / `shed-fc-*` and picks `linux/arm64` / `linux/amd64`
+  accordingly; an explicit `--platform <plat>` flag is available as an
+  override.
 - **`POST /api/images/pull` no longer 405s.** A chi router precedence
   bug routed `POST /api/images/pull` to the parametric
   `DELETE /api/images/{name}` handler, returning `405 Method Not Allowed,

--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -28,6 +28,7 @@ var (
 	imageBuildTarget    string
 	imageBuildSize      string
 	imageBuildOutputDir string
+	imageBuildPlatform  string
 	imageBuildForce     bool
 
 	imageDeleteForce bool
@@ -140,6 +141,7 @@ func init() {
 	imageBuildCmd.Flags().StringVar(&imageBuildTarget, "target", "", "Docker build target stage (Dockerfile mode only)")
 	imageBuildCmd.Flags().StringVar(&imageBuildSize, "size", "20G", "Rootfs image size")
 	imageBuildCmd.Flags().StringVar(&imageBuildOutputDir, "output-dir", "", "Output directory (auto-detected based on backend)")
+	imageBuildCmd.Flags().StringVar(&imageBuildPlatform, "platform", "", "Target docker platform (linux/arm64 or linux/amd64). Default: linux/arm64 for shed-vz-* targets, linux/amd64 for shed-fc-* targets, else host arch.")
 	imageBuildCmd.Flags().BoolVar(&imageBuildForce, "force", false, "Skip base image validation warning")
 	_ = imageBuildCmd.MarkFlagRequired("name")
 
@@ -195,12 +197,31 @@ func imageBackendContext() buildContext {
 func runImageBuild(cmd *cobra.Command, args []string) error {
 	bc := imageBackendContext()
 
+	// Platform resolution order:
+	//   1. --platform CLI flag (explicit override; used by CI publish workflow
+	//      where the runner arch doesn't match the target backend).
+	//   2. --target prefix (shed-vz-* → linux/arm64, shed-fc-* → linux/amd64).
+	//      Picked before the host-OS fallback so a cross-build (e.g., building
+	//      a VZ variant from a Linux runner) does not silently flip platforms.
+	//   3. Host OS default from imageBackendContext().
+	platform := imageBuildPlatform
+	if platform == "" {
+		switch {
+		case strings.HasPrefix(imageBuildTarget, "shed-vz-"):
+			platform = vmimage.DefaultPlatform
+		case strings.HasPrefix(imageBuildTarget, "shed-fc-"):
+			platform = vmimage.FirecrackerPlatform
+		default:
+			platform = bc.Platform
+		}
+	}
+
 	outputDir := imageBuildOutputDir
 	if outputDir == "" {
 		outputDir = bc.OutputDir
 	}
 
-	return runImageBuildFromDockerfile(cmd.Context(), args, outputDir, bc.Prefix, bc.Platform, bc.ExtractKernel, bc.NeedsInitrd)
+	return runImageBuildFromDockerfile(cmd.Context(), args, outputDir, bc.Prefix, platform, bc.ExtractKernel, bc.NeedsInitrd)
 }
 
 func runImageBuildFromDockerfile(ctx context.Context, args []string, outputDir, prefix, platform string, extractKernel, needsInitrd bool) error {


### PR DESCRIPTION
## Summary

publish-images.yaml's VZ job was failing during v0.5.0 with `exec format error` because `shed image build` inferred platform from `runtime.GOOS` rather than the target backend. On the `ubuntu-24.04-arm` runner that meant Linux → FC → linux/amd64, and the subsequent ext4 materialization step did `docker run --platform linux/amd64 ubuntu:24.04` on the arm64 host.

Fix: deduce platform from `--target shed-vz-*` / `shed-fc-*` before falling back to host. Add `--platform <plat>` as an explicit override.

## Why this surfaced now

PR #91 just shipped the per-layer ext4 materialization at build time; the v0.4.x flat-blob path didn't have this hot spot. v0.5.0 was cut, FC published cleanly (matching runner arch), VZ failed at the very last conversion step.

## Test plan

- [x] `make build` clean
- [x] `make lint` clean (0 issues)
- [x] `go test ./cmd/shed/...` green
- [ ] After merge: re-cut `v0.5.0` (the previous tag/release was deleted since it was minutes old and untouched) — publish workflow re-runs, VZ side completes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `shed image build` platform selection to intelligently detect based on target naming convention rather than just the host OS, eliminating `exec format error` failures on mismatched-architecture CI runners.

* **New Features**
  * Added explicit `--platform` flag to `shed image build` command for manual override of automatic platform detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->