### PR TITLE
Fix image build prefix + add --source-ref flag

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -88,12 +88,23 @@ jobs:
         run: |
           # Local OCI store; shed image build writes here, shed image
           # push streams from here to ghcr.io.
+          #
+          # --platform is set explicitly (belt-and-suspenders): even if
+          # CLI inference regresses, the runner is arm64 and these
+          # images must boot on Apple Silicon.
+          #
+          # --source-ref pins the manifest's io.shed.source-ref
+          # annotation to the registry ref we're about to push to, so
+          # the remote server's resolveImage cache-hit check matches
+          # on subsequent `shed create` pulls.
           mkdir -p /tmp/oci-store-vz
           for variant in base extensions full; do
             echo "=== building shed-vz-${variant} ==="
             ./bin/shed image build \
               --target "shed-vz-${variant}" \
               -n "${variant}" \
+              --platform linux/arm64 \
+              --source-ref "ghcr.io/charliek/shed-vz-${variant}:${{ steps.version.outputs.tag }}" \
               --initramfs /tmp/shed-initrd-vz.img \
               --output-dir /tmp/oci-store-vz \
               -f vz/Dockerfile \
@@ -195,12 +206,15 @@ jobs:
 
       - name: Build OCI images (base, extensions, full)
         run: |
+          # See VZ job for rationale on --platform and --source-ref.
           mkdir -p /tmp/oci-store-fc
           for variant in base extensions full; do
             echo "=== building shed-fc-${variant} ==="
             ./bin/shed image build \
               --target "shed-fc-${variant}" \
               -n "${variant}" \
+              --platform linux/amd64 \
+              --source-ref "ghcr.io/charliek/shed-fc-${variant}:${{ steps.version.outputs.tag }}" \
               --initramfs /tmp/shed-initrd-fc.img \
               --output-dir /tmp/oci-store-fc \
               -f firecracker/Dockerfile \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ All notable changes to this project will be documented in this file.
   `config.LoadServerConfigForCLI` + `ServerConfig.ValidateNoHostCoupling`
   for the image-only flows that never start a VM. Callers that *do* start
   a VM (shed-server serve) still use the strict path.
+- **`shed image build` picks the right tag prefix AND `io.shed.source-ref`
+  for cross-builds.** The PR #92 fix corrected `--platform` for
+  `--target shed-vz-*` invocations from a Linux runner, but the tag
+  prefix (`shed-fc-` vs `shed-vz-`), kernel-extraction flag, and initrd
+  flag were still derived from `runtime.GOOS` — so a Linux-built
+  `shed-vz-full` image landed on disk tagged `shed-fc-full:latest` and
+  its manifest's `io.shed.source-ref` annotation lied accordingly. The
+  per-target table is now centralized and driven off `--target`
+  uniformly. Added `--source-ref <ref>` so CI publish workflows can pin
+  the annotation to the final `ghcr.io/charliek/shed-*-*:<version>` ref
+  the image will be pushed to; without this, the server's
+  `resolveImage` cache-hit check (which compares the manifest annotation
+  against the configured `ref:`) missed on every subsequent `shed create`
+  and forced a re-pull.
 - **`shed image build` picks the right `--platform` for the target backend.**
   Previously the CLI inferred the platform purely from `runtime.GOOS`, so
   invoking `shed image build --target shed-vz-*` from a Linux runner (e.g.,

--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -29,6 +29,7 @@ var (
 	imageBuildSize      string
 	imageBuildOutputDir string
 	imageBuildPlatform  string
+	imageBuildSourceRef string
 	imageBuildForce     bool
 
 	imageDeleteForce bool
@@ -142,6 +143,15 @@ func init() {
 	imageBuildCmd.Flags().StringVar(&imageBuildSize, "size", "20G", "Rootfs image size")
 	imageBuildCmd.Flags().StringVar(&imageBuildOutputDir, "output-dir", "", "Output directory (auto-detected based on backend)")
 	imageBuildCmd.Flags().StringVar(&imageBuildPlatform, "platform", "", "Target docker platform (linux/arm64 or linux/amd64). Default: linux/arm64 for shed-vz-* targets, linux/amd64 for shed-fc-* targets, else host arch.")
+	// --source-ref controls the `io.shed.source-ref` manifest annotation
+	// that the server's resolveImage cache lookup compares against. CI
+	// publish workflows should pass the final registry ref here (e.g.,
+	// `ghcr.io/charliek/shed-vz-full:v0.5.0`) so subsequent `shed create`
+	// pulls on a remote host hit the cache instead of re-pulling. When
+	// empty, defaults to the local buildx tag (`<prefix><name>:latest`),
+	// which is fine for purely-local builds but does NOT match the
+	// registry ref the image is later pushed to.
+	imageBuildCmd.Flags().StringVar(&imageBuildSourceRef, "source-ref", "", "Override the io.shed.source-ref annotation baked into the manifest (default: <prefix><name>:latest). Pass the final registry ref in CI publish flows so server-side cache lookups match.")
 	imageBuildCmd.Flags().BoolVar(&imageBuildForce, "force", false, "Skip base image validation warning")
 	_ = imageBuildCmd.MarkFlagRequired("name")
 
@@ -164,6 +174,19 @@ func init() {
 }
 
 // buildContext holds backend-specific settings for image building.
+//
+// All four behavior-shaping fields (Prefix, Platform, ExtractKernel,
+// NeedsInitrd) MUST stay in lockstep with each other: VZ is arm64 +
+// needs-initrd, FC is amd64 + no-initrd. Splitting their resolution
+// (one source for Prefix, another for Platform) is what caused the
+// pre-PR #92/#94 bugs where a Linux-runner cross-build of `shed-vz-*`
+// got the right --platform but the wrong `shed-fc-` prefix in the
+// manifest's source-ref annotation. Keep the per-target table here
+// as the single source of truth.
+//
+// OutputDir is the one field that legitimately follows the host OS:
+// it's the on-disk path of the local OCI store, and the user's
+// explicit --output-dir always wins anyway.
 type buildContext struct {
 	Prefix        string // Docker tag prefix ("shed-vz-" or "shed-fc-")
 	Platform      string // Docker platform ("linux/arm64" or "linux/amd64")
@@ -172,48 +195,88 @@ type buildContext struct {
 	NeedsInitrd   bool   // Whether to extract initrd (VZ only)
 }
 
-// imageBackendContext returns build settings for the current host OS.
-// shed image build is a host-local operation — the platform is determined
-// by the host, not by server backend selection.
-func imageBackendContext() buildContext {
-	if runtime.GOOS == "linux" {
-		return buildContext{
-			Prefix:        "shed-fc-",
-			Platform:      vmimage.FirecrackerPlatform,
-			OutputDir:     config.DefaultFirecrackerImagesDir,
-			ExtractKernel: true,
-			NeedsInitrd:   false,
-		}
-	}
+// vzBuildContext returns the VZ-shaped per-target settings. OutputDir is
+// filled in by the caller (it follows host OS, not target).
+func vzBuildContext() buildContext {
 	return buildContext{
 		Prefix:        "shed-vz-",
 		Platform:      vmimage.DefaultPlatform,
-		OutputDir:     config.ExpandPath(config.DefaultVZImagesDir),
 		ExtractKernel: true,
 		NeedsInitrd:   true,
 	}
 }
 
-func runImageBuild(cmd *cobra.Command, args []string) error {
-	bc := imageBackendContext()
+// fcBuildContext returns the Firecracker-shaped per-target settings.
+// OutputDir is filled in by the caller (it follows host OS, not target).
+func fcBuildContext() buildContext {
+	return buildContext{
+		Prefix:        "shed-fc-",
+		Platform:      vmimage.FirecrackerPlatform,
+		ExtractKernel: true,
+		NeedsInitrd:   false,
+	}
+}
 
-	// Platform resolution order:
-	//   1. --platform CLI flag (explicit override; used by CI publish workflow
-	//      where the runner arch doesn't match the target backend).
-	//   2. --target prefix (shed-vz-* → linux/arm64, shed-fc-* → linux/amd64).
-	//      Picked before the host-OS fallback so a cross-build (e.g., building
-	//      a VZ variant from a Linux runner) does not silently flip platforms.
-	//   3. Host OS default from imageBackendContext().
+// hostDefaultOutputDir returns the local-OCI-store path appropriate for
+// goos. Extracted as a helper so imageBackendContext stays unit-testable
+// without mocking runtime.GOOS.
+func hostDefaultOutputDir(goos string) string {
+	if goos == "linux" {
+		return config.DefaultFirecrackerImagesDir
+	}
+	return config.ExpandPath(config.DefaultVZImagesDir)
+}
+
+// imageBackendContext returns build settings for the requested target.
+//
+// Resolution order:
+//  1. If target has a `shed-vz-` / `shed-fc-` prefix, return that
+//     backend's context. This covers the CI cross-build case (e.g.,
+//     building shed-vz-* from a Linux runner) where the host OS and
+//     the target backend disagree — without this fork, every
+//     non-OutputDir field would silently flip to the host's default.
+//  2. Otherwise fall back to the host OS default (vz on macOS, fc on
+//     linux). This is the day-to-day local-developer case where
+//     `shed image build -n myimg` should infer the backend from the
+//     machine running the build.
+//
+// OutputDir always follows the host OS: it's the location of the
+// on-disk OCI store, which has nothing to do with the image's target
+// architecture. Callers may override with --output-dir.
+func imageBackendContext(target string) buildContext {
+	return imageBackendContextForHost(target, runtime.GOOS)
+}
+
+// imageBackendContextForHost is the unit-testable inner of
+// imageBackendContext. goos is the host operating system identifier
+// (matches runtime.GOOS values: "linux", "darwin", ...).
+func imageBackendContextForHost(target, goos string) buildContext {
+	var bc buildContext
+	switch {
+	case strings.HasPrefix(target, "shed-vz-"):
+		bc = vzBuildContext()
+	case strings.HasPrefix(target, "shed-fc-"):
+		bc = fcBuildContext()
+	default:
+		if goos == "linux" {
+			bc = fcBuildContext()
+		} else {
+			bc = vzBuildContext()
+		}
+	}
+	bc.OutputDir = hostDefaultOutputDir(goos)
+	return bc
+}
+
+func runImageBuild(cmd *cobra.Command, args []string) error {
+	bc := imageBackendContext(imageBuildTarget)
+
+	// --platform CLI flag remains an explicit override on top of the
+	// target-driven default in bc.Platform (e.g., for non-shed-* targets
+	// where the user wants an arch that disagrees with the host).
 	platform := imageBuildPlatform
 	if platform == "" {
-		switch {
-		case strings.HasPrefix(imageBuildTarget, "shed-vz-"):
-			platform = vmimage.DefaultPlatform
-		case strings.HasPrefix(imageBuildTarget, "shed-fc-"):
-			platform = vmimage.FirecrackerPlatform
-		default:
-			platform = bc.Platform
-		}
+		platform = bc.Platform
 	}
 
 	outputDir := imageBuildOutputDir
@@ -250,6 +313,18 @@ func runImageBuildFromDockerfile(ctx context.Context, args []string, outputDir, 
 
 	dockerTag := fmt.Sprintf("%s%s:latest", prefix, imageBuildName)
 
+	// sourceRef is what gets baked into the manifest's
+	// io.shed.source-ref annotation, which the server's resolveImage
+	// cache-hit check (internal/config/server.go) compares against
+	// the configured `ref:` to decide whether a re-pull is needed.
+	// Default to the local buildx tag for ad-hoc developer builds;
+	// publish workflows override with the final registry ref so
+	// remote `shed create` pulls hit the cache.
+	sourceRef := imageBuildSourceRef
+	if sourceRef == "" {
+		sourceRef = dockerTag
+	}
+
 	// Emit buildx output as an OCI image-layout tar so shed's Convert
 	// ingests the full layer structure (Dockerfile stages that `FROM`
 	// each other share layers in the OCI store, which lights up the
@@ -282,11 +357,11 @@ func runImageBuildFromDockerfile(ctx context.Context, args []string, outputDir, 
 	}
 
 	fmt.Printf("\nIngesting OCI layers into shed store...\n")
-	digest, err := convertAndInstall(ctx, dockerTag, ociTarPath, outputDir, platform, extractKernel, needsInitrd)
+	digest, err := convertAndInstall(ctx, sourceRef, ociTarPath, outputDir, platform, extractKernel, needsInitrd)
 	if err != nil {
 		return err
 	}
-	finishImageBuild(outputDir, dockerTag, digest)
+	finishImageBuild(outputDir, sourceRef, digest)
 	return nil
 }
 
@@ -294,7 +369,12 @@ func runImageBuildFromDockerfile(ctx context.Context, args []string, outputDir, 
 // which writes the manifest+config+layer+kernel+initrd blobs into the
 // OCI layout and materializes a derived ext4 in the cache, then
 // advances the imageBuildName tag to the new manifest digest.
-// Returns the manifest digest.
+//
+// sourceRef is recorded verbatim in the manifest's io.shed.source-ref
+// annotation; pass the final registry ref here when this image will be
+// pushed, otherwise the server's resolveImage cache check (which
+// compares `manifest.ShedSourceRef() == cfg.ref`) will miss on every
+// subsequent pull. Returns the manifest digest.
 func convertAndInstall(ctx context.Context, sourceRef, ociArchivePath, imagesDir, platform string, extractKernel, needsInitrd bool) (string, error) {
 	if err := vmimage.ValidateImageName(imageBuildName); err != nil {
 		return "", fmt.Errorf("invalid image name %q: %w", imageBuildName, err)

--- a/cmd/shed/image_test.go
+++ b/cmd/shed/image_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/vmimage"
+)
+
+// TestImageBackendContextForHost locks in the per-target table that
+// drives `shed image build`. Regressing any of these rows reintroduces
+// the cross-build prefix bug (Linux runner producing a `shed-fc-*`
+// tag for a `--target shed-vz-*` build, which then corrupts the
+// io.shed.source-ref annotation and breaks server-side cache hits).
+func TestImageBackendContextForHost(t *testing.T) {
+	linuxFCStore := config.DefaultFirecrackerImagesDir
+	darwinVZStore := config.ExpandPath(config.DefaultVZImagesDir)
+
+	tests := []struct {
+		name          string
+		target        string
+		goos          string
+		wantPrefix    string
+		wantPlatform  string
+		wantOutputDir string
+		wantExtract   bool
+		wantInitrd    bool
+	}{
+		{
+			name:          "shed-vz target on linux host (cross-build)",
+			target:        "shed-vz-base",
+			goos:          "linux",
+			wantPrefix:    "shed-vz-",
+			wantPlatform:  vmimage.DefaultPlatform, // linux/arm64
+			wantOutputDir: linuxFCStore,            // OutputDir follows host OS
+			wantExtract:   true,
+			wantInitrd:    true,
+		},
+		{
+			name:          "shed-vz target on darwin host (native)",
+			target:        "shed-vz-full",
+			goos:          "darwin",
+			wantPrefix:    "shed-vz-",
+			wantPlatform:  vmimage.DefaultPlatform,
+			wantOutputDir: darwinVZStore,
+			wantExtract:   true,
+			wantInitrd:    true,
+		},
+		{
+			name:          "shed-fc target on linux host (native)",
+			target:        "shed-fc-full",
+			goos:          "linux",
+			wantPrefix:    "shed-fc-",
+			wantPlatform:  vmimage.FirecrackerPlatform, // linux/amd64
+			wantOutputDir: linuxFCStore,
+			wantExtract:   true,
+			wantInitrd:    false,
+		},
+		{
+			name:          "shed-fc target on darwin host (cross-build)",
+			target:        "shed-fc-experimental",
+			goos:          "darwin",
+			wantPrefix:    "shed-fc-",
+			wantPlatform:  vmimage.FirecrackerPlatform,
+			wantOutputDir: darwinVZStore, // OutputDir follows host OS
+			wantExtract:   true,
+			wantInitrd:    false,
+		},
+		{
+			name:          "empty target on darwin → VZ defaults",
+			target:        "",
+			goos:          "darwin",
+			wantPrefix:    "shed-vz-",
+			wantPlatform:  vmimage.DefaultPlatform,
+			wantOutputDir: darwinVZStore,
+			wantExtract:   true,
+			wantInitrd:    true,
+		},
+		{
+			name:          "empty target on linux → FC defaults",
+			target:        "",
+			goos:          "linux",
+			wantPrefix:    "shed-fc-",
+			wantPlatform:  vmimage.FirecrackerPlatform,
+			wantOutputDir: linuxFCStore,
+			wantExtract:   true,
+			wantInitrd:    false,
+		},
+		{
+			name:          "non-shed target on linux falls through to host default",
+			target:        "custom-stage",
+			goos:          "linux",
+			wantPrefix:    "shed-fc-",
+			wantPlatform:  vmimage.FirecrackerPlatform,
+			wantOutputDir: linuxFCStore,
+			wantExtract:   true,
+			wantInitrd:    false,
+		},
+		{
+			name:          "non-shed target on darwin falls through to host default",
+			target:        "custom-stage",
+			goos:          "darwin",
+			wantPrefix:    "shed-vz-",
+			wantPlatform:  vmimage.DefaultPlatform,
+			wantOutputDir: darwinVZStore,
+			wantExtract:   true,
+			wantInitrd:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bc := imageBackendContextForHost(tt.target, tt.goos)
+			if bc.Prefix != tt.wantPrefix {
+				t.Errorf("Prefix = %q, want %q", bc.Prefix, tt.wantPrefix)
+			}
+			if bc.Platform != tt.wantPlatform {
+				t.Errorf("Platform = %q, want %q", bc.Platform, tt.wantPlatform)
+			}
+			if bc.OutputDir != tt.wantOutputDir {
+				t.Errorf("OutputDir = %q, want %q", bc.OutputDir, tt.wantOutputDir)
+			}
+			if bc.ExtractKernel != tt.wantExtract {
+				t.Errorf("ExtractKernel = %v, want %v", bc.ExtractKernel, tt.wantExtract)
+			}
+			if bc.NeedsInitrd != tt.wantInitrd {
+				t.Errorf("NeedsInitrd = %v, want %v", bc.NeedsInitrd, tt.wantInitrd)
+			}
+		})
+	}
+}

--- a/internal/vmimage/convert.go
+++ b/internal/vmimage/convert.go
@@ -120,6 +120,34 @@ type ConvertResult struct {
 	RootfsLogicalSize int64
 }
 
+// buildShedAnnotations returns the manifest annotation map shed writes
+// to every image it ingests. Centralizing the construction here keeps
+// the OCI-archive and docker-export convert paths in lockstep — they
+// previously each open-coded the map, which let one drift while the
+// other was updated. Empty digest / size strings are omitted so the
+// emitted JSON matches the pre-helper byte shape.
+//
+// sourceRef is recorded verbatim in io.shed.source-ref; the server's
+// resolveImage cache-hit check compares this against the configured
+// `ref:`, so publish flows MUST pass the final registry ref here.
+func buildShedAnnotations(variant, sourceRef, kernelDigest, initrdDigest, rootfsLogicalSize string) map[string]string {
+	ann := map[string]string{
+		AnnotationSchemaVersion: ShedSchemaVersion,
+		AnnotationVariant:       variant,
+		AnnotationSourceRef:     sourceRef,
+	}
+	if kernelDigest != "" {
+		ann[AnnotationKernelDigest] = kernelDigest
+	}
+	if initrdDigest != "" {
+		ann[AnnotationInitrdDigest] = initrdDigest
+	}
+	if rootfsLogicalSize != "" {
+		ann[AnnotationRootfsLogicalSize] = rootfsLogicalSize
+	}
+	return ann
+}
+
 // IsDockerRef returns true if s is a Docker image reference rather than a filesystem path.
 func IsDockerRef(s string) bool {
 	if s == "" {
@@ -367,18 +395,8 @@ func convertFromOCIArchive(ctx context.Context, opts ConvertOptions) (*ConvertRe
 			Digest:    configDigest,
 			Size:      int64(len(cfgBytes)),
 		},
-		Layers: append([]Descriptor{}, srcManifest.Layers...),
-		Annotations: map[string]string{
-			AnnotationSchemaVersion: ShedSchemaVersion,
-			AnnotationVariant:       opts.Name,
-			AnnotationSourceRef:     opts.DockerRef,
-		},
-	}
-	if kernelDigest != "" {
-		manifest.Annotations[AnnotationKernelDigest] = kernelDigest
-	}
-	if initrdDigest != "" {
-		manifest.Annotations[AnnotationInitrdDigest] = initrdDigest
+		Layers:      append([]Descriptor{}, srcManifest.Layers...),
+		Annotations: buildShedAnnotations(opts.Name, opts.DockerRef, kernelDigest, initrdDigest, ""),
 	}
 	manData, err := manifest.MarshalIndent()
 	if err != nil {
@@ -661,18 +679,7 @@ func convertFromDockerExport(ctx context.Context, opts ConvertOptions) (*Convert
 			Digest:    layerDigest,
 			Size:      gzSize,
 		}},
-		Annotations: map[string]string{
-			AnnotationSchemaVersion:     ShedSchemaVersion,
-			AnnotationVariant:           opts.Name,
-			AnnotationSourceRef:         opts.DockerRef,
-			AnnotationRootfsLogicalSize: fmt.Sprintf("%d", tarStat.Size()),
-		},
-	}
-	if kernelDigest != "" {
-		manifest.Annotations[AnnotationKernelDigest] = kernelDigest
-	}
-	if initrdDigest != "" {
-		manifest.Annotations[AnnotationInitrdDigest] = initrdDigest
+		Annotations: buildShedAnnotations(opts.Name, opts.DockerRef, kernelDigest, initrdDigest, fmt.Sprintf("%d", tarStat.Size())),
 	}
 	manData, err := manifest.MarshalIndent()
 	if err != nil {

--- a/internal/vmimage/convert_test.go
+++ b/internal/vmimage/convert_test.go
@@ -115,3 +115,78 @@ func sumBytes(b []byte) []byte {
 	s := sha256.Sum256(b)
 	return s[:]
 }
+
+// TestBuildShedAnnotationsSourceRef pins down the contract that the
+// io.shed.source-ref annotation reads back EXACTLY the DockerRef the
+// caller passed in. The server's resolveImage cache lookup compares
+// `manifest.ShedSourceRef() == cfg.ref`, so any transformation here
+// (prefixing, lowercasing, dropping the registry) would silently
+// break post-publish cache hits and force a re-pull on every
+// `shed create`. Locking the round-trip here catches that class of
+// regression before it reaches a live shed.
+func TestBuildShedAnnotationsSourceRef(t *testing.T) {
+	tests := []struct {
+		name      string
+		sourceRef string
+	}{
+		{name: "registry ref with version tag", sourceRef: "ghcr.io/foo/bar:v1"},
+		{name: "registry ref with full version", sourceRef: "ghcr.io/charliek/shed-vz-full:v0.5.0"},
+		{name: "local buildx tag", sourceRef: "shed-vz-full:latest"},
+		{name: "digest ref", sourceRef: "ghcr.io/foo/bar@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ann := buildShedAnnotations("full", tt.sourceRef, "", "", "")
+			if got := ann[AnnotationSourceRef]; got != tt.sourceRef {
+				t.Errorf("AnnotationSourceRef = %q, want %q", got, tt.sourceRef)
+			}
+			// Round-trip through the parser to mirror the runtime path
+			// (Convert writes the manifest blob; the server later reads
+			// it back via ParseManifest before calling ShedSourceRef).
+			m := &OCIManifest{
+				SchemaVersion: 2,
+				MediaType:     MediaTypeOCIManifest,
+				Layers:        []Descriptor{{MediaType: MediaTypeOCILayer, Digest: "sha256:deadbeef", Size: 1}},
+				Annotations:   ann,
+			}
+			data, err := m.MarshalIndent()
+			if err != nil {
+				t.Fatalf("MarshalIndent: %v", err)
+			}
+			parsed, err := ParseManifest(data)
+			if err != nil {
+				t.Fatalf("ParseManifest: %v", err)
+			}
+			if got := parsed.ShedSourceRef(); got != tt.sourceRef {
+				t.Errorf("parsed ShedSourceRef() = %q, want %q", got, tt.sourceRef)
+			}
+		})
+	}
+}
+
+// TestBuildShedAnnotationsOptionalFields verifies that empty optional
+// values are omitted from the annotation map (so the on-disk manifest
+// JSON doesn't carry confusing empty-string entries).
+func TestBuildShedAnnotationsOptionalFields(t *testing.T) {
+	ann := buildShedAnnotations("base", "ghcr.io/x/y:v1", "", "", "")
+	if _, ok := ann[AnnotationKernelDigest]; ok {
+		t.Errorf("empty kernel digest should be omitted, got %q", ann[AnnotationKernelDigest])
+	}
+	if _, ok := ann[AnnotationInitrdDigest]; ok {
+		t.Errorf("empty initrd digest should be omitted, got %q", ann[AnnotationInitrdDigest])
+	}
+	if _, ok := ann[AnnotationRootfsLogicalSize]; ok {
+		t.Errorf("empty rootfs logical size should be omitted, got %q", ann[AnnotationRootfsLogicalSize])
+	}
+
+	ann2 := buildShedAnnotations("base", "ghcr.io/x/y:v1", "sha256:k", "sha256:i", "12345")
+	if ann2[AnnotationKernelDigest] != "sha256:k" {
+		t.Errorf("kernel digest = %q, want sha256:k", ann2[AnnotationKernelDigest])
+	}
+	if ann2[AnnotationInitrdDigest] != "sha256:i" {
+		t.Errorf("initrd digest = %q, want sha256:i", ann2[AnnotationInitrdDigest])
+	}
+	if ann2[AnnotationRootfsLogicalSize] != "12345" {
+		t.Errorf("rootfs logical size = %q, want 12345", ann2[AnnotationRootfsLogicalSize])
+	}
+}


### PR DESCRIPTION
## Summary

Two bugs in the cross-build path that `publish-images.yaml` exercises on the Linux arm64 runner, both hit in production every release:

1. **Wrong tag prefix + flags on cross-builds.** `imageBackendContext()` derived `Prefix`, `Platform`, `ExtractKernel`, and `NeedsInitrd` from `runtime.GOOS`. PR #92 fixed `Platform` downstream but left the other three drifting — so building `--target shed-vz-*` from a Linux runner landed `shed-fc-*:latest` in the store and a corresponding wrong `io.shed.source-ref` in the manifest. The function now takes a `target` string and centralizes the per-backend table in one place (with `OutputDir` still following host OS — that's the on-disk store location).

2. **`io.shed.source-ref` always pointed at the local buildx tag.** The annotation was hard-coded to `<prefix><name>:latest`, so the server-side `resolveImage` cache-hit check (which compares the annotation against the configured `ref:`) missed on every `shed create` and forced a re-pull. New `--source-ref <ref>` flag lets publish flows pin the annotation to the final ghcr.io ref; `publish-images.yaml` now passes `ghcr.io/charliek/shed-{vz,fc}-${variant}:${tag}`.

Defense-in-depth: `publish-images.yaml` also now passes `--platform linux/{arm64,amd64}` explicitly so even if CLI inference regresses, the workflow stays correct.

## Files touched
- `cmd/shed/image.go` — `imageBackendContext(target)` refactor, new `--source-ref` flag, `sourceRef` plumbed through the build flow
- `cmd/shed/image_test.go` (new) — table-driven `TestImageBackendContextForHost` covering all 4 target × host-OS combinations plus empty-target host defaults
- `internal/vmimage/convert.go` — extracted `buildShedAnnotations` helper so the two convert paths can't drift on the annotation map again
- `internal/vmimage/convert_test.go` — `TestBuildShedAnnotationsSourceRef` locks down the round-trip
- `.github/workflows/publish-images.yaml` — VZ + FC jobs pass `--platform` and `--source-ref` explicitly
- `CHANGELOG.md` — entry under v0.5.0

## Test plan

- [x] `make build` clean
- [x] `make test` clean (new + existing tests pass)
- [x] `make lint` clean (`0 issues.`)
- [ ] Validate end-to-end via `workflow_dispatch` against a published tag inside a Linux arm64 shed before merging
- [ ] After merge, confirm a subsequent `shed create` from a fresh shed hits the resolveImage cache instead of re-pulling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--source-ref` flag for image builds to explicitly set manifest annotations for improved cache behavior.

* **Bug Fixes**
  * Fixed cross-build issues for shed-vz and shed-fc targets to ensure correct tag prefixes and manifest annotations are applied when building images.

* **Tests**
  * Added test coverage for backend context logic and manifest annotation building.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->