### PR TITLE
docs + scripts cleanup post-v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,17 +46,17 @@ All notable changes to this project will be documented in this file.
   v0.4.x users upgrading without wiping `images_dir` previously hit a
   cryptic `... is a directory` error. `internal/vmimage/ocilayout.go`
   now detects this case and wraps it as `ErrLegacyBundledBlob`; the CLI
-  surfaces a message pointing the user at [`docs/UPGRADE.md`](docs/UPGRADE.md).
+  surfaces a message pointing the user at [`docs/upgrades/v0.4-to-v0.5.md`](docs/upgrades/v0.4-to-v0.5.md).
 - **`image has N layers (max 16)` rejection now includes a recovery
   hint.** `internal/vmimage/registry.go` extends the pull-time
   `MaxLayers` error with concrete next steps (wait for the v0.5.0+
   published image, or rebuild locally with the backend's build script).
 - **`SHED-INIT-04` panic cross-references the upgrade guide.** The
   initramfs overlay-mount panic in `initramfs/init` now points at
-  [`docs/UPGRADE.md#shed-init-04-panic-during-vm-boot`](docs/UPGRADE.md#shed-init-04-panic-during-vm-boot)
+  [`docs/upgrades/v0.4-to-v0.5.md#shed-init-04-panic-during-vm-boot`](docs/upgrades/v0.4-to-v0.5.md#shed-init-04-panic-during-vm-boot)
   so operators know to refresh the cached initramfs by re-running the
   build script.
-- **New top-level [`docs/UPGRADE.md`](docs/UPGRADE.md).** Walks v0.4.x →
+- **New top-level [`docs/upgrades/v0.4-to-v0.5.md`](docs/upgrades/v0.4-to-v0.5.md).** Walks v0.4.x →
   v0.5.0 with a "what's new", a keep/lose table, links into the
   backend-specific wipe steps in `vz-setup.md` / `fc-setup.md`, and a
   recovery-scenarios index keyed off the error strings users actually

--- a/docs/development/in-shed-build-debugging.md
+++ b/docs/development/in-shed-build-debugging.md
@@ -1,0 +1,186 @@
+# In-shed build debugging
+
+The publish-images workflow only runs on tag push to GitHub. When the
+flow regresses (a stale `--source-ref`, a `--platform` mistake, a
+buildx-driver compatibility break) the only feedback signal is a slow
+CI failure. This page documents how to reproduce that flow locally
+inside a shed so you can iterate in minutes instead of hours.
+
+## Why a shed (and not the host)?
+
+The publish flow targets `linux/arm64` rootfs images. Building those on
+an Apple Silicon Mac through `docker buildx --platform linux/arm64`
+works in theory, but the rest of the flow assumes a Linux host: the
+shed CLI shells out to `mkfs.ext4`, `mksquashfs`, and other tools that
+either don't exist or behave differently on macOS. Running everything
+inside a Linux shed eliminates that drift; the only difference between
+`scripts/publish-images-local.sh` and the GitHub Actions job is the
+target registry.
+
+## The buildx network-host trick
+
+`docker buildx create` defaults to the `docker-container` driver, which
+runs BuildKit inside a container with its own network namespace. When
+the build needs to reach a registry on the shed's loopback (the local
+`registry:2` we spin up to receive the push), the default driver
+cannot: `localhost:5050` inside BuildKit refers to BuildKit's own
+container, not the shed.
+
+The one-line fix is to ask the driver to share the shed's network
+namespace:
+
+```bash
+docker buildx create \
+  --driver docker-container \
+  --driver-opt network=host \
+  --use
+```
+
+That option does two things:
+
+1. Sets `--network host` on the BuildKit container so it shares the
+   shed's loopback with the registry.
+2. Boots BuildKit with `--allow-insecure-entitlement=network.host`,
+   which is also needed for any `RUN --network=host` directives in the
+   Dockerfile.
+
+You can confirm both by running `docker buildx inspect <name>` and
+looking for `Driver Options: network="host"` plus
+`BuildKit daemon flags: --allow-insecure-entitlement=network.host`.
+
+## One-shot validation
+
+The publish-flow simulation is wrapped up in
+`scripts/publish-images-local.sh`. It boots a buildx builder, a
+local `registry:2`, builds the shed-overlay initramfs, and then for
+each variant:
+
+1. Runs `shed image build` with `--source-ref` and `--platform` set
+   exactly the way the publish workflow does.
+2. Asserts the on-disk manifest's `io.shed.source-ref` annotation
+   matches the registry ref we're about to push to.
+3. Runs `shed image push --local` to stream the OCI layout to the
+   in-shed registry.
+4. Fetches the manifest back from the registry over HTTP and asserts
+   the annotation survived.
+5. For the first variant, runs `shed image pull` into a brand-new OCI
+   store and re-checks the annotation; this is what a remote
+   shed-server does when serving `shed create foo --image base` after
+   a publish.
+
+The exit code is the verdict: `0` for PASS, `1` for FAIL. The line
+preceding `FAIL:` identifies which variant tripped.
+
+## Setup
+
+1. Boot a validation shed with enough disk for buildx + intermediate
+   layers. The `full` image variant has docker + buildx pre-installed;
+   `--upper-size 40G` is the minimum that comfortably fits a single
+   variant build (a buildx builder image, `registry:2`, the ~3 GB
+   intermediate ext4 rootfs, plus headroom). For all three variants
+   in one run, use 80 GB.
+
+   ```bash
+   shed create publish-test --image full --cpus 4 --memory 8192 \
+                            --upper-size 40G
+   ```
+
+2. Open SSH to the shed:
+
+   ```bash
+   shed ssh-config publish-test > /tmp/publish-test-ssh
+   ssh -F /tmp/publish-test-ssh shed-publish-test
+   ```
+
+3. Neutralise the docker credential helper. The shed-agent inside the
+   shed installs a `credsStore` that talks to the host over vsock;
+   inside a validation shed there is no host to answer, so any
+   `docker pull` / `docker push` hangs forever waiting for creds.
+
+   ```bash
+   echo '{}' > "$HOME/.docker/config.json"
+   ```
+
+4. Cross-build the in-VM binaries on the host and stage everything
+   into the shed:
+
+   ```bash
+   # On the host:
+   GOOS=linux GOARCH=arm64 go build -o vz/shed-agent     ./cmd/shed-agent
+   GOOS=linux GOARCH=arm64 go build -o vz/shed-firstboot ./cmd/shed-firstboot
+   GOOS=linux GOARCH=arm64 go build -o /tmp/shed         ./cmd/shed
+   scp -F /tmp/publish-test-ssh -r . shed-publish-test:/home/shed/work
+   scp -F /tmp/publish-test-ssh /tmp/shed shed-publish-test:/tmp/shed
+   ssh -F /tmp/publish-test-ssh shed-publish-test \
+       'sudo install -m 0755 /tmp/shed /usr/local/bin/shed'
+   ```
+
+5. Run the validation script inside the shed:
+
+   ```bash
+   ssh -F /tmp/publish-test-ssh shed-publish-test \
+       'cd /home/shed/work && ./scripts/publish-images-local.sh'
+   ```
+
+   To exercise only one variant (faster on a small upper layer):
+
+   ```bash
+   ssh -F /tmp/publish-test-ssh shed-publish-test \
+       'cd /home/shed/work && VARIANTS=base ./scripts/publish-images-local.sh'
+   ```
+
+## Interpreting results
+
+PASS line:
+
+```
+PASS: built, pushed, and round-tripped 3 variant(s) at v0.0.0-local
+```
+
+means: every requested variant built successfully, the OCI manifest
+written by `shed image build` carried the right
+`io.shed.source-ref` annotation, the registry received the manifest
+byte-perfect, and a fresh `shed image pull` into a clean store still
+sees the same annotation.
+
+FAIL lines come in a few flavours:
+
+- `FAIL: base: local manifest source-ref mismatch ...` - the bug PR
+  #94 fixed has come back; `shed image build` is baking the wrong
+  annotation into the manifest. Check `--source-ref` handling in
+  `cmd/shed/image.go` and the OCI conversion path in
+  `internal/vmimage/convert.go`.
+- `FAIL: base: registry-side source-ref mismatch ...` - the on-disk
+  manifest is right but `shed image push` is rewriting it on the way
+  out. Check the push handler in `internal/api/server.go` and
+  `internal/vmimage/manager.go`.
+- `FAIL: base: round-trip source-ref mismatch ...` - the push succeeded
+  but `shed image pull` is dropping or rewriting the annotation. Check
+  the OCI ingest path in `internal/vmimage/registry.go`.
+- `FAIL: ... gzip: stdin: Input/output error` or
+  `EXT4-fs error ... Remounting filesystem read-only` - your shed ran
+  out of disk in the writable upper layer. Delete the shed and create
+  a new one with a larger `--upper-size`.
+
+## Gotchas
+
+- The buildx builder and `registry:2` are torn down on script exit,
+  even on failure. The OCI store at `/tmp/publish-images-local-store/`
+  is left in place so you can inspect blobs and manifests after a
+  failed run.
+- If you forget the `network=host` driver-opt, the symptom is
+  `dial tcp 127.0.0.1:5050: connect: connection refused` during the
+  `shed image build` phase - BuildKit reaches its own loopback, not
+  the shed's.
+- Docker daemon in the shed ships with `"bridge": "none"` in
+  `daemon.json`, so `docker run` without `--network host` will not
+  give the container network access. The script accounts for this by
+  using `--network host` on the registry container as well.
+- The 'full' image variant has docker + buildx, but it does NOT have
+  Go installed. Cross-build the shed CLI on the host and `scp` it in
+  rather than trying to `go build` inside the shed.
+- Don't be tempted to point the script at a real ghcr.io path with a
+  fake credential; the `--local` push path doesn't authenticate, but
+  the assertion step does an unauthenticated HTTP `GET` on the
+  manifest. Run it against a local `registry:2` and only flip to
+  `ghcr.io` once you actually want to publish.

--- a/docs/getting-started/fc-setup.md
+++ b/docs/getting-started/fc-setup.md
@@ -231,8 +231,8 @@ sudo systemctl start shed-server
 sudo shed-server pull-images
 ```
 
-See the [Upgrade Guide](../UPGRADE.md) for what's new in v0.5.0,
-what carries over, and recovery scenarios.
+See the [v0.4 → v0.5 Upgrade Guide](../upgrades/v0.4-to-v0.5.md) for
+what's new in v0.5.0, what carries over, and recovery scenarios.
 
 Workspace data under `--local-dir` mounts is unaffected. Workspace data
 that lived only inside the deleted upper layers is lost, by design.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -23,8 +23,8 @@ Shed has two install paths:
   Pick this if you're hacking on shed itself or want to run an unreleased
   commit.
 
-Upgrading from v0.4.x? See the [Upgrade Guide](../UPGRADE.md) — the
-v0.5.0 image store is not backwards-compatible.
+Upgrading from v0.4.x? See the [v0.4 → v0.5 Upgrade Guide](../upgrades/v0.4-to-v0.5.md) —
+the v0.5.0 image store is not backwards-compatible.
 
 ### Homebrew (macOS, Recommended)
 

--- a/docs/upgrades/v0.4-to-v0.5.md
+++ b/docs/upgrades/v0.4-to-v0.5.md
@@ -17,7 +17,7 @@ the existing setup guides, which this page links into.
   `{images_dir}/blobs/sha256/<digest>/`; tags at
   `{images_dir}/tags/<tag>.json`. Multiple tags can point at one digest
   with zero extra disk cost. See
-  [Storage Model](reference/storage-model.md) for the full layout.
+  [Storage Model](../reference/storage-model.md) for the full layout.
 - **Layer-preserving builds.** `shed image build` now writes one blob
   per Docker layer rather than flattening each variant. `base`,
   `extensions`, and `full` share their common parent layers byte-for-byte.
@@ -32,8 +32,8 @@ the existing setup guides, which this page links into.
   `shed create --upper-size <N>G` overrides the default upper size.
 - **New image commands.** `shed image inspect`, `shed image tag`,
   `shed image pull`, and refcount-protected `shed image prune`. See
-  [`shed image`](reference/cli.md) and the
-  [upgrade-and-reclaim cookbook](reference/images.md#cookbook-upgrading-image-versions).
+  [`shed image`](../reference/cli.md) and the
+  [upgrade-and-reclaim cookbook](../reference/images.md#cookbook-upgrading-image-versions).
 - **Metadata schema v3.** Instance and snapshot metadata gain
   `lower_digest`, `lower_image_tag`, `upper_path`, and `upper_size_bytes`.
   Pre-v3 metadata is rejected at load time with an actionable message.
@@ -59,9 +59,9 @@ alongside the rest of the install instructions and are kept in sync with
 the install path you use.
 
 - **macOS (VZ):**
-  [Upgrading from v0.4.x](getting-started/vz-setup.md#upgrading-from-v04x)
+  [Upgrading from v0.4.x](../getting-started/vz-setup.md#upgrading-from-v04x)
 - **Linux (Firecracker):**
-  [Upgrading from v0.4.x](getting-started/fc-setup.md#upgrading-from-v04x)
+  [Upgrading from v0.4.x](../getting-started/fc-setup.md#upgrading-from-v04x)
 
 At a high level, both flows are: stop the server, `rm -rf` the legacy
 blob / instance / snapshot / upper directories, install the new binary
@@ -82,8 +82,8 @@ vice versa. The blob store and the legacy cache cannot coexist on the
 same `images_dir`.
 
 Fix: follow the wipe steps in
-[VZ Setup](getting-started/vz-setup.md#upgrading-from-v04x) or
-[Firecracker Setup](getting-started/fc-setup.md#upgrading-from-v04x)
+[VZ Setup](../getting-started/vz-setup.md#upgrading-from-v04x) or
+[Firecracker Setup](../getting-started/fc-setup.md#upgrading-from-v04x)
 to drop the legacy `blobs/`, `instances/`, `snapshots/`, and
 `uppers/` directories, then re-pull or rebuild images.
 
@@ -118,7 +118,7 @@ initramfs. The build pipeline installs the rootfs, kernel, and initrd
 atomically into the blob store. If you're using published images,
 re-pull with `shed image pull <ref> -t <tag>` once v0.5.0 images ship.
 
-If the initramfs is fresh, see [Storage Model](reference/storage-model.md)
+If the initramfs is fresh, see [Storage Model](../reference/storage-model.md)
 for overlay layout. The panic codes are stable — `SHED-INIT-04` is
 specifically the overlay mount; `SHED-INIT-02` / `-03` are missing or
 unmountable lower blocks; `SHED-INIT-06` / `-08` are corrupt uppers

--- a/internal/vmimage/ocilayout.go
+++ b/internal/vmimage/ocilayout.go
@@ -252,7 +252,7 @@ func detectLegacyBundledBlob(path string) error {
 	}
 	return fmt.Errorf("%w: blob at %s is a v0.4.x bundled directory layout. "+
 		"This format is no longer supported. See "+
-		"https://github.com/charliek/shed/blob/main/docs/UPGRADE.md or "+
+		"https://github.com/charliek/shed/blob/main/docs/upgrades/v0.4-to-v0.5.md or "+
 		"docs/getting-started/{fc,vz}-setup.md#upgrading-from-v04x for the "+
 		"migration steps (stop server, wipe legacy store, re-pull or rebuild)",
 		ErrLegacyBundledBlob, path)

--- a/internal/vmimage/ocilayout_test.go
+++ b/internal/vmimage/ocilayout_test.go
@@ -158,7 +158,7 @@ func TestReadBlobDetectsLegacyBundledDirectory(t *testing.T) {
 	}
 	for _, want := range []string{
 		"v0.4.x bundled directory layout",
-		"docs/UPGRADE.md",
+		"docs/upgrades/v0.4-to-v0.5.md",
 		"wipe legacy store",
 	} {
 		if !strings.Contains(err.Error(), want) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,7 +92,8 @@ nav:
       - Quick Start: getting-started/quick-start.md
       - VZ Setup (macOS): getting-started/vz-setup.md
       - Firecracker Setup: getting-started/fc-setup.md
-      - Upgrade Guide: UPGRADE.md
+      - Upgrades:
+          - v0.4 → v0.5: upgrades/v0.4-to-v0.5.md
   - Tutorials:
       - Build Your Own Image: tutorials/build-your-own-image.md
   - Reference:
@@ -118,6 +119,7 @@ nav:
       - Setup: development/setup.md
       - Testing: development/testing.md
       - Architecture: development/architecture.md
+      - In-shed Build Debugging: development/in-shed-build-debugging.md
   - Roadmap: ROADMAP.md
 
 extra:

--- a/scripts/publish-images-local.sh
+++ b/scripts/publish-images-local.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# publish-images-local.sh
+#
+# Run the .github/workflows/publish-images.yaml VZ job's flow locally,
+# inside a shed development VM, against a local registry:2 container.
+#
+# Why this exists:
+#   The publish workflow only runs on tag push to GitHub. When the build
+#   regresses (wrong --platform, stale --source-ref annotation, layer
+#   ingest changes, etc.) the only feedback is a 30+ minute CI failure.
+#   This script reproduces the same flow on an Apple Silicon Mac in a
+#   shed, so changes can be validated end-to-end in a few minutes.
+#
+# How to use:
+#   1. Boot a validation shed on a Mac with the 'full' image and a
+#      generous upper layer (the publish flow needs room for a buildx
+#      builder, a registry:2 cache, and ~3 GB of intermediate rootfs
+#      layers per variant):
+#        shed create publish-test --image full --cpus 4 --memory 8192 \
+#                                 --upper-size 40G
+#
+#   2. Open an SSH session to the shed:
+#        shed ssh-config publish-test > /tmp/publish-test-ssh
+#        ssh -F /tmp/publish-test-ssh shed-publish-test
+#
+#   3. Inside the shed, neutralise the docker credential helper. The
+#      shed-agent installs a credsStore that talks to the host over
+#      vsock; inside a validation shed there is no host to answer, so
+#      docker pull/push hangs:
+#        echo '{}' > "$HOME/.docker/config.json"
+#
+#   4. Cross-build the in-VM binaries on the host (or get them onto the
+#      shed however you like) and copy the project tree in:
+#        GOOS=linux GOARCH=arm64 go build -o vz/shed-agent     ./cmd/shed-agent
+#        GOOS=linux GOARCH=arm64 go build -o vz/shed-firstboot ./cmd/shed-firstboot
+#        # On the host, scp the project tree and the linux/arm64 shed CLI:
+#        scp -F /tmp/publish-test-ssh -r . shed-publish-test:/home/shed/work
+#        GOOS=linux GOARCH=arm64 go build -o /tmp/shed ./cmd/shed
+#        scp -F /tmp/publish-test-ssh /tmp/shed shed-publish-test:/tmp/shed
+#        ssh -F /tmp/publish-test-ssh shed-publish-test \
+#            'sudo install -m 0755 /tmp/shed /usr/local/bin/shed'
+#
+#   5. Run this script from the project root inside the shed:
+#        ssh -F /tmp/publish-test-ssh shed-publish-test \
+#            'cd /home/shed/work && ./scripts/publish-images-local.sh'
+#
+#      Inputs (override via env):
+#        VERSION       (default: v0.0.0-local)
+#        REGISTRY_HOST (default: localhost:5050)
+#        VARIANTS      (default: "base extensions full")
+#        WORK_DIR      (default: current dir; must contain vz/ initramfs/
+#                       scripts/build-initramfs.sh)
+#        STORE_DIR     (default: /tmp/publish-images-local-store)
+#        OUT_DIR       (default: /tmp/publish-images-local)
+#        SHED_BIN      (default: /usr/local/bin/shed)
+#        BACKEND       (default: vz; pass "firecracker" on a Linux/KVM
+#                       host to exercise the FC publish path instead)
+#
+# Behavior:
+#   * Creates a docker buildx builder with --driver-opt network=host so
+#     BuildKit can reach the in-shed registry over loopback. The default
+#     docker-container driver runs in its own netns and cannot.
+#   * Starts a registry:2 container with --network host on :5050.
+#   * Builds the shed-overlay initramfs via scripts/build-initramfs.sh.
+#   * For each variant (base, extensions, full):
+#       - shed image build  (writes OCI layout + manifest with
+#                            io.shed.source-ref annotation)
+#       - shed image push   (streams the OCI layout to the registry)
+#       - asserts the manifest in the registry carries the expected
+#         source-ref annotation (the bug PR #94 fixed).
+#   * Round-trips the first variant through `shed image pull` to a
+#     fresh store and re-checks the source-ref annotation, mirroring
+#     what a remote shed-server's resolveImage cache check does.
+#
+# Exit codes:
+#   0  PASS - every variant built, pushed, and re-asserted with the
+#      expected io.shed.source-ref annotation.
+#   1  FAIL - one of the assertions tripped; the log line preceding
+#      "FAIL:" identifies which variant and which check.
+#
+# See: docs/development/in-shed-build-debugging.md for the rationale
+# behind --driver-opt network=host and how to interpret a failure.
+set -euo pipefail
+
+VERSION="${VERSION:-v0.0.0-local}"
+REGISTRY_HOST="${REGISTRY_HOST:-localhost:5050}"
+VARIANTS="${VARIANTS:-base extensions full}"
+WORK_DIR="${WORK_DIR:-$(pwd)}"
+STORE_DIR="${STORE_DIR:-/tmp/publish-images-local-store}"
+OUT_DIR="${OUT_DIR:-/tmp/publish-images-local}"
+SHED_BIN="${SHED_BIN:-/usr/local/bin/shed}"
+BACKEND="${BACKEND:-vz}"
+
+case "${BACKEND}" in
+  vz)
+    DEFAULT_PLATFORM="linux/arm64"
+    BACKEND_PREFIX="shed-vz"
+    BACKEND_DIR="vz"
+    ;;
+  firecracker)
+    DEFAULT_PLATFORM="linux/amd64"
+    BACKEND_PREFIX="shed-fc"
+    BACKEND_DIR="firecracker"
+    ;;
+  *)
+    echo "FAIL: unknown BACKEND='${BACKEND}' (want 'vz' or 'firecracker')" >&2
+    exit 1
+    ;;
+esac
+PLATFORM="${PLATFORM:-${DEFAULT_PLATFORM}}"
+
+BUILDER_NAME="publish-images-local"
+REGISTRY_CONTAINER="publish-images-local-registry"
+INITRAMFS="${OUT_DIR}/shed-initrd.img"
+SERVER_CFG="${OUT_DIR}/server.yaml"
+SERVER_CFG_RT="${OUT_DIR}/server-rt.yaml"
+STORE_RT="${STORE_DIR}-rt"
+
+log()  { printf '\n=== %s ===\n' "$*"; }
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+write_server_yaml() {
+  # Minimal shed-server config so `shed image push --local` /
+  # `shed image pull` know where the OCI store lives.
+  local path="$1"
+  local images_dir="$2"
+  case "${BACKEND}" in
+    vz)
+      cat > "${path}" <<YAML
+name: publish-images-local
+http_port: 0
+ssh_port: 0
+default_backend: vz
+vz:
+  vfkit_path: vfkit
+  images_dir: ${images_dir}
+  instance_dir: ${images_dir}/instances
+  socket_dir: ${images_dir}/sockets
+  default_cpus: 2
+  default_memory_mb: 1024
+  default_disk_gb: 1
+  console_port: 1024
+  notify_port: 1026
+  tcp_proxy_port: 1028
+  start_timeout: 60s
+  stop_timeout: 10s
+YAML
+      ;;
+    firecracker)
+      cat > "${path}" <<YAML
+name: publish-images-local
+http_port: 0
+ssh_port: 0
+default_backend: firecracker
+firecracker:
+  images_dir: ${images_dir}
+  instance_dir: ${images_dir}/instances
+  socket_dir: ${images_dir}/sockets
+  default_cpus: 2
+  default_memory_mb: 1024
+  default_disk_gb: 1
+  console_port: 1024
+  notify_port: 1026
+  vsock_base_cid: 100
+  bridge_name: shed-br0
+  bridge_cidr: 172.30.0.1/24
+  tap_prefix: shed-tap
+  start_timeout: 60s
+  stop_timeout: 10s
+YAML
+      ;;
+  esac
+}
+
+cleanup() {
+  log "cleanup"
+  docker rm -f "${REGISTRY_CONTAINER}" >/dev/null 2>&1 || true
+  docker buildx rm "${BUILDER_NAME}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+log "pre-flight"
+command -v docker >/dev/null || fail "docker missing"
+command -v "${SHED_BIN}" >/dev/null || fail "shed binary missing at ${SHED_BIN}"
+[ -d "${WORK_DIR}/${BACKEND_DIR}" ]              || fail "build context ${WORK_DIR}/${BACKEND_DIR} missing"
+[ -d "${WORK_DIR}/initramfs" ]                   || fail "${WORK_DIR}/initramfs missing"
+[ -x "${WORK_DIR}/scripts/build-initramfs.sh" ]  || fail "build-initramfs.sh missing/not executable"
+[ -f "${WORK_DIR}/${BACKEND_DIR}/shed-agent" ]     || fail "${WORK_DIR}/${BACKEND_DIR}/shed-agent missing; cross-build with GOOS=linux GOARCH=${PLATFORM#linux/}"
+[ -f "${WORK_DIR}/${BACKEND_DIR}/shed-firstboot" ] || fail "${WORK_DIR}/${BACKEND_DIR}/shed-firstboot missing; cross-build with GOOS=linux GOARCH=${PLATFORM#linux/}"
+
+mkdir -p "${OUT_DIR}"
+
+log "creating buildx builder with --driver-opt network=host"
+# This is the workaround that makes the in-shed publish flow work:
+# the default docker-container driver runs BuildKit in its own network
+# namespace, so it cannot reach localhost:5050 inside the shed. Using
+# network=host puts BuildKit on the shed's loopback. The flag also
+# implies --allow-insecure-entitlement=network.host inside BuildKit,
+# which is required for any `RUN --network=host` directives.
+docker buildx rm "${BUILDER_NAME}" >/dev/null 2>&1 || true
+docker buildx create \
+  --name "${BUILDER_NAME}" \
+  --driver docker-container \
+  --driver-opt network=host \
+  --use
+docker buildx inspect --bootstrap "${BUILDER_NAME}" >/dev/null
+
+log "starting registry:2 with --network host on ${REGISTRY_HOST}"
+docker rm -f "${REGISTRY_CONTAINER}" >/dev/null 2>&1 || true
+docker run -d --name "${REGISTRY_CONTAINER}" \
+  --network host \
+  -e REGISTRY_HTTP_ADDR=0.0.0.0:"${REGISTRY_HOST##*:}" \
+  registry:2 >/dev/null
+for i in $(seq 1 20); do
+  if curl -fsS "http://${REGISTRY_HOST}/v2/" >/dev/null 2>&1; then
+    echo "registry up after ${i} attempts"
+    break
+  fi
+  sleep 0.5
+  [ "${i}" -eq 20 ] && fail "registry did not come up on ${REGISTRY_HOST}"
+done
+
+log "building shed-overlay initramfs (${BACKEND}, ${PLATFORM})"
+"${WORK_DIR}/scripts/build-initramfs.sh" \
+  --backend "${BACKEND}" \
+  --platform "${PLATFORM}" \
+  --output "${INITRAMFS}"
+[ -s "${INITRAMFS}" ] || fail "initramfs not produced"
+
+rm -rf "${STORE_DIR}"
+mkdir -p "${STORE_DIR}"
+write_server_yaml "${SERVER_CFG}" "${STORE_DIR}"
+
+for variant in ${VARIANTS}; do
+  target="${BACKEND_PREFIX}-${variant}"
+  source_ref="${REGISTRY_HOST}/charliek/${target}:${VERSION}"
+
+  log "building ${target} (source-ref=${source_ref})"
+  "${SHED_BIN}" -c "${SERVER_CFG}" image build \
+    --target "${target}" \
+    --platform "${PLATFORM}" \
+    --source-ref "${source_ref}" \
+    -n "${variant}" \
+    --initramfs "${INITRAMFS}" \
+    --output-dir "${STORE_DIR}" \
+    -f "${WORK_DIR}/${BACKEND_DIR}/Dockerfile" \
+    "${WORK_DIR}/${BACKEND_DIR}/"
+
+  log "asserting local manifest source-ref for ${variant}"
+  "${SHED_BIN}" -c "${SERVER_CFG}" --json image inspect "${variant}" \
+    > "${OUT_DIR}/inspect-${variant}.json"
+  local_sr=$(jq -r '
+    .source_ref //
+    (.manifest.annotations // {})["io.shed.source-ref"] //
+    (.annotations // {})["io.shed.source-ref"] //
+    ""
+  ' < "${OUT_DIR}/inspect-${variant}.json")
+  echo "local source-ref (${variant}): ${local_sr}"
+  [ "${local_sr}" = "${source_ref}" ] || fail "${variant}: local manifest source-ref mismatch (got '${local_sr}', want '${source_ref}')"
+  case "${local_sr}" in
+    *"-${variant}:latest"*) fail "${variant}: manifest carries legacy :latest source-ref" ;;
+  esac
+
+  log "pushing ${variant} -> ${source_ref}"
+  "${SHED_BIN}" -c "${SERVER_CFG}" image push --local "${variant}" "${source_ref}"
+
+  log "asserting registry-side source-ref for ${variant}"
+  manifest=$(curl -fsS \
+    -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
+    -H 'Accept: application/vnd.oci.image.index.v1+json' \
+    -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+    "http://${REGISTRY_HOST}/v2/charliek/${target}/manifests/${VERSION}")
+  remote_sr=$(printf '%s' "${manifest}" | jq -r '(.annotations // {})["io.shed.source-ref"] // ""')
+  echo "registry source-ref (${variant}): ${remote_sr}"
+  [ "${remote_sr}" = "${source_ref}" ] || fail "${variant}: registry-side source-ref mismatch (got '${remote_sr}', want '${source_ref}')"
+done
+
+# Round-trip the first variant through `shed image pull` into a fresh
+# store. This is what a remote shed-server would do when serving
+# `shed create foo --image base` after a publish; the source-ref on
+# the pulled manifest needs to match the registry ref so the
+# resolveImage cache check hits.
+first_variant=$(echo "${VARIANTS}" | awk '{print $1}')
+first_target="${BACKEND_PREFIX}-${first_variant}"
+first_ref="${REGISTRY_HOST}/charliek/${first_target}:${VERSION}"
+
+log "round-trip pull of ${first_variant} into fresh store"
+rm -rf "${STORE_RT}"
+mkdir -p "${STORE_RT}"
+write_server_yaml "${SERVER_CFG_RT}" "${STORE_RT}"
+"${SHED_BIN}" -c "${SERVER_CFG_RT}" image pull "${first_ref}" \
+  --platform "${PLATFORM}" \
+  --tag "${first_variant}-rt"
+
+"${SHED_BIN}" -c "${SERVER_CFG_RT}" --json image inspect "${first_variant}-rt" \
+  > "${OUT_DIR}/inspect-rt-${first_variant}.json"
+rt_sr=$(jq -r '
+  .source_ref //
+  (.manifest.annotations // {})["io.shed.source-ref"] //
+  (.annotations // {})["io.shed.source-ref"] //
+  ""
+' < "${OUT_DIR}/inspect-rt-${first_variant}.json")
+echo "round-trip source-ref (${first_variant}): ${rt_sr}"
+[ "${rt_sr}" = "${first_ref}" ] || fail "${first_variant}: round-trip source-ref mismatch (got '${rt_sr}', want '${first_ref}')"
+
+printf '\nPASS: built, pushed, and round-tripped %d variant(s) at %s\n' \
+  "$(echo "${VARIANTS}" | wc -w | tr -d ' ')" \
+  "${VERSION}"


### PR DESCRIPTION
## Summary

Three small things picked up after the v0.5.0 release:

- New `scripts/publish-images-local.sh` — runs the `publish-images.yaml` VZ-job flow inside a shed (`linux/arm64`) so regressions like the chain of #92/#93/#94 fixes can be caught locally before tagging, not after a 30+ min CI failure. Includes the buildx `--driver-opt network=host` setup for in-shed networking + per-variant source-ref annotation assertions.
- New `docs/development/in-shed-build-debugging.md` — companion docs explaining why this is useful and how to interpret PASS/FAIL output, including the EXT4-read-only failure mode when the shed runs out of upper-layer disk.
- `docs/UPGRADE.md` → `docs/upgrades/v0.4-to-v0.5.md` so future major bumps slot in alongside this one without another rename. Cross-refs updated in `mkdocs.yml`, the getting-started guides, the legacy-bundled-blob error in `internal/vmimage/ocilayout.go`, the matching test, and CHANGELOG.

## Test plan

- [x] `go test ./...` green
- [x] `make lint` clean
- [x] `uv run mkdocs build --strict` clean (no broken links after the move)
- [ ] If anyone has a shed handy: `scripts/publish-images-local.sh` end-to-end against a local `registry:2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for debugging and reproducing the publish-images workflow locally within shed environments, including network configuration and validation procedures.
  * Reorganized upgrade documentation with a dedicated v0.4 → v0.5 upgrade guide replacing previous generic upgrade references.
  * Corrected internal documentation links for consistency.

* **Chores**
  * Added local image publishing validation script for development testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->