### PR TITLE
config: populate Digest in resolveBaseRootfs warm-cache hits

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1350,7 +1350,7 @@ func TestFirecrackerConfigResolveBaseRootfs(t *testing.T) {
 		}
 	})
 
-	t.Run("docker ref", func(t *testing.T) {
+	t.Run("docker ref cold cache", func(t *testing.T) {
 		cfg := &FirecrackerConfig{
 			BaseRootfs: "ghcr.io/charliek/shed-fc-default:v1.0.0",
 			ImagesDir:  t.TempDir(),
@@ -1361,6 +1361,89 @@ func TestFirecrackerConfigResolveBaseRootfs(t *testing.T) {
 		}
 		if resolved.Name != "_base" {
 			t.Errorf("Name = %q, want _base", resolved.Name)
+		}
+		if resolved.Digest != "" {
+			t.Errorf("Digest = %q, want empty on cold cache", resolved.Digest)
+		}
+	})
+
+	t.Run("docker ref warm cache populates Digest", func(t *testing.T) {
+		dir := t.TempDir()
+		ref := "ghcr.io/charliek/shed-fc-default:v1.0.0"
+		rootfsPath := installCachedBlob(t, dir, "_base", ref)
+
+		cfg := &FirecrackerConfig{BaseRootfs: ref, ImagesDir: dir}
+		resolved := cfg.ResolveBaseRootfs()
+		if resolved.Path != rootfsPath {
+			t.Errorf("Path = %q, want %q", resolved.Path, rootfsPath)
+		}
+		if resolved.Digest == "" {
+			t.Error("Digest is empty on warm cache (regression: EnsureImage needs it to refcount the blob)")
+		}
+		if resolved.DockerRef != "" {
+			t.Errorf("DockerRef = %q, want empty on warm cache", resolved.DockerRef)
+		}
+	})
+
+	t.Run("docker ref stale cache falls through to DockerRef", func(t *testing.T) {
+		dir := t.TempDir()
+		installCachedBlob(t, dir, "_base", "ghcr.io/charliek/shed-fc-default:v1.0.0")
+
+		cfg := &FirecrackerConfig{
+			BaseRootfs: "ghcr.io/charliek/shed-fc-default:v2.0.0",
+			ImagesDir:  dir,
+		}
+		resolved := cfg.ResolveBaseRootfs()
+		if resolved.DockerRef != "ghcr.io/charliek/shed-fc-default:v2.0.0" {
+			t.Errorf("DockerRef = %q, want v2.0.0 (stale source-ref should re-pull)", resolved.DockerRef)
+		}
+		if resolved.Path != "" {
+			t.Errorf("Path = %q, want empty when source-ref mismatches", resolved.Path)
+		}
+	})
+}
+
+func TestVZConfigResolveBaseRootfs(t *testing.T) {
+	t.Run("local path", func(t *testing.T) {
+		cfg := &VZConfig{BaseRootfs: "/var/lib/shed/vz/base-rootfs.ext4"}
+		resolved := cfg.ResolveBaseRootfs()
+		if resolved.Path != "/var/lib/shed/vz/base-rootfs.ext4" {
+			t.Errorf("Path = %q", resolved.Path)
+		}
+		if resolved.DockerRef != "" {
+			t.Errorf("DockerRef = %q, want empty", resolved.DockerRef)
+		}
+	})
+
+	t.Run("docker ref cold cache", func(t *testing.T) {
+		cfg := &VZConfig{
+			BaseRootfs: "ghcr.io/charliek/shed-vz-default:v1.0.0",
+			ImagesDir:  t.TempDir(),
+		}
+		resolved := cfg.ResolveBaseRootfs()
+		if resolved.DockerRef != "ghcr.io/charliek/shed-vz-default:v1.0.0" {
+			t.Errorf("DockerRef = %q", resolved.DockerRef)
+		}
+		if resolved.Name != "_base" {
+			t.Errorf("Name = %q, want _base", resolved.Name)
+		}
+	})
+
+	t.Run("docker ref warm cache populates Digest", func(t *testing.T) {
+		dir := t.TempDir()
+		ref := "ghcr.io/charliek/shed-vz-default:v1.0.0"
+		rootfsPath := installCachedBlob(t, dir, "_base", ref)
+
+		cfg := &VZConfig{BaseRootfs: ref, ImagesDir: dir}
+		resolved := cfg.ResolveBaseRootfs()
+		if resolved.Path != rootfsPath {
+			t.Errorf("Path = %q, want %q", resolved.Path, rootfsPath)
+		}
+		if resolved.Digest == "" {
+			t.Error("Digest is empty on warm cache (regression: EnsureImage needs it to refcount the blob)")
+		}
+		if resolved.DockerRef != "" {
+			t.Errorf("DockerRef = %q, want empty on warm cache", resolved.DockerRef)
 		}
 	})
 }

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -590,12 +590,38 @@ func resolveImage(images map[string]string, imagesDir, image, configKey string) 
 // resolveBaseRootfs is the shared implementation for base rootfs resolution.
 func resolveBaseRootfs(baseRootfs, imagesDir string) ResolvedImage {
 	if vmimage.IsDockerRef(baseRootfs) {
-		if cached := vmimage.Resolve(imagesDir, "_base", baseRootfs); cached != "" {
-			return ResolvedImage{Path: cached, Name: "_base"}
+		// Mirror the source-ref + Digest plumbing from resolveImage so
+		// EnsureImage receives a Digest alongside Path. Without it the
+		// backends reject the resolved image as "outside the blob store"
+		// (firecracker/client.go ~494, vz/client.go ~232) because they
+		// can't refcount a Path-only entry.
+		if imagesDir != "" {
+			if digest, cached, ok := resolveCachedBase(imagesDir, baseRootfs); ok {
+				return ResolvedImage{Path: cached, Name: "_base", Digest: digest}
+			}
 		}
 		return ResolvedImage{DockerRef: baseRootfs, Name: "_base"}
 	}
 	return ResolvedImage{Path: baseRootfs, Name: "_base"}
+}
+
+// resolveCachedBase looks up the "_base" tag and returns (digest, path)
+// when the manifest matches baseRootfs AND the cached lower image is
+// materialized on disk. Returns ok=false on any miss so the caller can
+// fall through to the DockerRef path (which forces a fresh pull).
+func resolveCachedBase(imagesDir, baseRootfs string) (string, string, bool) {
+	digest, cached, err := vmimage.ResolveTag(imagesDir, "_base")
+	if err != nil {
+		return "", "", false
+	}
+	manifest, err := vmimage.LoadManifestByDigest(imagesDir, digest)
+	if err != nil || manifest.ShedSourceRef() != baseRootfs {
+		return "", "", false
+	}
+	if _, err := os.Stat(cached); err != nil {
+		return "", "", false
+	}
+	return digest, cached, true
 }
 
 // availableImageVariants returns a sorted list of image names known to


### PR DESCRIPTION
## Summary
- `resolveBaseRootfs` short-circuited to `ResolvedImage{Path: cached, Name: "_base"}` on a warm cache without populating `Digest`, so `EnsureImage` returned an empty manifest digest and both backends rejected with *"image resolved to a path outside the blob store; the overlay model requires content-addressed images"* (firecracker/client.go:494, vz/client.go:232).
- Trigger: default `shed create` (no `--image` flag) against a server with the base image already pulled. Cold cache worked because `Resolve()` returned `""` and the docker-ref branch went through a full pull which populated Digest.
- Mirror the source-ref + Digest plumbing pattern `resolveImage` already uses: `ResolveTag` → `LoadManifestByDigest` → `ShedSourceRef` equality check, with an `os.Stat` on the cached lower so a missing erofs still falls through to the DockerRef branch (preserving the old `Resolve` behavior).
- Extracted `resolveCachedBase` so the conditional reads cleanly. No signature changes — `resolveBaseRootfs` still returns `ResolvedImage` only.

## Scope
- VZ path: identical code, identical fix. Mac VZ runtime not exercised from this box, but unit tests now cover both `FirecrackerConfig.ResolveBaseRootfs` and `VZConfig.ResolveBaseRootfs` warm-cache cases.
- Behaviour change is additive: warm cache now returns `(Path, Digest)` instead of `(Path, "")`. Cold cache and local-path branches unchanged.

## Test plan
- [x] `make test` clean.
- [x] `make fmt` clean.
- [x] `golangci-lint v2.10.1` (matches CI) — 0 issues.
- [x] Built binaries installed locally, `shed-server` restarted, `shed create test-pr1 --local-dir $(mktemp -d)` no longer fails at the digest defense. **Expected:** failure now surfaces at the *next* bug (kernel/erofs format mismatch — handled by the follow-up PR 2). Verified in shed-server logs: VM boots, erofs reports "unknown HEAD1 format 2 … please upgrade kernel". This PR intentionally does not address that; reviewers should not expect green end-to-end yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for base root filesystem resolution with Docker references, including cold cache, warm cache, and stale cache scenarios for both Firecracker and VZ configurations.

* **Improvements**
  * Enhanced base root filesystem resolution to better handle digest tracking and cache validation when using Docker references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->