### PR TITLE
build-tools: add shed-build-tools image with pinned mkfs.erofs

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -19,8 +19,58 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  publish-build-tools:
+    name: Publish shed-build-tools
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.version || github.ref_name }}
+
+      - name: Resolve version
+        id: version
+        run: |
+          VERSION="${{ github.event.inputs.version || github.ref_name }}"
+          if [[ ! "$VERSION" =~ ^v ]]; then
+            echo "::error::Version must start with 'v' (example: v1.2.3)"
+            exit 1
+          fi
+          echo "tag=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build + push the build-tools image first. The publish-vz /
+      # publish-fc jobs need:tag to be on ghcr before they start so
+      # they can `FROM` / `docker run` it during image build. See
+      # docs/reference/build-tools.md for the versioning model.
+      #
+      # Build for both amd64 (used by publish-fc, runs on ubuntu-latest
+      # x86_64) and arm64 (used by publish-vz, runs on ubuntu-24.04-arm).
+      # docker buildx handles the multi-arch manifest.
+      - name: Build and push shed-build-tools
+        uses: docker/build-push-action@v6
+        with:
+          context: build-tools
+          file: build-tools/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/charliek/shed-build-tools:${{ steps.version.outputs.tag }}
+            ghcr.io/charliek/shed-build-tools:latest
+
   publish-vz:
     name: Publish VZ Images
+    needs: publish-build-tools
     runs-on: ubuntu-24.04-arm
 
     steps:
@@ -143,6 +193,7 @@ jobs:
 
   publish-fc:
     name: Publish FC Images
+    needs: publish-build-tools
     runs-on: ubuntu-latest
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-cli build-server build-agent build-firstboot test test-integration release clean dev-server dev-cli check coverage lint-all docs docs-serve firecracker-rootfs download-firecracker vz-rootfs vz-rootfs-base vz-rootfs-all
+.PHONY: build build-cli build-server build-agent build-firstboot build-tools test test-integration release clean dev-server dev-cli check coverage lint-all docs docs-serve firecracker-rootfs download-firecracker vz-rootfs vz-rootfs-base vz-rootfs-all
 
 GOARCH ?= $(shell go env GOARCH)
 
@@ -123,3 +123,9 @@ vz-rootfs-base: build-cli build-agent build-firstboot
 # Build all VZ rootfs image variants
 vz-rootfs-all: build-cli build-agent build-firstboot
 	./scripts/build-vz-rootfs.sh --all
+
+# Build the shed-build-tools image (mkfs.erofs + friends) locally, tagged
+# `shed-build-tools:dev`. Consumers in development mode point at this tag
+# via --build-tools-version=dev. See build-tools/README.md for details.
+build-tools:
+	docker build -t shed-build-tools:dev build-tools/

--- a/build-tools/Dockerfile
+++ b/build-tools/Dockerfile
@@ -1,0 +1,110 @@
+# shed-build-tools — controlled environment for shed's image-build pipeline.
+#
+# Why this image exists
+# ---------------------
+# shed-fc-* and shed-vz-* images contain an erofs blob built from the
+# rootfs at image-publish time (see PR 2b for the consumer side). The
+# tool that builds that blob — mkfs.erofs from erofs-utils — has had
+# correctness bugs in the past where certain inode layouts (notably
+# the big-pcluster header set without the matching superblock feature
+# flag) produce filesystems that no kernel can read. Ubuntu noble and
+# Pop!_OS 24.04 ship erofs-utils 1.7.1-1build2, which is one of the
+# affected versions.
+#
+# To remove host erofs-utils as a variable in shed-fc / shed-vz image
+# builds, we pin the version centrally here, distributed as a regular
+# OCI image. CI runs `docker run --rm shed-build-tools:vX.Y.Z
+# mkfs.erofs ...` to produce every published shed-* erofs blob, which
+# means the on-disk format is identical regardless of where the
+# publish workflow runs.
+#
+# Versioning
+# ----------
+# This image is tagged in lockstep with shed-server releases
+# (ghcr.io/charliek/shed-build-tools:v0.5.2, :v0.5.3, ...). The image
+# content rarely changes — only when EROFS_UTILS_VERSION bumps or new
+# tools land — but every shed release publishes a new tag so consumers
+# can pin to the same version they're already pinning shed-server to.
+# See docs/reference/build-tools.md for the version-bump procedure.
+#
+# Building from source vs apt-get install
+# ---------------------------------------
+# We build from the upstream erofs-utils git tag rather than installing
+# debian's package: pinning the version explicitly decouples us from
+# distro release cadence (if a critical bug is found in 1.9.1, we can
+# bump immediately rather than wait for debian to update). Build is
+# ~30s; not worth the loss of control to skip it.
+
+# ---- builder stage ----
+FROM debian:trixie-slim AS builder
+
+ARG EROFS_UTILS_VERSION=v1.9.1
+
+# Build deps for erofs-utils:
+#   - autoconf/automake/libtool/pkg-config: build system
+#   - libuuid1/uuid-dev: required by mkfs.erofs
+#   - liblz4-dev/liblzma-dev/zlib1g-dev: compression backends
+#   - libselinux1-dev: optional but enables selinux label support
+#   - ca-certificates: TLS for the source fetch
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
+        ca-certificates \
+        curl \
+        libselinux1-dev \
+        liblz4-dev \
+        liblzma-dev \
+        libtool \
+        libuuid1 \
+        pkg-config \
+        uuid-dev \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN curl -fsSL "https://github.com/erofs/erofs-utils/archive/refs/tags/${EROFS_UTILS_VERSION}.tar.gz" \
+        -o erofs-utils.tar.gz \
+    && tar -xzf erofs-utils.tar.gz --strip-components=1 \
+    && rm erofs-utils.tar.gz
+
+# --enable-* flags mirror what debian's package enables, minus the
+# fuse runtime (we only need the offline tools). Static-link the lz4
+# backend so the resulting binaries don't depend on the runtime
+# image's lz4 ABI version.
+RUN ./autogen.sh \
+    && ./configure \
+        --prefix=/usr/local \
+        --enable-lz4 \
+        --enable-lzma \
+        --enable-static \
+    && make -j"$(nproc)" \
+    && make install-strip
+
+# ---- runtime stage ----
+FROM debian:trixie-slim
+
+# Runtime deps that the dynamically-linked tools need at execution time.
+# liblz4 and liblzma are the compression backends; libuuid1 provides
+# libuuid which mkfs.erofs uses for filesystem UUIDs.
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        liblz4-1 \
+        liblzma5 \
+        libuuid1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/bin/mkfs.erofs /usr/local/bin/mkfs.erofs
+COPY --from=builder /usr/local/bin/dump.erofs /usr/local/bin/dump.erofs
+COPY --from=builder /usr/local/bin/fsck.erofs /usr/local/bin/fsck.erofs
+
+# Quick smoke test embedded in the image: building it confirms the
+# binaries at least launch (catches obvious link errors at image-build
+# time rather than at first downstream use).
+RUN mkfs.erofs --help >/dev/null 2>&1 || (echo "mkfs.erofs smoke test failed" && exit 1)
+
+# Default to mkfs.erofs so `docker run --rm shed-build-tools:tag <args>`
+# is the common case. Callers needing dump.erofs / fsck.erofs override
+# the entrypoint.
+ENTRYPOINT ["/usr/local/bin/mkfs.erofs"]

--- a/build-tools/README.md
+++ b/build-tools/README.md
@@ -1,0 +1,56 @@
+# shed-build-tools
+
+Controlled environment for shed's image-build pipeline. See
+[`docs/reference/build-tools.md`](../docs/reference/build-tools.md) for
+the user-facing reference.
+
+This directory contains:
+
+- `Dockerfile` — builds the `ghcr.io/charliek/shed-build-tools:<tag>`
+  OCI image. The image carries pinned versions of the binaries shed
+  invokes during image publish (currently `mkfs.erofs`, `dump.erofs`,
+  `fsck.erofs` from `erofs-utils`).
+
+## Building locally
+
+```sh
+make build-tools                              # builds shed-build-tools:dev
+docker run --rm shed-build-tools:dev --help   # mkfs.erofs help (default entrypoint)
+```
+
+## Bumping the erofs-utils pin
+
+1. Pick a release at <https://github.com/erofs/erofs-utils/tags>.
+2. Update `ARG EROFS_UTILS_VERSION=` in `Dockerfile`.
+3. Rebuild: `make build-tools`.
+4. Sanity check the produced binary:
+
+   ```sh
+   # Make sure the bug class we care about is fixed: write an erofs
+   # with the flags shed publishes with, then confirm dump.erofs
+   # reports the big_pcluster feature when inodes use it.
+   docker run --rm -v /tmp:/tmp shed-build-tools:dev \
+       -b 4096 -z lz4 -E force-inode-compact -T 0 \
+       /tmp/test.erofs --tar=f <(echo "")
+   docker run --rm --entrypoint /usr/local/bin/dump.erofs \
+       -v /tmp:/tmp shed-build-tools:dev /tmp/test.erofs | grep features
+   ```
+
+5. Commit the bump alongside any consumer changes that depend on it.
+   The bump rides the next shed release.
+
+## Consumers
+
+No live consumers in this commit. The image is being introduced ahead
+of the shed image-build pipeline switch that will use it (the change
+needs the image to exist on `ghcr.io` first so it can be `FROM`'d /
+`docker run`'d from CI). Once consumers land:
+
+- They will pin the image tag to the current shed version via a
+  `BUILD_TOOLS_VERSION` build arg, mirroring the `SHED_EXT_VERSION`
+  pattern already used for shed-extensions.
+- This README should grow a list of every consumer file so binary
+  renames / entrypoint changes here can be traced forward.
+
+If you change the `ENTRYPOINT` or rename a binary, update this list
+as part of the consumer change.

--- a/docs/reference/build-tools.md
+++ b/docs/reference/build-tools.md
@@ -1,0 +1,94 @@
+# shed-build-tools
+
+`shed-build-tools` is an OCI image carrying the binaries shed uses
+when it publishes a shed-fc / shed-vz image. It exists so the on-disk
+format of every published shed image is determined by a pinned tool
+version, not by whatever the publishing host's distro happens to
+ship.
+
+## What's in the image
+
+| Binary | Source | Used for |
+| --- | --- | --- |
+| `mkfs.erofs` | [erofs-utils](https://github.com/erofs/erofs-utils) | Building the read-only rootfs blob inside shed-fc / shed-vz images. |
+| `dump.erofs` | erofs-utils | Inspecting an erofs blob (development / debugging). |
+| `fsck.erofs` | erofs-utils | Verifying erofs blobs in CI / smoke tests. |
+
+The `mkfs.erofs` binary is the headline reason this image exists.
+Distro-shipped versions have at times produced filesystems no kernel
+can read (e.g., erofs-utils 1.7.1 emits per-inode big-pcluster
+headers without the superblock feature flag when invoked with
+`-E force-inode-compact`). Pinning the version ensures every shed
+release's published images use a known-good writer.
+
+## Versioning
+
+Every shed-server release publishes a matching `shed-build-tools` tag:
+
+```
+ghcr.io/charliek/shed-build-tools:v0.5.2
+ghcr.io/charliek/shed-build-tools:v0.5.3
+...
+```
+
+The image content rarely changes — only when the pinned upstream
+tool versions bump or when new tools land. But every shed release
+gets a tag so consumers can pin to the same version they're already
+pinning shed-server to. Identical content across releases is
+deduplicated in the registry.
+
+The shed-build-tools image is currently versioned in lockstep with
+shed-server because both ship out of this repository and the release
+cadences are coupled. If/when shed-build-tools stabilizes and stops
+needing per-release rebuilds, it may move to an independent tag
+stream — until then, the lockstep model keeps the mental model
+small.
+
+## Bumping the pinned `erofs-utils` version
+
+1. Pick a release at <https://github.com/erofs/erofs-utils/tags>.
+2. Edit `build-tools/Dockerfile` and change the `ARG EROFS_UTILS_VERSION` line.
+3. Build locally: `make build-tools`.
+4. Sanity check that the new binary writes a filesystem the consumer
+   kernel can actually read — see `build-tools/README.md` for the
+   exact one-liner.
+5. Commit the bump. The new version rides the next shed release.
+
+There is no out-of-band release for `shed-build-tools` — it only
+publishes alongside a shed-server tag.
+
+## Adding new tools to the image
+
+Tools that the shed image-build / publish pipeline calls should live
+here when (a) the on-disk format they produce matters for
+reproducibility, or (b) their host version varies enough across
+distros to cause issues. Examples of tools that fit: a custom kernel
+build environment, an initramfs builder, a squashfs writer if we
+ever add one. Examples that don't: shed's own Go binaries (those
+ship in the shed-server release artifacts directly), generic CLI
+utilities already available everywhere.
+
+When adding a tool:
+
+1. Append it to `build-tools/Dockerfile` (preferably in the existing
+   builder stage; copy the resulting binary into the runtime stage).
+2. Document it in `build-tools/README.md` under "What's in the image".
+3. List the consumer file(s) in `build-tools/README.md` so future
+   binary renames / entrypoint changes can be traced.
+
+## Local development
+
+```sh
+make build-tools                              # builds shed-build-tools:dev
+docker run --rm shed-build-tools:dev --help   # mkfs.erofs help (default entrypoint)
+```
+
+When iterating on a consumer that hasn't been released yet, point
+the consumer's `BUILD_TOOLS_VERSION` build arg at `dev` and it will
+pick up your local image.
+
+If you want to test against a yet-unreleased upstream version,
+publish a temporary tag (`ghcr.io/charliek/shed-build-tools:dev-foo`),
+run the consumer against it, then delete the tag with
+`gh api --method DELETE /user/packages/container/shed-build-tools/versions/<id>`
+once you're done. Avoid leaving long-lived `dev-*` tags on ghcr.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
       - Firecracker Operations: reference/fc-operations.md
       - VZ Operations (macOS): reference/vz-operations.md
       - Image Variants: reference/images.md
+      - Build Tools: reference/build-tools.md
       - Extensions: reference/extensions.md
       - HTTP API: reference/api.md
   - Discovery:


### PR DESCRIPTION
## Summary
- New OCI image `ghcr.io/charliek/shed-build-tools:vX.Y.Z` carrying pinned `mkfs.erofs`, `dump.erofs`, `fsck.erofs` from upstream `erofs-utils` v1.9.1.
- Replaces a future host-side dependency on whatever `erofs-utils` the host distro ships. Ubuntu noble / Pop!_OS 24.04 / mini2 / mini3 all currently ship `erofs-utils 1.7.1-1build2`, which has a writer bug where `-E force-inode-compact` emits per-inode big-pcluster headers without the matching sb feature flag — producing filesystems no kernel can read (`erofs: per-inode big pcluster without sb feature for nid N`, `err [-117]`). This is the actual end-to-end blocker behind v0.5.1's broken `shed create` cycle.
- This PR introduces the image only — **no consumers yet**. The consumer side (`firecracker/Dockerfile`, `vz/Dockerfile`, `internal/vmimage` pull path, dropping the local `mkfs.erofs` step) lands in a follow-up so the image is on `ghcr` first.
- Publish workflow gates `publish-vz` and `publish-fc` on `publish-build-tools` succeeding first. Multi-arch (`linux/amd64`, `linux/arm64`) so both publish jobs can `FROM` / `docker run` the same tag.

## Scope
- `build-tools/Dockerfile` — two-stage build, runtime stage carries only the three binaries plus dynamic deps (`liblz4`, `liblzma`, `libuuid`). Top-of-file comment block documents *why this exists*, *why versioned with shed*, and *why built from source rather than apt-get install*.
- `build-tools/README.md` — developer reference for bumping the `EROFS_UTILS_VERSION` pin and the no-consumers-yet status.
- `docs/reference/build-tools.md` — user-facing reference: contents, versioning model, how to add tools, local dev story. Wired into `mkdocs.yml` Reference nav.
- `Makefile` — new `make build-tools` target produces `shed-build-tools:dev`.
- `.github/workflows/publish-images.yaml` — new `publish-build-tools` job; existing jobs add `needs: publish-build-tools`.

## Why now / sequencing
This is PR 2a of the v0.5.x release recovery plan. PR 2b (in flight) switches the image-build pipeline to use this image and ships the erofs as a content-addressed OCI blob, dropping the local `mkfs.erofs` invocation entirely. PR 2b's `firecracker/Dockerfile` and `vz/Dockerfile` will `FROM` `ghcr.io/charliek/shed-build-tools:${BUILD_TOOLS_VERSION}`, so the image needs to be on `ghcr` first. After this PR merges and goes out with the next tag, PR 2b can author against a real registry tag.

## Test plan
- [x] `make build-tools` builds the image cleanly (~25s after a warm cache, ~90s cold).
- [x] `docker run --rm shed-build-tools:dev --version` reports `mkfs.erofs (erofs-utils) v1.9.1`.
- [x] Built a test erofs against a 40 MB synthetic tarball using the same flags shed currently calls (`-b 4096 -z lz4 -E force-inode-compact -T 0`); `fsck.erofs` against the result exits 0.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the modified workflow.
- [x] `make fmt && make test` clean.
- [x] golangci-lint v2.10.1 (matches CI) — 0 issues.

The big-pcluster fix verification is necessarily limited at this stage — the bug only manifests on certain tarball contents and only when an actual kernel tries to mount the result. Full empirical proof comes when PR 2b uses this image to mint the v0.5.2 shed-fc / shed-vz erofs blobs and the smoke test boots them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)