### PR TITLE
vmimage: ship rootfs erofs as content-addressed OCI blob

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,15 +70,18 @@ The server config `default_backend` supports `vz`, `firecracker`, or `detect` (a
 
 ## VM Images
 
-VZ and Firecracker use multi-stage Dockerfiles (`vz/Dockerfile`, `firecracker/Dockerfile`) to build rootfs ext4 images. Variants: `base`, `default`, `experimental`. The `experimental` variant layers [shed-extensions](https://github.com/charliek/shed-extensions) guest binaries via `COPY --from=` a published multi-arch Docker image, pinned by `ARG SHED_EXT_VERSION`.
+VZ and Firecracker use multi-stage Dockerfiles (`vz/Dockerfile`, `firecracker/Dockerfile`) to build rootfs OCI images. Variants: `base`, `extensions`, `full`. The `extensions` and `full` variants layer [shed-extensions](https://github.com/charliek/shed-extensions) guest binaries via `COPY --from=` a published multi-arch Docker image, pinned by `ARG SHED_EXT_VERSION`.
 
-- Build locally: `./scripts/build-vz-rootfs.sh --variant experimental`
+Since v0.5.2 the read-only rootfs **erofs is built at image-publish time** by `mkfs.erofs` running inside the `ghcr.io/charliek/shed-build-tools:vX.Y.Z` container (pinned `erofs-utils` version, tagged in lockstep with shed releases). The resulting erofs ships as a content-addressed OCI blob referenced by the `io.shed.rootfs.erofs.digest` manifest annotation. Hosts pull the blob and mount it directly — no on-host `mkfs.erofs` invocation. Pre-v0.5.2 images lack the annotation and are rejected at boot with a clear "rebuild against current tooling" error (see `internal/vmimage/manager.go:resolveManifestLower`).
+
+- Build locally: `./scripts/build-vz-rootfs.sh --variant extensions`
 - Local dev with shed-extensions changes: `--shed-ext-version dev` (after building the shed-extensions Docker image locally)
-- See `docs/reference/images.md` for full variant docs and build instructions
+- Local dev iterating on the build-tools image: `make build-tools && ./scripts/build-{vz,firecracker}-rootfs.sh --build-tools-version dev`
+- See `docs/reference/images.md`, `docs/reference/build-tools.md`, and `docs/upgrades/v0.5.1-to-v0.5.2.md` for full docs.
 
 ## Storage Model
 
-Images are stored content-addressed under `{images_dir}/blobs/sha256/<digest>/` with tag indirection at `{images_dir}/tags/<tag>.json`. Each shed and snapshot pins the digest of its lower image in metadata so `shed image prune` can refcount-GC unreferenced blobs. Tags do NOT protect blobs from prune (Docker model). See `docs/reference/storage-model.md` for the full layout and the lifecycle commands (`shed image ls/inspect/tag/pull/rm/prune`).
+Images are stored content-addressed under `{images_dir}/blobs/sha256/<digest>` (flat files, one per blob — manifests, configs, layer tar.gz, kernel, initrd, rootfs erofs). Tags live at `{images_dir}/tags/<tag>.json`. Each shed and snapshot pins the manifest digest in metadata so `shed image prune` can refcount-GC unreferenced blobs. Tags do NOT protect blobs from prune (Docker model). See `docs/reference/storage-model.md` for the full layout and the lifecycle commands (`shed image ls/inspect/tag/pull/rm/prune`).
 
 ## Documentation
 

--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strings"
 	"text/tabwriter"
@@ -12,8 +13,65 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/version"
 	"github.com/charliek/shed/internal/vmimage"
 )
+
+// buildToolsRefDefault resolves the shed-build-tools OCI ref that
+// `shed image build` should use when minting the rootfs erofs blob.
+// Priority: explicit --build-tools-version flag > derive from
+// `version.Version` for clean release builds > "dev" fallback.
+//
+// Why three tiers:
+//   - CI's publish-images workflow passes --build-tools-version
+//     explicitly so a single source-of-truth (the tag being released)
+//     drives every build-tools reference.
+//   - Outside CI, a `go install` or `go build` from a clean checkout
+//     of a release tag has version.Version="X.Y.Z" — we derive
+//     `ghcr.io/charliek/shed-build-tools:vX.Y.Z` so consumers don't
+//     have to remember the flag.
+//   - All other dev builds (dirty, ahead-of-tag, version="dev") fall
+//     back to `:dev` and expect the caller to have run
+//     `make build-tools` first.
+const buildToolsImageBase = "ghcr.io/charliek/shed-build-tools"
+
+var releaseTagRE = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+
+func buildToolsRefDefault(override string) string {
+	if override != "" {
+		// Full image ref (anything containing "/" or ":") passes
+		// through verbatim — `shed-build-tools:dev`,
+		// `ghcr.io/.../shed-build-tools:custom`, or
+		// `localhost:5000/shed-build-tools:test` are all valid.
+		if strings.Contains(override, "/") || strings.Contains(override, ":") {
+			return override
+		}
+		// Bare tag (no path or colon). Only "release-shaped"
+		// tags (vX.Y.Z) are synthesized against the canonical
+		// registry — for anything else (`dev`, `mybuild`), use
+		// the bare image name so a `make build-tools`-produced
+		// local image resolves without an unwanted registry pull.
+		if releaseTagRE.MatchString(override) {
+			tag := override
+			if !strings.HasPrefix(tag, "v") {
+				tag = "v" + tag
+			}
+			return buildToolsImageBase + ":" + tag
+		}
+		return "shed-build-tools:" + override
+	}
+	v := strings.TrimSpace(version.Version)
+	if releaseTagRE.MatchString(v) {
+		if !strings.HasPrefix(v, "v") {
+			v = "v" + v
+		}
+		return buildToolsImageBase + ":" + v
+	}
+	// Dev build of shed CLI. Default to a locally-built
+	// shed-build-tools:dev image — no registry round-trip — and
+	// rely on `make build-tools` having been run first.
+	return "shed-build-tools:dev"
+}
 
 var imageCmd = &cobra.Command{
 	Use:   "image",
@@ -22,15 +80,16 @@ var imageCmd = &cobra.Command{
 }
 
 var (
-	imageBuildFile       string
-	imageBuildInitrd     string
-	imageBuildName       string
-	imageBuildTarget     string
-	imageBuildOutputDir  string
-	imageBuildPlatform   string
-	imageBuildSourceRef  string
-	imageBuildForce      bool
-	imageBuildOCIArchive string
+	imageBuildFile         string
+	imageBuildInitrd       string
+	imageBuildName         string
+	imageBuildTarget       string
+	imageBuildOutputDir    string
+	imageBuildPlatform     string
+	imageBuildSourceRef    string
+	imageBuildForce        bool
+	imageBuildOCIArchive   string
+	imageBuildToolsVersion string
 
 	imageDeleteForce bool
 	imagePruneForce  bool
@@ -153,6 +212,13 @@ func init() {
 	imageBuildCmd.Flags().StringVar(&imageBuildSourceRef, "source-ref", "", "Override the io.shed.source-ref annotation baked into the manifest (default: <prefix><name>:latest). Pass the final registry ref in CI publish flows so server-side cache lookups match.")
 	imageBuildCmd.Flags().BoolVar(&imageBuildForce, "force", false, "Skip base image validation warning")
 	imageBuildCmd.Flags().StringVar(&imageBuildOCIArchive, "from-oci-archive", "", "Skip docker buildx and ingest a pre-built OCI image-layout tar (e.g. produced by `podman build --output type=oci,dest=...` or `buildah bud --output oci-archive,...`). Mutually exclusive with --file/--target/--platform/--force.")
+	// --build-tools-version pins the shed-build-tools OCI image that
+	// runs mkfs.erofs during image build. Defaults to the shed CLI's
+	// own release tag so a `shed image build` invoked from a
+	// shed-server v0.5.2 install produces v0.5.2-shaped erofs blobs.
+	// Override with `dev` (or any other tag) when iterating on the
+	// build-tools image locally — see docs/reference/build-tools.md.
+	imageBuildCmd.Flags().StringVar(&imageBuildToolsVersion, "build-tools-version", "", "Override the shed-build-tools image tag used to mint the rootfs erofs (default: matches the shed CLI version; pass 'dev' for a locally-built shed-build-tools:dev image)")
 	_ = imageBuildCmd.MarkFlagRequired("name")
 
 	imageDeleteCmd.Flags().BoolVar(&imageDeleteForce, "force", false, "Skip confirmation prompt")
@@ -420,6 +486,7 @@ func convertAndInstall(ctx context.Context, sourceRef, ociArchivePath, imagesDir
 		return "", fmt.Errorf("invalid image name %q: %w", imageBuildName, err)
 	}
 
+	buildToolsRef := buildToolsRefDefault(imageBuildToolsVersion)
 	result, err := vmimage.Convert(ctx, vmimage.ConvertOptions{
 		OCIArchivePath:   ociArchivePath,
 		DockerRef:        sourceRef,
@@ -429,6 +496,7 @@ func convertAndInstall(ctx context.Context, sourceRef, ociArchivePath, imagesDir
 		ExtractKernel:    extractKernel,
 		NeedsInitrd:      needsInitrd,
 		InitrdSourcePath: imageBuildInitrd,
+		BuildToolsRef:    buildToolsRef,
 	})
 	if err != nil {
 		return "", fmt.Errorf("conversion failed: %w", err)

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -5,25 +5,36 @@ Shed images are OCI-compliant container images. The on-disk store is an
 directory, layers are shared across tags, and pulls/pushes go directly to any
 OCI registry — no Docker daemon required for transport.
 
-Each image carries one or more read-only gzipped tar layers and a few
-annotations (kernel digest, initrd digest, source ref, variant name, schema
-version). At materialize time on the host, every layer is read in OCI order,
-OCI whiteouts are applied, and the merged tree is fed to `mkfs.erofs --tar=f`
-to produce a single content-addressed erofs file (one per manifest digest,
-shared across every shed that boots from this image). At boot the in-guest
-initramfs assembles a single-lower overlayfs with the per-shed writable
-upper on top.
+Each image carries:
+
+- one or more read-only gzipped tar layers (Dockerfile-stage shape preserved),
+- a prebuilt rootfs erofs blob (`io.shed.rootfs.erofs.digest` annotation; this
+  is what the VM mounts read-only at `/dev/vdb`),
+- a kernel blob (`io.shed.kernel.digest`),
+- an initrd blob (`io.shed.initrd.digest`),
+- standard annotations (source ref, variant name, shed schema version).
+
+The rootfs erofs is minted at image-publish time by `mkfs.erofs` running
+inside the [shed-build-tools](build-tools.md) container — a known-good
+`erofs-utils` version is pinned there so every consumer sees byte-identical
+filesystem layout regardless of where the image was published or where
+it'll be mounted. Hosts do not invoke `mkfs.erofs` themselves; they
+download the blob and mount it directly. At boot the in-guest initramfs
+assembles a single-lower overlayfs with the per-shed writable upper on
+top.
 
 ## Prerequisites
 
-The host running `shed-server` needs `mkfs.erofs` on PATH so the materialize
-step can build the flattened lower:
+No host-side erofs tooling is required. The shed-server package does
+not depend on `erofs-utils`; the OCI manifests ship the prebuilt erofs
+as a content-addressed blob. (Hosts that *publish* images — i.e., run
+`shed image build` — need Docker so the build-tools container can run,
+but not `erofs-utils` directly on the host.)
 
-- **macOS:** `brew install erofs-utils` (1.9.1+ via Homebrew bottle).
-- **Debian/Ubuntu:** `apt install erofs-utils`.
-
-If absent, shed errors at first `shed create` (or `shed image pull` followed
-by boot) with a clear install hint.
+If you're upgrading from v0.5.1 or earlier, see the
+[v0.5.1 → v0.5.2 upgrade guide](../upgrades/v0.5.1-to-v0.5.2.md) for the
+breaking-change details and the required `shed image rm` / `pull-images`
+steps.
 
 ## Available Variants
 
@@ -92,24 +103,25 @@ The on-disk store under `{images_dir}/` is OCI image-layout-v1:
 {images_dir}/
   oci-layout                                   # {"imageLayoutVersion":"1.0.0"}
   index.json                                   # OCI image index
-  blobs/sha256/<hex>                           # OCI blobs (manifests, configs, layer tar.gz)
-  cache/sha256/<manifest-digest>.erofs         # flattened lower for the whole manifest, materialized lazily
+  blobs/sha256/<hex>                           # OCI blobs (manifests, configs, layer tar.gz, kernel, initrd, rootfs erofs)
   tags/<name>.json                             # tag → manifest digest pointers
   uppers/<shed>/upper.ext4                     # per-shed writable overlay upper
   instances/<shed>/metadata.json               # per-shed bookkeeping (pins manifest digest)
   snapshots/<snap>/snapshot.json               # per-snapshot bookkeeping
 ```
 
-**Two storage roles.** Layer blobs live in `blobs/sha256/` as gzipped
-tarballs and are deduplicated across manifests (the `apt-get install`
-layer is one blob no matter how many variants reference it). The
-materialized boot artifact is a separate object: a single erofs file
-under `cache/sha256/<manifest-digest>.erofs` that represents the entire
-manifest's layers flattened (with OCI whiteouts applied) into one
-read-only filesystem. Both forms stay on disk: the tar.gz so
-`shed image push` can byte-perfectly round-trip the manifest to a
-registry, the erofs so boot is fast and the same artifact is shared
-across every shed booting from that manifest.
+**Everything is a content-addressed blob.** Layer tarballs, kernel,
+initrd, and the prebuilt rootfs erofs all live in `blobs/sha256/` keyed
+by their content sha256. The rootfs erofs is what the VM mounts at boot
+as `/dev/vdb`; the layer tarballs sit alongside it so `shed image push`
+can byte-perfectly round-trip the manifest to a registry and so derived
+images (`FROM` chains) can reuse the lower-numbered layers without
+re-downloading them.
+
+The legacy `cache/sha256/<manifest-digest>.erofs` directory (used
+through v0.5.1 for locally-materialized erofs files) is gone. Older
+installs may still have one — it's safe to `rm -rf` after upgrading;
+see the [v0.5.1 → v0.5.2 upgrade guide](../upgrades/v0.5.1-to-v0.5.2.md).
 
 **Layer sharing happens at the blob layer.** Two tags that share a base
 layer share the underlying blob — pulling `shed-vz-full:v0.5.1` after
@@ -185,9 +197,10 @@ crane manifest --from-archive shed-vz-full.tar
 shed image load -i shed-vz-full.tar
 ```
 
-It unpacks each blob into the local store, advances the tag(s), and
-materializes the flattened erofs cache lazily on first boot. Layers
-already present locally are skipped.
+It unpacks each blob into the local store and advances the tag(s).
+The rootfs erofs blob ships in the OCI archive alongside the layers —
+no on-host `mkfs.erofs` step is needed. Layers already present
+locally are skipped.
 
 ### Push to a registry
 
@@ -219,6 +232,7 @@ Every shed-built manifest carries these annotations (visible via
 | `io.shed.source-ref` | The Docker / OCI reference the image was pulled or built from. |
 | `io.shed.kernel.digest` | Digest of the kernel blob embedded in the image. |
 | `io.shed.initrd.digest` | Digest of the initrd (shed-built initramfs) blob. |
+| `io.shed.rootfs.erofs.digest` | Digest of the prebuilt read-only rootfs erofs blob the VM mounts at `/dev/vdb`. v0.5.2+. Required — images missing this annotation are rejected at boot. |
 | `io.shed.schema-version` | Metadata schema version (currently `v3`). |
 | `io.shed.rootfs.logical-size` | Sum of layer logical sizes — what the merged overlay sees from inside the guest. |
 

--- a/docs/reference/storage-model.md
+++ b/docs/reference/storage-model.md
@@ -15,8 +15,8 @@ For each VM backend, all on-disk state lives under a single `images_dir`:
   oci-layout                                    # {"imageLayoutVersion":"1.0.0"}
   index.json                                    # OCI image index (manifest references)
   blobs/sha256/<hex>                            # FILES, not dirs — OCI blobs:
-                                                #   manifests, configs, layer tar.gz
-  cache/sha256/<manifest-digest>.erofs          # flattened manifest lower (lazy)
+                                                #   manifests, configs, layer tar.gz,
+                                                #   kernel, initrd, rootfs erofs
   tags/<tag>.json                               # {"digest":"sha256:...","updated_at":"..."}
   uppers/<shed>/upper.ext4                      # per-shed writable overlay upper
   instances/<shed>/metadata.json                # per-shed bookkeeping
@@ -26,20 +26,23 @@ For each VM backend, all on-disk state lives under a single `images_dir`:
 For Firecracker the default is `/var/lib/shed/firecracker/images/`; for
 VZ it's `~/Library/Application Support/shed/vz/`.
 
-Two storage roles to keep straight:
+**Everything in `blobs/sha256/<hex>` is a flat file**, not a directory.
+The blob can be a manifest JSON, an image config, a gzipped tar layer,
+a raw kernel, a raw initrd, or a raw erofs filesystem. All are
+deduplicated by sha256 — the `apt-get install` layer is one blob no
+matter how many manifests reference it.
 
-- **`blobs/sha256/<hex>` is a flat file**, not a directory. It contains
-  the raw OCI blob — a manifest JSON, an image config, or a gzipped tar
-  layer. Blobs are deduplicated across manifests (the `apt-get install`
-  layer is one blob whether `base`, `extensions`, and `full` all
-  reference it).
-- **`cache/sha256/<manifest-digest>.erofs` is the boot artifact**: a
-  single flattened erofs file representing the manifest's layers merged
-  with OCI whiteouts applied. Built lazily the first time a manifest is
-  needed for boot; shared across every shed booting from that manifest.
-  The boot artifact is keyed by manifest digest, not layer digest —
-  different variants get different erofs files, but the underlying layer
-  blobs are still shared.
+The read-only rootfs the VM mounts at `/dev/vdb` is the erofs blob
+referenced by the manifest's `io.shed.rootfs.erofs.digest` annotation.
+It's built once at image-publish time by `mkfs.erofs` inside the
+[shed-build-tools container](build-tools.md) (pinned `erofs-utils`),
+shipped as a content-addressed OCI blob, and downloaded verbatim by
+every host. The on-host pull path does not invoke `mkfs.erofs`.
+
+Through v0.5.1 the erofs was built lazily on the host into a separate
+`cache/sha256/<manifest-digest>.erofs` directory. That directory is no
+longer used; older installs may still have one and can `rm -rf` it.
+See the [v0.5.1 → v0.5.2 upgrade guide](../upgrades/v0.5.1-to-v0.5.2.md).
 
 ## Concepts, mapped to Docker
 
@@ -48,7 +51,8 @@ Two storage roles to keep straight:
 | **Manifest blob** — JSON file at `blobs/sha256/<hex>` whose media type is `application/vnd.oci.image.manifest.v1+json` | Image manifest |
 | **Config blob** — JSON file in `blobs/sha256/<hex>` referenced by the manifest | Image config |
 | **Layer blob** — gzipped tar at `blobs/sha256/<hex>` | Image layer |
-| **Flattened lower** — `cache/sha256/<manifest-digest>.erofs` derived from all of a manifest's layers | (no direct analog — boot-time artifact) |
+| **Rootfs erofs blob** — raw erofs at `blobs/sha256/<hex>` referenced by `io.shed.rootfs.erofs.digest` | (no direct analog — read-only root the VM mounts) |
+| **Kernel / initrd blobs** — raw binaries at `blobs/sha256/<hex>` referenced by `io.shed.kernel.digest` / `io.shed.initrd.digest` | (no direct analog — VM boot artifacts) |
 | **Tag** — `tags/<name>.json` pointing at a manifest digest | Image tag |
 | **Dangling manifest** — manifest with no tag and no shed/snapshot reference | `<none>:<none>` image |
 
@@ -64,10 +68,9 @@ When `shed create --image extensions` runs, the server:
 2. Writes `instances/<name>/metadata.json` with
    `"lower_digest": "sha256:<manifest-digest>"`, `"schema_version": 3`,
    and the list of layer digests captured at create time.
-3. Materializes the flattened erofs lower at
-   `cache/sha256/<manifest-digest>.erofs` if it isn't already cached.
-   This is one `mkfs.erofs --tar=f` over the merged layer tree (with OCI
-   whiteouts applied) — sub-10-second on typical hardware.
+3. Looks up the manifest's `io.shed.rootfs.erofs.digest` annotation
+   and resolves it to a blob path under `blobs/sha256/`. The blob IS
+   the read-only lower the VM mounts — no host-side `mkfs.erofs`.
 4. Creates the per-shed upper at `uppers/<name>/upper.ext4`.
 
 Subsequent `shed start` reads the same metadata. The shed boots from the
@@ -84,8 +87,9 @@ digest after the fact does not change what an existing shed boots.
 2. **Expand** — for every manifest digest in the seed set, parse the
    manifest and add its config blob and layer blob digests.
 3. **Sweep** — delete any blob in `blobs/sha256/` not in the reachable
-   set, and any `cache/sha256/<manifest-digest>.erofs` whose manifest is
-   unreachable.
+   set. (The reachable set includes layer blobs, manifest configs, the
+   kernel / initrd loose blobs, and the rootfs erofs blob via their
+   respective annotations.)
 
 Tags do **not** protect blobs. Following the Docker model,
 `shed image rm <tag>` only removes the tag — the manifest and its layers
@@ -145,16 +149,13 @@ Blob install is atomic:
 2. `fsync` the file.
 3. `rename` to `blobs/sha256/<hex>`; `fsync` the parent dir.
 
-Tag advancement follows the same pattern on `tags/<name>.json`. Cache
-materialization is similarly atomic on
-`cache/sha256/<manifest-digest>.erofs`: write to a staging tempfile,
-chmod 0o444, fsync, atomic rename into place.
+Tag advancement follows the same pattern on `tags/<name>.json`.
 
 Concurrent installs of the same blob are serialized by a flock on
 `blobs/sha256/.<hex>.lock`. Concurrent `EnsureImage` calls for the same
-tag take a flock on `tags/<name>.lock`. Concurrent materializations of
-the same manifest take a flock on
-`cache/sha256/.<manifest-digest>.erofs.lock`.
+tag take a flock on `tags/<name>.lock`. Since v0.5.2 ships the erofs as
+a content-addressed blob there's no separate cache materialization
+lock — `EnsureImage` is pure pull + path resolution.
 
 ## Lifecycle commands
 

--- a/docs/upgrades/v0.5.1-to-v0.5.2.md
+++ b/docs/upgrades/v0.5.1-to-v0.5.2.md
@@ -1,0 +1,153 @@
+# Upgrade Guide: v0.5.1 to v0.5.2
+
+v0.5.2 changes how the read-only rootfs erofs is produced. Through
+v0.5.1, every host that ran `shed create` invoked `mkfs.erofs`
+locally to flatten the OCI layer tarballs into a single erofs file
+cached at `{images_dir}/cache/sha256/<manifest-digest>.erofs`. That
+coupled the on-disk erofs format to whatever `erofs-utils` version
+the host distro happened to ship — and on Ubuntu noble (and
+Pop!_OS 24.04, and the mini2/mini3 deployment targets) the shipped
+`erofs-utils 1.7.1` has a writer bug that emits per-inode
+big-pcluster headers without the matching superblock feature flag.
+Resulting filesystems can't be mounted by any kernel — `shed create`
+boots the VM, the kernel rejects `/dev/vdb` with
+`erofs: per-inode big pcluster without sb feature ... err [-117]`,
+userspace can't read /workspace, and the agent's 9P mount times out.
+
+v0.5.2 fixes this by moving the `mkfs.erofs` invocation to image
+publish time, inside the new `ghcr.io/charliek/shed-build-tools:vX.Y.Z`
+container image that pins a known-good `erofs-utils` version (1.9.1 at
+the time of writing). The resulting erofs ships as a content-addressed
+OCI blob with the new `io.shed.rootfs.erofs.digest` annotation. Hosts
+just download the blob and mount it directly — no local `mkfs.erofs`
+required.
+
+## Breaking changes for users
+
+There is **no on-host fallback** in v0.5.2+. Pre-v0.5.2 images
+(those built before this change, including everything published
+through `v0.5.1`) lack the new annotation and **fail to boot** with:
+
+```
+image manifest <digest> lacks io.shed.rootfs.erofs.digest annotation
+(built with pre-v0.5.2 tooling). Re-pull against current images:
+  shed image rm <digest> && shed-server pull-images.
+```
+
+This is intentional: silently falling back to the broken local
+`mkfs.erofs` would re-introduce the bug we're escaping.
+
+## Required upgrade steps
+
+Every host running shed-server must wipe its local image cache and
+re-pull against the v0.5.2 published images.
+
+### 1. Stop existing sheds
+
+The new image format isn't compatible with the cached lowers v0.5.1
+created. Sheds that were created against v0.5.1 images need to be
+deleted before the upgrade — or the user can keep them by reverting
+to v0.5.1 temporarily.
+
+```sh
+shed list                       # see what's running
+shed stop <name>                # for each running shed
+shed delete <name> --force      # for each shed to be replaced
+```
+
+### 2. Upgrade the shed-server package
+
+```sh
+sudo apt update
+sudo apt install --only-upgrade shed-server
+```
+
+### 3. Wipe the legacy image cache
+
+```sh
+# Removes every tag (manifest digests remain until prune)
+shed image ls -q | xargs -r -n1 shed image rm
+shed image prune --force
+```
+
+If your `images_dir` still contains a legacy `cache/` directory
+(holdover from v0.5.1's locally-materialized erofs files), it's safe
+to remove:
+
+```sh
+sudo rm -rf /var/lib/shed/firecracker/images/cache
+# Or, for VZ: rm -rf ~/Library/Application\ Support/shed/vz/cache
+```
+
+### 4. Re-pull the v0.5.2 images
+
+```sh
+sudo shed-server pull-images
+```
+
+This downloads the new manifests, each carrying both the layer
+tarballs (unchanged) and the prebuilt rootfs erofs blob (new).
+On-disk usage is comparable to v0.5.1's cached layout (we trade
+a derived `cache/` file for a content-addressed blob), with the
+upside that the blob is shared across every tag pointing at the
+same manifest digest.
+
+### 5. Create a new shed
+
+```sh
+shed create test --local-dir $(mktemp -d)
+shed exec test -- ls /workspace
+shed delete test --force
+```
+
+## What's new architecturally
+
+- **`ghcr.io/charliek/shed-build-tools` image.** Pinned `mkfs.erofs`
+  (plus `dump.erofs`, `fsck.erofs`) tagged in lockstep with shed
+  releases. See [Build Tools](../reference/build-tools.md).
+- **New manifest annotation `io.shed.rootfs.erofs.digest`** carries
+  the prebuilt erofs blob's content digest. Sits alongside the
+  existing `io.shed.kernel.digest` and `io.shed.initrd.digest`
+  annotations (same loose-blob pattern).
+- **No more on-host `mkfs.erofs` dependency.** Hosts running
+  shed-server no longer need `erofs-utils` installed. Existing
+  installations can `apt remove erofs-utils` safely (the new image
+  pipeline only needs it for the publishing side, which runs inside
+  the build-tools container).
+- **Image build flag `--build-tools-version`.** `shed image build`
+  pins the build-tools image used to mint the erofs. Defaults match
+  the shed CLI's own version for clean releases; local dev should
+  pass `--build-tools-version dev` against a `make build-tools`
+  image.
+
+## Why no backwards compatibility
+
+A backwards-compatible path would require keeping the local
+`mkfs.erofs` flow as a fallback for pre-v0.5.2 images. That:
+
+1. Re-introduces the writer-bug surface area we're escaping
+   (since the v0.5.1 images would still be flattened with whatever
+   `mkfs.erofs` the host happens to have).
+2. Keeps ~200 lines of `cache.go` and the docker-export fallback
+   alive indefinitely.
+3. Makes the failure mode ambiguous when something goes wrong —
+   was it the new path or the old path?
+
+Cleaner: hard-fail on the missing annotation, document the precise
+upgrade command, accept the one-time inconvenience for a permanent
+simplification.
+
+## Rollback
+
+If v0.5.2 doesn't work in your environment:
+
+```sh
+sudo apt install --reinstall shed-server=0.5.1
+shed image rm <every v0.5.2 tag>
+shed-server pull-images        # re-pulls v0.5.1 images
+```
+
+Note that v0.5.1 itself was broken end-to-end on Ubuntu noble (the
+bug this guide describes), so "rollback" is only useful if you have
+a known-working environment with an older `erofs-utils` (e.g.,
+hand-built 1.8.x).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,8 +13,8 @@ import (
 
 // installCachedBlob installs a synthetic OCI image into imagesDir under
 // the given tag with the given source-ref annotation. Returns the path
-// to the manifest's cached lower image — the path that config resolution
-// surfaces to callers as ResolvedImage.Path.
+// to the manifest's prebuilt rootfs erofs blob — the path that config
+// resolution surfaces to callers as ResolvedImage.Path (v0.5.2+).
 func installCachedBlob(t *testing.T, imagesDir, tag, sourceRef string) string {
 	t.Helper()
 	body := []byte("fake-" + tag)
@@ -22,9 +22,17 @@ func installCachedBlob(t *testing.T, imagesDir, tag, sourceRef string) string {
 	if err != nil {
 		t.Fatalf("InstallSyntheticImage: %v", err)
 	}
-	path, err := vmimage.CacheLowerPath(imagesDir, digest)
+	manifest, err := vmimage.LoadManifestByDigest(imagesDir, digest)
 	if err != nil {
-		t.Fatalf("CacheLowerPath: %v", err)
+		t.Fatalf("LoadManifestByDigest: %v", err)
+	}
+	erofsDigest := manifest.ShedRootfsErofsDigest()
+	if erofsDigest == "" {
+		t.Fatalf("synthetic manifest %s missing %s annotation — InstallSyntheticImage should populate it", digest, vmimage.AnnotationRootfsErofsDigest)
+	}
+	path, err := vmimage.BlobPath(imagesDir, erofsDigest)
+	if err != nil {
+		t.Fatalf("BlobPath(erofs): %v", err)
 	}
 	return path
 }

--- a/internal/vmimage/convert.go
+++ b/internal/vmimage/convert.go
@@ -91,6 +91,19 @@ type ConvertOptions struct {
 	// and passes the path here so the resulting image boots through
 	// shed's overlay assembly path rather than Ubuntu's regular initrd.
 	InitrdSourcePath string
+
+	// BuildToolsRef, when set, triggers MintRootfsErofs after the
+	// layer blobs are installed: a docker container running mkfs.erofs
+	// from this image flattens the layers and produces the
+	// io.shed.rootfs.erofs.digest blob. The shed publish workflow pins
+	// this to ghcr.io/charliek/shed-build-tools:<current shed tag>;
+	// local `shed image build` runs default to the same pin via
+	// cmd/shed/image.go's BuildToolsRef flag (see --build-tools-version).
+	// When empty, no erofs is minted — the resulting image will be
+	// rejected by v0.5.2+ servers at EnsureImage. Empty is only
+	// appropriate for tests or for images that will be re-processed
+	// by a later mint pass.
+	BuildToolsRef string
 }
 
 // ConvertResult holds the digests produced by a successful conversion.
@@ -113,6 +126,10 @@ type ConvertResult struct {
 	// InitrdDigest names the shed-typed initrd blob (if extracted).
 	InitrdDigest string
 
+	// RootfsErofsDigest names the prebuilt rootfs erofs blob (only
+	// populated when ConvertOptions.BuildToolsRef was non-empty).
+	RootfsErofsDigest string
+
 	// RootfsLogicalSize records the uncompressed tar size in bytes.
 	RootfsLogicalSize int64
 }
@@ -127,7 +144,7 @@ type ConvertResult struct {
 // sourceRef is recorded verbatim in io.shed.source-ref; the server's
 // resolveImage cache-hit check compares this against the configured
 // `ref:`, so publish flows MUST pass the final registry ref here.
-func buildShedAnnotations(variant, sourceRef, kernelDigest, initrdDigest, rootfsLogicalSize string) map[string]string {
+func buildShedAnnotations(variant, sourceRef, kernelDigest, initrdDigest, rootfsErofsDigest, rootfsLogicalSize string) map[string]string {
 	ann := map[string]string{
 		AnnotationSchemaVersion: ShedSchemaVersion,
 		AnnotationVariant:       variant,
@@ -138,6 +155,9 @@ func buildShedAnnotations(variant, sourceRef, kernelDigest, initrdDigest, rootfs
 	}
 	if initrdDigest != "" {
 		ann[AnnotationInitrdDigest] = initrdDigest
+	}
+	if rootfsErofsDigest != "" {
+		ann[AnnotationRootfsErofsDigest] = rootfsErofsDigest
 	}
 	if rootfsLogicalSize != "" {
 		ann[AnnotationRootfsLogicalSize] = rootfsLogicalSize
@@ -183,19 +203,31 @@ func Resolve(imagesDir, tag, expectedRef string) string {
 	if len(manifest.Layers) == 0 {
 		return ""
 	}
-	cachePath, err := CacheLowerPath(imagesDir, t.Digest)
+	// v0.5.2+: the lower is the prebuilt rootfs erofs blob, not a
+	// locally-materialized cache file. Pre-v0.5.2 images have no
+	// annotation and are treated as cache misses so callers re-pull
+	// against the new tooling (manager.resolveManifestLower returns
+	// the precise "rebuild" error when EnsureImage actually tries to
+	// boot one).
+	erofsDigest := manifest.ShedRootfsErofsDigest()
+	if erofsDigest == "" {
+		return ""
+	}
+	if !BlobExists(imagesDir, erofsDigest) {
+		return ""
+	}
+	blobPath, err := BlobPath(imagesDir, erofsDigest)
 	if err != nil {
 		return ""
 	}
-	if _, err := os.Stat(cachePath); err != nil {
-		return ""
-	}
-	return cachePath
+	return blobPath
 }
 
 // ResolveTag looks up a tag and returns its manifest digest plus the
-// path to the manifest's cached lower image. Returns ErrTagNotFound or
-// ErrBlobNotFound on miss.
+// path to the manifest's prebuilt rootfs erofs blob. Returns
+// ErrTagNotFound or ErrBlobNotFound on miss; returns a clear error
+// when the manifest lacks the v0.5.2+ io.shed.rootfs.erofs.digest
+// annotation.
 func ResolveTag(imagesDir, tag string) (digest, rootfsPath string, err error) {
 	t, err := GetTag(imagesDir, tag)
 	if err != nil {
@@ -211,11 +243,24 @@ func ResolveTag(imagesDir, tag string) (digest, rootfsPath string, err error) {
 	if len(manifest.Layers) == 0 {
 		return t.Digest, "", fmt.Errorf("manifest %s has no layers", t.Digest)
 	}
-	cachePath, err := CacheLowerPath(imagesDir, t.Digest)
+	erofsDigest := manifest.ShedRootfsErofsDigest()
+	if erofsDigest == "" {
+		return t.Digest, "", fmt.Errorf(
+			"manifest %s (tag %q) lacks %s annotation — image was built with pre-v0.5.2 tooling; re-pull against current images",
+			ShortDigest(t.Digest), tag, AnnotationRootfsErofsDigest,
+		)
+	}
+	if !BlobExists(imagesDir, erofsDigest) {
+		return t.Digest, "", fmt.Errorf(
+			"%w: rootfs erofs %s referenced by manifest %s (tag %q)",
+			ErrBlobNotFound, erofsDigest, t.Digest, tag,
+		)
+	}
+	blobPath, err := BlobPath(imagesDir, erofsDigest)
 	if err != nil {
 		return t.Digest, "", err
 	}
-	return t.Digest, cachePath, nil
+	return t.Digest, blobPath, nil
 }
 
 // LoadManifestByDigest reads + parses an OCI manifest blob.
@@ -366,10 +411,25 @@ func convertFromOCIArchive(ctx context.Context, opts ConvertOptions) (*ConvertRe
 		initrdDigest = d
 	}
 
-	// The flattened manifest lower is materialized lazily on the next
-	// EnsureImage call (via resolveManifestLower) — no need to pre-bake
-	// the erofs here. Keeping image-build snappy when iterating on a
-	// rootfs that may not even be booted.
+	// Mint the read-only rootfs erofs blob (v0.5.2+). The publishing
+	// flow pins a known-good mkfs.erofs via the shed-build-tools OCI
+	// image — see internal/vmimage/erofs.go for the rationale. When
+	// BuildToolsRef is empty (test fixtures, special-purpose builds),
+	// skip minting and emit a manifest without the annotation; the
+	// resulting image will fail at EnsureImage on any v0.5.2+ server
+	// with a clear "rebuild with v0.5.2+ tooling" error.
+	var rootfsErofsDigest string
+	if opts.BuildToolsRef != "" {
+		d, err := MintRootfsErofs(ctx, MintErofsOptions{
+			ImagesDir:     opts.ImagesDir,
+			LayerDigests:  layerDigests,
+			BuildToolsRef: opts.BuildToolsRef,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("minting rootfs erofs: %w", err)
+		}
+		rootfsErofsDigest = d
+	}
 
 	// Build our shed-annotated manifest referencing the same layer +
 	// config digests as buildx emitted. Adding annotations changes the
@@ -385,7 +445,7 @@ func convertFromOCIArchive(ctx context.Context, opts ConvertOptions) (*ConvertRe
 			Size:      int64(len(cfgBytes)),
 		},
 		Layers:      append([]Descriptor{}, srcManifest.Layers...),
-		Annotations: buildShedAnnotations(opts.Name, opts.DockerRef, kernelDigest, initrdDigest, ""),
+		Annotations: buildShedAnnotations(opts.Name, opts.DockerRef, kernelDigest, initrdDigest, rootfsErofsDigest, ""),
 	}
 	manData, err := manifest.MarshalIndent()
 	if err != nil {
@@ -422,6 +482,7 @@ func convertFromOCIArchive(ctx context.Context, opts ConvertOptions) (*ConvertRe
 		LayerDigests:      layerDigests,
 		KernelDigest:      kernelDigest,
 		InitrdDigest:      initrdDigest,
+		RootfsErofsDigest: rootfsErofsDigest,
 		RootfsLogicalSize: rootfsLogical,
 	}, nil
 }
@@ -654,6 +715,24 @@ func convertFromDockerExport(ctx context.Context, opts ConvertOptions) (*Convert
 		return nil, fmt.Errorf("installing config blob: %w", err)
 	}
 
+	// Mint the rootfs erofs blob (v0.5.2+). See convertFromOCIArchive
+	// for rationale. This path (docker create + export) is the legacy
+	// fallback for refs not in an OCI archive; it'll mostly disappear
+	// in PR 4 once we drop the docker-daemon fallback chain. Until
+	// then, mint correctly when BuildToolsRef is set.
+	var rootfsErofsDigest string
+	if opts.BuildToolsRef != "" {
+		d, err := MintRootfsErofs(ctx, MintErofsOptions{
+			ImagesDir:     opts.ImagesDir,
+			LayerDigests:  []string{layerDigest},
+			BuildToolsRef: opts.BuildToolsRef,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("minting rootfs erofs: %w", err)
+		}
+		rootfsErofsDigest = d
+	}
+
 	// Build + install the OCI manifest.
 	manifest := &OCIManifest{
 		SchemaVersion: 2,
@@ -668,7 +747,7 @@ func convertFromDockerExport(ctx context.Context, opts ConvertOptions) (*Convert
 			Digest:    layerDigest,
 			Size:      gzSize,
 		}},
-		Annotations: buildShedAnnotations(opts.Name, opts.DockerRef, kernelDigest, initrdDigest, fmt.Sprintf("%d", tarStat.Size())),
+		Annotations: buildShedAnnotations(opts.Name, opts.DockerRef, kernelDigest, initrdDigest, rootfsErofsDigest, fmt.Sprintf("%d", tarStat.Size())),
 	}
 	manData, err := manifest.MarshalIndent()
 	if err != nil {
@@ -692,16 +771,13 @@ func convertFromDockerExport(ctx context.Context, opts ConvertOptions) (*Convert
 		return nil, fmt.Errorf("updating index.json: %w", err)
 	}
 
-	// Lower is materialized lazily on the next EnsureImage (via
-	// resolveManifestLower) so docker-fallback conversions don't
-	// block waiting on mkfs.erofs.
-
 	return &ConvertResult{
 		ManifestDigest:    manifestDigest,
 		ConfigDigest:      configDigest,
 		LayerDigests:      []string{layerDigest},
 		KernelDigest:      kernelDigest,
 		InitrdDigest:      initrdDigest,
+		RootfsErofsDigest: rootfsErofsDigest,
 		RootfsLogicalSize: tarStat.Size(),
 	}, nil
 }

--- a/internal/vmimage/convert_test.go
+++ b/internal/vmimage/convert_test.go
@@ -136,7 +136,7 @@ func TestBuildShedAnnotationsSourceRef(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ann := buildShedAnnotations("full", tt.sourceRef, "", "", "")
+			ann := buildShedAnnotations("full", tt.sourceRef, "", "", "", "")
 			if got := ann[AnnotationSourceRef]; got != tt.sourceRef {
 				t.Errorf("AnnotationSourceRef = %q, want %q", got, tt.sourceRef)
 			}
@@ -168,23 +168,29 @@ func TestBuildShedAnnotationsSourceRef(t *testing.T) {
 // values are omitted from the annotation map (so the on-disk manifest
 // JSON doesn't carry confusing empty-string entries).
 func TestBuildShedAnnotationsOptionalFields(t *testing.T) {
-	ann := buildShedAnnotations("base", "ghcr.io/x/y:v1", "", "", "")
+	ann := buildShedAnnotations("base", "ghcr.io/x/y:v1", "", "", "", "")
 	if _, ok := ann[AnnotationKernelDigest]; ok {
 		t.Errorf("empty kernel digest should be omitted, got %q", ann[AnnotationKernelDigest])
 	}
 	if _, ok := ann[AnnotationInitrdDigest]; ok {
 		t.Errorf("empty initrd digest should be omitted, got %q", ann[AnnotationInitrdDigest])
 	}
+	if _, ok := ann[AnnotationRootfsErofsDigest]; ok {
+		t.Errorf("empty rootfs erofs digest should be omitted, got %q", ann[AnnotationRootfsErofsDigest])
+	}
 	if _, ok := ann[AnnotationRootfsLogicalSize]; ok {
 		t.Errorf("empty rootfs logical size should be omitted, got %q", ann[AnnotationRootfsLogicalSize])
 	}
 
-	ann2 := buildShedAnnotations("base", "ghcr.io/x/y:v1", "sha256:k", "sha256:i", "12345")
+	ann2 := buildShedAnnotations("base", "ghcr.io/x/y:v1", "sha256:k", "sha256:i", "sha256:e", "12345")
 	if ann2[AnnotationKernelDigest] != "sha256:k" {
 		t.Errorf("kernel digest = %q, want sha256:k", ann2[AnnotationKernelDigest])
 	}
 	if ann2[AnnotationInitrdDigest] != "sha256:i" {
 		t.Errorf("initrd digest = %q, want sha256:i", ann2[AnnotationInitrdDigest])
+	}
+	if ann2[AnnotationRootfsErofsDigest] != "sha256:e" {
+		t.Errorf("rootfs erofs digest = %q, want sha256:e", ann2[AnnotationRootfsErofsDigest])
 	}
 	if ann2[AnnotationRootfsLogicalSize] != "12345" {
 		t.Errorf("rootfs logical size = %q, want 12345", ann2[AnnotationRootfsLogicalSize])

--- a/internal/vmimage/erofs.go
+++ b/internal/vmimage/erofs.go
@@ -1,0 +1,215 @@
+// Erofs blob minting for shed images at publish time.
+//
+// Prior to v0.5.2 the read-only rootfs erofs was built lazily on the
+// host at first `shed create` via local mkfs.erofs (see cache.go).
+// That coupled the on-disk format to whatever erofs-utils the host
+// distro shipped — and erofs-utils 1.7.1 (current Ubuntu noble) has
+// a writer bug where `-E force-inode-compact` emits per-inode
+// big-pcluster headers without the matching superblock feature flag.
+// Resulting filesystems can't be mounted by any kernel.
+//
+// v0.5.2+: the publisher (this file, called from `shed image build`)
+// runs a pinned mkfs.erofs from the shed-build-tools OCI image inside
+// a docker container, writes the erofs as a content-addressed blob in
+// the local OCI store, and stamps the digest into the manifest's
+// io.shed.rootfs.erofs.digest annotation. On `shed image push` the
+// blob rides along as a loose sibling (registry.go:PushFromOCILayout
+// already walks the annotation list). On pull the host fetches the
+// blob and mounts it directly — no local mkfs.erofs. See
+// docs/reference/storage-model.md for the full picture.
+
+package vmimage
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// MintErofsOptions controls what MintRootfsErofs invokes on the
+// publishing host.
+type MintErofsOptions struct {
+	// ImagesDir is the OCI store the layer blobs are already
+	// installed in and where the new erofs blob will be written.
+	ImagesDir string
+
+	// LayerDigests are the OCI manifest's layer digests in OCI order
+	// (lowest at index 0). MergeLayers flattens them into a single
+	// tarball before feeding mkfs.erofs.
+	LayerDigests []string
+
+	// BuildToolsRef is the OCI image carrying mkfs.erofs that will
+	// run inside `docker run --rm ...`. Pin to the same tag as the
+	// shed-server version being released — see
+	// docs/reference/build-tools.md for the versioning model.
+	BuildToolsRef string
+
+	// DockerBinary defaults to "docker"; tests / unusual hosts
+	// override (e.g. "podman" with a compat wrapper).
+	DockerBinary string
+}
+
+// MintRootfsErofs flattens layerDigests, runs mkfs.erofs inside the
+// build-tools container, and installs the resulting erofs as a
+// content-addressed blob in imagesDir. Returns the blob digest
+// (sha256:...) — caller stamps this into the manifest's
+// io.shed.rootfs.erofs.digest annotation.
+//
+// The mkfs.erofs invocation pins:
+//
+//   - `-b 4096`: erofs block size. Host page sizes vary (4 KiB on
+//     Linux/amd64, 16 KiB on Apple Silicon); fixing the block size
+//     keeps the same erofs mountable in both contexts. The guest
+//     kernel expects 4 KiB.
+//   - `-z lz4`: lz4 compression. Random-read friendly, ~50% on-disk
+//     reduction vs raw, decompression is cheap enough that the boot
+//     path doesn't measurably slow down.
+//   - `-E force-inode-compact`: 32-byte inodes (vs the default
+//     64-byte extended layout). Saves disk for image rootfs's
+//     thousands of files. The 1.7.x writer bug that motivated this
+//     whole change was an interaction between this flag and big
+//     pcluster headers; mkfs.erofs 1.8+ (which ships in
+//     shed-build-tools) fixes it.
+//   - `-T 0`: zeroes the per-inode mtime field. Without this the
+//     erofs digest would vary by clock skew on the build host,
+//     breaking content addressing for byte-for-byte identical
+//     rootfs content.
+//
+// Changing any of these flags changes the produced digest. The
+// shed-build-tools image is versioned in lockstep with shed-server
+// so a flag change rides a known release.
+func MintRootfsErofs(ctx context.Context, opts MintErofsOptions) (string, error) {
+	if opts.ImagesDir == "" {
+		return "", errors.New("MintRootfsErofs: ImagesDir is required")
+	}
+	if len(opts.LayerDigests) == 0 {
+		return "", errors.New("MintRootfsErofs: at least one layer digest is required")
+	}
+	if opts.BuildToolsRef == "" {
+		return "", errors.New("MintRootfsErofs: BuildToolsRef is required (e.g. ghcr.io/charliek/shed-build-tools:vX.Y.Z)")
+	}
+	docker := opts.DockerBinary
+	if docker == "" {
+		docker = "docker"
+	}
+	if _, err := exec.LookPath(docker); err != nil {
+		return "", fmt.Errorf("MintRootfsErofs: %s not on PATH: %w", docker, err)
+	}
+
+	// Flatten layers into a single tar so mkfs.erofs can ingest via
+	// --tar=f. Stage in a fresh tempdir so the container's bind
+	// mounts don't see anything else.
+	stagingDir, err := os.MkdirTemp("", "shed-mint-erofs-*")
+	if err != nil {
+		return "", fmt.Errorf("creating staging dir: %w", err)
+	}
+	defer os.RemoveAll(stagingDir)
+
+	tarPath := filepath.Join(stagingDir, "rootfs.tar")
+	if err := MergeLayers(ctx, opts.ImagesDir, opts.LayerDigests, tarPath); err != nil {
+		return "", fmt.Errorf("flattening layers into tar: %w", err)
+	}
+
+	// Output path the container will write to.
+	erofsName := "rootfs.erofs"
+	erofsPath := filepath.Join(stagingDir, erofsName)
+
+	// Mount the staging dir into /shed/work inside the container.
+	// Read-only would be nicer for the tar input, but mkfs.erofs
+	// needs to write the output into the same mount, and splitting
+	// into two mounts on the same parent dir hits docker's path
+	// overlap rejection.
+	dockerArgs := []string{
+		"run",
+		"--rm",
+		// Run as the host's UID so the output erofs ends up
+		// readable to non-root callers (CI runs as a normal user).
+		"-u", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
+		"-v", stagingDir + ":/shed/work",
+		"-w", "/shed/work",
+		opts.BuildToolsRef,
+		// Default entrypoint is mkfs.erofs (see build-tools/Dockerfile).
+		"--quiet",
+		"-b", "4096",
+		"-z", "lz4",
+		"-E", "force-inode-compact",
+		"-T", "0",
+		"--tar=f",
+		"/shed/work/" + erofsName,
+		"/shed/work/rootfs.tar",
+	}
+	cmd := exec.CommandContext(ctx, docker, dockerArgs...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stderr // mkfs.erofs prints stats to stdout — include in failure output
+	if err := cmd.Run(); err != nil {
+		out := strings.TrimSpace(stderr.String())
+		if out == "" {
+			out = "(no output)"
+		}
+		return "", fmt.Errorf("mkfs.erofs via %s %s: %w\n%s", docker, opts.BuildToolsRef, err, out)
+	}
+
+	// Hash the produced erofs and install it as a content-addressed
+	// blob. Streaming the hash and the install separately is fine
+	// because the staging file isn't going anywhere until the
+	// surrounding tempdir is removed.
+	digest, err := sha256File(erofsPath)
+	if err != nil {
+		return "", fmt.Errorf("hashing minted erofs: %w", err)
+	}
+	digestStr := DigestPrefix + digest
+
+	if BlobExists(opts.ImagesDir, digestStr) {
+		// Identical content already in the store (likely a sibling
+		// variant whose layers + flags collapsed to the same blob —
+		// or a retry). No-op; reuse the existing blob.
+		return digestStr, nil
+	}
+
+	dstPath, err := BlobPath(opts.ImagesDir, digestStr)
+	if err != nil {
+		return "", fmt.Errorf("resolving destination blob path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+		return "", fmt.Errorf("creating blob dir: %w", err)
+	}
+	// Try a rename first (same filesystem fast path); fall back to
+	// copy if the staging dir lives on a different mount than the
+	// blob store (`/tmp` vs `/var/lib/shed/...`).
+	if err := os.Rename(erofsPath, dstPath); err != nil {
+		if copyErr := copyFile(erofsPath, dstPath); copyErr != nil {
+			return "", fmt.Errorf("installing erofs blob: rename=%v copy=%w", err, copyErr)
+		}
+	}
+	// 0o444 mirrors how WriteBlob installs blobs — read-only so
+	// pruning is the only intentional remove path.
+	if err := os.Chmod(dstPath, 0o444); err != nil {
+		return "", fmt.Errorf("chmod erofs blob: %w", err)
+	}
+
+	return digestStr, nil
+}
+
+// sha256File streams a file's contents through SHA-256 and returns
+// the hex digest (without the "sha256:" prefix).
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/vmimage/erofs_test.go
+++ b/internal/vmimage/erofs_test.go
@@ -1,0 +1,184 @@
+package vmimage
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMintRootfsErofsIntegration verifies the end-to-end mint flow:
+// build a tar.gz layer, install it as a blob, run MintRootfsErofs
+// against it (which shells out to docker + the build-tools image),
+// and confirm the produced blob is a valid erofs.
+//
+// Skipped unless both docker and the locally-built
+// shed-build-tools:dev image are available, since the integration is
+// the point — there's no point running this against a mocked docker.
+func TestMintRootfsErofsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test (docker + shed-build-tools image); skipping in short mode")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not on PATH; skipping erofs mint integration")
+	}
+	// Confirm shed-build-tools:dev exists locally. CI will populate
+	// this via `make build-tools`; locally the user does the same.
+	check := exec.Command("docker", "image", "inspect", "shed-build-tools:dev")
+	if err := check.Run(); err != nil {
+		t.Skip("shed-build-tools:dev not present locally — run `make build-tools` to enable this test")
+	}
+
+	dir := t.TempDir()
+	if err := EnsureOCILayout(dir); err != nil {
+		t.Fatalf("EnsureOCILayout: %v", err)
+	}
+
+	// Build a real tar.gz layer with a few small files. mkfs.erofs
+	// --tar=f wants regular tar (no compression) since shed merges
+	// the layer first; the merger handles gzip extraction so the
+	// stored blob is gzip-compressed like every other OCI layer.
+	layerBytes := buildTarGzLayer(t, map[string]string{
+		"./etc/test.txt":    "hello from mint test\n",
+		"./usr/local/bin/x": "fake binary content",
+	})
+	layerDigest := DigestBytes(layerBytes)
+	if _, err := WriteBlob(dir, layerDigest, layerBytes); err != nil {
+		t.Fatalf("WriteBlob layer: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	erofsDigest, err := MintRootfsErofs(ctx, MintErofsOptions{
+		ImagesDir:     dir,
+		LayerDigests:  []string{layerDigest},
+		BuildToolsRef: "shed-build-tools:dev",
+	})
+	if err != nil {
+		t.Fatalf("MintRootfsErofs: %v", err)
+	}
+	if !strings.HasPrefix(erofsDigest, DigestPrefix) {
+		t.Fatalf("erofs digest = %q, want sha256: prefix", erofsDigest)
+	}
+	if !BlobExists(dir, erofsDigest) {
+		t.Fatalf("BlobExists(%s) = false after mint", erofsDigest)
+	}
+
+	// Verify the produced blob is actually an erofs by reading the
+	// 32-byte preamble + 4-byte magic.
+	blobPath, err := BlobPath(dir, erofsDigest)
+	if err != nil {
+		t.Fatalf("BlobPath: %v", err)
+	}
+	f, err := os.Open(blobPath)
+	if err != nil {
+		t.Fatalf("opening blob: %v", err)
+	}
+	defer f.Close()
+	header := make([]byte, 36)
+	if _, err := f.Read(header); err != nil {
+		t.Fatalf("reading blob preamble: %v", err)
+	}
+	// erofs magic 0xE0F5E1E2 (little-endian) lives at offset 1024
+	// (start of superblock). Check that instead — easier than parsing.
+	if _, err := f.Seek(1024, 0); err != nil {
+		t.Fatalf("seeking to superblock: %v", err)
+	}
+	magic := make([]byte, 4)
+	if _, err := f.Read(magic); err != nil {
+		t.Fatalf("reading magic: %v", err)
+	}
+	want := []byte{0xE2, 0xE1, 0xF5, 0xE0}
+	for i := range want {
+		if magic[i] != want[i] {
+			t.Fatalf("erofs magic at offset 1024 = %x, want %x", magic, want)
+		}
+	}
+}
+
+// TestMintRootfsErofsValidatesInputs spot-checks the argument
+// validation so a misconfigured caller fails fast rather than running
+// docker and getting a confusing failure.
+func TestMintRootfsErofsValidatesInputs(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		opts MintErofsOptions
+		want string
+	}{
+		{
+			name: "empty ImagesDir",
+			opts: MintErofsOptions{LayerDigests: []string{"sha256:x"}, BuildToolsRef: "shed-build-tools:dev"},
+			want: "ImagesDir is required",
+		},
+		{
+			name: "no layers",
+			opts: MintErofsOptions{ImagesDir: t.TempDir(), BuildToolsRef: "shed-build-tools:dev"},
+			want: "at least one layer digest is required",
+		},
+		{
+			name: "no build-tools ref",
+			opts: MintErofsOptions{ImagesDir: t.TempDir(), LayerDigests: []string{"sha256:x"}},
+			want: "BuildToolsRef is required",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := MintRootfsErofs(ctx, c.opts)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("error = %q, want substring %q", err.Error(), c.want)
+			}
+		})
+	}
+}
+
+// buildTarGzLayer composes a gzipped tar with the given path→contents
+// entries. Caller-controlled paths so tests can reproduce specific
+// layer shapes (whiteouts, opaque dirs, etc).
+func buildTarGzLayer(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "layer.tar.gz")
+	f, err := os.Create(tarPath)
+	if err != nil {
+		t.Fatalf("creating tar: %v", err)
+	}
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	for path, content := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     path,
+			Mode:     0o644,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatalf("tar header: %v", err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("tar write: %v", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gz close: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("file close: %v", err)
+	}
+	data, err := os.ReadFile(tarPath)
+	if err != nil {
+		t.Fatalf("read tar: %v", err)
+	}
+	return data
+}

--- a/internal/vmimage/flatten.go
+++ b/internal/vmimage/flatten.go
@@ -47,6 +47,21 @@ func MergeLayersFromManifest(ctx context.Context, imagesDir, manifestDigest, out
 	if len(manifest.Layers) == 0 {
 		return fmt.Errorf("manifest %s has no layers", manifestDigest)
 	}
+	layerDigests := make([]string, len(manifest.Layers))
+	for i, l := range manifest.Layers {
+		layerDigests[i] = l.Digest
+	}
+	return MergeLayers(ctx, imagesDir, layerDigests, outTarPath)
+}
+
+// MergeLayers is the manifest-less variant of MergeLayersFromManifest
+// used during image build, where we have the layer digests in hand
+// but the shed-annotated manifest hasn't been minted yet. layerDigests
+// must be in OCI order (lowest at index 0).
+func MergeLayers(ctx context.Context, imagesDir string, layerDigests []string, outTarPath string) error {
+	if len(layerDigests) == 0 {
+		return fmt.Errorf("MergeLayers: no layers")
+	}
 
 	outFile, err := os.Create(outTarPath)
 	if err != nil {
@@ -64,11 +79,11 @@ func MergeLayersFromManifest(ctx context.Context, imagesDir, manifestDigest, out
 
 	// Walk layers in reverse OCI order so the highest layer's entries
 	// are emitted first and shadow earlier-layer entries.
-	for layerIdx := len(manifest.Layers) - 1; layerIdx >= 0; layerIdx-- {
+	for layerIdx := len(layerDigests) - 1; layerIdx >= 0; layerIdx-- {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		layerDigest := manifest.Layers[layerIdx].Digest
+		layerDigest := layerDigests[layerIdx]
 		blobPath, err := BlobPath(imagesDir, layerDigest)
 		if err != nil {
 			return fmt.Errorf("resolving layer %s: %w", layerDigest, err)

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -353,14 +353,41 @@ func (m *Manager) resolveCachedTag(ctx context.Context, imagesDir, name, expecte
 	return res, true
 }
 
-// resolveManifestLower materializes (if needed) the single flattened
-// lower image for the manifest and returns its path. The cache file is
-// content-addressed by the manifest digest, so all sheds booting from
-// the same image share one erofs file on disk.
-func (m *Manager) resolveManifestLower(ctx context.Context, imagesDir, manifestDigest string) (EnsureResult, error) {
-	path, err := EnsureLowerFromManifest(ctx, imagesDir, manifestDigest)
+// resolveManifestLower resolves the single read-only lower image for a
+// manifest. v0.5.2+ images carry a prebuilt erofs blob referenced by
+// the io.shed.rootfs.erofs.digest annotation — we return that blob's
+// path directly, no local mkfs.erofs invocation, no cache file. The
+// blob path IS the lower the VM mounts.
+//
+// Images built with v0.5.1 or earlier tooling lack the annotation;
+// since shed-build-tools published a known-good mkfs.erofs starting
+// with v0.5.2, the upgrade path is to re-pull rather than fall back
+// to the host's mkfs.erofs (which has writer-bug exposure on
+// erofs-utils 1.7.x). The error surfaces the precise command needed.
+func (m *Manager) resolveManifestLower(_ context.Context, imagesDir, manifestDigest string) (EnsureResult, error) {
+	manifest, err := LoadManifestByDigest(imagesDir, manifestDigest)
 	if err != nil {
-		return EnsureResult{}, fmt.Errorf("materializing lower for manifest %s: %w", ShortDigest(manifestDigest), err)
+		return EnsureResult{}, fmt.Errorf("loading manifest %s: %w", ShortDigest(manifestDigest), err)
+	}
+	erofsDigest := manifest.ShedRootfsErofsDigest()
+	if erofsDigest == "" {
+		return EnsureResult{}, fmt.Errorf(
+			"image manifest %s lacks %s annotation (built with pre-v0.5.2 tooling); "+
+				"re-pull against current images: shed image rm %s && shed-server pull-images "+
+				"(see docs/upgrades/v0.5.1-to-v0.5.2.md for the full upgrade path)",
+			ShortDigest(manifestDigest), AnnotationRootfsErofsDigest, ShortDigest(manifestDigest),
+		)
+	}
+	if !BlobExists(imagesDir, erofsDigest) {
+		return EnsureResult{}, fmt.Errorf(
+			"rootfs erofs blob %s referenced by manifest %s is missing from the local store; "+
+				"re-pull the image (shed image pull <ref> -t <name>) to recover",
+			ShortDigest(erofsDigest), ShortDigest(manifestDigest),
+		)
+	}
+	path, err := BlobPath(imagesDir, erofsDigest)
+	if err != nil {
+		return EnsureResult{}, fmt.Errorf("resolving rootfs erofs blob path: %w", err)
 	}
 	return EnsureResult{
 		Path:   path,
@@ -747,6 +774,9 @@ func (m *Manager) PruneImages(dryRun bool) ([]ImageInfo, error) {
 			reachable[d] = true
 		}
 		if d := manifest.ShedInitrdDigest(); d != "" {
+			reachable[d] = true
+		}
+		if d := manifest.ShedRootfsErofsDigest(); d != "" {
 			reachable[d] = true
 		}
 	}

--- a/internal/vmimage/manifest.go
+++ b/internal/vmimage/manifest.go
@@ -49,6 +49,15 @@ const (
 	// associated with this image, when shed extracted one.
 	AnnotationInitrdDigest = "io.shed.initrd.digest"
 
+	// AnnotationRootfsErofsDigest names the blob digest of the
+	// flattened rootfs erofs that shed minted at image-build time
+	// (using a pinned mkfs.erofs from the shed-build-tools image).
+	// When present, the host skips local mkfs.erofs entirely and
+	// mounts this blob directly as the read-only lower; when absent,
+	// the host rejects the image (no on-host fallback in the v0.5.2+
+	// layout — see internal/vmimage/manager.go for the reject path).
+	AnnotationRootfsErofsDigest = "io.shed.rootfs.erofs.digest"
+
 	// AnnotationSchemaVersion records shed's own manifest schema version
 	// alongside OCI's schemaVersion (always 2 for OCI manifests). Lets
 	// us bump shed semantics independently of OCI.
@@ -252,4 +261,16 @@ func (m *OCIManifest) ShedInitrdDigest() string {
 		return ""
 	}
 	return m.Annotations[AnnotationInitrdDigest]
+}
+
+// ShedRootfsErofsDigest returns the prebuilt rootfs erofs blob digest
+// carried in annotations, or "" if the image was built before v0.5.2
+// (when this annotation was introduced). Callers that depend on the
+// blob being present should fail with a clear "image too old" error
+// rather than fall back to local mkfs.erofs — see manager.go.
+func (m *OCIManifest) ShedRootfsErofsDigest() string {
+	if m == nil || m.Annotations == nil {
+		return ""
+	}
+	return m.Annotations[AnnotationRootfsErofsDigest]
 }

--- a/internal/vmimage/registry.go
+++ b/internal/vmimage/registry.go
@@ -148,9 +148,10 @@ func PushFromOCILayout(ctx context.Context, opts PushOptions) error {
 		remote.WithContext(ctx),
 	}
 
-	// Upload kernel / initrd loose blobs first so the manifest's
-	// annotation references resolve when other clients fetch.
-	for _, ann := range []string{AnnotationKernelDigest, AnnotationInitrdDigest} {
+	// Upload kernel / initrd / rootfs-erofs loose blobs first so
+	// the manifest's annotation references resolve when other clients
+	// fetch.
+	for _, ann := range []string{AnnotationKernelDigest, AnnotationInitrdDigest, AnnotationRootfsErofsDigest} {
 		d := manifest.Annotations[ann]
 		if d == "" {
 			continue
@@ -420,6 +421,17 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 			return nil, fmt.Errorf("extracting initrd from layer tar: %w", err)
 		}
 		initrdDigest = d
+	}
+
+	// Pull the prebuilt rootfs erofs blob (v0.5.2+). Same loose-blob
+	// shape as kernel/initrd. When absent (older image), don't fail
+	// here — the host's EnsureImage rejects with a clearer "rebuild
+	// against v0.5.2+ tooling" error so the user knows the upgrade
+	// path. See internal/vmimage/manager.go.
+	if d := annotationFromManifest(manifestDesc, AnnotationRootfsErofsDigest); d != "" {
+		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts); err != nil {
+			return nil, fmt.Errorf("pulling rootfs erofs blob %s: %w", d, err)
+		}
 	}
 
 	// Record the manifest in the top-level OCI index.

--- a/internal/vmimage/testhelpers.go
+++ b/internal/vmimage/testhelpers.go
@@ -8,8 +8,6 @@ package vmimage
 import (
 	"encoding/hex"
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 )
 
@@ -33,35 +31,29 @@ func InstallSyntheticImage(imagesDir, tagName, sourceRef string, rootfsContent, 
 	}
 
 	// Layer blob (placeholder — real images store tar.gz here; for tests
-	// the bytes are opaque content addressed by their sha256).
+	// the bytes are opaque content addressed by their sha256). Tests
+	// that need the layer to merge cleanly should construct a real
+	// tar.gz instead and pass it through `Convert` directly.
 	layerDigest := DigestBytes(rootfsContent)
 	if _, err := WriteBlob(imagesDir, layerDigest, rootfsContent); err != nil {
 		return "", fmt.Errorf("writing layer blob: %w", err)
 	}
 
-	// Materialize a fake lower-image in the cache so callers that
-	// expect a ready-to-boot image see CacheLowerExists() returning
-	// true.
-	cachePath, err := CacheLowerPath(imagesDir, layerDigest)
-	if err != nil {
-		return "", err
-	}
-	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
-		return "", err
-	}
-	// Layer cache is content-addressed; if the file is already in
-	// place from an earlier synthetic install with the same content,
-	// leave it alone (it's 0o444 and would otherwise refuse a rewrite).
-	if _, statErr := os.Stat(cachePath); statErr != nil {
-		if err := os.WriteFile(cachePath, rootfsContent, 0o444); err != nil {
-			return "", fmt.Errorf("writing synthetic lower cache: %w", err)
-		}
+	// v0.5.2+: every shed image carries a prebuilt erofs blob
+	// referenced by io.shed.rootfs.erofs.digest. For tests the
+	// blob contents are opaque — we synthesize a unique digest by
+	// hashing a "rootfs-erofs:" + rootfsContent so tests for cache
+	// hits / misses on the lower blob behave correctly.
+	rootfsErofsDigest := DigestBytes(append([]byte("rootfs-erofs:"), rootfsContent...))
+	if _, err := WriteBlob(imagesDir, rootfsErofsDigest, append([]byte("rootfs-erofs:"), rootfsContent...)); err != nil {
+		return "", fmt.Errorf("writing rootfs erofs blob: %w", err)
 	}
 
 	annotations := map[string]string{
-		AnnotationSchemaVersion: ShedSchemaVersion,
-		AnnotationVariant:       tagName,
-		AnnotationSourceRef:     sourceRef,
+		AnnotationSchemaVersion:     ShedSchemaVersion,
+		AnnotationVariant:           tagName,
+		AnnotationSourceRef:         sourceRef,
+		AnnotationRootfsErofsDigest: rootfsErofsDigest,
 	}
 
 	if len(kernelContent) > 0 {
@@ -119,22 +111,6 @@ func InstallSyntheticImage(imagesDir, tagName, sourceRef string, rootfsContent, 
 	manifestDigest := DigestBytes(manData)
 	if _, err := WriteBlob(imagesDir, manifestDigest, manData); err != nil {
 		return "", fmt.Errorf("writing manifest blob: %w", err)
-	}
-
-	// Pre-populate the manifest-digest-keyed cache lower so tests that
-	// expect a ready-to-boot image skip the EnsureLowerFromManifest path
-	// (which would try to flatten the synthetic non-tar layer content).
-	mfCachePath, err := CacheLowerPath(imagesDir, manifestDigest)
-	if err != nil {
-		return "", err
-	}
-	if _, statErr := os.Stat(mfCachePath); statErr != nil {
-		if err := os.MkdirAll(filepath.Dir(mfCachePath), 0o755); err != nil {
-			return "", err
-		}
-		if err := os.WriteFile(mfCachePath, rootfsContent, 0o444); err != nil {
-			return "", fmt.Errorf("writing synthetic manifest cache: %w", err)
-		}
 	}
 
 	// Record the manifest in index.json so ListImages / PruneImages

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
       - Firecracker Setup: getting-started/fc-setup.md
       - Upgrades:
           - v0.4 → v0.5: upgrades/v0.4-to-v0.5.md
+          - v0.5.1 → v0.5.2: upgrades/v0.5.1-to-v0.5.2.md
   - Tutorials:
       - Build Your Own Image: tutorials/build-your-own-image.md
   - Reference:

--- a/scripts/build-firecracker-rootfs.sh
+++ b/scripts/build-firecracker-rootfs.sh
@@ -31,6 +31,7 @@ KNOWN_VARIANTS="base extensions full"
 VARIANT="full"
 BUILD_ALL=false
 SHED_EXT_VERSION=""
+BUILD_TOOLS_VERSION=""
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -57,6 +58,20 @@ while [[ $# -gt 0 ]]; do
             SHED_EXT_VERSION="$2"
             shift 2
             ;;
+        --build-tools-version)
+            # Forwarded to `shed image build`. Pins the
+            # shed-build-tools image used to mint the rootfs erofs.
+            # Default is derived from the shed CLI's version (see
+            # buildToolsRefDefault in cmd/shed/image.go); pass `dev`
+            # when iterating against a `make build-tools`-built image.
+            if [[ $# -lt 2 || "$2" == --* ]]; then
+                echo "ERROR: --build-tools-version requires a value"
+                echo "Run '$0 --help' for usage."
+                exit 1
+            fi
+            BUILD_TOOLS_VERSION="$2"
+            shift 2
+            ;;
         --help|-h)
             echo "Usage: $0 [OPTIONS]"
             echo ""
@@ -68,6 +83,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --all              Build all variants"
             echo "  --shed-ext-version Override shed-extensions image version for extensions/full variants"
             echo "                     (e.g., 'dev' to use a locally-built image)"
+            echo "  --build-tools-version  Override the shed-build-tools image tag used to mint the rootfs erofs"
+            echo "                         (e.g., 'dev' to use a locally-built shed-build-tools:dev image)"
             echo "  --help, -h         Show this help message"
             echo ""
             echo "Environment variables:"
@@ -159,12 +176,18 @@ build_variant() {
     echo "  Output dir:    $OUTPUT_DIR"
     echo "========================================"
 
+    local extra_args=()
+    if [ -n "$BUILD_TOOLS_VERSION" ]; then
+        extra_args+=(--build-tools-version "$BUILD_TOOLS_VERSION")
+    fi
+
     "$PROJECT_ROOT/bin/shed" image build \
         --target "$docker_target" \
         -n "$variant" \
         --initramfs "$SHED_INITRD" \
         --output-dir "$OUTPUT_DIR" \
         -f "$FIRECRACKER_DIR/Dockerfile" \
+        "${extra_args[@]}" \
         "$FIRECRACKER_DIR"
 }
 

--- a/scripts/build-vz-rootfs.sh
+++ b/scripts/build-vz-rootfs.sh
@@ -35,6 +35,7 @@ VARIANT="full"
 BUILD_ALL=false
 FORCE_KERNEL=false
 SHED_EXT_VERSION=""
+BUILD_TOOLS_VERSION=""
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -65,6 +66,17 @@ while [[ $# -gt 0 ]]; do
             SHED_EXT_VERSION="$2"
             shift 2
             ;;
+        --build-tools-version)
+            # Forwarded to `shed image build`. Pins the
+            # shed-build-tools image used to mint the rootfs erofs.
+            if [[ $# -lt 2 || "$2" == --* ]]; then
+                echo "ERROR: --build-tools-version requires a value"
+                echo "Run '$0 --help' for usage."
+                exit 1
+            fi
+            BUILD_TOOLS_VERSION="$2"
+            shift 2
+            ;;
         --help|-h)
             echo "Usage: $0 [OPTIONS]"
             echo ""
@@ -77,6 +89,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --force-kernel     Force kernel/initrd re-extraction even if files exist"
             echo "  --shed-ext-version Override shed-extensions image version for extensions/full variants"
             echo "                     (e.g., 'dev' to use a locally-built image)"
+            echo "  --build-tools-version  Override the shed-build-tools image tag used to mint the rootfs erofs"
+            echo "                         (e.g., 'dev' to use a locally-built shed-build-tools:dev image)"
             echo "  --help, -h         Show this help message"
             echo ""
             echo "Environment variables:"
@@ -181,6 +195,9 @@ build_variant() {
     echo "========================================"
 
     local extra_args=()
+    if [ -n "$BUILD_TOOLS_VERSION" ]; then
+        extra_args+=(--build-tools-version "$BUILD_TOOLS_VERSION")
+    fi
     if [ -n "$SHED_EXT_VERSION" ]; then
         # shed image build passes --build-arg through to buildx via the
         # builder. Encode as KEY=VALUE so the existing flag plumbing


### PR DESCRIPTION
## Summary

v0.5.2 architectural fix: move `mkfs.erofs` from on-host (per `shed create`) to image-build time. The publisher mints the read-only rootfs erofs inside the pinned `shed-build-tools` container (PR #103); the resulting erofs ships as a content-addressed OCI blob referenced by a new `io.shed.rootfs.erofs.digest` annotation. Hosts download the blob and mount it directly — no on-host mkfs.erofs.

**Why:** every shipped `erofs-utils 1.7.x` (Ubuntu noble, Pop!_OS 24.04, mini2/mini3) has a writer bug where `-E force-inode-compact` emits per-inode big-pcluster headers without the matching sb feature flag. Resulting filesystems fail to mount with `erofs: per-inode big pcluster without sb feature for nid N, err [-117]`. This is the end-to-end blocker behind v0.5.1's broken `shed create`. PR #102 fixed Bug 1 (digest plumbing); this PR addresses Bug 2.

## Behavior changes

- **New manifest annotation `io.shed.rootfs.erofs.digest`** is required on every shed image. Pre-v0.5.2 images lack it and are rejected at boot with a precise rebuild command. No silent fallback — that'd re-introduce the writer bug we're escaping.
- **No more on-host `mkfs.erofs` dependency.** `shed-server` no longer needs `erofs-utils` installed. Existing installs can `apt remove erofs-utils` after upgrade.
- **`shed image build --build-tools-version <tag>`** pins the build-tools image. Defaults: release builds → `ghcr.io/charliek/shed-build-tools:vX.Y.Z`, dev builds → local `shed-build-tools:dev`.
- **`Resolve` / `ResolveTag`** return the erofs blob path. Pre-v0.5.2 manifests are cache-misses (Resolve) or surface a clear "re-pull" error (ResolveTag).
- **Push / pull / prune** all walk the new annotation alongside kernel + initrd.
- **No backcompat** for v0.5.1 cached images — users must `shed image rm <each> && shed-server pull-images`. Documented in [`docs/upgrades/v0.5.1-to-v0.5.2.md`](https://github.com/charliek/shed/blob/feat/erofs-as-oci-blob/docs/upgrades/v0.5.1-to-v0.5.2.md).

## Scope

| Area | What changed |
|---|---|
| `internal/vmimage/erofs.go` (new) | `MintRootfsErofs` flattens layers, runs `docker run --rm shed-build-tools mkfs.erofs ...`, installs the produced erofs as a sha256-keyed blob. `-T 0` deterministic mtime; flag set matches the legacy on-host invocation. |
| `internal/vmimage/erofs_test.go` (new) | Integration test (docker + shed-build-tools:dev; gracefully skips when absent) and input-validation cases. |
| `internal/vmimage/manifest.go` | New constant + `ShedRootfsErofsDigest()` accessor. |
| `internal/vmimage/manager.go` | `resolveManifestLower` resolves the annotation to a blob path; precise legacy-reject error message. Prune reachability includes the new blob. |
| `internal/vmimage/convert.go` | Both convert paths call `MintRootfsErofs` when `BuildToolsRef` is set; `buildShedAnnotations` grows a parameter. |
| `internal/vmimage/registry.go` | Push + pull walk the new annotation alongside kernel/initrd. |
| `internal/vmimage/flatten.go` | Extracted `MergeLayers` (manifest-less variant) for the convert flow. |
| `internal/vmimage/testhelpers.go` | `InstallSyntheticImage` always emits the new annotation so existing tests don't need fixture updates. |
| `internal/config/config_test.go` | `installCachedBlob` returns the erofs blob path. |
| `cmd/shed/image.go` | `--build-tools-version` flag, `buildToolsRefDefault()` resolves the pinned ref from `version.Version`. |
| `scripts/build-{firecracker,vz}-rootfs.sh` | Forward `--build-tools-version` to `shed image build`. |
| Docs | `images.md`, `storage-model.md`, `CLAUDE.md` updated for the new model. New `docs/upgrades/v0.5.1-to-v0.5.2.md`. |

## Test plan

- [x] `make test` clean (full suite).
- [x] `make fmt` clean.
- [x] golangci-lint v2.10.1 (matches CI) — 0 issues.
- [x] `make build-tools` produces the build-tools image.
- [x] Integration test `TestMintRootfsErofsIntegration` passes against `shed-build-tools:dev`.
- [x] **Built a real shed-fc-base locally** with `OUTPUT_DIR=/tmp/shed-fc-test ./scripts/build-firecracker-rootfs.sh --variant base --build-tools-version dev`. Confirmed:
  - Resulting manifest has the new `io.shed.rootfs.erofs.digest` annotation.
  - `dump.erofs` on the produced blob shows valid metadata.
  - Installed locally over the apt-installed shed-server. `shed create test-v2 --image test-v2 --local-dir $(mktemp -d)` succeeds end-to-end. `shed exec test-v2 -- ls /workspace` works. `shed delete test-v2 --force` clean. Zero erofs error lines in `journalctl -u shed-server` for the boot.
- [x] **Legacy reject verified:** `shed create test-legacy --image base --local-dir ...` against the v0.5.1 `shed-fc-base:v0.5.1` cached image fails fast with `image manifest sha256:6a59210e2913 lacks io.shed.rootfs.erofs.digest annotation (built with pre-v0.5.2 tooling); re-pull against current images: shed image rm sha256:6a59210e2913 && shed-server pull-images`.

## Mac VZ caveat

VZ-side runtime can't be exercised from this Linux box. Unit + integration tests cover the shared `internal/vmimage` code path; the VZ-specific glue (`internal/vz/vm.go`'s `ResolveManifestLower` call site) wasn't changed in this PR. The full VZ e2e cycle will be exercised by the release validation step on a Mac before tagging v0.5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)