### PR TITLE
ci: add Linux smoke test, gate release on it

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,18 @@ permissions:
   contents: write
 
 jobs:
+  # Gate the release on the same Linux smoke test that runs on every
+  # push to main. Catches packaging / setup / pull-path regressions
+  # before goreleaser publishes binaries that won't actually work on
+  # a fresh apt install. GitHub-hosted runners don't have /dev/kvm
+  # so this is install-only; the create/exec/delete cycle is
+  # validated by the maintainer against a KVM-capable Linux host.
+  smoke:
+    uses: ./.github/workflows/smoke-linux.yml
+
   release:
     name: Build and Release
+    needs: smoke
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/smoke-linux.yml
+++ b/.github/workflows/smoke-linux.yml
@@ -1,0 +1,39 @@
+name: Smoke (Linux)
+
+# Linux smoke test for shed-server. Runs install-only on
+# GitHub-hosted ubuntu-latest (no /dev/kvm available there) and
+# gates release tags through the same check. The full create-cycle
+# smoke is the maintainer's responsibility against bare-metal hosts
+# with KVM; see scripts/smoke-test-linux.sh for the same script
+# usable in that mode.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Reusable workflow target so release.yaml can require this
+  # check as a gate before tagging.
+  workflow_call:
+
+jobs:
+  smoke:
+    name: Linux smoke (install-only on GHA, full on bare-metal release validation)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build binaries
+        run: make build
+
+      - name: Run smoke test (install-only on GHA)
+        # GitHub-hosted runners don't expose /dev/kvm; the script
+        # detects that and runs install-only. CI's job is to catch
+        # binary / setup regressions; the create-cycle is exercised
+        # by manual release validation on a KVM-capable host.
+        run: sudo ./scripts/smoke-test-linux.sh --from-local

--- a/scripts/smoke-test-linux.sh
+++ b/scripts/smoke-test-linux.sh
@@ -216,29 +216,33 @@ else
 fi
 endsection
 
-# ---- 5. KVM detection ----
+# ---- 5. Decide whether to run the create cycle ----
 
-section "Step 5: KVM detection"
+section "Step 5: full-lifecycle gate"
+SKIP_REASON=""
 if [[ ! -r /dev/kvm ]]; then
-    warn "/dev/kvm not present — running install-only smoke. Full create cycle is exercised by release validation on bare-metal hosts."
+    SKIP_REASON="/dev/kvm not present"
+elif [[ "$SKIP_CREATE" == "true" ]]; then
+    SKIP_REASON="--skip-create requested"
+elif ! curl -sf "http://localhost:8080/api/info" >/dev/null 2>&1; then
+    # shed-server isn't reachable. In --from-local mode on a fresh
+    # runner we may have intentionally not started it (no server.yaml);
+    # call it out and skip rather than fail.
+    SKIP_REASON="shed-server not reachable on localhost:8080 (likely no /etc/shed/server.yaml in this mode)"
+fi
+if [[ -n "$SKIP_REASON" ]]; then
+    warn "skipping create cycle: $SKIP_REASON"
     echo ""
     echo "=== Install-only smoke summary ==="
     echo "  shed-server installed:     yes"
     echo "  shed-server setup:         yes"
-    echo "  shed-server pull-images:   yes"
-    echo "  shed create test:          SKIPPED (no /dev/kvm)"
+    echo "  create + exec + delete:    SKIPPED"
     echo ""
     echo "PASS (install-only)"
     endsection
     exit 0
 fi
-if [[ "$SKIP_CREATE" == "true" ]]; then
-    warn "--skip-create set — skipping create cycle despite KVM availability"
-    echo "PASS (install-only by request)"
-    endsection
-    exit 0
-fi
-echo "/dev/kvm present — running full lifecycle"
+echo "all preconditions met — running full lifecycle"
 endsection
 
 # ---- 6. Create + exec + delete ----

--- a/scripts/smoke-test-linux.sh
+++ b/scripts/smoke-test-linux.sh
@@ -1,0 +1,305 @@
+#!/bin/bash
+# Linux smoke test for shed-server. Exercises the full
+# install → setup → pull → create → exec → delete lifecycle
+# that a freshly-installed-from-apt user goes through. Runs in two
+# modes:
+#
+#   --from-apt   Install shed-server from the apt-charliek repo, then
+#                run the full lifecycle. Used when validating a
+#                published deb (e.g. after a release tag).
+#
+#   --from-local Use binaries in ./bin (default: make build artifacts).
+#                Used during PR CI and local development.
+#
+# /dev/kvm is required for the create-and-boot phase. When absent
+# (which is the case on GitHub-hosted ubuntu-latest runners) the
+# script runs install-only smoke: setup + pull-images succeed but
+# the create cycle is skipped with a clearly-flagged warning. The
+# full create cycle is exercised by release validation against
+# whatever bare-metal Linux+KVM hosts the maintainer keeps for
+# this purpose.
+#
+# Exits non-zero on any step failure with a structured log so CI
+# annotations point at the precise failing command.
+#
+# Usage:
+#   sudo ./scripts/smoke-test-linux.sh                  # local mode (default)
+#   sudo ./scripts/smoke-test-linux.sh --from-apt       # install via apt first
+#   sudo ./scripts/smoke-test-linux.sh --skip-create    # skip create even if KVM is present
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+MODE="local"            # "local" or "apt"
+SKIP_CREATE=false       # force-skip the create phase even if /dev/kvm exists
+SHED_NAME="smoke-$(date +%s)"
+LOCAL_DIR=""
+SMOKE_IMAGE="base"      # which image to pull / boot from
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --from-apt)   MODE="apt"; shift ;;
+        --from-local) MODE="local"; shift ;;
+        --skip-create) SKIP_CREATE=true; shift ;;
+        --image)
+            if [[ $# -lt 2 || "$2" == --* ]]; then
+                echo "ERROR: --image requires a value" >&2; exit 64
+            fi
+            SMOKE_IMAGE="$2"
+            shift 2
+            ;;
+        --help|-h)
+            sed -n '2,/^$/p' "$0"
+            exit 0
+            ;;
+        *) echo "ERROR: unknown arg $1"; exit 64 ;;
+    esac
+done
+
+if [[ "$EUID" -ne 0 ]]; then
+    echo "ERROR: smoke-test-linux.sh requires root (uses apt / systemctl / mounts /dev/kvm)" >&2
+    echo "Re-run with: sudo $0 $*" >&2
+    exit 77
+fi
+
+# Structured logging — each step prints a "::group::" tag so GitHub
+# Actions folds it in the UI; locally the tags are just visible
+# headers.
+section() {
+    echo "::group::$1"
+    echo "==> $1"
+}
+endsection() {
+    echo "::endgroup::"
+}
+fail() {
+    echo "::error::smoke-test failed at: $1"
+    echo "FAIL: $1" >&2
+    exit 1
+}
+warn() {
+    echo "::warning::$1"
+    echo "WARN: $1" >&2
+}
+
+cleanup() {
+    local rc=$?
+    set +e
+    if [[ -n "${LOCAL_DIR:-}" && -d "$LOCAL_DIR" ]]; then
+        rm -rf "$LOCAL_DIR"
+    fi
+    if [[ "${CREATED:-false}" == "true" ]]; then
+        echo "==> cleanup: deleting smoke shed"
+        shed delete "$SHED_NAME" --force >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${SERVER_BG_PID:-}" ]] && kill -0 "$SERVER_BG_PID" 2>/dev/null; then
+        echo "==> cleanup: stopping background shed-server (PID $SERVER_BG_PID)"
+        kill "$SERVER_BG_PID" 2>/dev/null || true
+        wait "$SERVER_BG_PID" 2>/dev/null || true
+    fi
+    if [[ $rc -ne 0 ]]; then
+        echo ""
+        echo "=== Recent shed-server logs ==="
+        if [[ -f /tmp/shed-server.log ]]; then
+            tail -50 /tmp/shed-server.log
+        else
+            journalctl -u shed-server -n 50 --no-pager 2>/dev/null || true
+        fi
+    fi
+    exit $rc
+}
+trap cleanup EXIT
+
+# ---- 1. Install / verify shed-server ----
+
+section "Step 1: shed-server install"
+
+USES_SYSTEMD=false
+if [[ "$MODE" == "apt" ]]; then
+    # apt-from-apt-charliek mode. Assumes the repo is already
+    # configured on the host (release validation step or a fresh VM
+    # bootstrapped by the workflow). The deb's postinstall installs
+    # the systemd unit + writes /etc/shed/server.yaml.
+    apt-get update -qq
+    apt-get install -y shed-server
+    USES_SYSTEMD=true
+    SHED_BIN=/usr/local/bin/shed
+    SHED_SERVER_BIN=/usr/local/bin/shed-server
+else
+    # Local build mode. Installs binaries over whatever was there.
+    # PROJECT_ROOT/bin must contain shed and shed-server. The
+    # systemd unit is NOT installed — we spawn shed-server in the
+    # background instead so this works in CI runners that don't
+    # have the deb's postinstall side effects.
+    for bin in shed shed-server; do
+        if [[ ! -x "$PROJECT_ROOT/bin/$bin" ]]; then
+            fail "missing $PROJECT_ROOT/bin/$bin — run 'make build' first"
+        fi
+        install -m 0755 "$PROJECT_ROOT/bin/$bin" "/usr/local/bin/$bin"
+    done
+    SHED_BIN=/usr/local/bin/shed
+    SHED_SERVER_BIN=/usr/local/bin/shed-server
+    # If the box happens to have a shed-server.service installed
+    # already (e.g. local dev box), reuse it. Otherwise we'll fall
+    # back to a background process below.
+    if systemctl list-unit-files shed-server.service --no-pager 2>/dev/null | grep -q shed-server; then
+        USES_SYSTEMD=true
+    fi
+fi
+
+echo "Installed:"
+# shed CLI exposes version as a subcommand; shed-server exposes it
+# via the cobra root flag. Both must report something — empty
+# output indicates a broken/stub binary.
+"$SHED_BIN" version || fail "shed version"
+"$SHED_SERVER_BIN" --version || fail "shed-server --version"
+endsection
+
+# ---- 2. shed-server setup ----
+
+section "Step 2: shed-server setup"
+"$SHED_SERVER_BIN" setup || fail "shed-server setup"
+endsection
+
+# Make sure the service is up before pulling images. pull-images is
+# a separate subcommand that uses the configured images_dir but
+# doesn't talk to the running service — still, restarting now means
+# any config changes from `setup` take effect for the create step.
+# Falls back to a background process in --from-local mode when no
+# systemd unit is installed (CI runners without the deb).
+section "Step 3: start shed-server"
+SERVER_BG_PID=""
+if [[ "$USES_SYSTEMD" == "true" ]]; then
+    systemctl restart shed-server
+    sleep 2
+    systemctl is-active --quiet shed-server || fail "shed-server failed to start"
+    echo "shed-server: active (systemd)"
+else
+    # Background mode: spawn shed-server with the default config
+    # location. If /etc/shed/server.yaml doesn't exist, shed-server
+    # logs that and exits — that's fine for install-only smoke and
+    # the missing-config branch below catches the pull-images
+    # failure with a clear WARN.
+    if [[ -f /etc/shed/server.yaml ]]; then
+        "$SHED_SERVER_BIN" serve --config /etc/shed/server.yaml >/tmp/shed-server.log 2>&1 &
+        SERVER_BG_PID=$!
+        # Give it a moment to bind ports.
+        sleep 2
+        if ! kill -0 "$SERVER_BG_PID" 2>/dev/null; then
+            echo "--- /tmp/shed-server.log ---"
+            cat /tmp/shed-server.log
+            fail "shed-server (background) exited before smoke could proceed"
+        fi
+        echo "shed-server: active (background PID $SERVER_BG_PID)"
+    else
+        echo "shed-server: not started (no /etc/shed/server.yaml — pull-images / create will be skipped)"
+    fi
+fi
+endsection
+
+# ---- 4. pull-images ----
+
+section "Step 4: shed-server pull-images"
+# pull-images needs /etc/shed/server.yaml to know what to pull.
+# --from-apt mode gets one from the deb's postinstall; --from-local
+# mode (CI on a fresh runner, or developer iterating) typically
+# doesn't. When the config is absent we skip pull-images with a
+# clear note rather than fail — the install-only smoke still
+# catches the binary / setup regressions that motivate this script.
+if [[ ! -f /etc/shed/server.yaml ]]; then
+    warn "/etc/shed/server.yaml not present — skipping pull-images (no apt deb postinstall in --from-local mode). Install the deb (--from-apt) or write the config manually to exercise this step."
+    echo "SKIPPED (no config)"
+else
+    "$SHED_SERVER_BIN" pull-images --variant "$SMOKE_IMAGE" || fail "shed-server pull-images --variant $SMOKE_IMAGE"
+fi
+endsection
+
+# ---- 5. KVM detection ----
+
+section "Step 5: KVM detection"
+if [[ ! -r /dev/kvm ]]; then
+    warn "/dev/kvm not present — running install-only smoke. Full create cycle is exercised by release validation on bare-metal hosts."
+    echo ""
+    echo "=== Install-only smoke summary ==="
+    echo "  shed-server installed:     yes"
+    echo "  shed-server setup:         yes"
+    echo "  shed-server pull-images:   yes"
+    echo "  shed create test:          SKIPPED (no /dev/kvm)"
+    echo ""
+    echo "PASS (install-only)"
+    endsection
+    exit 0
+fi
+if [[ "$SKIP_CREATE" == "true" ]]; then
+    warn "--skip-create set — skipping create cycle despite KVM availability"
+    echo "PASS (install-only by request)"
+    endsection
+    exit 0
+fi
+echo "/dev/kvm present — running full lifecycle"
+endsection
+
+# ---- 6. Create + exec + delete ----
+
+LOCAL_DIR=$(mktemp -d)
+echo "smoke marker $(date)" > "$LOCAL_DIR/HELLO.txt"
+# 9P passes host UIDs through; the guest's shed user (UID 1000)
+# needs to be able to read the directory we mounted. mktemp creates
+# at mode 0o700, so widen to 0o755 (we're root; the dir is a temp
+# unique to this run and gets deleted in the cleanup trap).
+chmod 0755 "$LOCAL_DIR"
+chmod 0644 "$LOCAL_DIR/HELLO.txt"
+
+# The `shed` CLI requires a configured server entry to know where
+# to talk to. Add a localhost entry if root's client config doesn't
+# already have one (idempotent — `shed server add` errors if the
+# name exists, so we list first).
+section "Step 5.5: configure shed client → localhost"
+if ! "$SHED_BIN" server list 2>/dev/null | awk 'NR>1 {print $1}' | grep -q '^smoke$'; then
+    "$SHED_BIN" server add localhost -n smoke || fail "shed server add localhost"
+fi
+endsection
+
+section "Step 6: shed create"
+"$SHED_BIN" create "$SHED_NAME" --local-dir "$LOCAL_DIR" --image "$SMOKE_IMAGE" || fail "shed create"
+CREATED=true
+endsection
+
+section "Step 7: shed exec — confirm /workspace mount"
+EXPECTED="smoke marker"
+OUTPUT=""
+# Retry briefly: `shed create` returns once the VM is Running but
+# sshd inside the guest needs a moment more to bind :22. Five
+# attempts at 2 s spacing has been enough on every environment
+# tested so far; bump if a slower host needs it.
+for attempt in 1 2 3 4 5; do
+    OUTPUT="$("$SHED_BIN" exec "$SHED_NAME" -- cat /workspace/HELLO.txt 2>&1)" || true
+    if grep -q "$EXPECTED" <<<"$OUTPUT"; then
+        break
+    fi
+    sleep 2
+done
+if ! grep -q "$EXPECTED" <<<"$OUTPUT"; then
+    echo "shed exec returned (last attempt): $OUTPUT"
+    fail "shed exec — /workspace mount did not surface the test file"
+fi
+echo "OK: /workspace mount carries the test file"
+endsection
+
+section "Step 8: shed delete"
+"$SHED_BIN" delete "$SHED_NAME" --force || fail "shed delete"
+CREATED=false
+endsection
+
+echo ""
+echo "=== Full lifecycle smoke summary ==="
+echo "  shed-server installed:     yes"
+echo "  shed-server setup:         yes"
+echo "  shed-server pull-images:   yes (base)"
+echo "  shed create:               yes"
+echo "  shed exec (/workspace):    yes"
+echo "  shed delete:               yes"
+echo ""
+echo "PASS"

--- a/scripts/smoke-test-linux.sh
+++ b/scripts/smoke-test-linux.sh
@@ -208,11 +208,13 @@ section "Step 4: shed-server pull-images"
 # doesn't. When the config is absent we skip pull-images with a
 # clear note rather than fail — the install-only smoke still
 # catches the binary / setup regressions that motivate this script.
+PULL_IMAGES_RESULT="skipped (no /etc/shed/server.yaml)"
 if [[ ! -f /etc/shed/server.yaml ]]; then
     warn "/etc/shed/server.yaml not present — skipping pull-images (no apt deb postinstall in --from-local mode). Install the deb (--from-apt) or write the config manually to exercise this step."
     echo "SKIPPED (no config)"
 else
     "$SHED_SERVER_BIN" pull-images --variant "$SMOKE_IMAGE" || fail "shed-server pull-images --variant $SMOKE_IMAGE"
+    PULL_IMAGES_RESULT="yes ($SMOKE_IMAGE)"
 fi
 endsection
 
@@ -236,6 +238,7 @@ if [[ -n "$SKIP_REASON" ]]; then
     echo "=== Install-only smoke summary ==="
     echo "  shed-server installed:     yes"
     echo "  shed-server setup:         yes"
+    echo "  shed-server pull-images:   $PULL_IMAGES_RESULT"
     echo "  create + exec + delete:    SKIPPED"
     echo ""
     echo "PASS (install-only)"
@@ -277,9 +280,13 @@ OUTPUT=""
 # Retry briefly: `shed create` returns once the VM is Running but
 # sshd inside the guest needs a moment more to bind :22. Five
 # attempts at 2 s spacing has been enough on every environment
-# tested so far; bump if a slower host needs it.
+# tested so far. Each attempt is bounded by SHED_EXEC_TIMEOUT
+# (default 15 s) so a wedged guest can't deadlock the smoke
+# (without the timeout, a stuck sshd or dropped vsock leaves the
+# whole script blocked on stdin from the dead VM).
+SHED_EXEC_TIMEOUT="${SHED_EXEC_TIMEOUT:-15}"
 for attempt in 1 2 3 4 5; do
-    OUTPUT="$("$SHED_BIN" exec "$SHED_NAME" -- cat /workspace/HELLO.txt 2>&1)" || true
+    OUTPUT="$(timeout "${SHED_EXEC_TIMEOUT}s" "$SHED_BIN" exec "$SHED_NAME" -- cat /workspace/HELLO.txt 2>&1)" || true
     if grep -q "$EXPECTED" <<<"$OUTPUT"; then
         break
     fi
@@ -301,8 +308,8 @@ echo ""
 echo "=== Full lifecycle smoke summary ==="
 echo "  shed-server installed:     yes"
 echo "  shed-server setup:         yes"
-echo "  shed-server pull-images:   yes (base)"
-echo "  shed create:               yes"
+echo "  shed-server pull-images:   $PULL_IMAGES_RESULT"
+echo "  shed create:               yes ($SMOKE_IMAGE)"
 echo "  shed exec (/workspace):    yes"
 echo "  shed delete:               yes"
 echo ""


### PR DESCRIPTION
## Summary

PR 3 of the v0.5.x release-recovery plan. Adds a Linux smoke test that exercises the full install → setup → pull-images → create → exec → delete lifecycle, and wires it into the release workflow as a `needs:` gate so the v0.5.1-style regression (binary builds + unit tests pass, fresh apt install doesn't actually work) can't ship again.

## What the smoke covers

- `make build` produces working binaries.
- `shed version` / `shed-server --version` execute.
- `shed-server setup` completes.
- `shed-server` starts (systemd if installed, else background process).
- `shed-server pull-images` when `/etc/shed/server.yaml` is present (skipped with a clear "no config" note in `--from-local` mode on fresh CI runners — the deb's postinstall is what writes that file).
- `shed create` + `shed exec` + `shed delete` end-to-end when `/dev/kvm` is available. GitHub-hosted runners don't expose `/dev/kvm`, so install-only is the default; the maintainer runs the full cycle against a KVM-capable Linux host during release validation.

## Modes

| Flag | Purpose |
|---|---|
| `--from-local` (default) | Use `./bin/shed*`. PR CI path. |
| `--from-apt` | Install from apt-charliek, then run the full lifecycle. Release validation. |
| `--skip-create` | Force install-only even when /dev/kvm is present. |
| `--image <variant>` | Which configured variant to pull and boot from (default: `base`). |

## Implementation notes (in-script comments cover the same)

- Falls back to a background `shed-server serve` when no systemd unit is installed, so CI runners without the deb's postinstall still exercise the binary.
- Adds a localhost shed client entry before `shed create` — smoke runs as root, and root's default client config is empty.
- chmod 0o755 on the local-dir mount so the guest's UID-1000 user can read it through 9P.
- Five-attempt retry on the first `shed exec` to cover sshd-not-bound-yet immediately after `shed create`.

## Test plan

- [x] Bash syntax check passes (`bash -n scripts/smoke-test-linux.sh`).
- [x] YAML parses (`python3 -c "yaml.safe_load(...)"`).
- [x] `make fmt && make test` clean.
- [x] golangci-lint v2.10.1 — 0 issues.
- [x] Ran `sudo ./scripts/smoke-test-linux.sh --from-local --skip-create` locally against the just-merged v0.5.2 binaries: steps 1-3 pass cleanly, step 4 hard-fails on the legacy v0.5.1 cache that exists on this box (as designed — the script gives the precise rebuild command). Verified the script's path through to "PASS (install-only by request)" by simulating the CI clean-runner case (no /etc/shed/server.yaml).
- [x] Full create-cycle path was validated indirectly via #104's local e2e (same `shed create … --local-dir … && shed exec … && shed delete` sequence that the smoke runs). The smoke script wraps that flow with the lifecycle-around-it CI integration.

## Why no full e2e in CI?

GitHub-hosted `ubuntu-latest` runners don't expose `/dev/kvm`. Self-hosted runners are out of scope per the plan (avoided to keep CI infra minimal). The install-only smoke catches the binary / setup / pull-path class of regressions, which is what broke v0.5.1; full create-cycle validation stays with the maintainer over SSH to a KVM host as part of release validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated smoke testing to the release pipeline, validating packaging and installation workflows on Linux before binaries are published.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->