### PR TITLE
v0.5.3: file-cred hint + shed-server doctor + registry retry

### DIFF
--- a/cmd/shed-server/doctor_linux.go
+++ b/cmd/shed-server/doctor_linux.go
@@ -1,0 +1,337 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/vmimage"
+)
+
+// doctorCmd is a one-stop "is this install healthy?" report for the
+// Firecracker backend. Designed to be the first thing a user runs
+// when shed-server "isn't working" — the output is meant to make
+// the failure mode obvious without having to grep journalctl or
+// read internal docs.
+//
+// Each check has three outcomes:
+//   - PASS: green, no action needed
+//   - WARN: yellow, surfaces something worth knowing but won't
+//     block normal operation (e.g. shed-server unit not
+//     active when the user is iterating locally without
+//     systemd)
+//   - FAIL: red, would prevent `shed create` from working;
+//     doctor returns a non-zero exit code if any FAIL fires
+//
+// Reuses the setup helpers (loadBridgeConfig, ensureFirecracker
+// version constant, etc.) rather than duplicating the prerequisite
+// matrix.
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Check whether this host is configured correctly to run shed-server",
+	Long: `Run a sequence of self-checks against the local shed-server
+install and report PASS / WARN / FAIL for each.
+
+Designed as the first diagnostic step when "shed create" or
+"shed-server pull-images" fail unexpectedly. Output groups checks
+by category (host, package, config, network, images, extensions)
+so a single run surfaces the most common misconfigurations.
+
+Exits 0 if every check is PASS or WARN, 1 if any FAIL fired.`,
+	RunE: runDoctor,
+}
+
+func init() {
+	rootCmd.AddCommand(doctorCmd)
+}
+
+type checkResult struct {
+	name   string
+	status string // "PASS", "WARN", "FAIL"
+	detail string
+}
+
+type doctor struct {
+	cfg     *config.ServerConfig
+	results []checkResult
+}
+
+func (d *doctor) record(name, status, detail string) {
+	d.results = append(d.results, checkResult{name: name, status: status, detail: detail})
+}
+
+func (d *doctor) pass(name, detail string) { d.record(name, "PASS", detail) }
+func (d *doctor) warn(name, detail string) { d.record(name, "WARN", detail) }
+func (d *doctor) fail(name, detail string) { d.record(name, "FAIL", detail) }
+
+func runDoctor(cmd *cobra.Command, args []string) error {
+	d := &doctor{}
+
+	// --- Host prerequisites ---
+	d.checkKVM()
+	d.checkDocker()
+	d.checkFirecracker()
+
+	// --- Configuration ---
+	// loadConfig is in serve.go and shared with `shed-server serve`
+	// + `shed-server pull-images`; reuse so an unparseable config
+	// becomes a doctor FAIL with the same error users see at
+	// service start.
+	cfg, err := loadConfig()
+	if err != nil {
+		d.fail("server.yaml", fmt.Sprintf("loadConfig: %v", err))
+		d.print(cmd)
+		// Without a config we can't run the rest of the checks
+		// meaningfully — return the FAIL exit code now.
+		return fmt.Errorf("doctor: configuration is broken; fix the FAIL above first")
+	}
+	d.cfg = cfg
+	d.pass("server.yaml", "loaded from "+findConfigPath())
+
+	// --- Kernel + bridge ---
+	d.checkKernel()
+	d.checkBridge()
+
+	// --- Images + extensions ---
+	d.checkImages()
+	d.checkExtensions()
+
+	// --- Systemd unit ---
+	d.checkSystemdUnit(cmd.Context())
+
+	d.print(cmd)
+	for _, r := range d.results {
+		if r.status == "FAIL" {
+			return fmt.Errorf("doctor: %d check(s) failed; see report above", countStatus(d.results, "FAIL"))
+		}
+	}
+	return nil
+}
+
+func (d *doctor) checkKVM() {
+	f, err := os.OpenFile("/dev/kvm", os.O_RDWR, 0)
+	if err != nil {
+		d.fail("/dev/kvm", fmt.Sprintf("not readable: %v (enable virtualization in BIOS / nested-virt settings)", err))
+		return
+	}
+	f.Close()
+	d.pass("/dev/kvm", "readable")
+}
+
+func (d *doctor) checkDocker() {
+	if _, err := exec.LookPath("docker"); err != nil {
+		// Post-v0.5.2, the host no longer invokes mkfs.erofs via
+		// docker — but image publish (shed image build) still does
+		// for the local-dev path. Treat as WARN, not FAIL.
+		d.warn("docker", "not on PATH; needed only for `shed image build` (not for `shed create`)")
+		return
+	}
+	d.pass("docker", "on PATH")
+}
+
+func (d *doctor) checkFirecracker() {
+	if _, err := os.Stat(firecrackerBinPath); err != nil {
+		d.fail("firecracker", fmt.Sprintf("%s missing (run `sudo shed-server setup`)", firecrackerBinPath))
+		return
+	}
+	// Capture --version so the operator can tell at a glance which
+	// Firecracker is installed without shelling in further.
+	out, err := exec.Command(firecrackerBinPath, "--version").Output()
+	if err != nil {
+		d.warn("firecracker", fmt.Sprintf("present at %s but --version failed: %v", firecrackerBinPath, err))
+		return
+	}
+	d.pass("firecracker", strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0]))
+}
+
+func (d *doctor) checkKernel() {
+	if d.cfg.Firecracker == nil {
+		return
+	}
+	kp := d.cfg.Firecracker.KernelPath
+	if kp == "" {
+		d.warn("kernel_path", "unset in firecracker.kernel_path; sheds will use the per-image kernel blob (the normal v0.5.2+ path)")
+		return
+	}
+	info, err := os.Stat(kp)
+	if err != nil {
+		d.fail("kernel_path", fmt.Sprintf("%s: %v", kp, err))
+		return
+	}
+	// 10 MB is a sanity floor: real vmlinux is ~30-40 MB. A few KB
+	// is almost certainly a truncated download or empty placeholder.
+	const minKernelBytes = 10 * 1024 * 1024
+	if info.Size() < minKernelBytes {
+		d.fail("kernel_path", fmt.Sprintf("%s is only %d bytes (< %d MB); likely truncated", kp, info.Size(), minKernelBytes/(1024*1024)))
+		return
+	}
+	d.pass("kernel_path", fmt.Sprintf("%s (%d bytes)", kp, info.Size()))
+}
+
+func (d *doctor) checkBridge() {
+	if d.cfg.Firecracker == nil {
+		return
+	}
+	name := d.cfg.Firecracker.BridgeName
+	if name == "" {
+		d.warn("bridge", "firecracker.bridge_name unset; setup defaults to shed-br0")
+		return
+	}
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		d.fail("bridge", fmt.Sprintf("interface %q not present: %v (run `sudo shed-server setup`)", name, err))
+		return
+	}
+	if iface.Flags&net.FlagUp == 0 {
+		d.warn("bridge", fmt.Sprintf("interface %q exists but is DOWN; bring up with `sudo ip link set %s up`", name, name))
+		return
+	}
+	d.pass("bridge", fmt.Sprintf("%s up (idx %d, mtu %d)", name, iface.Index, iface.MTU))
+}
+
+func (d *doctor) checkImages() {
+	if d.cfg.Firecracker == nil || d.cfg.Firecracker.ImagesDir == "" {
+		return
+	}
+	imagesDir := d.cfg.Firecracker.ImagesDir
+	tags, err := vmimage.ListTags(imagesDir)
+	if err != nil {
+		d.fail("images", fmt.Sprintf("ListTags(%s): %v", imagesDir, err))
+		return
+	}
+	if len(tags) == 0 {
+		d.warn("images", "no tags installed (run `sudo shed-server pull-images`)")
+		return
+	}
+	var missing []string
+	var legacy []string
+	for _, tag := range tags {
+		t, err := vmimage.GetTag(imagesDir, tag)
+		if err != nil {
+			missing = append(missing, fmt.Sprintf("%s (tag lookup: %v)", tag, err))
+			continue
+		}
+		manifest, err := vmimage.LoadManifestByDigest(imagesDir, t.Digest)
+		if err != nil {
+			missing = append(missing, fmt.Sprintf("%s (manifest %s: %v)", tag, vmimage.ShortDigest(t.Digest), err))
+			continue
+		}
+		// v0.5.2+: every shed manifest must reference an erofs blob.
+		// Tags pointing at pre-v0.5.2 manifests would fail at boot
+		// with the legacy-reject error in manager.resolveManifestLower
+		// — surface that early as a FAIL here.
+		erofsDigest := manifest.ShedRootfsErofsDigest()
+		if erofsDigest == "" {
+			legacy = append(legacy, fmt.Sprintf("%s (manifest %s lacks %s annotation)", tag, vmimage.ShortDigest(t.Digest), vmimage.AnnotationRootfsErofsDigest))
+			continue
+		}
+		if !vmimage.BlobExists(imagesDir, erofsDigest) {
+			missing = append(missing, fmt.Sprintf("%s (erofs blob %s not installed)", tag, vmimage.ShortDigest(erofsDigest)))
+		}
+	}
+	if len(missing) > 0 || len(legacy) > 0 {
+		var msg []string
+		if len(missing) > 0 {
+			msg = append(msg, fmt.Sprintf("missing blobs: %s", strings.Join(missing, "; ")))
+		}
+		if len(legacy) > 0 {
+			msg = append(msg, fmt.Sprintf("pre-v0.5.2 manifests: %s (re-pull with `shed-server pull-images`)", strings.Join(legacy, "; ")))
+		}
+		d.fail("images", strings.Join(msg, " | "))
+		return
+	}
+	d.pass("images", fmt.Sprintf("%d tag(s), all manifests + erofs blobs present", len(tags)))
+}
+
+func (d *doctor) checkExtensions() {
+	if d.cfg.Extensions == nil || len(d.cfg.Extensions.Enabled) == 0 {
+		d.pass("extensions", "none enabled")
+		return
+	}
+	enabled := d.cfg.Extensions.Enabled
+	// Extensions ship as a directory of *.yaml manifests installed
+	// under /etc/shed-extensions.d (per shed-extensions's deb). If
+	// the user enabled an extension by name but the corresponding
+	// manifest isn't present, the credential broker won't start.
+	const extDir = "/etc/shed-extensions.d"
+	var missing []string
+	for _, name := range enabled {
+		manifestPath := filepath.Join(extDir, name+".yaml")
+		if _, err := os.Stat(manifestPath); err != nil {
+			missing = append(missing, fmt.Sprintf("%s (%s)", name, manifestPath))
+		}
+	}
+	if len(missing) > 0 {
+		d.warn("extensions", fmt.Sprintf("enabled in config but manifest missing: %s; install the shed-extensions deb", strings.Join(missing, ", ")))
+		return
+	}
+	d.pass("extensions", fmt.Sprintf("%d enabled, all manifests present", len(enabled)))
+}
+
+func (d *doctor) checkSystemdUnit(ctx context.Context) {
+	out, err := exec.CommandContext(ctx, "systemctl", "is-active", "shed-server").CombinedOutput()
+	state := strings.TrimSpace(string(out))
+	if err != nil {
+		// is-active returns non-zero when the unit isn't active.
+		// Treat "inactive" as WARN (some dev workflows run
+		// shed-server in foreground via `make dev-server` without
+		// systemd) rather than FAIL.
+		d.warn("shed-server.service", fmt.Sprintf("not active (state=%s); start with `sudo systemctl start shed-server`", state))
+		return
+	}
+	d.pass("shed-server.service", state)
+}
+
+// findConfigPath replicates loadConfig's search order for display
+// purposes only. Best-effort; if the user passed -c we don't see
+// it here because loadConfig doesn't expose its resolved path.
+func findConfigPath() string {
+	for _, p := range []string{"/etc/shed/server.yaml", "configs/server.yaml"} {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return "(default location)"
+}
+
+func (d *doctor) print(cmd *cobra.Command) {
+	w := cmd.OutOrStdout()
+	pass, warn, fail := 0, 0, 0
+	for _, r := range d.results {
+		switch r.status {
+		case "PASS":
+			pass++
+		case "WARN":
+			warn++
+		case "FAIL":
+			fail++
+		}
+	}
+	fmt.Fprintf(w, "shed-server doctor: %d PASS, %d WARN, %d FAIL\n\n", pass, warn, fail)
+	// Fixed-width tag column keeps the eye scanning the status
+	// indicator (the part that matters) instead of jagged left
+	// edges.
+	const tagWidth = 24
+	for _, r := range d.results {
+		fmt.Fprintf(w, "  %-*s %-4s  %s\n", tagWidth, r.name, r.status, r.detail)
+	}
+}
+
+func countStatus(results []checkResult, status string) int {
+	n := 0
+	for _, r := range results {
+		if r.status == status {
+			n++
+		}
+	}
+	return n
+}

--- a/cmd/shed-server/doctor_linux.go
+++ b/cmd/shed-server/doctor_linux.go
@@ -291,11 +291,23 @@ func (d *doctor) checkSystemdUnit(ctx context.Context) {
 	d.pass("shed-server.service", state)
 }
 
-// findConfigPath replicates loadConfig's search order for display
-// purposes only. Best-effort; if the user passed -c we don't see
-// it here because loadConfig doesn't expose its resolved path.
+// findConfigPath mirrors LoadServerConfigFromPath's search order for
+// display purposes. Honors the global --config flag when set so
+// `shed-server doctor --config /tmp/server.yaml` reports the actual
+// file in use rather than a misleading default.
 func findConfigPath() string {
-	for _, p := range []string{"/etc/shed/server.yaml", "configs/server.yaml"} {
+	if configPath != "" {
+		expanded := config.ExpandPath(configPath)
+		if _, err := os.Stat(expanded); err == nil {
+			return expanded
+		}
+		return configPath + " (configured but not present)"
+	}
+	for _, p := range []string{
+		"./server.yaml",
+		config.ExpandPath("~/.config/shed/server.yaml"),
+		"/etc/shed/server.yaml",
+	} {
 		if _, err := os.Stat(p); err == nil {
 			return p
 		}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -886,6 +886,30 @@ sudo shed-server setup
 
 Linux only. Not available on macOS.
 
+### shed-server doctor
+
+Runs a one-pass health report against the local shed-server install. Designed as the first diagnostic step when `shed create` or `shed-server pull-images` fail unexpectedly.
+
+```bash
+sudo shed-server doctor
+```
+
+Each check reports `PASS` / `WARN` / `FAIL`. The command exits non-zero if any `FAIL` fires.
+
+| Check | What it verifies |
+|---|---|
+| `/dev/kvm` | KVM is readable (hardware virtualization on, nested-virt enabled) |
+| `docker` | Present on PATH (used by `shed image build`, not by `shed create`) |
+| `firecracker` | `firecracker` binary installed at `/usr/local/bin/firecracker` and reports a version |
+| `server.yaml` | Config parses cleanly via `loadConfig` (same parser as `shed-server serve`) |
+| `kernel_path` | The configured kernel exists and is larger than 10 MB (sanity floor against truncated downloads) |
+| `bridge` | The bridge interface named in `firecracker.bridge_name` exists and is up |
+| `images` | Every installed tag points at a manifest with the v0.5.2+ `io.shed.rootfs.erofs.digest` annotation and the referenced blob exists locally |
+| `extensions` | Every extension named in `extensions.enabled` has its manifest under `/etc/shed-extensions.d/` |
+| `shed-server.service` | systemd unit is active |
+
+Linux only. Not available on macOS.
+
 ### shed-server pull-images
 
 Pre-caches VM images by pulling Docker refs and converting to ext4.

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -912,9 +912,15 @@ func LoadServerConfigFromPath(path string) (*ServerConfig, error) {
 		if info, err := os.Stat(source); err == nil && !info.IsDir() {
 			return nil, fmt.Errorf(
 				"credential %q source %s is a file, not a directory; "+
-					"only directory credentials are supported — "+
-					"use 'shed sync' for single-file configs like .gitconfig",
+					"single-file configs use `shed sync` instead — "+
+					"append to ~/.shed/sync.yaml:\n\n"+
+					"  features:\n"+
+					"    %s:\n"+
+					"      paths:\n"+
+					"        - source: %s\n"+
+					"          target: %s",
 				name, source,
+				name, source, target,
 			)
 		}
 

--- a/internal/vmimage/registry.go
+++ b/internal/vmimage/registry.go
@@ -316,7 +316,12 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		opts.Progress("image", fmt.Sprintf("Fetching manifest %s...", ref.String()))
 	}
 
-	desc, err := remote.Get(ref, remoteOpts...)
+	var desc *remote.Descriptor
+	err = withRetry(ctx, "fetching manifest "+ref.String(), func() error {
+		var rerr error
+		desc, rerr = remote.Get(ref, remoteOpts...)
+		return rerr
+	})
 	if err != nil {
 		return nil, fmt.Errorf("fetching descriptor: %w", err)
 	}
@@ -551,16 +556,25 @@ func pullLooseBlob(ctx context.Context, ref name.Reference, digest, imagesDir st
 	if err != nil {
 		return fmt.Errorf("forming digest ref: %w", err)
 	}
-	layer, err := remote.Layer(blobRef, remoteOpts...)
-	if err != nil {
-		return fmt.Errorf("requesting layer %s: %w", digest, err)
-	}
-	rc, err := layer.Compressed()
-	if err != nil {
-		return fmt.Errorf("opening loose blob: %w", err)
-	}
-	defer rc.Close()
-	return writeBlobFromReader(imagesDir, digest, rc)
+	// Whole-blob retry: a mid-stream TCP cut leaves a partial
+	// blobs/sha256/<hex>.tmp on disk that writeBlobFromReader's
+	// rename never commits, so each retry attempt re-starts from a
+	// clean slate. Suitable for kernel + initrd + rootfs erofs
+	// blobs (all sub-100 MB); for the multi-hundred-MB rootfs
+	// layers a more granular range-resume would pay off — file a
+	// follow-up if that ever becomes the bottleneck.
+	return withRetry(ctx, "pulling loose blob "+ShortDigest(digest), func() error {
+		layer, lerr := remote.Layer(blobRef, remoteOpts...)
+		if lerr != nil {
+			return fmt.Errorf("requesting layer %s: %w", digest, lerr)
+		}
+		rc, oerr := layer.Compressed()
+		if oerr != nil {
+			return fmt.Errorf("opening loose blob: %w", oerr)
+		}
+		defer rc.Close()
+		return writeBlobFromReader(imagesDir, digest, rc)
+	})
 }
 
 // nameOptsForInsecure returns the name parsing options needed for a

--- a/internal/vmimage/registry_retry.go
+++ b/internal/vmimage/registry_retry.go
@@ -1,0 +1,110 @@
+// Transient-failure retry wrapper for the registry-direct pull path.
+//
+// Without retries, a single TCP reset / DNS hiccup / 5xx during a
+// shed image pull surfaces as a hard failure. That's particularly
+// painful for the kernel/initrd loose-blob fetches that ride along
+// with `pull-images`: lose one of those mid-stream and the user has
+// to re-run the whole command. Adding three-attempt exponential
+// backoff covers the common "blip during a 10-minute pull" failure
+// mode without hiding real outages (since 4xx errors and context
+// cancellations skip the retry loop).
+
+package vmimage
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+// retryAttempts and retryBackoffs configure the retry envelope.
+//
+// 1 s / 4 s = ~5 s total wait on the worst case, which is short
+// enough that a foreground `shed image pull` doesn't feel hung
+// but long enough to absorb a typical TCP retransmit window. Two
+// retries (three attempts total) is the sweet spot: one retry
+// catches the common case, two catches the unlucky cascade, and
+// adding a third costs more than it earns since persistent
+// failures are usually persistent (DNS misconfigured, auth wrong,
+// etc.).
+var retryBackoffs = []time.Duration{1 * time.Second, 4 * time.Second}
+
+// withRetry calls fn, and on transient failure waits + retries
+// according to retryBackoffs. opName is included in the log line
+// emitted on each retry so the user can see which fetch is
+// stuttering. Returns the last attempt's error verbatim — no
+// wrapping that would hide retry semantics from a caller that
+// pattern-matches on the original error.
+func withRetry(ctx context.Context, opName string, fn func() error) error {
+	err := fn()
+	if err == nil || !isRetryablePullErr(err) {
+		return err
+	}
+	for i, backoff := range retryBackoffs {
+		log.Printf("retrying %s after transient error (attempt %d/%d in %v): %v", opName, i+2, len(retryBackoffs)+1, backoff, err)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+		err = fn()
+		if err == nil || !isRetryablePullErr(err) {
+			return err
+		}
+	}
+	return err
+}
+
+// isRetryablePullErr returns true for the error shapes a brief
+// registry blip typically produces. Conservative on purpose:
+// retrying a 401/403/404 just spams the registry and delays the
+// real diagnostic.
+func isRetryablePullErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Context cancellation / deadline is the caller saying "stop",
+	// not a transient failure.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	// Mid-stream TCP cut. Common on flaky links during the
+	// multi-hundred-MB layer pulls.
+	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+		return true
+	}
+	// Network-layer issues (DNS, connection refused, TCP reset).
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+	// go-containerregistry classifies HTTP failures via
+	// transport.Error. 5xx + 429 are worth retrying; 4xx (auth,
+	// not-found) are not.
+	var transErr *transport.Error
+	if errors.As(err, &transErr) {
+		code := transErr.StatusCode
+		return code >= 500 || code == 429
+	}
+	// Fallback for string-matched lower-layer errors that don't
+	// implement Is/As nicely. Keep the list narrow.
+	msg := err.Error()
+	for _, fragment := range []string{
+		"connection reset by peer",
+		"connection refused",
+		"i/o timeout",
+		"TLS handshake timeout",
+		"no such host",
+	} {
+		if strings.Contains(msg, fragment) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/vmimage/registry_retry.go
+++ b/internal/vmimage/registry_retry.go
@@ -93,13 +93,16 @@ func isRetryablePullErr(err error) bool {
 		return code >= 500 || code == 429
 	}
 	// Fallback for string-matched lower-layer errors that don't
-	// implement Is/As nicely. Keep the list narrow.
-	msg := err.Error()
+	// implement Is/As nicely. Lowercased comparison — the net/http
+	// "tls handshake timeout" string is lowercase but historical
+	// reports of it appear in mixed case, and lowercasing once is
+	// cheaper than maintaining both spellings.
+	msg := strings.ToLower(err.Error())
 	for _, fragment := range []string{
 		"connection reset by peer",
 		"connection refused",
 		"i/o timeout",
-		"TLS handshake timeout",
+		"tls handshake timeout",
 		"no such host",
 	} {
 		if strings.Contains(msg, fragment) {

--- a/internal/vmimage/registry_retry_test.go
+++ b/internal/vmimage/registry_retry_test.go
@@ -44,6 +44,8 @@ func TestIsRetryablePullErr(t *testing.T) {
 		{"transport 404", &transport.Error{StatusCode: http.StatusNotFound}, false},
 		{"connection reset string", errors.New("read tcp: connection reset by peer"), true},
 		{"i/o timeout string", errors.New("dial tcp 1.2.3.4: i/o timeout"), true},
+		{"tls handshake timeout lowercase", errors.New("net/http: tls handshake timeout"), true},
+		{"tls handshake timeout mixed case", errors.New("net/http: TLS handshake timeout"), true},
 		{"no such host string", errors.New("lookup foo.invalid: no such host"), true},
 		{"random string", errors.New("disk full"), false},
 	} {

--- a/internal/vmimage/registry_retry_test.go
+++ b/internal/vmimage/registry_retry_test.go
@@ -1,0 +1,141 @@
+package vmimage
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+// Tests use a zeroed backoff so they don't actually wait between
+// retries. The retry envelope is what we care about (right number
+// of attempts, right termination on success / non-retryable);
+// timing is configuration, not behavior worth verifying here.
+func setFastBackoff(t *testing.T) {
+	t.Helper()
+	orig := retryBackoffs
+	retryBackoffs = []time.Duration{0, 0}
+	t.Cleanup(func() { retryBackoffs = orig })
+}
+
+func TestIsRetryablePullErr(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"context canceled", context.Canceled, false},
+		{"context deadline", context.DeadlineExceeded, false},
+		{"io.EOF", io.EOF, true},
+		{"io.ErrUnexpectedEOF", io.ErrUnexpectedEOF, true},
+		{"net.OpError", &net.OpError{Op: "read", Err: errors.New("reset")}, true},
+		{"transport 500", &transport.Error{StatusCode: http.StatusInternalServerError}, true},
+		{"transport 502", &transport.Error{StatusCode: http.StatusBadGateway}, true},
+		{"transport 503", &transport.Error{StatusCode: http.StatusServiceUnavailable}, true},
+		{"transport 429", &transport.Error{StatusCode: http.StatusTooManyRequests}, true},
+		{"transport 401", &transport.Error{StatusCode: http.StatusUnauthorized}, false},
+		{"transport 403", &transport.Error{StatusCode: http.StatusForbidden}, false},
+		{"transport 404", &transport.Error{StatusCode: http.StatusNotFound}, false},
+		{"connection reset string", errors.New("read tcp: connection reset by peer"), true},
+		{"i/o timeout string", errors.New("dial tcp 1.2.3.4: i/o timeout"), true},
+		{"no such host string", errors.New("lookup foo.invalid: no such host"), true},
+		{"random string", errors.New("disk full"), false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRetryablePullErr(tt.err)
+			if got != tt.want {
+				t.Errorf("isRetryablePullErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestWithRetrySucceedsAfterTransient verifies the happy-recovery
+// path: fail once with a retryable error, then succeed.
+func TestWithRetrySucceedsAfterTransient(t *testing.T) {
+	setFastBackoff(t)
+	calls := 0
+	err := withRetry(context.Background(), "op", func() error {
+		calls++
+		if calls == 1 {
+			return io.ErrUnexpectedEOF
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withRetry: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2 (one transient failure + one success)", calls)
+	}
+}
+
+// TestWithRetryExhausts verifies the failure path runs the full
+// attempt budget and returns the last error.
+func TestWithRetryExhausts(t *testing.T) {
+	setFastBackoff(t)
+	calls := 0
+	err := withRetry(context.Background(), "op", func() error {
+		calls++
+		return io.ErrUnexpectedEOF
+	})
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("withRetry: got %v, want io.ErrUnexpectedEOF", err)
+	}
+	want := len(retryBackoffs) + 1
+	if calls != want {
+		t.Errorf("calls = %d, want %d (initial attempt + len(backoffs) retries)", calls, want)
+	}
+}
+
+// TestWithRetryDoesNotRetryNonRetryable confirms a 401 / not-found
+// short-circuits immediately rather than spamming the registry.
+func TestWithRetryDoesNotRetryNonRetryable(t *testing.T) {
+	setFastBackoff(t)
+	calls := 0
+	err := withRetry(context.Background(), "op", func() error {
+		calls++
+		return &transport.Error{StatusCode: http.StatusUnauthorized}
+	})
+	if err == nil {
+		t.Fatal("withRetry: expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (non-retryable should not retry)", calls)
+	}
+}
+
+// TestWithRetryRespectsContext confirms a cancelled context aborts
+// the backoff sleep instead of running through it.
+func TestWithRetryRespectsContext(t *testing.T) {
+	// Use real backoff so cancellation actually has something to interrupt.
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- withRetry(ctx, "op", func() error {
+			calls++
+			return io.ErrUnexpectedEOF
+		})
+	}()
+	// Let the first attempt run, then cancel during backoff.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("withRetry: got %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("withRetry did not return after context cancel")
+	}
+	if calls < 1 {
+		t.Errorf("calls = %d, want at least 1", calls)
+	}
+}


### PR DESCRIPTION
## Summary

Three smaller resilience / observability improvements bundled for v0.5.3. None changes the boot path or the published image format; all are additive.

### 1. File-credential migration hint

When a `server.yaml` credential's `source` is a regular file (not a directory) the validator previously errored with a generic "use shed sync instead" message. The new message embeds the exact `sync.yaml` snippet the user needs, with their config's name + source + target substituted in:

```
credential "gitconfig" source /home/charliek/.gitconfig is a file, not a directory;
single-file configs use `shed sync` instead — append to ~/.shed/sync.yaml:

  features:
    gitconfig:
      paths:
        - source: /home/charliek/.gitconfig
          target: /home/shed/.gitconfig
```

### 2. `shed-server doctor`

New subcommand. Runs a one-pass health report against the local install. Each check is `PASS` / `WARN` / `FAIL`; exits non-zero if any `FAIL` fires.

Sample output against today's v0.5.2 install:

```
shed-server doctor: 9 PASS, 0 WARN, 0 FAIL

  /dev/kvm                 PASS  readable
  docker                   PASS  on PATH
  firecracker              PASS  Firecracker v1.14.1
  server.yaml              PASS  loaded from /etc/shed/server.yaml
  kernel_path              PASS  /var/lib/shed/firecracker/images/vmlinux (40774472 bytes)
  bridge                   PASS  shed-br0 up (idx 413, mtu 1500)
  images                   PASS  2 tag(s), all manifests + erofs blobs present
  extensions               PASS  none enabled
  shed-server.service      PASS  active
```

Checks performed: KVM readable, docker on PATH, firecracker binary present + version, server.yaml parse, kernel_path size sanity (>10 MB), bridge interface state, every installed tag → manifest → erofs blob chain, every enabled extension's manifest present, systemd unit active.

Linux-only (Firecracker-specific). Docs updated in `docs/reference/cli.md`.

### 3. Registry-pull retry envelope

Wraps the two network-touching remote calls (`remote.Get` for the manifest descriptor, `remote.Layer + Compressed` for each loose blob) in a 3-attempt exponential backoff (1 s, 4 s) that only retries on transient shapes:

- `net.OpError` (DNS / connection-reset / refused)
- `io.EOF` / `io.ErrUnexpectedEOF` (mid-stream TCP cut)
- `transport.Error` with status 5xx or 429
- Common DNS / connection-string fragments (`connection reset by peer`, `i/o timeout`, `no such host`, etc.)

4xx errors (401/403/404) and context cancellations skip the loop so the user sees the real diagnostic immediately.

The `pullLooseBlob` retry is whole-blob (close + re-request + restart). Adequate for kernel + initrd + rootfs erofs (all sub-100 MB); the multi-hundred-MB rootfs layer fetches would benefit from range-resume but that's a separate optimization.

## Files

| File | Purpose |
|---|---|
| `internal/config/server.go` | Augmented credential-validator error message. |
| `cmd/shed-server/doctor_linux.go` (new) | The doctor subcommand. |
| `internal/vmimage/registry_retry.go` (new) | `withRetry` wrapper + `isRetryablePullErr` classifier. |
| `internal/vmimage/registry_retry_test.go` (new) | Coverage for happy-recovery, exhaustion, non-retryable short-circuit, context-cancel-during-backoff. |
| `internal/vmimage/registry.go` | Wrap `remote.Get` + `pullLooseBlob` calls. |
| `docs/reference/cli.md` | `shed-server doctor` reference. |

## Test plan

- [x] `make fmt && make test` clean.
- [x] golangci-lint v2.10.1 — 0 issues.
- [x] `sudo shed-server doctor` locally → 9 PASS on the v0.5.2-validated box.
- [x] Retry test suite (`TestIsRetryablePullErr`, `TestWithRetrySucceedsAfterTransient`, `TestWithRetryExhausts`, `TestWithRetryDoesNotRetryNonRetryable`, `TestWithRetryRespectsContext`) all pass.

## Closes the rev-2 plan

This is the last PR from the v0.5.x release recovery plan. Pairs with #107 for v0.5.3 — see `docs/upgrades/v0.5.1-to-v0.5.2.md` for the architectural recap covering everything since v0.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `shed-server doctor` command for Linux to run health checks and report overall system status (PASS/WARN/FAIL).

* **Bug Fixes**
  * Improved error messages for credential configuration, providing clearer setup instructions with code examples.

* **Improvements**
  * Enhanced registry pull reliability with automatic retry logic for handling transient network failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->