### PR TITLE
Add shed as a distributable Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "shed",
+  "description": "shed skills for driving the shed dev-environment CLI from your agent.",
+  "owner": {
+    "name": "Charlie Knudsen",
+    "url": "https://github.com/charliek"
+  },
+  "plugins": [
+    {
+      "name": "shed",
+      "source": "./",
+      "description": "Guidance for using the shed CLI: persistent VM-based dev environments — create, attach, tunnels, sync, and multi-server workflows."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "shed",
+  "version": "0.5.3",
+  "description": "Guidance for using the shed CLI: persistent VM-based dev environments — create, attach, tunnels, sync, and multi-server workflows.",
+  "author": {
+    "name": "Charlie Knudsen",
+    "url": "https://github.com/charliek"
+  },
+  "homepage": "https://github.com/charliek/shed",
+  "repository": "https://github.com/charliek/shed",
+  "license": "MIT",
+  "keywords": ["shed", "skills", "dev-environment", "vm", "firecracker"]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,10 @@ jobs:
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
+
+  plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate Claude Code plugin manifest and skills
+        run: scripts/validate-plugin.sh

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -389,3 +389,40 @@ jobs:
             -F "client_payload[package]=shed-server" \
             -F "client_payload[tag]=${{ github.ref_name }}"
           echo "::notice::Watch publish at https://github.com/charliek/apt-charliek/actions"
+
+  # Keep the committed .claude-plugin/plugin.json version in lockstep with the
+  # released tag, so Claude Code installs the right plugin version. Runs only
+  # after a real tag-push release (gated like the release job and needs it).
+  sync-version:
+    name: Commit plugin version to main
+    needs: release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Set plugin version from tag
+        run: scripts/set-version.sh "${GITHUB_REF_NAME#v}"
+
+      - name: Commit and push if plugin.json drifted
+        # Idempotent: a no-op when the version was bumped by hand before
+        # tagging. The GITHUB_TOKEN push does not re-trigger workflows (GitHub
+        # blocks recursive runs).
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -z "$(git status --porcelain .claude-plugin/plugin.json)" ]; then
+            echo "plugin.json already matches ${GITHUB_REF_NAME}; nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/plugin.json
+          git commit -m "chore: set plugin version ${GITHUB_REF_NAME}"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Charlie Knudsen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ make build
 go install github.com/charliek/shed/cmd/shed@latest
 ```
 
+#### Claude Code / agent skills
+
+shed ships a skill that teaches your coding agent to drive the shed CLI (create and attach to sheds, forward ports, sync files, work across servers). Install the CLI (above) first, since the skill drives it.
+
+The general route ([`skills`](https://skills.sh)) installs into Claude Code, GitHub Copilot, OpenCode, and other agents:
+
+```bash
+npx skills add charliek/shed
+```
+
+For Claude Code, a native plugin is also available (it namespaces the skill as `shed:shed`):
+
+```text
+/plugin marketplace add charliek/shed
+/plugin install shed@shed
+```
+
 ### 2. Add a Server
 
 ```bash

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Set the plugin version in .claude-plugin/plugin.json (read by Claude Code at
+# install/update time). The Go binaries' version comes from the git tag via
+# GoReleaser ldflags, so this is the only committed file that hardcodes a version.
+# Usage: scripts/set-version.sh 0.4.4
+set -euo pipefail
+
+version="${1:?usage: set-version.sh <X.Y.Z>}"
+root="$(cd "$(dirname "$0")/.." && pwd)"
+plugin="$root/.claude-plugin/plugin.json"
+
+tmp="$(mktemp)"
+sed -E 's/("version"[[:space:]]*:[[:space:]]*")[^"]*"/\1'"$version"'"/' "$plugin" > "$tmp"
+mv "$tmp" "$plugin"
+
+echo "plugin version set to $version"

--- a/scripts/validate-plugin.sh
+++ b/scripts/validate-plugin.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Validate the Claude Code plugin: manifest JSON parses and every skill has the
+# required YAML frontmatter (name + description). Runner-agnostic (jq + python3).
+# Run locally or from CI: scripts/validate-plugin.sh
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+jq -e . .claude-plugin/plugin.json >/dev/null
+jq -e . .claude-plugin/marketplace.json >/dev/null
+echo "ok: .claude-plugin JSON parses"
+
+python3 - <<'PY'
+import re, pathlib, sys
+
+skills = sorted(pathlib.Path("skills").glob("*/SKILL.md"))
+if not skills:
+    sys.exit("FAIL: no skills/*/SKILL.md found")
+
+bad = 0
+for sk in skills:
+    m = re.match(r"^---\n(.*?)\n---\n", sk.read_text(), re.S)
+    if not m:
+        print(f"FAIL: {sk} missing YAML frontmatter"); bad += 1; continue
+    fm = m.group(1)
+    missing = [f for f in ("name", "description") if not re.search(rf"^{f}:\s*\S", fm, re.M)]
+    if missing:
+        print(f"FAIL: {sk} missing {missing}"); bad += 1
+    else:
+        print(f"ok: {sk}")
+
+sys.exit(1 if bad else 0)
+PY

--- a/skills/shed/SKILL.md
+++ b/skills/shed/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: shed
+description: "Use when the user works with shed, the CLI for persistent VM-based development environments, or mentions a shed, sheds, or ~/.shed config. Covers day-to-day client usage: creating, listing, starting, stopping, and deleting sheds; connecting via console or attaching to persistent tmux sessions; running commands with exec; forwarding ports with tunnels; syncing files; managing images, snapshots, and disk usage; and working across multiple servers. Also reach for it on phrases like 'spin up a shed', 'attach to my shed', 'create a shed for this repo', or 'run it on a shed'. This is the shed dev-environment CLI specifically; do not use it for operating or installing the shed-server daemon (server/admin setup), or for unrelated meanings of the word 'shed'."
+---
+
+# Shed: Remote Dev Environments
+
+shed is a CLI for persistent, VM-based development environments that live on one or more servers. You create a **shed** (an isolated Linux VM, optionally cloned from a repo, with AI tools like Claude Code preinstalled), attach to it over SSH, work inside it, disconnect, and reconnect later with your work intact. Backends are Apple VZ (macOS Apple Silicon) and Firecracker (Linux); as a user you rarely care which.
+
+## Scope: using sheds, not running the server
+
+This skill covers **using the `shed` client** day-to-day. Operating the server — the `shed-server` daemon, `shed-server setup`/`serve`/`install`, backend/KVM/systemd configuration, and `server.yaml` — is out of scope. For server setup, point the user to the repo docs (`docs/getting-started/vz-setup.md`, `docs/getting-started/fc-setup.md`).
+
+## Mental model
+
+- A **shed** is a named, persistent VM that lives on a **server**. The client can target several servers; commands act on the default server unless you pass `-s/--server`, and `--all` fans out across all of them (for `list`, `sessions`, `system`).
+- **The VM persists** after you disconnect. To also keep the *programs* inside alive (an agent, a dev server), run them in a **tmux** session via `shed attach` — not `shed console`.
+- A shed's rootfs is a shared, read-only **image** (variants `base`/`extensions`/`full`) plus a per-shed **writable upper layer**. `shed reset` discards everything written inside the VM and starts fresh from the image, while leaving the workspace intact.
+- The client is configured by `~/.shed/config.yaml` (servers + a cache of known sheds). Networking assumes a private network (Tailscale); auth is SSH-key based, so there is no login/token flag.
+
+## First step: know the servers and sheds
+
+Before acting, read the lay of the land:
+
+```bash
+shed server list          # configured servers + which is default/online
+shed list                 # sheds on the default server (use --all for every server)
+shed list -v              # expanded: backend, status, SSH target, IP, resources
+```
+
+If no server is configured yet, add one (one-time): `shed server add <host> --name <name>`.
+
+## Core workflow
+
+```bash
+shed create myproj --repo charliek/myrepo   # create a shed and clone a repo into it
+shed attach myproj                          # open a persistent tmux session (auto-starts the shed)
+#   ...work inside; e.g. run `claude` or a dev server...
+#   detach with Ctrl-B D — the VM AND the tmux session keep running
+shed attach myproj                          # later: reattach exactly where you left off
+shed stop myproj                            # stop the VM when done (state is kept; `shed start` resumes)
+```
+
+Other ways to create: `--local-dir ~/path` mounts a host directory as the workspace (instead of `--repo`); `--from-snapshot <name>` spawns from a saved snapshot; bare `shed create myproj` makes an empty shed.
+
+## Commands you will use most
+
+| Task | Command |
+|------|---------|
+| Create a shed | `shed create <name> [--repo owner/repo \| --local-dir PATH]` |
+| List / inspect | `shed list [--all] [-v]` |
+| Start / stop / delete | `shed start <name>` · `shed stop <name>` · `shed delete <name> [--force]` |
+| Reset the writable layer | `shed reset <name>` (discard in-VM changes, keep the workspace; shed must be stopped) |
+| Persistent session (preferred) | `shed attach <name> [-S <session>]` (detach: `Ctrl-B D`) |
+| Ephemeral shell | `shed console <name>` |
+| One-off command | `shed exec <name> <command...>` |
+| List / kill sessions | `shed sessions [--all]` · `shed sessions kill <shed> <session>` |
+| Forward ports | `shed tunnels start <name> -t <port> -d` |
+| Sync local files in | `shed sync <name> [-p <profile>]` |
+| IDE (Cursor/VS Code) | `shed ssh-config --all --install` |
+| Disk usage / cleanup | `shed system df` · `shed system prune` |
+| Snapshots | `shed snapshot create <shed> <snap>` · `shed create <new> --from-snapshot <snap>` |
+
+Usage notes that matter:
+
+- **`console` vs `attach`:** `console` is a direct shell that dies on disconnect; `attach` is a tmux session that survives. For anything long-running (agents, dev servers), use `attach`.
+- **One-off vs interactive:** `shed exec <name> <command...>` runs a single command over SSH with the argv passed through verbatim (it is not a shell), e.g. `shed exec myproj git status`. For pipes, `&&`, redirection, or `cd`, wrap it yourself: `shed exec myproj bash -lc "cd /workspace && npm test"`. Reserve `attach`/`console` for interactive work.
+- **Multi-server:** target one with `-s <server>`; sweep all with `--all` (on `list`, `sessions`, `system`).
+- **Scripting:** `--json` emits structured output. Destructive commands require `--force` when combined with `--json` (no interactive prompt).
+
+## Reaching services inside a shed (tunnels)
+
+Forward a VM port to localhost:
+
+```bash
+shed tunnels start myproj -t 3000 -d        # localhost:3000 -> shed :3000, in background
+shed tunnels start myproj -t 4501:4096      # different local:remote ports
+shed tunnels start myproj -p webdev -d      # a named profile from ~/.shed/tunnels.yaml
+shed tunnels list                           # active tunnels    (stop: shed tunnels stop myproj)
+```
+
+## Getting files in (sync)
+
+`shed sync` pushes local files (dotfiles, certs, scripts) into a shed using profiles/features from `~/.shed/sync.yaml`; the `default` profile runs automatically on `shed create` (skip with `--no-sync`).
+
+```bash
+shed sync myproj            # default profile      (preview with --dry-run)
+shed sync myproj -p full    # a named profile
+```
+
+For ad-hoc transfers, `scp`/`rsync`/`sftp` work through the SSH config that `shed ssh-config --all --install` writes (hosts named `shed-<name>`).
+
+## CLI help is authoritative
+
+For exact flags and subcommands, run `shed <command> --help` (and `shed <command> <subcommand> --help`). The built-in help is comprehensive and always matches the installed version.
+
+## References
+
+- `references/commands.md` — usage command + flag reference (client commands only)
+- `references/configuration.md` — `~/.shed/config.yaml`, `sync.yaml`, and `tunnels.yaml`

--- a/skills/shed/references/commands.md
+++ b/skills/shed/references/commands.md
@@ -1,0 +1,156 @@
+# shed CLI: usage command reference
+
+Client (`shed`) commands only. Server operation (`shed-server setup/serve/install/uninstall/pull-images`) is intentionally omitted — see the repo's setup docs for that. `shed <command> --help` is the authoritative, version-matched source for every flag.
+
+## Global flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--server` | `-s` | Target a specific server (overrides the default) |
+| `--verbose` | `-v` | More output (`-v` expanded, `-vv` full detail) |
+| `--config` | `-c` | Config file path (default `~/.shed/config.yaml`) |
+| `--json` | | Structured JSON to stdout (for scripting) |
+
+`--json` + a destructive command requires `--force` (no interactive prompt in JSON mode).
+
+## Servers
+
+| Command | Purpose |
+|---------|---------|
+| `shed server add <host> [--name <n>] [--port 8080]` | Add a server to client config (SSH port auto-discovered) |
+| `shed server list` | List configured servers, online status, default marker |
+| `shed server remove <name>` | Remove a server |
+| `shed server set-default <name>` | Set the default server |
+
+## Shed lifecycle
+
+`shed create <name> [flags]`
+
+| Flag | Description |
+|------|-------------|
+| `--repo, -r <owner/repo\|url>` | Clone a repo into the shed |
+| `--local-dir <path>` | Mount a host directory as the workspace (mutually exclusive with `--repo`) |
+| `--from-snapshot <name>` | Spawn from a snapshot (mutually exclusive with `--repo`/`--image`) |
+| `--image, -i <base\|extensions\|full>` | Image variant (default: server default, usually `full`) |
+| `--backend <firecracker\|vz>` | Override backend (default: server default) |
+| `--cpus <n>` / `--memory <MB>` | Resource overrides |
+| `--upper-size <size>` | Size of the per-shed writable upper layer, e.g. `5G`, `20G` (default: server config) |
+| `--sync-profile <name>` | Profile to sync after create (default `default`) |
+| `--no-sync` / `--no-provision` | Skip sync / skip provisioning hooks |
+| `--timeout <dur>` | Create timeout, e.g. `30s`, `5m`, `30m` (default `10m`) |
+
+| Command | Purpose |
+|---------|---------|
+| `shed list [--all] [-s <server>] [-v]` | List sheds (default server, or all servers) |
+| `shed start <name> [--timeout <dur>]` | Start a stopped shed |
+| `shed stop <name>` | Stop a running shed (state kept) |
+| `shed delete <name> [--keep-volume] [--force/-f]` | Delete a shed (`--force` skips confirm; required with `--json`) |
+| `shed reset <name> [--force/-f]` | Discard the per-shed writable upper (in-VM changes); keeps the lower image and the workspace. Shed must be stopped |
+
+```bash
+shed create scratch
+shed create codelens --repo charliek/codelens
+shed create myproj --local-dir ~/projects/myproj
+shed create big --repo org/large-repo --timeout 30m
+```
+
+## Interactive access & sessions
+
+| Command | Purpose |
+|---------|---------|
+| `shed attach <name> [-S <session>] [--new]` | Attach to a persistent tmux session (creates if absent). Detach: `Ctrl-B D` |
+| `shed console <name>` | Direct bash shell; ephemeral (dies on disconnect). Auto-starts a stopped shed |
+| `shed exec <name> <command...> [-S <session>]` | Run a single command over SSH; argv is passed through verbatim (not a shell) |
+| `shed sessions [shed] [--all]` | List tmux sessions (one shed, default server, or all servers) |
+| `shed sessions kill <shed> <session>` | Kill a tmux session |
+
+```bash
+shed attach codelens
+shed attach codelens -S debug
+shed exec codelens git status
+shed exec codelens bash -lc "cd /workspace && npm test"   # shell features need an explicit shell
+shed sessions --all
+```
+
+## Port forwarding (tunnels)
+
+| Command | Purpose |
+|---------|---------|
+| `shed tunnels start <shed> [-t <port\|local:remote>]... [-p <profile>] [-d] [--replace]` | Open tunnels (`-d` = background) |
+| `shed tunnels stop [shed] [--all]` | Stop tunnels |
+| `shed tunnels list [-v] [--json]` | List active tunnels |
+| `shed tunnels config <shed> [-p <profile>] [-t ...]` | Preview the mapping without starting |
+
+```bash
+shed tunnels start myproj -t 3000 -d
+shed tunnels start myproj -t 4501:4096
+shed tunnels start myproj -p webdev -t 5432 -d
+```
+
+`-t` takes a bare `port` (same local+remote) or `local:remote`. Profiles live in `~/.shed/tunnels.yaml`. Background tunnels track PIDs in `~/.shed/tunnels.state`.
+
+## File sync
+
+| Command | Purpose |
+|---------|---------|
+| `shed sync <name> [-p <profile>] [-f <feature>] [--dry-run]` | Push local files into a shed per `~/.shed/sync.yaml` |
+
+The `default` profile auto-runs on `shed create` (skip with `--no-sync`). For ad-hoc transfers use `scp`/`rsync`/`sftp` against the `shed-<name>` hosts written by `shed ssh-config`.
+
+## IDE integration
+
+| Command | Purpose |
+|---------|---------|
+| `shed ssh-config [name] [--all] [--install] [--dry-run] [--uninstall]` | Generate/install SSH config entries for Cursor/VS Code Remote-SSH |
+
+```bash
+shed ssh-config --all --install --dry-run   # preview
+shed ssh-config --all --install             # apply (managed block in ~/.ssh/config)
+```
+
+## Snapshots
+
+A snapshot captures a **stopped** shed's rootfs as a named, immutable artifact; new sheds spawned from it get a fresh identity.
+
+| Command | Purpose |
+|---------|---------|
+| `shed snapshot create <shed> <snap> [--comment "..."]` | Capture a stopped shed |
+| `shed snapshot list` / `shed snapshot info <snap>` | List / inspect snapshots |
+| `shed snapshot delete <snap> [-f]` | Remove a snapshot (spawned sheds remain independent) |
+| `shed create <new> --from-snapshot <snap>` | Spawn a shed from a snapshot |
+
+## Images
+
+Rootfs images are content-addressed OCI artifacts in variants `base` / `extensions` / `full`; tags point at digests, Docker-style. Most users never touch these — `shed create` pulls what it needs.
+
+| Command | Purpose |
+|---------|---------|
+| `shed image ls` | List image tags (alias: `list`) |
+| `shed image pull <docker-ref> [-t <tag>] [--platform <p>]` | Pull a Docker/OCI ref into the blob store and advance a tag (replaces the old `build --from`) |
+| `shed image build [context] -n <name> [-f Dockerfile] [--target <stage>] [--platform <p>] [--force]` | Build a rootfs image from a Dockerfile |
+| `shed image tag <src> <new-tag>` | Point a new tag at an existing image |
+| `shed image rm <name> [--force]` | Remove a tag (alias: `delete`; the blob is garbage-collected later by `prune`) |
+| `shed image prune [--dry-run] [--force]` | Remove cached images not referenced by config or any shed |
+| `shed image push <tag-or-digest> <dest-ref> [--local]` | Push an image to a registry, byte-perfect |
+| `shed image inspect` / `history` / `save` / `load` | Inspect a manifest, show layer history, or export/import an OCI-layout tar |
+
+`shed image build` no longer has `--size` or `--from`: a shed's writable size is set per-shed with `create --upper-size`, and pulling a prebuilt ref is now `shed image pull <ref>`.
+
+## System (disk usage)
+
+| Command | Purpose |
+|---------|---------|
+| `shed system df [--all] [-s <server>] [-v] [--json]` | Disk usage: image cache, per-shed rootfs, orphans |
+| `shed system prune [--images] [--instances] [--logs] [--orphans] [--until <dur>] [--dry-run] [--force] [--all]` | Reclaim space (additive scopes; previews before mutating) |
+
+```bash
+shed system df -v
+shed system prune --dry-run
+shed system prune --instances --until 1h --force
+```
+
+## Utility
+
+| Command | Purpose |
+|---------|---------|
+| `shed version [-v]` | Version (`-v` includes build/dependency detail) |

--- a/skills/shed/references/configuration.md
+++ b/skills/shed/references/configuration.md
@@ -1,0 +1,73 @@
+# shed client configuration
+
+The `shed` client uses three files under `~/.shed/`. (Server configuration — `server.yaml`, backends, credentials — is separate and out of scope for client usage.)
+
+## `~/.shed/config.yaml` — servers and known sheds
+
+Written and updated by `shed server add` / `shed create`; you rarely edit it by hand.
+
+```yaml
+default_server: my-server          # used when -s/--server is not passed
+servers:
+  my-server:
+    host: my-server.tailnet.ts.net # hostname/IP on the private network (Tailscale)
+    http_port: 8080                # API port (default 8080)
+    ssh_port: 2222                 # auto-discovered from the server's /api/info
+sheds:                             # local cache of where each shed lives
+  myproj:
+    server: my-server
+    status: running
+create_timeout: 10m                # optional; default create timeout
+```
+
+Auth is SSH-key based (keys from `~/.ssh`); there is no token/login field. The server's SSH host key is fetched and cached on first `shed server add`.
+
+## `~/.shed/sync.yaml` — file sync profiles
+
+Defines reusable **features** (sets of paths + optional post-sync commands) grouped into **profiles**. `shed sync` and `shed create` (default profile) consume this.
+
+```yaml
+features:
+  devproxy:
+    description: "Sync mkcert certificates for HTTPS development"
+    paths:
+      - source: ~/.local/share/mkcert/rootCA.pem
+        target: /usr/local/share/ca-certificates/mkcert-ca.crt
+      - source: ~/.devproxy/certs
+        target: /etc/ssl/devproxy
+        include: "*.pem"           # optional glob filter
+    postSync:
+      - run: update-ca-certificates
+  dotfiles:
+    description: "Shell + git config"
+    paths:
+      - source: ~/.gitconfig
+        target: /home/shed/.gitconfig
+
+profiles:
+  default:                          # runs automatically on `shed create`
+    features: [devproxy]
+  full:
+    features: [devproxy, dotfiles]
+```
+
+- Path fields: `source` (local, `~` expands), `target` (path in the shed), optional `include` glob.
+- `shed sync <name> -p <profile>` runs a profile; `-f <feature>` runs one feature; `--dry-run` previews.
+
+## `~/.shed/tunnels.yaml` — port-forwarding profiles
+
+Named port sets per shed, used by `shed tunnels start <shed> -p <profile>`.
+
+```yaml
+sheds:
+  myproj:
+    profiles:
+      webdev:
+        - "3000"
+        - "5173"
+      database:
+        - "5432"
+        - "6379"
+```
+
+Each entry is a port the tunnel forwards (`local == remote`). For different local/remote ports or one-off ports, pass `-t local:remote` / `-t port` on the command line (combinable with `-p`). Background tunnels record their PIDs in `~/.shed/tunnels.state`.


### PR DESCRIPTION
## What

Adds a **usage-focused** Claude Code skill for the `shed` client CLI plus the plugin scaffolding to install it, so `charliek/shed` becomes a self-installing source for the skill (like `charliek/prox` and `charliek/codelens`). Rebased on **v0.5.3** and reconciled to the current CLI.

The skill covers day-to-day **client** usage — creating/listing/starting/stopping sheds, `reset`, attaching to persistent tmux sessions, `exec`, tunnels, file sync, images/snapshots, disk usage, and multi-server workflows. Operating the **shed-server** daemon (setup/serve/install, backends, `server.yaml`) is intentionally out of scope.

## Changes

- **`skills/shed/`** — `SKILL.md` + `references/commands.md` + `references/configuration.md`, written against the current v0.5.3 CLI and the `~/.shed/{config,sync,tunnels}.yaml` schemas. Reflects the v0.5.x changes: `shed reset`, `create --upper-size`, the layered-OCI image model (`base`/`extensions`/`full`), the redesigned `shed image` subcommands (`pull`/`push`/`tag`/`rm`/...), and argv-preserving `shed exec`.
- **`.claude-plugin/plugin.json`** + **`marketplace.json`** — manifest + self-contained marketplace (`source: "./"`); version **`0.5.3`** (matches the current `v0.5.3` tag).
- **`scripts/set-version.sh`** + **`sync-version` job in `publish-images.yaml`** — keep `plugin.json`'s version in lockstep with the released git tag (runs after the `release` job, tag-push only).
- **`scripts/validate-plugin.sh`** + a **`plugin` job in `ci.yml`** — validate the manifest JSON and skill frontmatter on PRs (runner-agnostic: `jq` + `python3`).
- **`README`** — "Claude Code / agent skills" install subsection (skills.sh + Claude Code plugin).
- **`LICENSE`** (MIT; the repo had none, README already declared MIT).

This PR does **not** cut a shed release; the `sync-version` job runs on your next `v*` tag.

## Deferred

- **Skill-creator triggering optimization** — the description is hand-written and scoped; no eval/benchmark pass yet.

## Install (after merge)

```
/plugin marketplace add charliek/shed
/plugin install shed@shed
```

The skill is namespaced `shed:shed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
