### PR TITLE
vz: copy-on-write upper from a pre-formatted ext4 template

### DIFF
--- a/build-tools/Dockerfile
+++ b/build-tools/Dockerfile
@@ -88,8 +88,14 @@ FROM debian:trixie-slim
 # Runtime deps that the dynamically-linked tools need at execution time.
 # liblz4 and liblzma are the compression backends; libuuid1 provides
 # libuuid which mkfs.erofs uses for filesystem UUIDs.
+#
+# e2fsprogs supplies mkfs.ext4, used to pre-format the per-shed writable
+# upper template on the host. Cloning that template into a new shed's
+# upper lets the guest mount it directly and skip the multi-second
+# in-guest mkfs.ext4 on first boot (see internal/vz/uppertemplate.go).
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        e2fsprogs \
         liblz4-1 \
         liblzma5 \
         libuuid1 \
@@ -103,6 +109,7 @@ COPY --from=builder /usr/local/bin/fsck.erofs /usr/local/bin/fsck.erofs
 # binaries at least launch (catches obvious link errors at image-build
 # time rather than at first downstream use).
 RUN mkfs.erofs --help >/dev/null 2>&1 || (echo "mkfs.erofs smoke test failed" && exit 1)
+RUN mkfs.ext4 -V >/dev/null 2>&1 || (echo "mkfs.ext4 smoke test failed" && exit 1)
 
 # Default to mkfs.erofs so `docker run --rm shed-build-tools:tag <args>`
 # is the common case. Callers needing dump.erofs / fsck.erofs override

--- a/docs/discovery/platform-runtime-optimization.md
+++ b/docs/discovery/platform-runtime-optimization.md
@@ -145,6 +145,19 @@ This is the single change that pays off across **speed, disk, and
 complexity simultaneously**, and it is a textbook "lean into platform
 differences" move.
 
+> **Status: implemented for VZ and measured (2026-05-26).** An A/B reboot
+> (fresh upper vs. reused formatted upper) isolated the in-guest
+> `mkfs.ext4` on the raw 5 GB virtio-blk device at **~4.2 s** — it is the
+> dominant cost of a fresh boot, not the cheap operation a sparse-file
+> `mkfs` test suggests. Pre-formatting the upper on the host (`mkfs.ext4`
+> in the build-tools container) and CoW-cloning it per shed
+> (`clone.CloneFile`, APFS clonefile) drops a warm-template create from
+> **~5.9 s to ~1.7 s** (ext4 mounts at 0.1 s instead of 4.3 s), with the
+> template only ~4 MB on disk for a 5 GB fs. See
+> `internal/vz/uppertemplate.go`. The Firecracker mirror (reflink) and
+> shipping a template with the image (instead of minting on the host) are
+> open follow-ups.
+
 ### 3a. What happens today
 
 Both backends allocate a per-shed sparse `upper.ext4`, stamp a

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -274,6 +274,19 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		if fi, statErr := os.Stat(upperPath); statErr == nil {
 			upperSizeBytes = fi.Size()
 		}
+	} else {
+		// Clone a pre-formatted ext4 template into the upper so the guest
+		// mounts it directly and skips the multi-second in-guest mkfs on
+		// first boot. Best-effort: any failure leaves the freshly-allocated
+		// signature upper in place (formatted in-guest), so create never
+		// regresses.
+		if tmpl, terr := EnsureUpperTemplate(ctx, c.templatesDir(), resolveBuildToolsRef(), upperSizeBytes, ""); terr != nil {
+			log.Printf("[%s] upper template unavailable (%v); formatting in guest", req.Name, terr)
+		} else if perr := provisionUpperFromTemplate(upperPath, tmpl); perr != nil {
+			log.Printf("[%s] upper template clone failed (%v); formatting in guest", req.Name, perr)
+		} else {
+			backend.Progress(ctx, "rootfs", "Provisioned upper from template (skips in-guest mkfs)")
+		}
 	}
 	rootfsPath := upperPath
 

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -281,8 +281,18 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		// signature upper in place (formatted in-guest), so create never
 		// regresses.
 		if tmpl, terr := EnsureUpperTemplate(ctx, c.templatesDir(), resolveBuildToolsRef(), upperSizeBytes, ""); terr != nil {
+			// A canceled/timed-out request must abort, not silently fall
+			// back and keep mutating resources past the deadline.
+			if errors.Is(terr, context.Canceled) || errors.Is(terr, context.DeadlineExceeded) {
+				_ = DeleteUpper(c.cfg.UppersDir, req.Name)
+				return nil, fmt.Errorf("upper template provisioning canceled: %w", terr)
+			}
 			log.Printf("[%s] upper template unavailable (%v); formatting in guest", req.Name, terr)
 		} else if perr := provisionUpperFromTemplate(upperPath, tmpl); perr != nil {
+			if errors.Is(perr, context.Canceled) || errors.Is(perr, context.DeadlineExceeded) {
+				_ = DeleteUpper(c.cfg.UppersDir, req.Name)
+				return nil, fmt.Errorf("upper template provisioning canceled: %w", perr)
+			}
 			log.Printf("[%s] upper template clone failed (%v); formatting in guest", req.Name, perr)
 		} else {
 			backend.Progress(ctx, "rootfs", "Provisioned upper from template (skips in-guest mkfs)")

--- a/internal/vz/uppertemplate.go
+++ b/internal/vz/uppertemplate.go
@@ -1,0 +1,230 @@
+//go:build darwin
+// +build darwin
+
+package vz
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/charliek/shed/internal/version"
+	"github.com/charliek/shed/internal/vmimage/clone"
+)
+
+// Upper-template provisioning.
+//
+// A freshly-created shed's writable upper (/dev/vda) is an empty ext4
+// filesystem. Historically the initramfs formatted it with mkfs.ext4 on
+// first boot — but on the raw virtio-blk device under VZ that costs
+// ~4 s (journal + superblock writes), dominating an otherwise ~2 s boot.
+//
+// Instead we keep a single pre-formatted ext4 image per upper size on the
+// host and copy-on-write clone it into each new shed's upper. The clone
+// already carries the ext4 superblock, so the initramfs detects the magic
+// and mounts it directly, skipping mkfs entirely. clone.CloneFile uses
+// APFS clonefile / Linux reflink, so the clone is near-instant and shares
+// extents (the template is sparse — a few MB on disk).
+//
+// macOS has no native mkfs.ext4, so the template is minted by mkfs.ext4
+// inside the shed-build-tools container (the same image that already runs
+// mkfs.erofs at publish time). Everything here is best-effort: any failure
+// returns an error and the caller falls back to the in-guest mkfs path, so
+// shed creation never regresses.
+
+const upperTemplateLabel = "shed-upper"
+
+// templatesDir is where pre-formatted upper templates are cached, a
+// sibling of the per-shed uppers directory (e.g. .../vz/templates).
+func (c *Client) templatesDir() string {
+	return filepath.Join(filepath.Dir(c.cfg.UppersDir), "templates")
+}
+
+// resolveBuildToolsRef returns the shed-build-tools image ref used to run
+// mkfs.ext4 for upper templates. SHED_BUILD_TOOLS_REF overrides (e.g.
+// "shed-build-tools:dev" for local iteration). Otherwise it derives from
+// the server version, matching the image-build pipeline's pinning model.
+// Dev/dirty builds have no matching published tag, so they return "" —
+// the caller then falls back to in-guest mkfs.
+func resolveBuildToolsRef() string {
+	if ref := os.Getenv("SHED_BUILD_TOOLS_REF"); ref != "" {
+		return ref
+	}
+	v := version.Version
+	if v == "" || v == "dev" || strings.Contains(v, "-g") || strings.Contains(v, "-dirty") {
+		return ""
+	}
+	return "ghcr.io/charliek/shed-build-tools:" + v
+}
+
+// upperTemplatePath is the cached template image for a given upper size.
+// Templates are keyed by exact byte size since a clone inherits the
+// template's size verbatim.
+func upperTemplatePath(templatesDir string, sizeBytes int64) string {
+	return filepath.Join(templatesDir, fmt.Sprintf("ext4-%d.img", sizeBytes))
+}
+
+// EnsureUpperTemplate returns the path to a cached, pre-formatted ext4
+// image of exactly sizeBytes, minting it on first use via mkfs.ext4 in the
+// build-tools container. Returns ("", err) when no template can be
+// produced (no build-tools ref, docker missing, mkfs failure); callers
+// fall back to allocating an empty upper and formatting it in the guest.
+func EnsureUpperTemplate(ctx context.Context, templatesDir, buildToolsRef string, sizeBytes int64, docker string) (string, error) {
+	if buildToolsRef == "" {
+		return "", errors.New("no shed-build-tools ref configured (dev build or unset SHED_BUILD_TOOLS_REF)")
+	}
+	if sizeBytes <= 0 {
+		return "", fmt.Errorf("invalid template size %d", sizeBytes)
+	}
+	if docker == "" {
+		docker = "docker"
+	}
+	if _, err := exec.LookPath(docker); err != nil {
+		return "", fmt.Errorf("%s not on PATH: %w", docker, err)
+	}
+	if err := os.MkdirAll(templatesDir, 0o755); err != nil {
+		return "", fmt.Errorf("creating templates dir: %w", err)
+	}
+
+	tmplPath := upperTemplatePath(templatesDir, sizeBytes)
+	if validTemplate(tmplPath, sizeBytes) {
+		return tmplPath, nil
+	}
+
+	// Serialize concurrent minting across create calls of the same size.
+	unlock, err := lockTemplate(templatesDir, sizeBytes)
+	if err != nil {
+		return "", err
+	}
+	defer unlock()
+	if validTemplate(tmplPath, sizeBytes) { // re-check under lock
+		return tmplPath, nil
+	}
+
+	staging, err := os.CreateTemp(templatesDir, ".ext4-*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("creating staging file: %w", err)
+	}
+	stagingPath := staging.Name()
+	_ = staging.Close()
+	defer os.Remove(stagingPath) // no-op once renamed into place
+
+	if err := os.Truncate(stagingPath, sizeBytes); err != nil {
+		return "", fmt.Errorf("sizing staging file: %w", err)
+	}
+
+	// mkfs.ext4 in the build-tools container. lazy_itable_init +
+	// lazy_journal_init + nodiscard keep generation fast and the template
+	// sparse (a few MB); the inode tables and journal initialize lazily
+	// inside the guest, off the boot critical path.
+	dir := filepath.Dir(stagingPath)
+	base := filepath.Base(stagingPath)
+	args := []string{
+		"run", "--rm",
+		"-u", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
+		"-v", dir + ":/shed/work",
+		"-w", "/shed/work",
+		"--entrypoint", "mkfs.ext4",
+		buildToolsRef,
+		"-F", "-q",
+		"-L", upperTemplateLabel,
+		"-E", "lazy_itable_init=1,lazy_journal_init=1,nodiscard",
+		"/shed/work/" + base,
+	}
+	cmd := exec.CommandContext(ctx, docker, args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(out.String())
+		if msg == "" {
+			msg = "(no output)"
+		}
+		return "", fmt.Errorf("mkfs.ext4 via %s %s: %w\n%s", docker, buildToolsRef, err, msg)
+	}
+	if !hasExt4Magic(stagingPath) {
+		return "", errors.New("minted template lacks ext4 magic")
+	}
+	if err := os.Chmod(stagingPath, 0o444); err != nil {
+		return "", fmt.Errorf("chmod template: %w", err)
+	}
+	if err := os.Rename(stagingPath, tmplPath); err != nil {
+		return "", fmt.Errorf("installing template: %w", err)
+	}
+	return tmplPath, nil
+}
+
+// provisionUpperFromTemplate replaces the freshly-allocated signature
+// upper at upperPath with a copy-on-write clone of templatePath. The
+// cloned upper carries the ext4 superblock, so the initramfs mounts it
+// directly instead of running mkfs.ext4. The clone goes to a temp sibling
+// first so a failure leaves the original signature upper intact for the
+// in-guest-mkfs fallback.
+func provisionUpperFromTemplate(upperPath, templatePath string) error {
+	tmp := upperPath + ".tmpl"
+	_ = os.Remove(tmp) // clone.CloneFile requires dst to be absent
+	if _, err := clone.CloneFile(templatePath, tmp); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("cloning template: %w", err)
+	}
+	if err := os.Chmod(tmp, 0o644); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("chmod cloned upper: %w", err)
+	}
+	if err := os.Rename(tmp, upperPath); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("installing cloned upper: %w", err)
+	}
+	return nil
+}
+
+// validTemplate reports whether path is a usable template: present, the
+// expected size, and carrying the ext4 magic.
+func validTemplate(path string, sizeBytes int64) bool {
+	fi, err := os.Stat(path)
+	if err != nil || fi.Size() != sizeBytes {
+		return false
+	}
+	return hasExt4Magic(path)
+}
+
+// hasExt4Magic reports whether path carries the ext4 superblock magic
+// (0x53 0xEF, little-endian s_magic) at offset 1080 — the same marker the
+// initramfs checks to decide whether the upper needs formatting.
+func hasExt4Magic(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	b := make([]byte, 2)
+	if _, err := f.ReadAt(b, 1080); err != nil {
+		return false
+	}
+	return b[0] == 0x53 && b[1] == 0xEF
+}
+
+// lockTemplate takes an exclusive flock on a per-size lock file so two
+// concurrent creates don't mint the same template at once. Returns an
+// unlock func.
+func lockTemplate(templatesDir string, sizeBytes int64) (func(), error) {
+	lockPath := filepath.Join(templatesDir, fmt.Sprintf(".ext4-%d.lock", sizeBytes))
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("opening template lock: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("locking template: %w", err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/internal/vz/uppertemplate_test.go
+++ b/internal/vz/uppertemplate_test.go
@@ -1,0 +1,100 @@
+//go:build darwin
+// +build darwin
+
+package vz
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charliek/shed/internal/version"
+)
+
+func TestUpperTemplatePathKeyedBySize(t *testing.T) {
+	dir := "/tmp/templates"
+	a := upperTemplatePath(dir, 5*1024*1024*1024)
+	b := upperTemplatePath(dir, 20*1024*1024*1024)
+	if a == b {
+		t.Fatalf("templates of different sizes must have distinct paths: %q == %q", a, b)
+	}
+	if filepath.Dir(a) != dir {
+		t.Errorf("template path %q not under %q", a, dir)
+	}
+}
+
+func TestHasExt4MagicAndValidTemplate(t *testing.T) {
+	dir := t.TempDir()
+	size := int64(2048)
+
+	// A file with the ext4 magic (0x53 0xEF) at offset 1080.
+	good := filepath.Join(dir, "good.img")
+	buf := make([]byte, size)
+	buf[1080] = 0x53
+	buf[1081] = 0xEF
+	if err := os.WriteFile(good, buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !hasExt4Magic(good) {
+		t.Error("expected ext4 magic to be detected")
+	}
+	if !validTemplate(good, size) {
+		t.Error("expected good file to be a valid template")
+	}
+	if validTemplate(good, size+1) {
+		t.Error("size mismatch must invalidate the template")
+	}
+
+	// A file without the magic.
+	bad := filepath.Join(dir, "bad.img")
+	if err := os.WriteFile(bad, make([]byte, size), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if hasExt4Magic(bad) {
+		t.Error("did not expect ext4 magic in a zeroed file")
+	}
+
+	// A short file (no byte at offset 1080).
+	short := filepath.Join(dir, "short.img")
+	if err := os.WriteFile(short, []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if hasExt4Magic(short) {
+		t.Error("short file cannot carry the magic")
+	}
+
+	if validTemplate(filepath.Join(dir, "missing.img"), size) {
+		t.Error("missing file is not a valid template")
+	}
+}
+
+func TestResolveBuildToolsRef(t *testing.T) {
+	t.Setenv("SHED_BUILD_TOOLS_REF", "shed-build-tools:dev")
+	if got := resolveBuildToolsRef(); got != "shed-build-tools:dev" {
+		t.Errorf("env override not honored: got %q", got)
+	}
+
+	t.Setenv("SHED_BUILD_TOOLS_REF", "")
+	orig := version.Version
+	t.Cleanup(func() { version.Version = orig })
+
+	version.Version = "v0.5.3"
+	if got := resolveBuildToolsRef(); got != "ghcr.io/charliek/shed-build-tools:v0.5.3" {
+		t.Errorf("release version: got %q", got)
+	}
+
+	for _, dev := range []string{"dev", "v0.5.3-2-g493976f-dirty", "v0.5.3-5-gabcdef0"} {
+		version.Version = dev
+		if got := resolveBuildToolsRef(); got != "" {
+			t.Errorf("dev/dirty version %q should yield no ref, got %q", dev, got)
+		}
+	}
+}
+
+func TestEnsureUpperTemplateNoRef(t *testing.T) {
+	// With no build-tools ref, EnsureUpperTemplate must error (caller
+	// then falls back to in-guest mkfs) rather than attempting docker.
+	if _, err := EnsureUpperTemplate(t.Context(), t.TempDir(), "", 5<<30, ""); err == nil {
+		t.Error("expected error when build-tools ref is empty")
+	}
+}

--- a/internal/vz/uppertemplate_test.go
+++ b/internal/vz/uppertemplate_test.go
@@ -25,75 +25,81 @@ func TestUpperTemplatePathKeyedBySize(t *testing.T) {
 
 func TestHasExt4MagicAndValidTemplate(t *testing.T) {
 	dir := t.TempDir()
-	size := int64(2048)
+	const size = int64(2048)
 
-	// A file with the ext4 magic (0x53 0xEF) at offset 1080.
+	ext4 := make([]byte, size)
+	ext4[1080] = 0x53
+	ext4[1081] = 0xEF
+
+	tests := []struct {
+		name      string
+		content   []byte
+		write     bool // false => file does not exist
+		wantMagic bool
+		wantValid bool // validTemplate(path, size)
+	}{
+		{name: "ext4_magic_present", content: ext4, write: true, wantMagic: true, wantValid: true},
+		{name: "zeroed_no_magic", content: make([]byte, size), write: true, wantMagic: false, wantValid: false},
+		{name: "too_short_for_magic", content: []byte("hi"), write: true, wantMagic: false, wantValid: false},
+		{name: "missing_file", write: false, wantMagic: false, wantValid: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, tc.name+".img")
+			if tc.write {
+				if err := os.WriteFile(path, tc.content, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := hasExt4Magic(path); got != tc.wantMagic {
+				t.Errorf("hasExt4Magic = %v, want %v", got, tc.wantMagic)
+			}
+			if got := validTemplate(path, size); got != tc.wantValid {
+				t.Errorf("validTemplate = %v, want %v", got, tc.wantValid)
+			}
+		})
+	}
+
+	// A correctly-formed template must also be rejected on a size mismatch.
 	good := filepath.Join(dir, "good.img")
-	buf := make([]byte, size)
-	buf[1080] = 0x53
-	buf[1081] = 0xEF
-	if err := os.WriteFile(good, buf, 0o644); err != nil {
+	if err := os.WriteFile(good, ext4, 0o644); err != nil {
 		t.Fatal(err)
-	}
-	if !hasExt4Magic(good) {
-		t.Error("expected ext4 magic to be detected")
-	}
-	if !validTemplate(good, size) {
-		t.Error("expected good file to be a valid template")
 	}
 	if validTemplate(good, size+1) {
 		t.Error("size mismatch must invalidate the template")
 	}
-
-	// A file without the magic.
-	bad := filepath.Join(dir, "bad.img")
-	if err := os.WriteFile(bad, make([]byte, size), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if hasExt4Magic(bad) {
-		t.Error("did not expect ext4 magic in a zeroed file")
-	}
-
-	// A short file (no byte at offset 1080).
-	short := filepath.Join(dir, "short.img")
-	if err := os.WriteFile(short, []byte("hi"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if hasExt4Magic(short) {
-		t.Error("short file cannot carry the magic")
-	}
-
-	if validTemplate(filepath.Join(dir, "missing.img"), size) {
-		t.Error("missing file is not a valid template")
-	}
 }
 
 func TestResolveBuildToolsRef(t *testing.T) {
-	t.Setenv("SHED_BUILD_TOOLS_REF", "shed-build-tools:dev")
-	if got := resolveBuildToolsRef(); got != "shed-build-tools:dev" {
-		t.Errorf("env override not honored: got %q", got)
-	}
-
-	t.Setenv("SHED_BUILD_TOOLS_REF", "")
 	orig := version.Version
 	t.Cleanup(func() { version.Version = orig })
 
-	version.Version = "v0.5.3"
-	if got := resolveBuildToolsRef(); got != "ghcr.io/charliek/shed-build-tools:v0.5.3" {
-		t.Errorf("release version: got %q", got)
+	tests := []struct {
+		name    string
+		envRef  string
+		ver     string
+		wantRef string
+	}{
+		{name: "env_override_wins", envRef: "shed-build-tools:dev", ver: "v0.5.3", wantRef: "shed-build-tools:dev"},
+		{name: "release_version", envRef: "", ver: "v0.5.3", wantRef: "ghcr.io/charliek/shed-build-tools:v0.5.3"},
+		{name: "dev_version_none", envRef: "", ver: "dev", wantRef: ""},
+		{name: "dirty_version_none", envRef: "", ver: "v0.5.3-2-g493976f-dirty", wantRef: ""},
+		{name: "untagged_commit_none", envRef: "", ver: "v0.5.3-5-gabcdef0", wantRef: ""},
 	}
-
-	for _, dev := range []string{"dev", "v0.5.3-2-g493976f-dirty", "v0.5.3-5-gabcdef0"} {
-		version.Version = dev
-		if got := resolveBuildToolsRef(); got != "" {
-			t.Errorf("dev/dirty version %q should yield no ref, got %q", dev, got)
-		}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SHED_BUILD_TOOLS_REF", tc.envRef)
+			version.Version = tc.ver
+			if got := resolveBuildToolsRef(); got != tc.wantRef {
+				t.Errorf("resolveBuildToolsRef() = %q, want %q", got, tc.wantRef)
+			}
+		})
 	}
 }
 
 func TestEnsureUpperTemplateNoRef(t *testing.T) {
-	// With no build-tools ref, EnsureUpperTemplate must error (caller
-	// then falls back to in-guest mkfs) rather than attempting docker.
+	// With no build-tools ref, EnsureUpperTemplate must error (caller then
+	// falls back to in-guest mkfs) rather than attempting docker.
 	if _, err := EnsureUpperTemplate(t.Context(), t.TempDir(), "", 5<<30, ""); err == nil {
 		t.Error("expected error when build-tools ref is empty")
 	}


### PR DESCRIPTION
## What

**Phase 2** of the boot-optimization plan. Eliminates the in-guest `mkfs.ext4` on first boot by pre-formatting the writable upper on the host and copy-on-write cloning it per shed.

> ⚠️ **Do not merge yet** — this is the validated starting point for review (per the plan). See "For review" below.

## Why (data from Phase 1 instrumentation, #118)

Phase 1's per-phase timing localized **~99 % of a warm create to the guest-boot (`agent`) phase**. Drilling in with an A/B reboot:

| boot | `mkfs`? | ext4 mounts at | kernel time |
|---|---|---|---|
| 1st (fresh upper) | yes | 4.29 s | 4.325 s |
| 2nd (reuse formatted upper) | skipped | 0.096 s | 113 ms |

So the in-guest `mkfs.ext4` on the **raw 5 GB virtio-blk device** costs **~4.2 s** under VZ (writing the journal/superblocks for real — a sparse-file `mkfs` measuring 6 ms was a red herring).

## How

- `build-tools` image gains `e2fsprogs` (`mkfs.ext4`) next to `mkfs.erofs`.
- `EnsureUpperTemplate` mints a **size-keyed, sparse** ext4 template via `mkfs.ext4` in the build-tools container (`lazy_itable_init`/`lazy_journal_init`/`nodiscard` keep it ~MBs and fast), cached and `flock`-guarded.
- `CreateShed` clones the template into the fresh upper via `clone.CloneFile` (APFS clonefile / Linux reflink). The clone carries the ext4 superblock, so the **existing** initramfs mounts it directly and skips `mkfs` — no guest change.
- **Best-effort with safe fallback**: no build-tools ref (dev/dirty build), no docker, or any mint/clone failure falls back to the current allocate-empty + format-in-guest path. **Create never regresses.**

## Measured (macOS/VZ)

```text
baseline:        total=5744ms ... vm=1ms agent=5703ms ...
warm template:   total=1693ms ... rootfs=4ms vm=0ms agent=1653ms ...
```

~3.5× faster create; ext4 mounts at 0.1 s vs 4.3 s; template **4 MB on disk** for a 5 GB fs; no `formatting` line in the guest console.

## For review (not blocking CI; intentionally unmerged)

- **Release coordination**: the published `shed-build-tools:vX.Y.Z` must be rebuilt with `e2fsprogs` before this activates on released versions. Until then hosts log "upper template unavailable" and fall back. Validate locally with `make build-tools && SHED_BUILD_TOOLS_REF=shed-build-tools:dev`.
- **Firecracker mirror** (reflink path) is a follow-up — this PR is VZ-only.
- **Alternative to weigh**: ship the template *in the image* rather than minting it on the host (removes the runtime Docker dependency for upper creation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host-side ext4 template caching for VZ-based instances, cutting warm-create time (~5.9s → ~1.7s) with minimal template size.

* **Bug Fixes / Reliability**
  * Attempt pre-formatted upper provisioning to skip in-guest formatting, with safe fallback if preparation fails.

* **Chores**
  * Runtime image now includes required filesystem tooling and adds a build-time smoke test.

* **Documentation**
  * Updated platform runtime optimization doc with measured A/B results and status.

* **Tests**
  * Added unit tests covering template validation and build-tool resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->