### PR TITLE
network-setup: re-resolve the interface (fix rename race)

### DIFF
--- a/firecracker/network-setup.sh
+++ b/firecracker/network-setup.sh
@@ -6,7 +6,6 @@
 set -e
 
 # Default values
-INTERFACE="eth0"
 GATEWAY="172.30.0.1"
 DNS="8.8.8.8"
 
@@ -38,14 +37,24 @@ fi
 
 echo "Configuring network: IP=$IP_ADDR, Gateway=$GATEWAY"
 
-# Wait for interface to be available
+# Resolve the primary non-loopback interface, re-resolving each pass until it
+# appears. Previously hardcoded to eth0; the kernel can rename the NIC
+# (e.g. eth0 -> enp0s1), so resolve dynamically with eth0 as a last-resort
+# fallback. See docs/discovery/platform-runtime-optimization.md §12.
+INTERFACE=""
 for i in $(seq 1 10); do
-    if ip link show "$INTERFACE" &>/dev/null; then
+    INTERFACE=$(ip -o link show | grep -v 'lo:' | awk -F': ' '{print $2}' | head -1)
+    if [ -n "$INTERFACE" ]; then
         break
     fi
-    echo "Waiting for $INTERFACE..."
+    echo "Waiting for network interface..."
     sleep 1
 done
+if [ -z "$INTERFACE" ]; then
+    INTERFACE="eth0"
+    echo "WARNING: no interface detected, falling back to $INTERFACE"
+fi
+echo "Using interface: $INTERFACE"
 
 # Configure interface
 ip addr add "${IP_ADDR}/24" dev "$INTERFACE" 2>/dev/null || true

--- a/vz/network-setup.sh
+++ b/vz/network-setup.sh
@@ -6,37 +6,33 @@
 
 set -e
 
-# Wait for a network interface to be available
+# Wait for a network interface to come up with an IPv4 address (DHCP via
+# systemd-networkd). The interface name is RE-RESOLVED every iteration: the
+# kernel renames the NIC shortly after it first appears (e.g. eth0 -> enp0s1),
+# so latching the name once can leave us polling a device that no longer
+# exists for the full timeout. This matters whenever network-setup runs early
+# in boot (it raced the rename and hung ~30s). See
+# docs/discovery/platform-runtime-optimization.md §12.
 INTERFACE=""
-for i in $(seq 1 15); do
-    # VZ presents the NIC as enp0sN or similar
+IP_ADDR=""
+for i in $(seq 1 30); do
+    # VZ presents the NIC as enp0sN or similar; re-resolve each pass.
     INTERFACE=$(ip -o link show | grep -v 'lo:' | awk -F': ' '{print $2}' | head -1)
     if [ -n "$INTERFACE" ]; then
-        break
-    fi
-    echo "Waiting for network interface..."
-    sleep 1
-done
-
-if [ -z "$INTERFACE" ]; then
-    echo "WARNING: No network interface found, continuing without network"
-fi
-
-# Wait for an IP address (DHCP via systemd-networkd)
-if [ -n "$INTERFACE" ]; then
-    for i in $(seq 1 30); do
         IP_ADDR=$(ip -4 addr show "$INTERFACE" | grep -oP 'inet \K[0-9.]+' || true)
         if [ -n "$IP_ADDR" ]; then
             echo "Network ready: interface=$INTERFACE ip=$IP_ADDR"
             break
         fi
-        echo "Waiting for DHCP on $INTERFACE..."
-        sleep 1
-    done
-
-    if [ -z "$IP_ADDR" ]; then
-        echo "WARNING: No IP address assigned via DHCP"
     fi
+    echo "Waiting for network (interface=${INTERFACE:-none})..."
+    sleep 1
+done
+
+if [ -z "$INTERFACE" ]; then
+    echo "WARNING: No network interface found, continuing without network"
+elif [ -z "$IP_ADDR" ]; then
+    echo "WARNING: No IPv4 address assigned via DHCP on $INTERFACE"
 fi
 
 # Ensure /etc/resolv.conf points to systemd-resolved stub.


### PR DESCRIPTION
`network-setup.sh` latched the NIC name (VZ resolved it once; FC hardcoded `eth0`), but the kernel renames the interface shortly after it appears (`eth0→enp0s1` on VZ). When network-setup runs early in boot it would latch the pre-rename name and poll a vanished device for the full ~30s timeout. Today this is masked only because `shed-firstboot` (ordered `Before=network-setup`) incidentally delays network-setup until after the rename — a fragile coincidence (and the prerequisite for moving firstboot off the create path, item 3c).

**Fix:** re-resolve the interface each poll iteration (VZ) and detect it dynamically with an `eth0` fallback (FC), so the script can't latch a name udev later renames, regardless of when it runs.

## Validation (both platforms)
- **VZ (mac):** built a rootfs image with the fix + the firstboot reorder (which forces network-setup to run early, exercising the race). Before the fix: 30s hang. After: no hang — interface `enp0s1`, IP assigned, host keys unique across 2 sheds, sshd after firstboot.
- **Firecracker (mini3):** the dynamic detection resolves `eth0` (FC doesn't rename), so it's behaviorally identical to the old hardcoded value. Validated on 2 FC sheds running the fixed script: "Using interface: eth0", network configured, IPs 172.30.0.2/.3, gateway ping OK, host keys unique. (FC's `go` toolchain wasn't available for a full image rebuild on mini3, so the fixed script was exercised on real FC boots via overlay override.)

Note: in the current shipped config (firstboot ordered before network-setup) this is behaviorally a no-op — it's a **robustness fix** and the prerequisite for item 3c. Reviewed via codex:rescue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)