### PR TITLE
fix: v-prefix the build-tools ref so the VZ upper template activates (Phase 2 regression in 0.5.4)

### DIFF
--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"regexp"
 	"runtime"
 	"strings"
 	"text/tabwriter"
@@ -33,10 +32,6 @@ import (
 //   - All other dev builds (dirty, ahead-of-tag, version="dev") fall
 //     back to `:dev` and expect the caller to have run
 //     `make build-tools` first.
-const buildToolsImageBase = "ghcr.io/charliek/shed-build-tools"
-
-var releaseTagRE = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
-
 func buildToolsRefDefault(override string) string {
 	if override != "" {
 		// Full image ref (anything containing "/" or ":") passes
@@ -46,26 +41,18 @@ func buildToolsRefDefault(override string) string {
 		if strings.Contains(override, "/") || strings.Contains(override, ":") {
 			return override
 		}
-		// Bare tag (no path or colon). Only "release-shaped"
-		// tags (vX.Y.Z) are synthesized against the canonical
-		// registry — for anything else (`dev`, `mybuild`), use
-		// the bare image name so a `make build-tools`-produced
-		// local image resolves without an unwanted registry pull.
-		if releaseTagRE.MatchString(override) {
-			tag := override
-			if !strings.HasPrefix(tag, "v") {
-				tag = "v" + tag
-			}
-			return buildToolsImageBase + ":" + tag
+		// Bare tag (no path or colon). Release-shaped tags (vX.Y.Z) are
+		// synthesized against the canonical registry; for anything else
+		// (`dev`, `mybuild`), use the bare image name so a
+		// `make build-tools`-produced local image resolves without an
+		// unwanted registry pull.
+		if ref := version.BuildToolsRefForTag(override); ref != "" {
+			return ref
 		}
 		return "shed-build-tools:" + override
 	}
-	v := strings.TrimSpace(version.Version)
-	if releaseTagRE.MatchString(v) {
-		if !strings.HasPrefix(v, "v") {
-			v = "v" + v
-		}
-		return buildToolsImageBase + ":" + v
+	if ref := version.ReleaseBuildToolsRef(); ref != "" {
+		return ref
 	}
 	// Dev build of shed CLI. Default to a locally-built
 	// shed-build-tools:dev image — no registry round-trip — and

--- a/internal/version/buildtools.go
+++ b/internal/version/buildtools.go
@@ -1,0 +1,47 @@
+package version
+
+import (
+	"regexp"
+	"strings"
+)
+
+// BuildToolsImageBase is the canonical registry path for the
+// shed-build-tools image (pinned mkfs.erofs / mkfs.ext4 used to mint
+// rootfs erofs blobs and pre-formatted upper templates). Published tags
+// are v-prefixed (vX.Y.Z), versioned in lockstep with shed-server.
+const BuildToolsImageBase = "ghcr.io/charliek/shed-build-tools"
+
+// releaseVersionRE matches a clean semver tag with or without the leading
+// "v" — release binaries embed "X.Y.Z" (no v), `git describe` yields
+// "vX.Y.Z" (with v).
+var releaseVersionRE = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+
+// BuildToolsRefForTag returns the canonical shed-build-tools image ref
+// (BuildToolsImageBase:vX.Y.Z, ALWAYS v-prefixed) for a release-shaped
+// version/tag string, or "" if s is not release-shaped (dev, dirty,
+// ahead-of-tag, or a custom name).
+//
+// The v-prefix is added when absent. This is the whole point of having
+// one shared implementation: published build-tools tags are v-prefixed,
+// so concatenating a bare "0.5.4" version yields ":0.5.4" — a tag that
+// does not exist, which silently disabled the upper-template fast path in
+// v0.5.4 (it fell back to slow in-guest mkfs). Resolve every build-tools
+// ref through here so the prefix can't drift between call sites.
+func BuildToolsRefForTag(s string) string {
+	s = strings.TrimSpace(s)
+	if !releaseVersionRE.MatchString(s) {
+		return ""
+	}
+	if !strings.HasPrefix(s, "v") {
+		s = "v" + s
+	}
+	return BuildToolsImageBase + ":" + s
+}
+
+// ReleaseBuildToolsRef returns the canonical shed-build-tools ref for the
+// current build's Version, or "" for dev/dirty/ahead-of-tag builds (the
+// caller decides the fallback: a locally-built shed-build-tools:dev, or
+// skipping the build-tools step entirely).
+func ReleaseBuildToolsRef() string {
+	return BuildToolsRefForTag(Version)
+}

--- a/internal/version/buildtools_test.go
+++ b/internal/version/buildtools_test.go
@@ -1,0 +1,42 @@
+package version
+
+import "testing"
+
+func TestBuildToolsRefForTag(t *testing.T) {
+	const base = "ghcr.io/charliek/shed-build-tools"
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "release no v-prefix (the v0.5.4 bug)", in: "0.5.4", want: base + ":v0.5.4"},
+		{name: "release with v-prefix", in: "v0.5.4", want: base + ":v0.5.4"},
+		{name: "whitespace tolerated", in: "  0.5.4 ", want: base + ":v0.5.4"},
+		{name: "dev", in: "dev", want: ""},
+		{name: "empty", in: "", want: ""},
+		{name: "ahead-of-tag/dirty", in: "v0.5.4-2-g493976f", want: ""},
+		{name: "dirty suffix", in: "0.5.4-dirty", want: ""},
+		{name: "custom name", in: "mybuild", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := BuildToolsRefForTag(tc.in); got != tc.want {
+				t.Errorf("BuildToolsRefForTag(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReleaseBuildToolsRefUsesVersion(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+
+	Version = "0.5.4" // release binary form (no leading v)
+	if got := ReleaseBuildToolsRef(); got != "ghcr.io/charliek/shed-build-tools:v0.5.4" {
+		t.Errorf("ReleaseBuildToolsRef() = %q, want the v-prefixed published tag", got)
+	}
+	Version = "dev"
+	if got := ReleaseBuildToolsRef(); got != "" {
+		t.Errorf("dev build should yield no ref, got %q", got)
+	}
+}

--- a/internal/vz/uppertemplate.go
+++ b/internal/vz/uppertemplate.go
@@ -49,18 +49,15 @@ func (c *Client) templatesDir() string {
 // resolveBuildToolsRef returns the shed-build-tools image ref used to run
 // mkfs.ext4 for upper templates. SHED_BUILD_TOOLS_REF overrides (e.g.
 // "shed-build-tools:dev" for local iteration). Otherwise it derives from
-// the server version, matching the image-build pipeline's pinning model.
-// Dev/dirty builds have no matching published tag, so they return "" —
-// the caller then falls back to in-guest mkfs.
+// the server version via the shared canonical resolver (which v-prefixes
+// the tag to match the published images — see version.BuildToolsRefForTag).
+// Dev/dirty builds have no matching published tag, so it returns "" and the
+// caller falls back to in-guest mkfs.
 func resolveBuildToolsRef() string {
 	if ref := os.Getenv("SHED_BUILD_TOOLS_REF"); ref != "" {
 		return ref
 	}
-	v := version.Version
-	if v == "" || v == "dev" || strings.Contains(v, "-g") || strings.Contains(v, "-dirty") {
-		return ""
-	}
-	return "ghcr.io/charliek/shed-build-tools:" + v
+	return version.ReleaseBuildToolsRef()
 }
 
 // upperTemplatePath is the cached template image for a given upper size.

--- a/internal/vz/uppertemplate_test.go
+++ b/internal/vz/uppertemplate_test.go
@@ -81,7 +81,10 @@ func TestResolveBuildToolsRef(t *testing.T) {
 		wantRef string
 	}{
 		{name: "env_override_wins", envRef: "shed-build-tools:dev", ver: "v0.5.3", wantRef: "shed-build-tools:dev"},
-		{name: "release_version", envRef: "", ver: "v0.5.3", wantRef: "ghcr.io/charliek/shed-build-tools:v0.5.3"},
+		// Release binaries embed "X.Y.Z" with no leading v; the ref must
+		// still be the v-prefixed published tag (the v0.5.4 regression).
+		{name: "release_version_no_v", envRef: "", ver: "0.5.4", wantRef: "ghcr.io/charliek/shed-build-tools:v0.5.4"},
+		{name: "release_version_with_v", envRef: "", ver: "v0.5.3", wantRef: "ghcr.io/charliek/shed-build-tools:v0.5.3"},
 		{name: "dev_version_none", envRef: "", ver: "dev", wantRef: ""},
 		{name: "dirty_version_none", envRef: "", ver: "v0.5.3-2-g493976f-dirty", wantRef: ""},
 		{name: "untagged_commit_none", envRef: "", ver: "v0.5.3-5-gabcdef0", wantRef: ""},


### PR DESCRIPTION
## The bug (shipped in v0.5.4)
The VZ upper-template fast path (Phase 2, the ~3× faster `shed create`) resolved the shed-build-tools ref as `"ghcr.io/charliek/shed-build-tools:" + version.Version`. Release binaries embed `X.Y.Z` (no leading `v`), but the published tags are **v-prefixed** (`vX.Y.Z`). So on a clean v0.5.4 install the mint requested `:0.5.4` (nonexistent) → `docker ... exit status 125` → fell back to slow in-guest `mkfs.ext4`. The headline speedup silently did nothing.

It looked fine in dev only because I'd been setting `SHED_BUILD_TOOLS_REF`, which bypasses this path — the version-derived path was never exercised until I tested a release-version build on a box with no cached template.

## Fix
`cmd/shed/image.go` already v-prefixed correctly. The bug was a **divergent second copy** of the logic in `internal/vz`. Consolidated both onto one canonical resolver — `version.BuildToolsRefForTag` / `version.ReleaseBuildToolsRef` — which always v-prefixes release-shaped tags (with or without a leading `v`) and returns `""` for dev/dirty/ahead-of-tag builds. Removes the duplication that caused the drift.

## Validation (macOS/VZ)
Release-version (`0.5.4`) server, no cached template, no env override:
```
before fix: docker ...:0.5.4 exit 125 → in-guest mkfs → create 6.4s (agent 5.85s)
after fix:  mint via ...:v0.5.4 → template clone → create 1.8s (agent 1.5s); warm create rootfs=6ms
```
Guest skips mkfs (ext4 mounts at 0.098s). Unit tests cover both `0.5.4` and `v0.5.4` → `:v0.5.4`, plus dev/dirty → `""`. Firecracker unaffected (no upper-template path; `image.go` output unchanged for releases). Reviewed via codex:rescue.

Follow-up to v0.5.4 — will ship in v0.5.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)