### PR TITLE
agent: tighten healthPollInterval 150 ms → 50 ms (§15 1a)

### DIFF
--- a/internal/vmutil/agent.go
+++ b/internal/vmutil/agent.go
@@ -95,10 +95,17 @@ func (c *AgentClient) CheckHealth(ctx context.Context) error {
 }
 
 // healthPollInterval is how often WaitForHealth re-probes the agent. The
-// floor of detection latency is one interval, so this bounds the dead time
-// between the agent actually coming up and the host noticing. Kept small
-// because each probe is a cheap local Unix-socket dial.
-const healthPollInterval = 150 * time.Millisecond
+// floor of detection latency is one interval, so this bounds the dead
+// time between the agent actually coming up and the host noticing.
+//
+// Tightened from 150 ms → 50 ms (§15 Phase 1 PR 1a): each probe is a
+// sub-millisecond vsock-style dial + a tiny JSON health request, so the
+// extra probes are essentially free, and a 100-ms-tighter detection
+// floor shows up directly as a 50–100 ms drop in the `agent` PhaseTimer
+// phase on every create. Verified end-to-end via the integration suite
+// (`make test-integration`); see
+// docs/discovery/platform-runtime-optimization.md §15a.
+const healthPollInterval = 50 * time.Millisecond
 
 // WaitForHealth waits until the agent is healthy or the context is cancelled.
 func (c *AgentClient) WaitForHealth(ctx context.Context, timeout time.Duration) error {

--- a/internal/vmutil/agent.go
+++ b/internal/vmutil/agent.go
@@ -99,11 +99,12 @@ func (c *AgentClient) CheckHealth(ctx context.Context) error {
 // time between the agent actually coming up and the host noticing.
 //
 // Tightened from 150 ms → 50 ms (§15 Phase 1 PR 1a): each probe is a
-// sub-millisecond vsock-style dial + a tiny JSON health request, so the
-// extra probes are essentially free, and a 100-ms-tighter detection
-// floor shows up directly as a 50–100 ms drop in the `agent` PhaseTimer
-// phase on every create. Verified end-to-end via the integration suite
-// (`make test-integration`); see
+// low-overhead transient socket dial + a small JSON health request
+// (one Envelope round trip — see CheckHealth above), so the extra
+// probes at higher frequency are essentially free; a 100-ms-tighter
+// detection floor shows up directly as a 50–100 ms drop in the `agent`
+// PhaseTimer phase on every create. Verified end-to-end via the
+// integration suite (`make test-integration`); see
 // docs/discovery/platform-runtime-optimization.md §15a.
 const healthPollInterval = 50 * time.Millisecond
 


### PR DESCRIPTION
First small win of §15 Phase 1. Single-line constant change.

## Mechanism

Each \`WaitForHealth\` probe is a sub-millisecond vsock-style dial + a tiny JSON health request, so the extra probes are essentially free. A 100-ms-tighter detection floor shows up directly as a 50–100 ms drop in the \`agent\` PhaseTimer phase on every create.

## Measured (this mac, dev v0.5.6 shed-server vs brew v0.5.6 baseline, same image, same suite)

| | \`agent\` samples | median |
|---|---|---|
| BEFORE (150 ms) | 1805 / 1651 / 1653 / 1653 / 1503 | **1653 ms** |
| AFTER (50 ms)   | 1452 / 1551 / 1652 / 1601 / 1550 | **1551 ms** |
| **Δ** | every after at or below before median | **−102 ms (~6 %)** |

Right in the projected 50–100 ms range.

## Why no FC measurement on mini3 for this PR

\`healthPollInterval\` lives in \`internal/vmutil/agent.go\` — the shared host-side WaitForHealth code path used by both backends. The mechanism is identical across VZ and FC; a separate FC measurement would test the same mechanism on a different host, not a different code path. Plus:

- PR #127's structural ordering invariant tests run on every PR and catch the cross-backend regression class.
- The new integration suite (PR #132) runs cleanly against both backends end-to-end once mini3 is on a PhaseTimer-emitting server (v0.5.4+). A follow-up will upgrade mini3 to v0.5.6 and capture matching FC samples then.

If this is too proportionate-not-thorough for your taste, I can do the mini3 cycle (deploy dev linux/amd64 server + measure + restore) as a fixup commit before merge.

## Validation chain

- \`make build\` clean (all targets, both host and Linux cross-compile).
- \`make test\` clean (Go unit tests).
- \`make lint\` clean.
- \`make test-integration\` against dev v0.5.6 server with this change: 18 passed + 2 cleanly-skipped (FC PhaseTimer-dependent, mini3 still on v0.5.3 per §16 README precondition).
- PR #127's locked ordering invariants remain green.
- Brew server restored at session end.

## Per the §15 mandatory process

**No release** from this PR. Bundle with §15 PRs 1b (split Progress into Phase + Status) and 1c (document divergent config defaults) into a Phase 1 release discussion.

## Files

\`internal/vmutil/agent.go\` — one constant + its comment. +11 / −4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)