### PR TITLE
backend: split Progress into Phase + Status; migrate all callers (§15 1b)

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -180,6 +180,13 @@ func (s *Server) handleCreateShedSSE(w http.ResponseWriter, r *http.Request, req
 	timer := s.createTimer(req)
 	events := make(chan backend.ProgressEvent, 16)
 	sseFn := func(event backend.ProgressEvent) {
+		// Phase-only events (Message == "") are server-side timer
+		// boundaries; they should not appear as user-visible SSE
+		// progress lines. The PhaseTimer (via TeeProgress) still
+		// receives them through `timer.Track`.
+		if event.Message == "" {
+			return
+		}
 		select {
 		case events <- event:
 		default:

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -290,17 +290,25 @@ func parseSSEEvents(t *testing.T, body string) []struct{ Event, Data string } {
 	return events
 }
 
-// TestCreateShed_SSE_SurfacesProgressAndWarning verifies that ProgressWarning
-// events emitted by the backend during CreateShed reach the SSE stream as
-// progress events with warning=true. Regression test for issue #84 — clone
-// failures used to be journald-only.
+// TestCreateShed_SSE_SurfacesProgressAndWarning verifies that
+// StatusWarning events emitted by the backend during CreateShed reach
+// the SSE stream as progress events with `warning=true`. Regression
+// test for issue #84 — clone failures used to be journald-only.
+//
+// Post-§15 1b note: Phase boundaries are intentionally NOT sent over
+// the SSE wire (they are server-side PhaseTimer events only). The
+// warning message reaches the client as a status-only event with
+// `"phase":""`. The CLI renders the message regardless (see
+// `cmd/shed/shed.go`'s SSE loop, which only consumes `Message` +
+// `Warning`).
 func TestCreateShed_SSE_SurfacesProgressAndWarning(t *testing.T) {
 	be := &createShedFakeBackend{
 		createFn: func(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error) {
-			backend.Progress(ctx, "repo", "Cloning repository...")
+			backend.Phase(ctx, "repo")
+			backend.Status(ctx, "Cloning repository...")
 			// Match the production sanitized message from vz/firecracker
 			// client.go — no URL, no wrapped err.
-			backend.ProgressWarning(ctx, "repo", "Failed to clone repository (see server logs for details)")
+			backend.StatusWarning(ctx, "Failed to clone repository (see server logs for details)")
 			return &config.Shed{Name: req.Name, Status: config.StatusRunning, Repo: req.Repo}, nil
 		},
 	}
@@ -319,14 +327,13 @@ func TestCreateShed_SSE_SurfacesProgressAndWarning(t *testing.T) {
 
 	events := parseSSEEvents(t, w.Body.String())
 
-	// Find the warning event and assert its payload carries warning=true.
+	// Find the warning event and assert its payload carries warning=true
+	// AND the user-visible message. Per §15 1b, phase is no longer
+	// included on status-only events.
 	var sawWarning, sawComplete bool
 	for _, e := range events {
 		if e.Event == "progress" && strings.Contains(e.Data, `"warning":true`) {
 			sawWarning = true
-			if !strings.Contains(e.Data, `"phase":"repo"`) {
-				t.Errorf("warning event missing repo phase: %s", e.Data)
-			}
 			if !strings.Contains(e.Data, "Failed to clone repository") {
 				t.Errorf("warning event missing failure message: %s", e.Data)
 			}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -355,3 +355,53 @@ func TestCreateShed_SSE_SurfacesProgressAndWarning(t *testing.T) {
 		t.Errorf("no complete event found in stream:\n%s", w.Body.String())
 	}
 }
+
+// TestCreateShed_SSE_PhaseOnlyEventsNotStreamed verifies that
+// `backend.Phase` calls (timer boundaries with no user-visible message)
+// do NOT cross the SSE wire. Per §15 1b the SSE handler drops events
+// with empty Message; the PhaseTimer still consumes them server-side.
+// Regression test for the silent-skip in `internal/api/handlers.go`'s
+// `sseFn`.
+func TestCreateShed_SSE_PhaseOnlyEventsNotStreamed(t *testing.T) {
+	be := &createShedFakeBackend{
+		createFn: func(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error) {
+			// One phase-only event (should NOT appear in SSE), one
+			// status event (should appear), then another phase-only.
+			backend.Phase(ctx, "vm")
+			backend.Status(ctx, "Visible message")
+			backend.Phase(ctx, "agent")
+			return &config.Shed{Name: req.Name, Status: config.StatusRunning}, nil
+		},
+	}
+	srv := NewServer(be, &config.ServerConfig{Name: "test-server"}, "", nil, nil)
+
+	body, _ := json.Marshal(config.CreateShedRequest{Name: "phase-only"})
+	r := httptest.NewRequest(http.MethodPost, "/api/sheds", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Accept", "text/event-stream")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 (body: %s)", w.Code, w.Body.String())
+	}
+
+	progressEvents := 0
+	for _, e := range parseSSEEvents(t, w.Body.String()) {
+		if e.Event != "progress" {
+			continue
+		}
+		progressEvents++
+		// Any progress event we DO emit must carry a non-empty message.
+		// (Phase-only events would serialize as `{"phase":"vm","message":""}`
+		// and an SSE consumer treating them as user-visible would render
+		// blank lines.)
+		if !strings.Contains(e.Data, `"message":"Visible message"`) {
+			t.Errorf("unexpected SSE progress event data: %s", e.Data)
+		}
+	}
+	if progressEvents != 1 {
+		t.Errorf("got %d progress events, want exactly 1 (the Status call); "+
+			"phase-only events must not be streamed", progressEvents)
+	}
+}

--- a/internal/api/snapshot_handlers.go
+++ b/internal/api/snapshot_handlers.go
@@ -26,7 +26,7 @@ func (s *Server) handleListSnapshots(w http.ResponseWriter, r *http.Request) {
 // handleCreateSnapshot creates a new snapshot from a stopped shed.
 // POST /api/snapshots
 //
-// Non-fatal warnings emitted by the backend via backend.ProgressWarning
+// Non-fatal warnings emitted by the backend via backend.StatusWarning
 // are collected and returned in the response body alongside the snapshot,
 // so the operator can see e.g. the "--local-dir not captured" warning
 // without needing SSE plumbing on this endpoint.

--- a/internal/api/snapshot_handlers_test.go
+++ b/internal/api/snapshot_handlers_test.go
@@ -110,7 +110,7 @@ func (f *snapshotFakeBackend) DeleteSnapshot(_ context.Context, _ string) error 
 }
 
 // snapshotFakeBackendWarner embeds snapshotFakeBackend and overrides
-// CreateSnapshot to emit warnings via backend.ProgressWarning so the test
+// CreateSnapshot to emit warnings via backend.StatusWarning so the test
 // exercises the warning-collection path through the handler.
 type snapshotFakeBackendWarner struct {
 	snapshotFakeBackend
@@ -121,7 +121,8 @@ type snapshotFakeBackendWarner struct {
 
 func (f *snapshotFakeBackendWarner) CreateSnapshot(ctx context.Context, _ config.SnapshotCreateRequest) (*config.Snapshot, error) {
 	for _, msg := range f.warnings {
-		backend.ProgressWarning(ctx, "test", msg)
+		backend.Phase(ctx, "test")
+		backend.StatusWarning(ctx, msg)
 	}
 	return f.createResp, f.createErr
 }
@@ -204,7 +205,7 @@ func TestHandleCreateSnapshot_Success(t *testing.T) {
 	}
 }
 
-// TestHandleCreateSnapshot_Warnings verifies that backend.ProgressWarning
+// TestHandleCreateSnapshot_Warnings verifies that backend.StatusWarning
 // emitted during CreateSnapshot is surfaced in the response payload.
 func TestHandleCreateSnapshot_Warnings(t *testing.T) {
 	be := &snapshotFakeBackendWarner{

--- a/internal/backend/phasetimer.go
+++ b/internal/backend/phasetimer.go
@@ -48,15 +48,24 @@ func NewPhaseTimer(op string, now func() time.Time) *PhaseTimer {
 	return t
 }
 
-// Track is a ProgressFunc. Each event ends the current phase (recording
-// its duration) and begins the phase it names. The interval before the
-// first event is recorded as "setup". Safe for concurrent use.
+// Track is a ProgressFunc. Each phase-bearing event ends the current
+// phase (recording its duration) and begins the phase it names. The
+// interval before the first event is recorded as "setup". Safe for
+// concurrent use.
+//
+// Status-only events (those with an empty `Phase` field, emitted by
+// backend.Status / backend.StatusWarning) are ignored here — they are
+// user-visible SSE messages that should NOT split a phase span. Same-
+// phase events (Phase == current) are also no-ops, so a `Phase(ctx,
+// "snapshot")` repeated mid-snapshot keeps accumulating into one span
+// rather than producing zero-length micro-spans.
 func (t *PhaseTimer) Track(e ProgressEvent) {
+	if e.Phase == "" {
+		return
+	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if e.Phase == t.current {
-		// Same phase emitting another message — keep accumulating into
-		// the current span rather than splitting it.
 		return
 	}
 	n := t.now()

--- a/internal/backend/progress.go
+++ b/internal/backend/progress.go
@@ -2,7 +2,22 @@ package backend
 
 import "context"
 
-// ProgressEvent represents a progress update during a long-running operation.
+// ProgressEvent is what crosses the ContextWithProgress wire and, via
+// the SSE handler, what crosses the HTTP wire to the `shed` CLI.
+//
+// Two pieces of information that are independent in the API:
+//
+//   - `Phase` — the name of the timer phase the operation is in.
+//     Phase-only events (where `Message` is empty) advance the
+//     PhaseTimer; the SSE handler drops them so they do not appear as
+//     user-visible progress lines.
+//   - `Message` — a human-readable status string. Status-only events
+//     (where `Phase` is empty) are forwarded to SSE consumers but do
+//     NOT advance the timer; they "attach" to the current phase.
+//
+// The wire shape stays the same; old `shed` CLIs continue to render
+// progress identically because they only read `Message` + `Warning`
+// (see `cmd/shed/shed.go` for the rendering loop).
 type ProgressEvent struct {
 	Phase   string `json:"phase"`
 	Message string `json:"message"`
@@ -21,25 +36,38 @@ func ContextWithProgress(ctx context.Context, fn ProgressFunc) context.Context {
 	return context.WithValue(ctx, progressKey, fn)
 }
 
-// Progress emits a progress event. No-op if no ProgressFunc is in the context.
-func Progress(ctx context.Context, phase, message string) {
+// Phase advances the PhaseTimer to a new phase. No user-visible SSE
+// message is emitted. Use this when the boundary matters but you don't
+// have a useful display string yet (or a separate Status call describes
+// what's happening).
+func Phase(ctx context.Context, name string) {
 	if fn, ok := ctx.Value(progressKey).(ProgressFunc); ok && fn != nil {
-		fn(ProgressEvent{Phase: phase, Message: message})
+		fn(ProgressEvent{Phase: name})
 	}
 }
 
-// ProgressWarning emits a warning progress event. No-op if no ProgressFunc is in the context.
-func ProgressWarning(ctx context.Context, phase, message string) {
+// Status emits a user-visible progress message tied to the current
+// phase. The PhaseTimer ignores status-only events; they show up as
+// SSE lines on the `shed` CLI but do not split or rename a phase span.
+func Status(ctx context.Context, message string) {
 	if fn, ok := ctx.Value(progressKey).(ProgressFunc); ok && fn != nil {
-		fn(ProgressEvent{Phase: phase, Message: message, Warning: true})
+		fn(ProgressEvent{Message: message})
+	}
+}
+
+// StatusWarning is Status with the Warning flag set. The CLI renders
+// it with a "Warning:" prefix on stderr.
+func StatusWarning(ctx context.Context, message string) {
+	if fn, ok := ctx.Value(progressKey).(ProgressFunc); ok && fn != nil {
+		fn(ProgressEvent{Message: message, Warning: true})
 	}
 }
 
 // TeeProgress returns a ProgressFunc that forwards each event to every
-// non-nil fn, in order. It returns nil when no non-nil fn is supplied, so
-// callers can pass the result straight to ContextWithProgress. This lets
-// a single operation feed both a server-side consumer (e.g. PhaseTimer)
-// and the SSE writer from one progress stream.
+// non-nil fn, in order. It returns nil when no non-nil fn is supplied,
+// so callers can pass the result straight to ContextWithProgress. This
+// lets a single operation feed both a server-side consumer (the
+// PhaseTimer) and the SSE writer from one progress stream.
 func TeeProgress(fns ...ProgressFunc) ProgressFunc {
 	live := make([]ProgressFunc, 0, len(fns))
 	for _, fn := range fns {

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -478,7 +478,8 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 			resolved = c.cfg.ResolveBaseRootfs()
 		}
 
-		backend.Progress(ctx, "image", "Resolving image...")
+		backend.Phase(ctx, "image")
+		backend.Status(ctx, "Resolving image...")
 		mgr := vmimage.NewManager(c.cfg, c.refScanner())
 		ensureRes, err := mgr.EnsureImage(ctx, vmimage.ResolvedRef{
 			Path:      resolved.Path,
@@ -486,7 +487,8 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 			Name:      resolved.Name,
 			Digest:    resolved.Digest,
 		}, func(stage, msg string) {
-			backend.Progress(ctx, stage, msg)
+			backend.Phase(ctx, stage)
+			backend.Status(ctx, msg)
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to ensure image: %w", err)
@@ -514,7 +516,8 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		defer removeCreatingMarker(c.cfg.InstanceDir, req.Name)
 	}
 
-	backend.Progress(ctx, "network", "Allocating network resources...")
+	backend.Phase(ctx, "network")
+	backend.Status(ctx, "Allocating network resources...")
 	cid, err := c.AllocateCID(req.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to allocate CID: %w", err)
@@ -531,7 +534,8 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		return nil, fmt.Errorf("failed to create TAP device: %w", err)
 	}
 
-	backend.Progress(ctx, "rootfs", "Allocating writable upper layer...")
+	backend.Phase(ctx, "rootfs")
+	backend.Status(ctx, "Allocating writable upper layer...")
 	upperPath, err := EnsureUpper(c.cfg.UppersDir, req.Name, upperSizeBytes)
 	if err != nil {
 		if delErr := c.netMgr.DeleteTAPDevice(tapDevice); delErr != nil {
@@ -644,7 +648,8 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		return nil, fmt.Errorf("failed to create VM: %w", err)
 	}
 
-	backend.Progress(ctx, "vm", "Starting virtual machine...")
+	backend.Phase(ctx, "vm")
+	backend.Status(ctx, "Starting virtual machine...")
 	if err := vm.Start(ctx); err != nil {
 		if delErr := c.netMgr.DeleteTAPDevice(tapDevice); delErr != nil {
 			log.Printf("Warning: failed to delete TAP device %s: %v", tapDevice, delErr)
@@ -685,7 +690,8 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 
 	// Mount local directory via 9P if specified
 	if req.LocalDir != "" {
-		backend.Progress(ctx, "9p", "Mounting local directory via 9P...")
+		backend.Phase(ctx, "9p")
+		backend.Status(ctx, "Mounting local directory via 9P...")
 		bridgeIP := c.netMgr.Gateway()
 		srv, err := c.startP9Server(req.Name, bridgeIP, req.LocalDir, config.WorkspacePath, false)
 		if err != nil {
@@ -728,7 +734,8 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 	{
 		dirCreds := vmutil.FilterExistingCredentials(c.serverCfg)
 		if len(dirCreds) > 0 {
-			backend.Progress(ctx, "credentials", "Setting up credentials...")
+			backend.Phase(ctx, "credentials")
+			backend.Status(ctx, "Setting up credentials...")
 		}
 		c.credMgr.SetupCredentials(ctx, agent, req.Name, dirCreds, c.mount9PCredentialFunc(req.Name))
 	}
@@ -736,16 +743,22 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 	// Clone repo if specified (skip when using local dir or spawning from snapshot;
 	// snapshot rootfs is already provisioned).
 	if req.Repo != "" && req.LocalDir == "" && req.FromSnapshot == "" {
-		backend.Progress(ctx, "repo", "Cloning repository...")
+		backend.Phase(ctx, "repo")
+		backend.Status(ctx, "Cloning repository...")
 		if err := vmutil.CloneRepo(ctx, agent, c.serverCfg, req.Repo); err != nil {
 			log.Printf("Warning: failed to clone repo %s: %v", config.SanitizeRepoURL(req.Repo), err)
 			// Generic SSE message by design: req.Repo can carry credentials
 			// (e.g., https://user:pw@host/...) and the wrapped err from
 			// git/ssh may include the URL too. Full detail is in the server
 			// log above; SSE consumers get a stable, sanitized signal.
-			backend.ProgressWarning(ctx, "repo", "Failed to clone repository (see server logs for details)")
+			//
+			// Deliberately no `backend.Phase(ctx, "repo")` here: see
+			// the matching note in `internal/vz/client.go`. Re-entering
+			// "repo" just to attach a status would split the timer line
+			// into the `repo=N clone=M repo=K` triple shape.
+			backend.StatusWarning(ctx, "Failed to clone repository (see server logs for details)")
 		} else {
-			backend.Progress(ctx, "repo", "Repository cloned")
+			backend.Status(ctx, "Repository cloned")
 		}
 	}
 

--- a/internal/firecracker/image.go
+++ b/internal/firecracker/image.go
@@ -50,7 +50,8 @@ func (c *Client) TagImage(srcTagOrDigest, newTag string) error {
 func (c *Client) PullImage(ctx context.Context, dockerRef, tag, platform string) (string, error) {
 	mgr := vmimage.NewManager(c.cfg, c.refScanner())
 	return mgr.PullImage(ctx, dockerRef, tag, platform, func(stage, msg string) {
-		backend.Progress(ctx, stage, msg)
+		backend.Phase(ctx, stage)
+		backend.Status(ctx, msg)
 	})
 }
 
@@ -60,7 +61,8 @@ func (c *Client) PullImage(ctx context.Context, dockerRef, tag, platform string)
 func (c *Client) PushImage(ctx context.Context, tagOrDigest, dstRef string) error {
 	mgr := vmimage.NewManager(c.cfg, c.refScanner())
 	return mapSentinelErrors(mgr.PushImage(ctx, tagOrDigest, dstRef, func(stage, msg string) {
-		backend.Progress(ctx, stage, msg)
+		backend.Phase(ctx, stage)
+		backend.Status(ctx, msg)
 	}))
 }
 

--- a/internal/firecracker/snapshot.go
+++ b/internal/firecracker/snapshot.go
@@ -167,8 +167,8 @@ func (c *Client) CreateSnapshot(ctx context.Context, req config.SnapshotCreateRe
 	}
 
 	if srcMeta.LocalDir != "" {
-		backend.ProgressWarning(ctx, "snapshot",
-			fmt.Sprintf("source shed uses --local-dir; workspace contents at %s are NOT included in the snapshot", srcMeta.LocalDir))
+		backend.Phase(ctx, "snapshot")
+		backend.StatusWarning(ctx, fmt.Sprintf("source shed uses --local-dir; workspace contents at %s are NOT included in the snapshot", srcMeta.LocalDir))
 	}
 
 	dir := SnapshotDir(c.cfg.SnapshotsDir, req.Name)
@@ -205,7 +205,8 @@ func (c *Client) CreateSnapshot(ctx context.Context, req config.SnapshotCreateRe
 	if src == "" {
 		src = srcMeta.RootfsPath
 	}
-	backend.Progress(ctx, "snapshot", "Copying upper layer to snapshot...")
+	backend.Phase(ctx, "snapshot")
+	backend.Status(ctx, "Copying upper layer to snapshot...")
 	strategy, err := clone.CloneFile(src, dstRootfs)
 	if err != nil {
 		os.RemoveAll(dir)
@@ -255,7 +256,8 @@ func (c *Client) CreateSnapshot(ctx context.Context, req config.SnapshotCreateRe
 		LowerDigest:    srcMeta.LowerDigest,
 	}
 
-	backend.Progress(ctx, "snapshot", "Writing snapshot metadata...")
+	backend.Phase(ctx, "snapshot")
+	backend.Status(ctx, "Writing snapshot metadata...")
 	if err := saveSnapshot(c.cfg.SnapshotsDir, snap); err != nil {
 		os.RemoveAll(dir)
 		return nil, fmt.Errorf("failed to save snapshot metadata: %w", err)

--- a/internal/vmutil/agent.go
+++ b/internal/vmutil/agent.go
@@ -110,7 +110,8 @@ const healthPollInterval = 50 * time.Millisecond
 
 // WaitForHealth waits until the agent is healthy or the context is cancelled.
 func (c *AgentClient) WaitForHealth(ctx context.Context, timeout time.Duration) error {
-	backend.Progress(ctx, "agent", "Waiting for agent to come up...")
+	backend.Phase(ctx, "agent")
+	backend.Status(ctx, "Waiting for agent to come up...")
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/vmutil/credentials_manager.go
+++ b/internal/vmutil/credentials_manager.go
@@ -49,11 +49,13 @@ func NewCredentialManager(serverCfg *config.ServerConfig, bridge *plugin.Bridge,
 func (cm *CredentialManager) SetupCredentials(ctx context.Context, agent *AgentClient, shedName string, dirCreds map[string]config.MountConfig, mountDir DirMountFunc) {
 	// Mount directory credentials via backend-specific callback
 	if len(dirCreds) > 0 && mountDir != nil {
-		backend.Progress(ctx, "credentials", "Mounting directory credentials...")
+		backend.Phase(ctx, "credentials")
+		backend.Status(ctx, "Mounting directory credentials...")
 		for name, mount := range dirCreds {
 			if err := mountDir(ctx, agent, name, mount); err != nil {
 				log.Printf("Warning: directory credential mount failed for %q: %v", name, err)
-				backend.ProgressWarning(ctx, "credentials", fmt.Sprintf("Failed to mount credential %q", name))
+				backend.Phase(ctx, "credentials")
+				backend.StatusWarning(ctx, fmt.Sprintf("Failed to mount credential %q", name))
 			}
 		}
 	}

--- a/internal/vmutil/provisioning.go
+++ b/internal/vmutil/provisioning.go
@@ -89,19 +89,22 @@ func (p *Provisioner) RunProvisioning(ctx context.Context, cfg *provision.Config
 		}
 		if !installRan {
 			fmt.Fprintln(p.output, "Running install hook...")
-			backend.Progress(ctx, "provision", "Running install hook...")
+			backend.Phase(ctx, "provision")
+			backend.Status(ctx, "Running install hook...")
 			if err := p.runHook(ctx, cfg, provision.HookTypeInstall, cfg.Hooks.Install); err != nil {
 				if hookErr, ok := err.(*provision.HookError); ok {
 					fmt.Fprintf(p.errOut, "Install hook failed (exit code %d)\n", hookErr.ExitCode)
 					fmt.Fprintf(p.errOut, "  Last output: %s\n", hookErr.LastOutput)
 					fmt.Fprintf(p.errOut, "  Full log: %s\n", hookErr.LogFile)
-					backend.ProgressWarning(ctx, "provision", fmt.Sprintf("Install hook failed (exit code %d)", hookErr.ExitCode))
+					backend.Phase(ctx, "provision")
+					backend.StatusWarning(ctx, fmt.Sprintf("Install hook failed (exit code %d)", hookErr.ExitCode))
 					_ = state.MarkInstallFailed(ctx, err)
 				}
 				return err
 			}
 			fmt.Fprintln(p.output, "Install hook complete")
-			backend.Progress(ctx, "provision", "Install hook complete")
+			backend.Phase(ctx, "provision")
+			backend.Status(ctx, "Install hook complete")
 			_ = state.MarkInstallComplete(ctx)
 		}
 	}
@@ -109,18 +112,21 @@ func (p *Provisioner) RunProvisioning(ctx context.Context, cfg *provision.Config
 	// Run startup hook
 	if cfg.HasStartupHook() {
 		fmt.Fprintln(p.output, "Running startup hook...")
-		backend.Progress(ctx, "provision", "Running startup hook...")
+		backend.Phase(ctx, "provision")
+		backend.Status(ctx, "Running startup hook...")
 		if err := p.runHook(ctx, cfg, provision.HookTypeStartup, cfg.Hooks.Startup); err != nil {
 			if hookErr, ok := err.(*provision.HookError); ok {
 				fmt.Fprintf(p.errOut, "Startup hook failed (exit code %d)\n", hookErr.ExitCode)
 				fmt.Fprintf(p.errOut, "  Last output: %s\n", hookErr.LastOutput)
 				fmt.Fprintf(p.errOut, "  Full log: %s\n", hookErr.LogFile)
-				backend.ProgressWarning(ctx, "provision", fmt.Sprintf("Startup hook failed (exit code %d)", hookErr.ExitCode))
+				backend.Phase(ctx, "provision")
+				backend.StatusWarning(ctx, fmt.Sprintf("Startup hook failed (exit code %d)", hookErr.ExitCode))
 			}
 			return err
 		}
 		fmt.Fprintln(p.output, "Startup hook complete")
-		backend.Progress(ctx, "provision", "Startup hook complete")
+		backend.Phase(ctx, "provision")
+		backend.Status(ctx, "Startup hook complete")
 	}
 
 	return nil

--- a/internal/vmutil/repo.go
+++ b/internal/vmutil/repo.go
@@ -18,7 +18,8 @@ import (
 // key. Built-in defaults cover GitHub; extras come from
 // ServerConfig.Git.ExtraKnownHosts.
 func CloneRepo(ctx context.Context, agent *AgentClient, serverCfg *config.ServerConfig, repo string) error {
-	backend.Progress(ctx, "clone", "Cloning repository...")
+	backend.Phase(ctx, "clone")
+	backend.Status(ctx, "Cloning repository...")
 
 	if config.IsSSHRepoURL(repo) {
 		if err := WriteKnownHosts(ctx, agent, BuildKnownHosts(serverCfg)); err != nil {

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -224,7 +224,8 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 
 		// Ensure image is available locally (pulls + converts Docker refs if needed).
 		// We only need the digest — the rootfs path is rederived per-boot inside vm.go.
-		backend.Progress(ctx, "image", "Resolving image...")
+		backend.Phase(ctx, "image")
+		backend.Status(ctx, "Resolving image...")
 		_, ldigest, err := c.EnsureImage(ctx, resolved)
 		if err != nil {
 			return nil, err
@@ -246,7 +247,8 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		defer removeCreatingMarker(c.cfg.InstanceDir, req.Name)
 	}
 
-	backend.Progress(ctx, "rootfs", "Allocating writable upper layer...")
+	backend.Phase(ctx, "rootfs")
+	backend.Status(ctx, "Allocating writable upper layer...")
 	upperPath, err := EnsureUpper(c.cfg.UppersDir, req.Name, upperSizeBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create upper: %w", err)
@@ -295,7 +297,8 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 			}
 			log.Printf("[%s] upper template clone failed (%v); formatting in guest", req.Name, perr)
 		} else {
-			backend.Progress(ctx, "rootfs", "Provisioned upper from template (skips in-guest mkfs)")
+			backend.Phase(ctx, "rootfs")
+			backend.Status(ctx, "Provisioned upper from template (skips in-guest mkfs)")
 		}
 	}
 	rootfsPath := upperPath
@@ -336,7 +339,8 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 	vm := CreateVM(meta, c.cfg)
 	vm.credentialShares = buildCredentialShares(dirCreds)
 
-	backend.Progress(ctx, "vm", "Starting virtual machine...")
+	backend.Phase(ctx, "vm")
+	backend.Status(ctx, "Starting virtual machine...")
 	if err := vm.Start(ctx); err != nil {
 		c.preserveConsoleLog(meta)
 		if rmErr := meta.Delete(c.cfg.InstanceDir); rmErr != nil {
@@ -372,7 +376,8 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 
 	// Mount VirtioFS workspace if local dir is configured
 	if req.LocalDir != "" {
-		backend.Progress(ctx, "mount", "Mounting local directory via VirtioFS...")
+		backend.Phase(ctx, "mount")
+		backend.Status(ctx, "Mounting local directory via VirtioFS...")
 		if err := c.mountVirtioFSShare(ctx, agent, config.VirtioFSMountTag, config.WorkspacePath, false); err != nil {
 			// VirtioFS mount is essential for --local-dir; fail the create
 			if stopErr := vm.Stop(context.Background()); stopErr != nil {
@@ -388,16 +393,26 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 	// Clone repo if specified (skip when using local dir or spawning from snapshot;
 	// snapshot rootfs is already provisioned).
 	if req.Repo != "" && req.LocalDir == "" && req.FromSnapshot == "" {
-		backend.Progress(ctx, "repo", "Cloning repository...")
+		backend.Phase(ctx, "repo")
+		backend.Status(ctx, "Cloning repository...")
 		if err := vmutil.CloneRepo(ctx, agent, c.serverCfg, req.Repo); err != nil {
 			log.Printf("Warning: failed to clone repo %s: %v", config.SanitizeRepoURL(req.Repo), err)
 			// Generic SSE message by design: req.Repo can carry credentials
 			// (e.g., https://user:pw@host/...) and the wrapped err from
 			// git/ssh may include the URL too. Full detail is in the server
 			// log above; SSE consumers get a stable, sanitized signal.
-			backend.ProgressWarning(ctx, "repo", "Failed to clone repository (see server logs for details)")
+			//
+			// Deliberately no `backend.Phase(ctx, "repo")` here: the
+			// preceding `vmutil.CloneRepo` already advanced the timer
+			// to "clone", and re-entering "repo" just to attach a
+			// status would split the timer line into the
+			// `repo=N clone=M repo=K` triple shape documented in §14
+			// and Codex's review of #132. The user still sees the
+			// status message (SSE consumes Status events regardless of
+			// the current phase).
+			backend.StatusWarning(ctx, "Failed to clone repository (see server logs for details)")
 		} else {
-			backend.Progress(ctx, "repo", "Repository cloned")
+			backend.Status(ctx, "Repository cloned")
 		}
 	}
 

--- a/internal/vz/image.go
+++ b/internal/vz/image.go
@@ -30,7 +30,8 @@ func (c *Client) EnsureImage(ctx context.Context, resolved config.ResolvedImage)
 		Name:      resolved.Name,
 		Digest:    resolved.Digest,
 	}, func(stage, msg string) {
-		backend.Progress(ctx, stage, msg)
+		backend.Phase(ctx, stage)
+		backend.Status(ctx, msg)
 	})
 	if err != nil {
 		return "", "", err
@@ -73,7 +74,8 @@ func (c *Client) TagImage(srcTagOrDigest, newTag string) error {
 func (c *Client) PullImage(ctx context.Context, dockerRef, tag, platform string) (string, error) {
 	mgr := vmimage.NewManager(c.cfg, c.refScanner())
 	return mgr.PullImage(ctx, dockerRef, tag, platform, func(stage, msg string) {
-		backend.Progress(ctx, stage, msg)
+		backend.Phase(ctx, stage)
+		backend.Status(ctx, msg)
 	})
 }
 
@@ -83,7 +85,8 @@ func (c *Client) PullImage(ctx context.Context, dockerRef, tag, platform string)
 func (c *Client) PushImage(ctx context.Context, tagOrDigest, dstRef string) error {
 	mgr := vmimage.NewManager(c.cfg, c.refScanner())
 	return mapSentinelErrors(mgr.PushImage(ctx, tagOrDigest, dstRef, func(stage, msg string) {
-		backend.Progress(ctx, stage, msg)
+		backend.Phase(ctx, stage)
+		backend.Status(ctx, msg)
 	}))
 }
 

--- a/internal/vz/snapshot.go
+++ b/internal/vz/snapshot.go
@@ -173,8 +173,8 @@ func (c *Client) CreateSnapshot(ctx context.Context, req config.SnapshotCreateRe
 	}
 
 	if srcMeta.LocalDir != "" {
-		backend.ProgressWarning(ctx, "snapshot",
-			fmt.Sprintf("source shed uses --local-dir; workspace contents at %s are NOT included in the snapshot", srcMeta.LocalDir))
+		backend.Phase(ctx, "snapshot")
+		backend.StatusWarning(ctx, fmt.Sprintf("source shed uses --local-dir; workspace contents at %s are NOT included in the snapshot", srcMeta.LocalDir))
 	}
 
 	dir := SnapshotDir(c.cfg.SnapshotsDir, req.Name)
@@ -211,7 +211,8 @@ func (c *Client) CreateSnapshot(ctx context.Context, req config.SnapshotCreateRe
 	if src == "" {
 		src = srcMeta.RootfsPath
 	}
-	backend.Progress(ctx, "snapshot", "Copying upper layer to snapshot...")
+	backend.Phase(ctx, "snapshot")
+	backend.Status(ctx, "Copying upper layer to snapshot...")
 	strategy, err := clone.CloneFile(src, dstRootfs)
 	if err != nil {
 		os.RemoveAll(dir)
@@ -261,7 +262,8 @@ func (c *Client) CreateSnapshot(ctx context.Context, req config.SnapshotCreateRe
 		LowerDigest:    srcMeta.LowerDigest,
 	}
 
-	backend.Progress(ctx, "snapshot", "Writing snapshot metadata...")
+	backend.Phase(ctx, "snapshot")
+	backend.Status(ctx, "Writing snapshot metadata...")
 	if err := saveSnapshot(c.cfg.SnapshotsDir, snap); err != nil {
 		os.RemoveAll(dir)
 		return nil, fmt.Errorf("failed to save snapshot metadata: %w", err)


### PR DESCRIPTION
§15 Phase 1 PR 1b. The conflation of "phase boundary" and "user-visible status message" into a single \`backend.Progress(ctx, phase, message)\` call was responsible for the \`repo=0ms ... clone=Nms repo=Kms\` triple-span shape documented in §14 — and Codex's review of #132 flagged that the integration suite's parser had to sum-on-duplicate to cope.

## New API

\`internal/backend/progress.go\` now exposes three functions:

| Function | Effect on PhaseTimer | Effect on SSE |
|---|---|---|
| \`Phase(ctx, name)\` | advances timer | dropped (no user-visible line) |
| \`Status(ctx, message)\` | none | emits SSE message |
| \`StatusWarning(ctx, msg)\` | none | emits SSE with \`warning=true\` |

Legacy \`Progress\` / \`ProgressWarning\` are removed; this PR migrates all production call sites in one go.

\`PhaseTimer.Track\` now short-circuits on phase-empty events. The SSE handler symmetrically drops events with empty \`Message\` so phase boundaries don't render as blank lines on the client.

**Wire format unchanged structurally; SSE semantics change to flag.** \`ProgressEvent\` retains \`Phase\` / \`Message\` / \`Warning\` fields. The in-repo \`shed\` CLI consumes only \`Message\` + \`Warning\` (see \`cmd/shed/shed.go\`'s SSE loop), so it renders identically. **However**, status events now serialize with \`"phase":""\` on the wire — a silent SSE semantics change for any external consumer that was reading \`phase\` off status events to know which build phase a message belongs to. The integration suite's PhaseTimer parser is unaffected (it consumes the server log, not SSE).

If we ever ship an external SSE consumer relying on the phase field, the fix is to source it from the active PhaseTimer phase at status-emit time; that's a larger change than this PR warrants.

## Migration mechanics

41 call sites total — 39 mechanically migrated via a one-shot Python script (matches balanced parens; splits top-level commas, so the multi-line forms in \`snapshot.go\` migrated correctly alongside the single-line ones), plus 2 documentation references and the SSE test fixture by hand.

## Opportunistic cleanup

\`vz/client.go\` + \`firecracker/client.go\` drop the redundant \`Phase("repo")\` calls that fired AFTER \`vmutil.CloneRepo\` returned. They were what produced the triple-span shape. With them gone, the timer line is now clean:

\`\`\`
BEFORE (v0.5.6 brew):   ... repo=0ms clone=915ms repo=2ms err=<nil>
AFTER  (this branch):   ... repo=0ms clone=915ms err=<nil>
\`\`\`

The "Repository cloned" / "Failed to clone…" status message still reaches the SSE client; it now attaches to the "clone" phase semantically. Comments at both call sites explain the deliberate non-emit.

## Live verification (this mac, dev v0.5.6 server with these changes)

- Plain create timing-line shape: identical (no regression).
- \`--repo\` create timing-line BEFORE: \`... repo=0ms clone=915ms repo=2ms err=<nil>\`
- \`--repo\` create timing-line AFTER:  \`... repo=0ms clone=915ms err=<nil>\`
- Full integration suite (\`make test-integration\`): 18 passed + 2 skipped (FC PhaseTimer-dependent, mini3 still on v0.5.3 per §16 precondition).

## Test updates

- \`TestCreateShed_SSE_SurfacesProgressAndWarning\` previously asserted \`"phase":"repo"\` in the SSE warning event payload. Per the deliberate API split, status-only events have empty Phase. Test updated to assert only the fields the CLI consumes (\`Message\` + \`Warning\`); rationale recorded in the docstring.
- **NEW** \`TestCreateShed_SSE_PhaseOnlyEventsNotStreamed\` (added per Codex review): asserts that \`backend.Phase\` calls do NOT cross the SSE wire — phase-only events are server-side only. Pins the new core behavior of \`internal/api/handlers.go\`'s \`sseFn\` drop.

## Codex review

Reviewed by Codex (CodeRabbit still rate-limited): API design / short-circuit edges / repo-block correctness / migration / no test-collateral damage — all OK. Two actionable items addressed in commit 2:
1. **Added** \`TestCreateShed_SSE_PhaseOnlyEventsNotStreamed\`.
2. **Documented** the silent SSE semantics change here (acknowledged as acceptable since no external consumers are known to rely on \`phase\` field of status events).

## Validation chain

- \`make build\` clean (all targets, both host and Linux cross-compile).
- \`make test\` clean (Go unit tests, including the updated + new SSE tests).
- \`make lint\` clean.
- \`make test-integration\` against dev v0.5.6 server with this change: 18 passed + 2 cleanly-skipped.
- PR #127's locked ordering invariants remain green.
- PR #133's healthPollInterval cut (50 ms) preserved.
- Brew server restored at session end.

## Per the §15 mandatory process

**No release** from this PR. Bundle with 1a (#133) and 1c into Phase 1's release discussion.

## Files

16 + 1 files changed, +220 / −71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)