### PR TITLE
backend: cleanup-stack helper + migrate VZ/FC CreateShed (§15 2a)

### DIFF
--- a/internal/backend/cleanup.go
+++ b/internal/backend/cleanup.go
@@ -112,6 +112,12 @@ func (c *Cleanup) Commit() {
 // still run, so a slow `vm.Stop` doesn't leak an upper-layer file.
 // Idempotent: subsequent calls are no-ops.
 //
+// Cleanup closures are run inside an isolating panic-recovery wrapper —
+// a panic in step N is logged and the remaining steps still execute.
+// Without this, a buggy `vm.Stop` could leave an upper-layer file
+// behind, which is precisely the class of leak this type exists to
+// prevent.
+//
 // Designed to be called from `defer cleanup.Run()` at the top of a
 // lifecycle method. The defer guarantees rollback on panic-mid-create
 // too (the rollback runs before the panic propagates out).
@@ -124,8 +130,20 @@ func (c *Cleanup) Run() {
 
 	for i := len(steps) - 1; i >= 0; i-- {
 		step := steps[i]
-		if err := step.fn(); err != nil {
-			log.Printf("Warning: cleanup %q failed: %v", step.name, err)
+		runCleanupStep(step)
+	}
+}
+
+// runCleanupStep wraps a single cleanup invocation in `defer recover`
+// so a panicking closure does not abort the LIFO unwind. Reported
+// errors and recovered panics share the same log shape.
+func runCleanupStep(step cleanupStep) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("Warning: cleanup %q panicked: %v", step.name, r)
 		}
+	}()
+	if err := step.fn(); err != nil {
+		log.Printf("Warning: cleanup %q failed: %v", step.name, err)
 	}
 }

--- a/internal/backend/cleanup.go
+++ b/internal/backend/cleanup.go
@@ -1,0 +1,131 @@
+// Package backend's cleanup.go provides Cleanup — a LIFO rollback stack
+// for the per-shed multi-step `CreateShed` (and `StartShed`, snapshot
+// spawn, ...) lifecycle.
+//
+// The problem it replaces: today both backends' `CreateShed`
+// implementations have ~10 inline rollback blocks per file that look
+// like:
+//
+//	if err := step3(); err != nil {
+//	    if stopErr := vm.Stop(...); stopErr != nil { log.Printf(...) }
+//	    c.preserveConsoleLog(meta)
+//	    if rmErr := meta.Delete(...); rmErr != nil { log.Printf(...) }
+//	    if rmErr := DeleteUpper(...); rmErr != nil { log.Printf(...) }
+//	    return nil, fmt.Errorf("step3: %w", err)
+//	}
+//
+// VZ has ~19 such lines today, Firecracker has ~47 (more cleanups
+// because of CID + IP + TAP device + 9P servers). Easy to forget one;
+// easy to put two in the wrong order; harder still to keep the two
+// backends in sync as new steps are added.
+//
+// The Cleanup pattern flips that around: each successful step
+// `Register`s its own teardown closure at acquisition time, with a
+// short name for the log. On any error the caller invokes
+// `RunReverse(err)`, which runs every registered cleanup in
+// last-in-first-out order, logs individual failures, and returns the
+// original error unchanged so the call site reads:
+//
+//	cleanup := backend.NewCleanup()
+//	defer cleanup.Run() // no-op after Commit
+//
+//	if err := allocateUpper(); err != nil {
+//	    return nil, fmt.Errorf("allocate upper: %w", err)
+//	}
+//	cleanup.Register("delete upper", func() error {
+//	    return DeleteUpper(c.cfg.UppersDir, req.Name)
+//	})
+//
+//	if err := saveMeta(); err != nil {
+//	    return nil, fmt.Errorf("save metadata: %w", err)
+//	}
+//	cleanup.Register("preserve console log + delete instance dir", func() error {
+//	    c.preserveConsoleLog(meta)
+//	    return meta.Delete(c.cfg.InstanceDir)
+//	})
+//
+//	// ... etc ...
+//	cleanup.Commit()
+//	return shed, nil
+//
+// The defer guarantees cleanup runs on *any* return path, including
+// panic recovery in callers (the rollback runs before the panic
+// propagates). The `Commit` call on the happy path zeros the stack so
+// the defer becomes a no-op.
+
+package backend
+
+import (
+	"log"
+	"sync"
+)
+
+// Cleanup is a LIFO rollback stack for multi-step lifecycle methods
+// (e.g. CreateShed). Safe for concurrent use; the lifecycle methods
+// don't share Cleanup instances across goroutines, but Register from
+// inside an in-flight goroutine is legal.
+type Cleanup struct {
+	mu        sync.Mutex
+	steps     []cleanupStep
+	committed bool
+}
+
+type cleanupStep struct {
+	name string
+	fn   func() error
+}
+
+// NewCleanup returns an empty Cleanup stack.
+func NewCleanup() *Cleanup {
+	return &Cleanup{}
+}
+
+// Register pushes a cleanup onto the stack. `name` appears in the
+// warning log emitted by Run when the cleanup fails — keep it short
+// and operator-friendly (e.g. "stop VM", "delete upper layer").
+//
+// Cleanups registered after Commit are silently ignored, so a caller
+// can defensively Register a cleanup for a step whose success-path
+// teardown is the operation's job (e.g. cluster the cleanup with the
+// step that needs it without worrying about the success-path).
+func (c *Cleanup) Register(name string, fn func() error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.committed {
+		return
+	}
+	c.steps = append(c.steps, cleanupStep{name: name, fn: fn})
+}
+
+// Commit declares the operation successful — Run becomes a no-op.
+// Idempotent. Call from the happy path right before returning the
+// successful result.
+func (c *Cleanup) Commit() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.committed = true
+	c.steps = nil
+}
+
+// Run invokes every registered cleanup in LIFO order. Individual
+// cleanup errors are logged at warning level; cleanups after a failure
+// still run, so a slow `vm.Stop` doesn't leak an upper-layer file.
+// Idempotent: subsequent calls are no-ops.
+//
+// Designed to be called from `defer cleanup.Run()` at the top of a
+// lifecycle method. The defer guarantees rollback on panic-mid-create
+// too (the rollback runs before the panic propagates out).
+func (c *Cleanup) Run() {
+	c.mu.Lock()
+	steps := c.steps
+	c.steps = nil
+	c.committed = true
+	c.mu.Unlock()
+
+	for i := len(steps) - 1; i >= 0; i-- {
+		step := steps[i]
+		if err := step.fn(); err != nil {
+			log.Printf("Warning: cleanup %q failed: %v", step.name, err)
+		}
+	}
+}

--- a/internal/backend/cleanup_test.go
+++ b/internal/backend/cleanup_test.go
@@ -1,0 +1,102 @@
+package backend
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestCleanup_RunsInLIFO(t *testing.T) {
+	var order []string
+	c := NewCleanup()
+	c.Register("first", func() error { order = append(order, "first"); return nil })
+	c.Register("second", func() error { order = append(order, "second"); return nil })
+	c.Register("third", func() error { order = append(order, "third"); return nil })
+	c.Run()
+
+	want := []string{"third", "second", "first"}
+	if !equal(order, want) {
+		t.Errorf("LIFO order = %v, want %v", order, want)
+	}
+}
+
+func TestCleanup_CommitMakesRunNoOp(t *testing.T) {
+	called := false
+	c := NewCleanup()
+	c.Register("must-not-run", func() error { called = true; return nil })
+	c.Commit()
+	c.Run()
+
+	if called {
+		t.Error("cleanup ran after Commit; should have been a no-op")
+	}
+}
+
+func TestCleanup_RegisterAfterCommitIgnored(t *testing.T) {
+	called := false
+	c := NewCleanup()
+	c.Commit()
+	c.Register("late", func() error { called = true; return nil })
+	c.Run()
+
+	if called {
+		t.Error("cleanup registered after Commit ran; should have been ignored")
+	}
+}
+
+func TestCleanup_ContinuesPastFailure(t *testing.T) {
+	var order []string
+	c := NewCleanup()
+	c.Register("first", func() error { order = append(order, "first"); return nil })
+	c.Register("failing", func() error { order = append(order, "failing"); return errors.New("boom") })
+	c.Register("third", func() error { order = append(order, "third"); return nil })
+	c.Run()
+
+	want := []string{"third", "failing", "first"}
+	if !equal(order, want) {
+		t.Errorf("expected to continue past a failure; order = %v, want %v", order, want)
+	}
+}
+
+func TestCleanup_RunIdempotent(t *testing.T) {
+	calls := 0
+	c := NewCleanup()
+	c.Register("once", func() error { calls++; return nil })
+	c.Run()
+	c.Run()
+	c.Run()
+
+	if calls != 1 {
+		t.Errorf("cleanup ran %d times, want 1 (Run must be idempotent)", calls)
+	}
+}
+
+func TestCleanup_ConcurrentRegisters(t *testing.T) {
+	c := NewCleanup()
+	var wg sync.WaitGroup
+	const n = 50
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.Register("concurrent", func() error { return nil })
+		}()
+	}
+	wg.Wait()
+	c.Run()
+	// If the test reaches here without a race-detector trip or a
+	// deadlock, Register is safely concurrent.
+}
+
+// equal compares two string slices.
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/backend/cleanup_test.go
+++ b/internal/backend/cleanup_test.go
@@ -71,6 +71,23 @@ func TestCleanup_RunIdempotent(t *testing.T) {
 	}
 }
 
+func TestCleanup_PanickingStepDoesNotAbortChain(t *testing.T) {
+	var order []string
+	c := NewCleanup()
+	c.Register("first", func() error { order = append(order, "first"); return nil })
+	c.Register("panicking", func() error {
+		order = append(order, "panicking")
+		panic("synthetic panic from test")
+	})
+	c.Register("third", func() error { order = append(order, "third"); return nil })
+	c.Run()
+
+	want := []string{"third", "panicking", "first"}
+	if !equal(order, want) {
+		t.Errorf("panic recovery broke the LIFO chain; order = %v, want %v", order, want)
+	}
+}
+
 func TestCleanup_ConcurrentRegisters(t *testing.T) {
 	c := NewCleanup()
 	var wg sync.WaitGroup

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -395,6 +395,14 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 	// creates into corrupting the first caller's rootfs.
 	defer c.acquireCreateLock(req.Name)()
 
+	// LIFO rollback stack. Each successful resource-acquiring step
+	// Registers its teardown; on any error-return the deferred
+	// `cleanup.Run` invokes them in reverse. The success path calls
+	// `cleanup.Commit()` just before `return`, which zeroes the stack
+	// so the defer becomes a no-op. See `internal/backend/cleanup.go`.
+	cleanup := backend.NewCleanup()
+	defer cleanup.Run()
+
 	if _, err := LoadMetadata(c.cfg.InstanceDir, req.Name); err == nil {
 		return nil, fmt.Errorf("%w: %s", config.ErrShedAlreadyExistsSentinel, req.Name)
 	}
@@ -522,58 +530,48 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to allocate CID: %w", err)
 	}
+	cleanup.Register("release CID", func() error {
+		c.ReleaseCID(cid)
+		return nil
+	})
+
 	tapDevice, ipAddress, err := c.AllocateNetwork(req.Name)
 	if err != nil {
-		c.ReleaseCID(cid)
 		return nil, fmt.Errorf("failed to allocate network: %w", err)
 	}
+	cleanup.Register("release IP", func() error {
+		c.ReleaseIP(ipAddress)
+		return nil
+	})
 
 	if err := c.netMgr.CreateTAPDevice(tapDevice); err != nil {
-		c.ReleaseIP(ipAddress)
-		c.ReleaseCID(cid)
 		return nil, fmt.Errorf("failed to create TAP device: %w", err)
 	}
+	cleanup.Register("delete TAP device", func() error {
+		return c.netMgr.DeleteTAPDevice(tapDevice)
+	})
 
 	backend.Phase(ctx, "rootfs")
 	backend.Status(ctx, "Allocating writable upper layer...")
 	upperPath, err := EnsureUpper(c.cfg.UppersDir, req.Name, upperSizeBytes)
 	if err != nil {
-		if delErr := c.netMgr.DeleteTAPDevice(tapDevice); delErr != nil {
-			log.Printf("Warning: failed to delete TAP device %s: %v", tapDevice, delErr)
-		}
-		c.ReleaseIP(ipAddress)
-		c.ReleaseCID(cid)
 		return nil, fmt.Errorf("failed to create upper: %w", err)
 	}
+	cleanup.Register("delete upper layer", func() error {
+		return DeleteUpper(c.cfg.UppersDir, req.Name)
+	})
+
 	// from-snapshot: replace the freshly allocated empty upper with a
 	// reflink clone of the snapshot's stored upper so the new shed
 	// inherits its parent's writable contents.
 	if snapshotUpperSource != "" {
 		if err := os.Remove(upperPath); err != nil && !os.IsNotExist(err) {
-			_ = DeleteUpper(c.cfg.UppersDir, req.Name)
-			if delErr := c.netMgr.DeleteTAPDevice(tapDevice); delErr != nil {
-				log.Printf("Warning: failed to delete TAP device %s: %v", tapDevice, delErr)
-			}
-			c.ReleaseIP(ipAddress)
-			c.ReleaseCID(cid)
 			return nil, fmt.Errorf("failed to clear upper for snapshot clone: %w", err)
 		}
 		if _, err := clone.CloneFile(snapshotUpperSource, upperPath); err != nil {
-			_ = DeleteUpper(c.cfg.UppersDir, req.Name)
-			if delErr := c.netMgr.DeleteTAPDevice(tapDevice); delErr != nil {
-				log.Printf("Warning: failed to delete TAP device %s: %v", tapDevice, delErr)
-			}
-			c.ReleaseIP(ipAddress)
-			c.ReleaseCID(cid)
 			return nil, fmt.Errorf("failed to clone snapshot upper: %w", err)
 		}
 		if err := os.Chmod(upperPath, 0o644); err != nil {
-			_ = DeleteUpper(c.cfg.UppersDir, req.Name)
-			if delErr := c.netMgr.DeleteTAPDevice(tapDevice); delErr != nil {
-				log.Printf("Warning: failed to delete TAP device %s: %v", tapDevice, delErr)
-			}
-			c.ReleaseIP(ipAddress)
-			c.ReleaseCID(cid)
 			return nil, fmt.Errorf("failed to chmod cloned upper: %w", err)
 		}
 		// The metadata's UpperSizeBytes must reflect the *cloned* file's
@@ -617,74 +615,42 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 	}
 
 	if err := meta.Save(c.cfg.InstanceDir); err != nil {
-		if delErr := c.netMgr.DeleteTAPDevice(tapDevice); delErr != nil {
-			log.Printf("Warning: failed to delete TAP device %s: %v", tapDevice, delErr)
-		}
-		if rmErr := meta.Delete(c.cfg.InstanceDir); rmErr != nil {
-			log.Printf("Warning: failed to delete instance dir for %s: %v", req.Name, rmErr)
-		}
-		if rmErr := DeleteUpper(c.cfg.UppersDir, req.Name); rmErr != nil {
-			log.Printf("Warning: failed to delete upper for %s: %v", req.Name, rmErr)
-		}
-		c.ReleaseIP(ipAddress)
-		c.ReleaseCID(cid)
 		return nil, fmt.Errorf("failed to save metadata: %w", err)
 	}
+	cleanup.Register("delete instance dir", func() error {
+		return meta.Delete(c.cfg.InstanceDir)
+	})
 
 	c.RegisterInstance(req.Name, cid, ipAddress)
 
 	vm, err := CreateVM(ctx, meta, c.cfg, c.netMgr)
 	if err != nil {
-		if delErr := c.netMgr.DeleteTAPDevice(tapDevice); delErr != nil {
-			log.Printf("Warning: failed to delete TAP device %s: %v", tapDevice, delErr)
-		}
-		if rmErr := meta.Delete(c.cfg.InstanceDir); rmErr != nil {
-			log.Printf("Warning: failed to delete instance dir for %s: %v", req.Name, rmErr)
-		}
-		if rmErr := DeleteUpper(c.cfg.UppersDir, req.Name); rmErr != nil {
-			log.Printf("Warning: failed to delete upper for %s: %v", req.Name, rmErr)
-		}
-		c.UnregisterInstance(req.Name, cid, ipAddress)
 		return nil, fmt.Errorf("failed to create VM: %w", err)
 	}
 
 	backend.Phase(ctx, "vm")
 	backend.Status(ctx, "Starting virtual machine...")
 	if err := vm.Start(ctx); err != nil {
-		if delErr := c.netMgr.DeleteTAPDevice(tapDevice); delErr != nil {
-			log.Printf("Warning: failed to delete TAP device %s: %v", tapDevice, delErr)
-		}
-		if rmErr := meta.Delete(c.cfg.InstanceDir); rmErr != nil {
-			log.Printf("Warning: failed to delete instance dir for %s: %v", req.Name, rmErr)
-		}
-		if rmErr := DeleteUpper(c.cfg.UppersDir, req.Name); rmErr != nil {
-			log.Printf("Warning: failed to delete upper for %s: %v", req.Name, rmErr)
-		}
-		c.UnregisterInstance(req.Name, cid, ipAddress)
 		return nil, fmt.Errorf("failed to start VM: %w", err)
 	}
+	cleanup.Register("stop VM", func() error {
+		return vm.Stop(context.Background())
+	})
 
 	meta.Status = config.StatusRunning
 	if err := meta.Save(c.cfg.InstanceDir); err != nil {
-		if stopErr := vm.Stop(context.Background()); stopErr != nil {
-			log.Printf("Warning: failed to stop VM: %v", stopErr)
-		}
-		if delErr := c.netMgr.DeleteTAPDevice(tapDevice); delErr != nil {
-			log.Printf("Warning: failed to delete TAP device %s: %v", tapDevice, delErr)
-		}
-		if rmErr := meta.Delete(c.cfg.InstanceDir); rmErr != nil {
-			log.Printf("Warning: failed to delete instance dir for %s: %v", req.Name, rmErr)
-		}
-		if rmErr := DeleteUpper(c.cfg.UppersDir, req.Name); rmErr != nil {
-			log.Printf("Warning: failed to delete upper for %s: %v", req.Name, rmErr)
-		}
-		c.UnregisterInstance(req.Name, cid, ipAddress)
 		return nil, fmt.Errorf("failed to save metadata: %w", err)
 	}
 
 	c.mu.Lock()
 	c.vms[req.Name] = vm
 	c.mu.Unlock()
+	cleanup.Register("remove from vms map", func() error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		delete(c.vms, req.Name)
+		return nil
+	})
 
 	agent := c.newAgentClient(meta.Name)
 
@@ -695,37 +661,15 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		bridgeIP := c.netMgr.Gateway()
 		srv, err := c.startP9Server(req.Name, bridgeIP, req.LocalDir, config.WorkspacePath, false)
 		if err != nil {
-			c.stopP9Servers(req.Name)
-			if stopErr := vm.Stop(context.Background()); stopErr != nil {
-				log.Printf("Warning: failed to stop VM: %v", stopErr)
-			}
-			if delErr := c.netMgr.DeleteTAPDevice(tapDevice); delErr != nil {
-				log.Printf("Warning: failed to delete TAP device %s: %v", tapDevice, delErr)
-			}
-			if rmErr := meta.Delete(c.cfg.InstanceDir); rmErr != nil {
-				log.Printf("Warning: failed to delete instance dir for %s: %v", req.Name, rmErr)
-			}
-			if rmErr := DeleteUpper(c.cfg.UppersDir, req.Name); rmErr != nil {
-				log.Printf("Warning: failed to delete upper for %s: %v", req.Name, rmErr)
-			}
-			c.UnregisterInstance(req.Name, cid, ipAddress)
 			return nil, fmt.Errorf("failed to start 9P server for local dir: %w", err)
 		}
-		if err := c.mount9PInGuest(ctx, agent, srv.Addr(), config.WorkspacePath, false, "workspace"); err != nil {
+		// Register the 9P teardown after the server starts so a guest-
+		// mount failure below cleans up the server too.
+		cleanup.Register("stop 9P servers", func() error {
 			c.stopP9Servers(req.Name)
-			if stopErr := vm.Stop(context.Background()); stopErr != nil {
-				log.Printf("Warning: failed to stop VM: %v", stopErr)
-			}
-			if delErr := c.netMgr.DeleteTAPDevice(tapDevice); delErr != nil {
-				log.Printf("Warning: failed to delete TAP device %s: %v", tapDevice, delErr)
-			}
-			if rmErr := meta.Delete(c.cfg.InstanceDir); rmErr != nil {
-				log.Printf("Warning: failed to delete instance dir for %s: %v", req.Name, rmErr)
-			}
-			if rmErr := DeleteUpper(c.cfg.UppersDir, req.Name); rmErr != nil {
-				log.Printf("Warning: failed to delete upper for %s: %v", req.Name, rmErr)
-			}
-			c.UnregisterInstance(req.Name, cid, ipAddress)
+			return nil
+		})
+		if err := c.mount9PInGuest(ctx, agent, srv.Addr(), config.WorkspacePath, false, "workspace"); err != nil {
 			return nil, fmt.Errorf("failed to mount 9P in guest: %w", err)
 		}
 	}
@@ -779,6 +723,9 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		}
 	}
 
+	// Happy path: zero out the cleanup stack so the deferred Run is a
+	// no-op. From here on the shed is the caller's responsibility.
+	cleanup.Commit()
 	return metadataToShed(meta), nil
 }
 

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -614,12 +614,18 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		FromSnapshot:   req.FromSnapshot,
 	}
 
-	if err := meta.Save(c.cfg.InstanceDir); err != nil {
-		return nil, fmt.Errorf("failed to save metadata: %w", err)
-	}
+	// Register the instance-dir cleanup BEFORE calling Save. Save's
+	// `os.MkdirAll` runs first; if any subsequent write fails partway
+	// through, the directory it created is left behind. `meta.Delete`
+	// is `os.RemoveAll`, so it's safe to register against a not-yet-
+	// existent path (the cleanup is a no-op if the dir was never
+	// created).
 	cleanup.Register("delete instance dir", func() error {
 		return meta.Delete(c.cfg.InstanceDir)
 	})
+	if err := meta.Save(c.cfg.InstanceDir); err != nil {
+		return nil, fmt.Errorf("failed to save metadata: %w", err)
+	}
 
 	c.RegisterInstance(req.Name, cid, ipAddress)
 

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -328,17 +328,20 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		FromSnapshot:   req.FromSnapshot,
 	}
 
-	if err := meta.Save(c.cfg.InstanceDir); err != nil {
-		// Save can leave a partially-written instance dir even on error —
-		// preserve the console log (if any) and let the LIFO cleanup
-		// remove it on return.
-		c.preserveConsoleLog(meta)
-		return nil, fmt.Errorf("failed to save metadata: %w", err)
-	}
+	// Register the instance-dir cleanup BEFORE calling Save. Save's
+	// `os.MkdirAll` runs first; if any subsequent write fails partway
+	// through, the directory it created is left behind. `meta.Delete`
+	// is `os.RemoveAll`, so it's safe to register against a not-yet-
+	// existent path (the cleanup is a no-op if the dir was never
+	// created). `preserveConsoleLog` is also safe pre-Start (it skips
+	// when console.log is absent — see vz/metadata.go).
 	cleanup.Register("preserve console log + delete instance dir", func() error {
 		c.preserveConsoleLog(meta)
 		return meta.Delete(c.cfg.InstanceDir)
 	})
+	if err := meta.Save(c.cfg.InstanceDir); err != nil {
+		return nil, fmt.Errorf("failed to save metadata: %w", err)
+	}
 
 	// Filter credentials to those with existing source directories.
 	// Non-existent sources are skipped to avoid vfkit VirtioFS failures.

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -132,6 +132,14 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 	// creates into corrupting the first caller's rootfs.
 	defer c.acquireCreateLock(req.Name)()
 
+	// LIFO rollback stack. Each successful resource-acquiring step
+	// `Register`s its teardown; on any error-return the deferred
+	// `cleanup.Run` invokes them in reverse. The success path calls
+	// `cleanup.Commit()` just before `return`, which zeroes the stack so
+	// the defer becomes a no-op. See `internal/backend/cleanup.go`.
+	cleanup := backend.NewCleanup()
+	defer cleanup.Run()
+
 	if _, err := LoadMetadata(c.cfg.InstanceDir, req.Name); err == nil {
 		return nil, fmt.Errorf("%w: %s", config.ErrShedAlreadyExistsSentinel, req.Name)
 	}
@@ -253,20 +261,21 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to create upper: %w", err)
 	}
+	cleanup.Register("delete upper layer", func() error {
+		return DeleteUpper(c.cfg.UppersDir, req.Name)
+	})
+
 	if snapshotUpperSource != "" {
 		// Replace the freshly allocated empty upper with a clone of the
 		// snapshot's stored upper so the new shed inherits its parent's
 		// writable contents.
 		if err := os.Remove(upperPath); err != nil && !os.IsNotExist(err) {
-			_ = DeleteUpper(c.cfg.UppersDir, req.Name)
 			return nil, fmt.Errorf("failed to clear upper for snapshot clone: %w", err)
 		}
 		if _, err := clone.CloneFile(snapshotUpperSource, upperPath); err != nil {
-			_ = DeleteUpper(c.cfg.UppersDir, req.Name)
 			return nil, fmt.Errorf("failed to clone snapshot upper: %w", err)
 		}
 		if err := os.Chmod(upperPath, 0o644); err != nil {
-			_ = DeleteUpper(c.cfg.UppersDir, req.Name)
 			return nil, fmt.Errorf("failed to chmod cloned upper: %w", err)
 		}
 		// The metadata's UpperSizeBytes must reflect the *cloned* file's
@@ -286,13 +295,11 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 			// A canceled/timed-out request must abort, not silently fall
 			// back and keep mutating resources past the deadline.
 			if errors.Is(terr, context.Canceled) || errors.Is(terr, context.DeadlineExceeded) {
-				_ = DeleteUpper(c.cfg.UppersDir, req.Name)
 				return nil, fmt.Errorf("upper template provisioning canceled: %w", terr)
 			}
 			log.Printf("[%s] upper template unavailable (%v); formatting in guest", req.Name, terr)
 		} else if perr := provisionUpperFromTemplate(upperPath, tmpl); perr != nil {
 			if errors.Is(perr, context.Canceled) || errors.Is(perr, context.DeadlineExceeded) {
-				_ = DeleteUpper(c.cfg.UppersDir, req.Name)
 				return nil, fmt.Errorf("upper template provisioning canceled: %w", perr)
 			}
 			log.Printf("[%s] upper template clone failed (%v); formatting in guest", req.Name, perr)
@@ -322,15 +329,16 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 	}
 
 	if err := meta.Save(c.cfg.InstanceDir); err != nil {
+		// Save can leave a partially-written instance dir even on error —
+		// preserve the console log (if any) and let the LIFO cleanup
+		// remove it on return.
 		c.preserveConsoleLog(meta)
-		if rmErr := meta.Delete(c.cfg.InstanceDir); rmErr != nil {
-			log.Printf("Warning: failed to delete instance dir for %s: %v", req.Name, rmErr)
-		}
-		if rmErr := DeleteUpper(c.cfg.UppersDir, req.Name); rmErr != nil {
-			log.Printf("Warning: failed to delete upper for %s: %v", req.Name, rmErr)
-		}
 		return nil, fmt.Errorf("failed to save metadata: %w", err)
 	}
+	cleanup.Register("preserve console log + delete instance dir", func() error {
+		c.preserveConsoleLog(meta)
+		return meta.Delete(c.cfg.InstanceDir)
+	})
 
 	// Filter credentials to those with existing source directories.
 	// Non-existent sources are skipped to avoid vfkit VirtioFS failures.
@@ -342,35 +350,27 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 	backend.Phase(ctx, "vm")
 	backend.Status(ctx, "Starting virtual machine...")
 	if err := vm.Start(ctx); err != nil {
-		c.preserveConsoleLog(meta)
-		if rmErr := meta.Delete(c.cfg.InstanceDir); rmErr != nil {
-			log.Printf("Warning: failed to delete instance dir for %s: %v", req.Name, rmErr)
-		}
-		if rmErr := DeleteUpper(c.cfg.UppersDir, req.Name); rmErr != nil {
-			log.Printf("Warning: failed to delete upper for %s: %v", req.Name, rmErr)
-		}
 		return nil, fmt.Errorf("failed to start VM: %w", err)
 	}
+	cleanup.Register("stop VM", func() error {
+		return vm.Stop(context.Background())
+	})
 
 	meta.Status = config.StatusRunning
 	meta.PID = vm.meta.PID
 	if err := meta.Save(c.cfg.InstanceDir); err != nil {
-		if stopErr := vm.Stop(context.Background()); stopErr != nil {
-			log.Printf("Warning: failed to stop VM: %v", stopErr)
-		}
-		c.preserveConsoleLog(meta)
-		if rmErr := meta.Delete(c.cfg.InstanceDir); rmErr != nil {
-			log.Printf("Warning: failed to delete instance dir for %s: %v", req.Name, rmErr)
-		}
-		if rmErr := DeleteUpper(c.cfg.UppersDir, req.Name); rmErr != nil {
-			log.Printf("Warning: failed to delete upper for %s: %v", req.Name, rmErr)
-		}
 		return nil, fmt.Errorf("failed to save metadata: %w", err)
 	}
 
 	c.mu.Lock()
 	c.vms[req.Name] = vm
 	c.mu.Unlock()
+	cleanup.Register("remove from vms map", func() error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		delete(c.vms, req.Name)
+		return nil
+	})
 
 	agent := c.newAgentClient(meta.Name)
 
@@ -379,10 +379,10 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		backend.Phase(ctx, "mount")
 		backend.Status(ctx, "Mounting local directory via VirtioFS...")
 		if err := c.mountVirtioFSShare(ctx, agent, config.VirtioFSMountTag, config.WorkspacePath, false); err != nil {
-			// VirtioFS mount is essential for --local-dir; fail the create
-			if stopErr := vm.Stop(context.Background()); stopErr != nil {
-				log.Printf("Warning: failed to stop VM after mount failure: %v", stopErr)
-			}
+			// VirtioFS mount is essential for --local-dir; fail the
+			// create. The deferred cleanup now fully unwinds: vms
+			// map entry, VM, instance dir, upper — previously only
+			// `vm.Stop` ran here, leaking the rest.
 			return nil, fmt.Errorf("VirtioFS mount failed for local dir %s: %w", req.LocalDir, err)
 		}
 	}
@@ -435,6 +435,9 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		}
 	}
 
+	// Happy path: zero out the cleanup stack so the deferred `Run` is a
+	// no-op. From here on the shed is the caller's responsibility.
+	cleanup.Commit()
 	return metadataToShed(meta, "127.0.0.1"), nil
 }
 


### PR DESCRIPTION
§15 Phase 2 PR 2a. The foundation step of the orchestrator refactor — a LIFO rollback stack that absorbs the ~66 lines of cleanup boilerplate from VZ and FC CreateShed.

## The Cleanup type (\`internal/backend/cleanup.go\`)

| Method | Effect |
|---|---|
| \`Register(name, fn)\` | Push a teardown closure onto the stack. |
| \`Run()\` | Invoke registered cleanups in LIFO order. Failures logged at warning, do not abort the stack. Idempotent. |
| \`Commit()\` | Declare the operation successful; Run becomes a no-op. |

Call sites use \`defer cleanup.Run()\` at the top of CreateShed, \`Register\` after each successful resource acquisition, and \`Commit\` just before the happy-path return.

## Rollback-line reduction

Counts of \`rmErr\` / \`stopErr\` / \`preserveConsoleLog\` / \`UnregisterInstance\` / \`DeleteTAPDevice\` / \`stopP9Servers\` patterns inside each \`CreateShed\` body:

| | BEFORE | AFTER | Δ |
|---|---|---|---|
| VZ \`CreateShed\` | 19 | 2 | **−17** |
| FC \`CreateShed\` | 47 | 2 | **−45** |
| **Total** | 66 | 4 | **−62 lines of boilerplate** |

## Latent-bug fix (free)

VZ's mount-VirtioFS failure path previously called only \`vm.Stop\` and returned, leaving the instance dir + upper file + vms-map entry behind in a state where \`shed list\` showed the shed as \"running\" but the VM process was gone. After migration the same failure unwinds via the deferred \`Cleanup.Run\`, removing all four resources in the correct LIFO order.

FC's mount-9P failure paths were already complete cleanups; post-migration their behavior is unchanged but the boilerplate is gone.

## What's in this PR

| File | Δ | Role |
|---|---|---|
| \`internal/backend/cleanup.go\` | +new | The Cleanup type + Run/Commit/Register API |
| \`internal/backend/cleanup_test.go\` | +new | 6 tests: LIFO order, idempotent Run, post-Commit no-op, post-Commit Register ignored, continue-past-failure, concurrent Register safety |
| \`internal/vz/client.go\` | refactor | CreateShed: 4 registered cleanups (delete upper, preserve+delete instance, stop VM, remove from vms) |
| \`internal/firecracker/client.go\` | refactor | CreateShed: 7 registered cleanups (release CID, release IP, delete TAP, delete upper, delete instance, stop VM, remove from vms, stop P9 servers) |

## What's NOT in this PR (deliberate, comes later)

- The orchestrator scaffolding (\`internal/backend/orchestrator/create.go\` + \`BackendCreator\` interface) — that's **2b**. This PR keeps each backend's \`CreateShed\` in place; it only consolidates the rollback pattern.
- Migration of \`StartShed\` / from-snapshot to use the cleanup stack — natural follow-up but kept out of this PR for size.
- A deliberate-failure integration test. The closest mechanism (invalid \`--local-dir\`) is caught client-side before any server cleanup runs. The natural failure-injection seam will appear in **2c** when CreateShed runs through the orchestrator's interface; for now the unit-test coverage on Cleanup itself + the happy-path integration suite (which proves \`Commit\` correctly zeroes the stack) are the safety net.

## Validation chain

- \`make build\` clean (host + Linux cross-compile).
- \`make test\` clean (Go unit tests, including the new \`cleanup_test.go\`).
- \`make lint\` clean.
- \`make test-integration\` against dev v0.5.6 server with this change on this mac: **18 passed + 2 cleanly-skipped** (identical shape to PR #133's baseline; FC PhaseTimer-dependent skips because mini3 is still on v0.5.3).
- PR #127's locked ordering invariants remain green.
- PR #133's \`healthPollInterval\` cut preserved.
- Brew server restored at session end.

## Per the §15 mandatory process

**No release** from this PR. Foundation for 2b (orchestrator scaffolding) and 2c (migrate CreateShed through orchestrator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)