### PR TITLE
backend: orchestrator scaffolding + BackendCreator interface (§15 2b)

### DIFF
--- a/internal/backend/orchestrator/create.go
+++ b/internal/backend/orchestrator/create.go
@@ -29,6 +29,25 @@
 //     accepts the in-progress Cleanup and Registers its own teardown,
 //     so the orchestrator never needs to know what resources a
 //     backend acquires.
+//
+// Caller contract (what the per-backend CreateShed wrapper must do
+// BEFORE calling orchestrator.CreateShed):
+//
+//   - Acquire any cross-name locks. VZ + FC use snapshot-lock(source)
+//     then create-lock(new shed) — see the lock-order comments in
+//     each backend's CreateShed. The orchestrator does not own these.
+//   - Reject duplicate-name creates (LoadMetadata check). The
+//     orchestrator's hooks assume the shed is new.
+//   - Sweep any orphan upper from a previously-crashed create. Same
+//     reason — hooks assume a clean slate.
+//   - Validate request-only invariants the orchestrator cannot
+//     express (cpus/memory bounds, upper-size bounds, --image vs
+//     --from-snapshot exclusivity).
+//
+// These tasks intentionally stay in the per-backend wrapper because
+// they need backend-private state (lock maps, instance-dir layout)
+// the orchestrator does not own. PreFlight + the subsequent hooks
+// take it from there.
 package orchestrator
 
 import (
@@ -38,10 +57,11 @@ import (
 	"github.com/charliek/shed/internal/config"
 )
 
-// PreFlightResult is the orchestrator-opaque output of the
-// backend's PreFlight step. Carries early-resolved values
-// (image-source digest, snapshot-source path) so the rest of
-// the lifecycle does not re-resolve them.
+// PreFlightResult is the orchestrator-opaque output of the backend's
+// PreFlight step. Carries early-resolved values (image-source digest,
+// snapshot-source path) so the rest of the lifecycle does not
+// re-resolve them. Backends type-assert back to their concrete type
+// inside subsequent hooks.
 type PreFlightResult interface {
 	// IsFromSnapshot reports whether the create is sourced from a
 	// snapshot rather than a fresh image. The orchestrator uses
@@ -50,50 +70,36 @@ type PreFlightResult interface {
 	IsFromSnapshot() bool
 }
 
-// UpperInfo is the orchestrator-opaque handle to a backend's
-// just-allocated writable upper layer.
-type UpperInfo interface {
-	// Path returns the upper layer's filesystem path on the host
-	// (used for diagnostics; the backend internally tracks more).
-	Path() string
-
-	// SizeBytes returns the upper layer's logical size, which may
-	// differ from the freshly-allocated size when the upper was
-	// cloned from a snapshot.
-	SizeBytes() int64
-}
+// UpperInfo is the orchestrator-opaque handle to a just-allocated
+// writable upper layer. Backends type-assert back to their concrete
+// type when they need the host-side path or size.
+type UpperInfo interface{ isUpperInfo() }
 
 // NetworkResources is the orchestrator-opaque handle to the per-shed
-// network resources acquired by the backend. For backends without
-// per-shed network allocation (VZ uses Apple's vmnet shared NAT),
-// implementations return a zero-value NetworkResources that satisfies
-// the interface and registers no cleanups.
-type NetworkResources interface {
-	// Summary returns a short human-readable description of the
-	// allocated resources, used in diagnostic logs. Implementations
-	// may return "" if no per-shed network state was allocated.
-	Summary() string
-}
+// network resources acquired by the backend. Backends without
+// per-shed network allocation (VZ uses Apple's vmnet shared NAT)
+// return a zero-value NetworkResources that satisfies the interface
+// and registers no cleanups.
+type NetworkResources interface{ isNetworkResources() }
 
 // MetadataHandle is the orchestrator-opaque handle to the persisted
 // per-shed Metadata record. Each backend has its own Metadata type
 // today (`vz.Metadata`, `firecracker.Metadata`); the interface keeps
 // the orchestrator from depending on either struct's shape.
+//
+// Only `Name()` is exposed: it's used internally for diagnostic logs
+// and to derive the vms-map key. Backends type-assert to their
+// concrete type when they need other fields.
 type MetadataHandle interface {
-	// Name returns the shed name (used as a key in logs and in the
-	// vms map). Required to match the request's Name.
 	Name() string
 }
 
 // VMHandle is the orchestrator-opaque handle to a started VM. The
-// orchestrator doesn't operate on it directly (the backend's hooks
-// own VM-side work); it threads VMHandle from StartVM to FinalizeVM
-// and CommitVM so backends can pass their concrete VM type around.
-type VMHandle interface {
-	// Backend returns the backend identifier for the started VM
-	// (used for logging and to assert no cross-backend mix-ups).
-	Backend() string
-}
+// orchestrator threads it from StartVM through FinalizeStartedVM,
+// MountLocalDir, SetupCredentials, CloneRepo, and RunProvisioning
+// so backends can pass their concrete VM type around without the
+// orchestrator depending on it.
+type VMHandle interface{ isVMHandle() }
 
 // BackendCreator is the per-backend hook contract used by
 // orchestrator.CreateShed. Methods are listed in the order
@@ -105,27 +111,45 @@ type VMHandle interface {
 // invokes them in LIFO order on any error-return. Implementations
 // MUST NOT call `cleanup.Run()` or `cleanup.Commit()` themselves —
 // those are the orchestrator's responsibility.
+//
+// Hooks that emit user-visible status messages should use
+// `backend.Phase(ctx, name)` + `backend.Status(ctx, message)` from
+// `internal/backend` (split per PR #135). Hooks that DON'T have
+// status text should still emit their own Phase boundary if they
+// represent a distinct cost the operator should see in the
+// PhaseTimer log.
 type BackendCreator interface {
-	// Name returns the backend identifier (used as a PhaseTimer
-	// label and in diagnostic logs).
-	Name() string
-
 	// PreFlight runs early validation and resolves any
-	// image-source or snapshot-source references. Errors here cause
-	// an immediate return from the orchestrator — no cleanups have
-	// been registered yet.
-	PreFlight(ctx context.Context, req config.CreateShedRequest) (PreFlightResult, error)
-
-	// AllocateUpper provisions a writable upper layer for the new
-	// shed. Implementations MUST Register a "delete upper layer"
-	// cleanup on `cleanup` so a downstream failure unwinds it.
-	AllocateUpper(ctx context.Context, req config.CreateShedRequest, pre PreFlightResult, cleanup *backend.Cleanup) (UpperInfo, error)
+	// image-source or snapshot-source references, and registers any
+	// protective cleanups that must hold for the rest of the
+	// lifecycle (e.g., the `.creating` marker that protects the
+	// lower-digest blob from a concurrent `shed image prune`).
+	//
+	// Errors here cause an immediate return from the orchestrator.
+	// Any cleanups registered before the failure WILL still run via
+	// the deferred `cleanup.Run()`, so implementations must register
+	// each protective bit individually rather than as a single
+	// "undo PreFlight" block.
+	PreFlight(ctx context.Context, req config.CreateShedRequest, cleanup *backend.Cleanup) (PreFlightResult, error)
 
 	// AllocateNetwork performs backend-specific per-shed network
-	// resource allocation (FC: CID + IP + TAP; VZ: a no-op
-	// returning empty NetworkResources). Implementations MUST
-	// Register a cleanup for each acquired resource individually.
+	// resource allocation. FC: CID + IP + TAP. VZ: no-op returning
+	// an empty NetworkResources. Implementations MUST Register a
+	// cleanup for each acquired resource individually so a later
+	// failure unwinds them in registration-reverse order.
+	//
+	// Called BEFORE AllocateUpper because per-shed network state is
+	// cheap to fail (CID/IP exhaustion) and the upper layer is
+	// expensive to undo (large sparse file). Matches FC's existing
+	// CreateShed order; preserves measured timing during 2c.
 	AllocateNetwork(ctx context.Context, req config.CreateShedRequest, cleanup *backend.Cleanup) (NetworkResources, error)
+
+	// AllocateUpper provisions a writable upper layer for the new
+	// shed (including any snapshot-clone or template-mint
+	// substeps). Implementations MUST Register a "delete upper
+	// layer" cleanup on `cleanup` so a downstream failure unwinds
+	// it.
+	AllocateUpper(ctx context.Context, req config.CreateShedRequest, pre PreFlightResult, cleanup *backend.Cleanup) (UpperInfo, error)
 
 	// BuildAndPersistMetadata constructs the platform-specific
 	// metadata record and persists it to disk. Implementations MUST
@@ -141,34 +165,37 @@ type BackendCreator interface {
 	// boundary before calling.
 	StartVM(ctx context.Context, meta MetadataHandle, upper UpperInfo, net NetworkResources, cleanup *backend.Cleanup) (VMHandle, error)
 
-	// FinalizeVM updates the persisted metadata with post-Start
-	// state (Status=Running, PID, ...) and registers the
-	// "remove from vms map" cleanup. Splitting this from StartVM
-	// keeps the StartVM contract focused on actually booting the
-	// guest.
-	FinalizeVM(ctx context.Context, meta MetadataHandle, vm VMHandle, cleanup *backend.Cleanup) error
+	// FinalizeStartedVM updates the persisted metadata with
+	// post-Start state (Status=Running, PID, ...) and registers
+	// the "remove from vms map" cleanup. The name is honest about
+	// the two things it does — the second meta.Save plus the
+	// vms-map registration — both of which must commit-or-rollback
+	// as a unit.
+	FinalizeStartedVM(ctx context.Context, meta MetadataHandle, vm VMHandle, cleanup *backend.Cleanup) error
 
-	// MountWorkspace mounts the requested local directory (if any)
-	// into the guest via the backend's transport (VirtioFS on VZ,
-	// 9P on FC). A nil-error return is required when no local-dir
-	// is configured.
-	MountWorkspace(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) error
+	// MountLocalDir mounts the requested `--local-dir` into the
+	// guest's `/workspace` via the backend's transport (VirtioFS
+	// on VZ, 9P on FC). No-op return nil when `req.LocalDir` is
+	// empty.
+	MountLocalDir(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) error
 
 	// SetupCredentials mounts any configured credentials into the
-	// guest. Best-effort: failures are logged but do not return an
-	// error (matching today's behavior in
+	// guest. Best-effort: failures are logged inside the hook but
+	// do not return an error (matching today's behavior in
 	// `vmutil.CredentialManager.SetupCredentials`).
 	SetupCredentials(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle)
 
-	// CloneRepo clones the request's --repo into the guest's
-	// workspace if specified. Best-effort: failures emit a
-	// StatusWarning via the ctx-bound progress and return nil so
-	// the create completes (matching today's behavior).
-	CloneRepo(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) error
+	// CloneRepo clones `req.Repo` into the guest's workspace if
+	// specified. Best-effort: hook implementations log + emit
+	// `backend.StatusWarning` on failure and return nothing — the
+	// orchestrator continues to the next step regardless. Matches
+	// today's behavior in both backends.
+	CloneRepo(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle)
 
 	// RunProvisioning runs the shed's provisioning hooks (loaded
 	// from .shed/provision.yaml inside the guest workspace) unless
-	// the request opted out via NoProvision. Best-effort.
+	// the request opted out via NoProvision. Best-effort — same
+	// contract as SetupCredentials.
 	RunProvisioning(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle)
 
 	// ToShedResult returns the *config.Shed value to hand back to
@@ -187,14 +214,21 @@ type BackendCreator interface {
 // success, cleanup.Commit zeroes the stack so the defer is a no-op.
 //
 // CreateShed does not itself acquire per-shed locks or do request
-// validation beyond what a backend's PreFlight does — call sites
-// (the backend's existing CreateShed wrapper) keep that
-// responsibility.
+// validation beyond what a backend's PreFlight does — call sites (the
+// backend's existing CreateShed wrapper) keep that responsibility
+// per the package doc-comment contract.
 func CreateShed(ctx context.Context, b BackendCreator, req config.CreateShedRequest) (*config.Shed, error) {
 	cleanup := backend.NewCleanup()
 	defer cleanup.Run()
 
-	pre, err := b.PreFlight(ctx, req)
+	pre, err := b.PreFlight(ctx, req, cleanup)
+	if err != nil {
+		return nil, err
+	}
+
+	// Network allocation runs first (fail-cheap; matches FC's
+	// existing order). VZ's hook is a no-op and registers nothing.
+	net, err := b.AllocateNetwork(ctx, req, cleanup)
 	if err != nil {
 		return nil, err
 	}
@@ -202,15 +236,6 @@ func CreateShed(ctx context.Context, b BackendCreator, req config.CreateShedRequ
 	backend.Phase(ctx, "rootfs")
 	backend.Status(ctx, "Allocating writable upper layer...")
 	upper, err := b.AllocateUpper(ctx, req, pre, cleanup)
-	if err != nil {
-		return nil, err
-	}
-
-	// Phase boundary for "network" is emitted only by backends that
-	// actually allocate network resources; VZ's AllocateNetwork is a
-	// no-op so emitting "network" there would show a 0-ms entry. The
-	// hook is responsible for its own Phase/Status events.
-	net, err := b.AllocateNetwork(ctx, req, cleanup)
 	if err != nil {
 		return nil, err
 	}
@@ -227,20 +252,16 @@ func CreateShed(ctx context.Context, b BackendCreator, req config.CreateShedRequ
 		return nil, err
 	}
 
-	if err := b.FinalizeVM(ctx, meta, vm, cleanup); err != nil {
+	if err := b.FinalizeStartedVM(ctx, meta, vm, cleanup); err != nil {
 		return nil, err
 	}
 
-	if err := b.MountWorkspace(ctx, req, meta, vm); err != nil {
+	if err := b.MountLocalDir(ctx, req, meta, vm); err != nil {
 		return nil, err
 	}
 
 	b.SetupCredentials(ctx, req, meta, vm)
-
-	if err := b.CloneRepo(ctx, req, meta, vm); err != nil {
-		return nil, err
-	}
-
+	b.CloneRepo(ctx, req, meta, vm)
 	b.RunProvisioning(ctx, req, meta, vm)
 
 	cleanup.Commit()

--- a/internal/backend/orchestrator/create.go
+++ b/internal/backend/orchestrator/create.go
@@ -1,0 +1,248 @@
+// Package orchestrator hosts the backend-agnostic CreateShed lifecycle
+// that both VZ and Firecracker implement. Per §15 Phase 2 of the
+// runtime-opt doc, the goal is to express the create / start / spawn
+// lifecycle once, with each backend providing a small set of platform-
+// specific hooks via the BackendCreator interface.
+//
+// Today (PR 2b — scaffolding) this package is interface-only: VZ and
+// Firecracker continue to use their existing CreateShed
+// implementations in `internal/vz/client.go` and
+// `internal/firecracker/client.go`. PR 2c migrates VZ to call the
+// orchestrator; 2d migrates FC and removes the duplicated lifecycle
+// code from both backends.
+//
+// Why an interface (and not a base struct or shared closures)?
+//
+//   - VZ and FC have genuinely divergent platform code at each step
+//     (vfkit vs firecracker process management; VirtioFS vs 9P
+//     workspace transport; in-blob kernel vs separate kernel file;
+//     etc.). A shared CreateShed body that branches on backend at every
+//     decision is harder to read than two backends implementing a
+//     small contract.
+//   - The interface forces every cross-backend assumption to be
+//     spelled out as a method signature. When 2c migrates VZ, any
+//     leftover shape mismatch between "what the interface promises"
+//     and "what VZ actually does" surfaces as a compile error, not a
+//     runtime surprise.
+//   - The cleanup-stack from PR #137 (`internal/backend.Cleanup`) is
+//     the shared mechanism for rollback. Each BackendCreator method
+//     accepts the in-progress Cleanup and Registers its own teardown,
+//     so the orchestrator never needs to know what resources a
+//     backend acquires.
+package orchestrator
+
+import (
+	"context"
+
+	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/config"
+)
+
+// PreFlightResult is the orchestrator-opaque output of the
+// backend's PreFlight step. Carries early-resolved values
+// (image-source digest, snapshot-source path) so the rest of
+// the lifecycle does not re-resolve them.
+type PreFlightResult interface {
+	// IsFromSnapshot reports whether the create is sourced from a
+	// snapshot rather than a fresh image. The orchestrator uses
+	// this to skip steps that snapshot-spawned sheds don't need
+	// (e.g., re-running install hooks).
+	IsFromSnapshot() bool
+}
+
+// UpperInfo is the orchestrator-opaque handle to a backend's
+// just-allocated writable upper layer.
+type UpperInfo interface {
+	// Path returns the upper layer's filesystem path on the host
+	// (used for diagnostics; the backend internally tracks more).
+	Path() string
+
+	// SizeBytes returns the upper layer's logical size, which may
+	// differ from the freshly-allocated size when the upper was
+	// cloned from a snapshot.
+	SizeBytes() int64
+}
+
+// NetworkResources is the orchestrator-opaque handle to the per-shed
+// network resources acquired by the backend. For backends without
+// per-shed network allocation (VZ uses Apple's vmnet shared NAT),
+// implementations return a zero-value NetworkResources that satisfies
+// the interface and registers no cleanups.
+type NetworkResources interface {
+	// Summary returns a short human-readable description of the
+	// allocated resources, used in diagnostic logs. Implementations
+	// may return "" if no per-shed network state was allocated.
+	Summary() string
+}
+
+// MetadataHandle is the orchestrator-opaque handle to the persisted
+// per-shed Metadata record. Each backend has its own Metadata type
+// today (`vz.Metadata`, `firecracker.Metadata`); the interface keeps
+// the orchestrator from depending on either struct's shape.
+type MetadataHandle interface {
+	// Name returns the shed name (used as a key in logs and in the
+	// vms map). Required to match the request's Name.
+	Name() string
+}
+
+// VMHandle is the orchestrator-opaque handle to a started VM. The
+// orchestrator doesn't operate on it directly (the backend's hooks
+// own VM-side work); it threads VMHandle from StartVM to FinalizeVM
+// and CommitVM so backends can pass their concrete VM type around.
+type VMHandle interface {
+	// Backend returns the backend identifier for the started VM
+	// (used for logging and to assert no cross-backend mix-ups).
+	Backend() string
+}
+
+// BackendCreator is the per-backend hook contract used by
+// orchestrator.CreateShed. Methods are listed in the order
+// CreateShed calls them.
+//
+// Every method that may register a cleanup is passed the in-progress
+// `*backend.Cleanup`. Implementations Register their own teardown
+// closures on success; the orchestrator's deferred `cleanup.Run()`
+// invokes them in LIFO order on any error-return. Implementations
+// MUST NOT call `cleanup.Run()` or `cleanup.Commit()` themselves —
+// those are the orchestrator's responsibility.
+type BackendCreator interface {
+	// Name returns the backend identifier (used as a PhaseTimer
+	// label and in diagnostic logs).
+	Name() string
+
+	// PreFlight runs early validation and resolves any
+	// image-source or snapshot-source references. Errors here cause
+	// an immediate return from the orchestrator — no cleanups have
+	// been registered yet.
+	PreFlight(ctx context.Context, req config.CreateShedRequest) (PreFlightResult, error)
+
+	// AllocateUpper provisions a writable upper layer for the new
+	// shed. Implementations MUST Register a "delete upper layer"
+	// cleanup on `cleanup` so a downstream failure unwinds it.
+	AllocateUpper(ctx context.Context, req config.CreateShedRequest, pre PreFlightResult, cleanup *backend.Cleanup) (UpperInfo, error)
+
+	// AllocateNetwork performs backend-specific per-shed network
+	// resource allocation (FC: CID + IP + TAP; VZ: a no-op
+	// returning empty NetworkResources). Implementations MUST
+	// Register a cleanup for each acquired resource individually.
+	AllocateNetwork(ctx context.Context, req config.CreateShedRequest, cleanup *backend.Cleanup) (NetworkResources, error)
+
+	// BuildAndPersistMetadata constructs the platform-specific
+	// metadata record and persists it to disk. Implementations MUST
+	// Register the "delete instance dir" cleanup BEFORE writing —
+	// `meta.Save` typically creates the directory before writing,
+	// so a partial-write failure must still unwind. See PR #137
+	// for the regression-fix history on this point.
+	BuildAndPersistMetadata(ctx context.Context, req config.CreateShedRequest, pre PreFlightResult, upper UpperInfo, net NetworkResources, cleanup *backend.Cleanup) (MetadataHandle, error)
+
+	// StartVM constructs and starts the per-shed VM. Implementations
+	// MUST Register a "stop VM" cleanup on cleanup so a downstream
+	// failure unwinds it. The orchestrator emits the "vm" PhaseTimer
+	// boundary before calling.
+	StartVM(ctx context.Context, meta MetadataHandle, upper UpperInfo, net NetworkResources, cleanup *backend.Cleanup) (VMHandle, error)
+
+	// FinalizeVM updates the persisted metadata with post-Start
+	// state (Status=Running, PID, ...) and registers the
+	// "remove from vms map" cleanup. Splitting this from StartVM
+	// keeps the StartVM contract focused on actually booting the
+	// guest.
+	FinalizeVM(ctx context.Context, meta MetadataHandle, vm VMHandle, cleanup *backend.Cleanup) error
+
+	// MountWorkspace mounts the requested local directory (if any)
+	// into the guest via the backend's transport (VirtioFS on VZ,
+	// 9P on FC). A nil-error return is required when no local-dir
+	// is configured.
+	MountWorkspace(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) error
+
+	// SetupCredentials mounts any configured credentials into the
+	// guest. Best-effort: failures are logged but do not return an
+	// error (matching today's behavior in
+	// `vmutil.CredentialManager.SetupCredentials`).
+	SetupCredentials(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle)
+
+	// CloneRepo clones the request's --repo into the guest's
+	// workspace if specified. Best-effort: failures emit a
+	// StatusWarning via the ctx-bound progress and return nil so
+	// the create completes (matching today's behavior).
+	CloneRepo(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) error
+
+	// RunProvisioning runs the shed's provisioning hooks (loaded
+	// from .shed/provision.yaml inside the guest workspace) unless
+	// the request opted out via NoProvision. Best-effort.
+	RunProvisioning(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle)
+
+	// ToShedResult returns the *config.Shed value to hand back to
+	// the orchestrator's caller. Called once the create is fully
+	// committed.
+	ToShedResult(meta MetadataHandle) *config.Shed
+}
+
+// CreateShed runs the backend-agnostic shed-creation lifecycle. Each
+// backend supplies its platform-specific behavior via `b`; the
+// orchestrator owns the call ordering, the PhaseTimer boundaries, the
+// cleanup-stack scaffolding, and the success/failure return contract.
+//
+// On any error from a hook, the deferred cleanup.Run unwinds every
+// cleanup the hook chain has registered so far, in LIFO order. On
+// success, cleanup.Commit zeroes the stack so the defer is a no-op.
+//
+// CreateShed does not itself acquire per-shed locks or do request
+// validation beyond what a backend's PreFlight does — call sites
+// (the backend's existing CreateShed wrapper) keep that
+// responsibility.
+func CreateShed(ctx context.Context, b BackendCreator, req config.CreateShedRequest) (*config.Shed, error) {
+	cleanup := backend.NewCleanup()
+	defer cleanup.Run()
+
+	pre, err := b.PreFlight(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	backend.Phase(ctx, "rootfs")
+	backend.Status(ctx, "Allocating writable upper layer...")
+	upper, err := b.AllocateUpper(ctx, req, pre, cleanup)
+	if err != nil {
+		return nil, err
+	}
+
+	// Phase boundary for "network" is emitted only by backends that
+	// actually allocate network resources; VZ's AllocateNetwork is a
+	// no-op so emitting "network" there would show a 0-ms entry. The
+	// hook is responsible for its own Phase/Status events.
+	net, err := b.AllocateNetwork(ctx, req, cleanup)
+	if err != nil {
+		return nil, err
+	}
+
+	meta, err := b.BuildAndPersistMetadata(ctx, req, pre, upper, net, cleanup)
+	if err != nil {
+		return nil, err
+	}
+
+	backend.Phase(ctx, "vm")
+	backend.Status(ctx, "Starting virtual machine...")
+	vm, err := b.StartVM(ctx, meta, upper, net, cleanup)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := b.FinalizeVM(ctx, meta, vm, cleanup); err != nil {
+		return nil, err
+	}
+
+	if err := b.MountWorkspace(ctx, req, meta, vm); err != nil {
+		return nil, err
+	}
+
+	b.SetupCredentials(ctx, req, meta, vm)
+
+	if err := b.CloneRepo(ctx, req, meta, vm); err != nil {
+		return nil, err
+	}
+
+	b.RunProvisioning(ctx, req, meta, vm)
+
+	cleanup.Commit()
+	return b.ToShedResult(meta), nil
+}

--- a/internal/backend/orchestrator/create_test.go
+++ b/internal/backend/orchestrator/create_test.go
@@ -1,0 +1,290 @@
+// Mock-backed tests for orchestrator.CreateShed. These pin the
+// orchestrator's call ordering, error-propagation, and cleanup-LIFO
+// behavior without touching either real backend — a regression in
+// CreateShed's shape (a hook called in the wrong order, a failure
+// that doesn't unwind, a success that doesn't commit) shows up as a
+// test failure here.
+
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/config"
+)
+
+// ---------------------------------------------------------------------------
+// Mock fixtures
+// ---------------------------------------------------------------------------
+
+type mockPreFlight struct{ fromSnapshot bool }
+
+func (p mockPreFlight) IsFromSnapshot() bool { return p.fromSnapshot }
+
+type mockUpper struct {
+	path string
+	size int64
+}
+
+func (u mockUpper) Path() string     { return u.path }
+func (u mockUpper) SizeBytes() int64 { return u.size }
+
+type mockNet struct{ summary string }
+
+func (n mockNet) Summary() string { return n.summary }
+
+type mockMeta struct{ name string }
+
+func (m mockMeta) Name() string { return m.name }
+
+type mockVM struct{ backend string }
+
+func (v mockVM) Backend() string { return v.backend }
+
+// mockBackend records every hook invocation in order and exposes
+// failure-injection knobs so each error-propagation path is testable
+// independently. Default behavior is a clean happy path that registers
+// the cleanups a real backend would.
+type mockBackend struct {
+	// Recorded ordered list of hook names called (in call order).
+	calls []string
+
+	// Injected errors keyed by hook name.
+	failAt map[string]error
+
+	// What the mock's hooks Register on cleanup.
+	cleanupsRun []string
+}
+
+func newMockBackend() *mockBackend {
+	return &mockBackend{failAt: map[string]error{}}
+}
+
+func (b *mockBackend) record(name string) { b.calls = append(b.calls, name) }
+
+// makeCleanup returns a closure that, when invoked by Cleanup.Run,
+// appends a marker so the test can assert LIFO ordering.
+func (b *mockBackend) makeCleanup(name string) func() error {
+	return func() error {
+		b.cleanupsRun = append(b.cleanupsRun, name)
+		return nil
+	}
+}
+
+func (b *mockBackend) Name() string { return config.BackendVZ }
+
+func (b *mockBackend) PreFlight(ctx context.Context, req config.CreateShedRequest) (PreFlightResult, error) {
+	b.record("PreFlight")
+	if err := b.failAt["PreFlight"]; err != nil {
+		return nil, err
+	}
+	return mockPreFlight{}, nil
+}
+
+func (b *mockBackend) AllocateUpper(ctx context.Context, req config.CreateShedRequest, pre PreFlightResult, c *backend.Cleanup) (UpperInfo, error) {
+	b.record("AllocateUpper")
+	if err := b.failAt["AllocateUpper"]; err != nil {
+		return nil, err
+	}
+	c.Register("delete upper", b.makeCleanup("delete upper"))
+	return mockUpper{path: "/tmp/test-upper", size: 1 << 30}, nil
+}
+
+func (b *mockBackend) AllocateNetwork(ctx context.Context, req config.CreateShedRequest, c *backend.Cleanup) (NetworkResources, error) {
+	b.record("AllocateNetwork")
+	if err := b.failAt["AllocateNetwork"]; err != nil {
+		return nil, err
+	}
+	c.Register("release network", b.makeCleanup("release network"))
+	return mockNet{summary: "mock-net"}, nil
+}
+
+func (b *mockBackend) BuildAndPersistMetadata(ctx context.Context, req config.CreateShedRequest, pre PreFlightResult, upper UpperInfo, net NetworkResources, c *backend.Cleanup) (MetadataHandle, error) {
+	b.record("BuildAndPersistMetadata")
+	// Register BEFORE the "save would create a partial dir" — same
+	// invariant as the real backends (see PR #137 review).
+	c.Register("delete instance dir", b.makeCleanup("delete instance dir"))
+	if err := b.failAt["BuildAndPersistMetadata"]; err != nil {
+		return nil, err
+	}
+	return mockMeta{name: req.Name}, nil
+}
+
+func (b *mockBackend) StartVM(ctx context.Context, meta MetadataHandle, upper UpperInfo, net NetworkResources, c *backend.Cleanup) (VMHandle, error) {
+	b.record("StartVM")
+	if err := b.failAt["StartVM"]; err != nil {
+		return nil, err
+	}
+	c.Register("stop VM", b.makeCleanup("stop VM"))
+	return mockVM{backend: config.BackendVZ}, nil
+}
+
+func (b *mockBackend) FinalizeVM(ctx context.Context, meta MetadataHandle, vm VMHandle, c *backend.Cleanup) error {
+	b.record("FinalizeVM")
+	if err := b.failAt["FinalizeVM"]; err != nil {
+		return err
+	}
+	c.Register("remove from vms map", b.makeCleanup("remove from vms map"))
+	return nil
+}
+
+func (b *mockBackend) MountWorkspace(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) error {
+	b.record("MountWorkspace")
+	return b.failAt["MountWorkspace"]
+}
+
+func (b *mockBackend) SetupCredentials(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) {
+	b.record("SetupCredentials")
+}
+
+func (b *mockBackend) CloneRepo(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) error {
+	b.record("CloneRepo")
+	return b.failAt["CloneRepo"]
+}
+
+func (b *mockBackend) RunProvisioning(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) {
+	b.record("RunProvisioning")
+}
+
+func (b *mockBackend) ToShedResult(meta MetadataHandle) *config.Shed {
+	b.record("ToShedResult")
+	return &config.Shed{Name: meta.Name(), Backend: config.BackendVZ}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestCreateShed_HappyPathOrder pins the hook call sequence. A regression
+// that reorders a step or skips one shows up here.
+func TestCreateShed_HappyPathOrder(t *testing.T) {
+	b := newMockBackend()
+	got, err := CreateShed(context.Background(), b, config.CreateShedRequest{Name: "x"})
+	if err != nil {
+		t.Fatalf("happy-path CreateShed returned error: %v", err)
+	}
+	if got == nil || got.Name != "x" {
+		t.Fatalf("ToShedResult returned %v; want a Shed named x", got)
+	}
+
+	want := []string{
+		"PreFlight",
+		"AllocateUpper",
+		"AllocateNetwork",
+		"BuildAndPersistMetadata",
+		"StartVM",
+		"FinalizeVM",
+		"MountWorkspace",
+		"SetupCredentials",
+		"CloneRepo",
+		"RunProvisioning",
+		"ToShedResult",
+	}
+	if !sliceEqual(b.calls, want) {
+		t.Errorf("hook call order =\n  %v\nwant\n  %v", b.calls, want)
+	}
+
+	// Success path: cleanups NEVER ran (Commit zeroed the stack).
+	if len(b.cleanupsRun) != 0 {
+		t.Errorf("cleanups ran on success path: %v", b.cleanupsRun)
+	}
+}
+
+// TestCreateShed_FailureUnwindLIFO injects a failure at each hook that
+// returns an error and asserts the registered cleanups unwind in
+// reverse order. The test name in the table identifies the failure point.
+func TestCreateShed_FailureUnwindLIFO(t *testing.T) {
+	cases := []struct {
+		failAt       string
+		wantCalled   []string
+		wantCleanups []string
+	}{
+		{
+			failAt:       "PreFlight",
+			wantCalled:   []string{"PreFlight"},
+			wantCleanups: nil, // nothing registered yet
+		},
+		{
+			failAt:       "AllocateUpper",
+			wantCalled:   []string{"PreFlight", "AllocateUpper"},
+			wantCleanups: nil, // AllocateUpper failed before registering
+		},
+		{
+			failAt:       "AllocateNetwork",
+			wantCalled:   []string{"PreFlight", "AllocateUpper", "AllocateNetwork"},
+			wantCleanups: []string{"delete upper"},
+		},
+		{
+			failAt:     "BuildAndPersistMetadata",
+			wantCalled: []string{"PreFlight", "AllocateUpper", "AllocateNetwork", "BuildAndPersistMetadata"},
+			// Cleanup for delete-instance-dir IS registered before the
+			// fail-injection point (mock mirrors the real backend's
+			// "register before Save" invariant from PR #137).
+			wantCleanups: []string{"delete instance dir", "release network", "delete upper"},
+		},
+		{
+			failAt:       "StartVM",
+			wantCalled:   []string{"PreFlight", "AllocateUpper", "AllocateNetwork", "BuildAndPersistMetadata", "StartVM"},
+			wantCleanups: []string{"delete instance dir", "release network", "delete upper"},
+		},
+		{
+			failAt:       "FinalizeVM",
+			wantCalled:   []string{"PreFlight", "AllocateUpper", "AllocateNetwork", "BuildAndPersistMetadata", "StartVM", "FinalizeVM"},
+			wantCleanups: []string{"stop VM", "delete instance dir", "release network", "delete upper"},
+		},
+		{
+			failAt: "MountWorkspace",
+			wantCalled: []string{
+				"PreFlight", "AllocateUpper", "AllocateNetwork", "BuildAndPersistMetadata",
+				"StartVM", "FinalizeVM", "MountWorkspace",
+			},
+			wantCleanups: []string{"remove from vms map", "stop VM", "delete instance dir", "release network", "delete upper"},
+		},
+		{
+			failAt: "CloneRepo",
+			wantCalled: []string{
+				"PreFlight", "AllocateUpper", "AllocateNetwork", "BuildAndPersistMetadata",
+				"StartVM", "FinalizeVM", "MountWorkspace", "SetupCredentials", "CloneRepo",
+			},
+			wantCleanups: []string{"remove from vms map", "stop VM", "delete instance dir", "release network", "delete upper"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.failAt, func(t *testing.T) {
+			b := newMockBackend()
+			b.failAt[tc.failAt] = errors.New("injected failure")
+			_, err := CreateShed(context.Background(), b, config.CreateShedRequest{Name: "fail-" + tc.failAt})
+			if err == nil {
+				t.Fatal("expected error from injected failure")
+			}
+			if !strings.Contains(err.Error(), "injected failure") {
+				t.Errorf("error %q does not contain the injected message", err)
+			}
+			if !sliceEqual(b.calls, tc.wantCalled) {
+				t.Errorf("hook calls =\n  %v\nwant\n  %v", b.calls, tc.wantCalled)
+			}
+			if !sliceEqual(b.cleanupsRun, tc.wantCleanups) {
+				t.Errorf("cleanup unwind order =\n  %v\nwant (LIFO)\n  %v", b.cleanupsRun, tc.wantCleanups)
+			}
+		})
+	}
+}
+
+// sliceEqual compares two string slices for full equality (including
+// length 0 vs nil treated as equal).
+func sliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/backend/orchestrator/create_test.go
+++ b/internal/backend/orchestrator/create_test.go
@@ -25,25 +25,21 @@ type mockPreFlight struct{ fromSnapshot bool }
 
 func (p mockPreFlight) IsFromSnapshot() bool { return p.fromSnapshot }
 
-type mockUpper struct {
-	path string
-	size int64
-}
+type mockUpper struct{}
 
-func (u mockUpper) Path() string     { return u.path }
-func (u mockUpper) SizeBytes() int64 { return u.size }
+func (mockUpper) isUpperInfo() {}
 
-type mockNet struct{ summary string }
+type mockNet struct{}
 
-func (n mockNet) Summary() string { return n.summary }
+func (mockNet) isNetworkResources() {}
 
 type mockMeta struct{ name string }
 
 func (m mockMeta) Name() string { return m.name }
 
-type mockVM struct{ backend string }
+type mockVM struct{}
 
-func (v mockVM) Backend() string { return v.backend }
+func (mockVM) isVMHandle() {}
 
 // mockBackend records every hook invocation in order and exposes
 // failure-injection knobs so each error-propagation path is testable
@@ -75,23 +71,16 @@ func (b *mockBackend) makeCleanup(name string) func() error {
 	}
 }
 
-func (b *mockBackend) Name() string { return config.BackendVZ }
-
-func (b *mockBackend) PreFlight(ctx context.Context, req config.CreateShedRequest) (PreFlightResult, error) {
+func (b *mockBackend) PreFlight(ctx context.Context, req config.CreateShedRequest, c *backend.Cleanup) (PreFlightResult, error) {
 	b.record("PreFlight")
 	if err := b.failAt["PreFlight"]; err != nil {
 		return nil, err
 	}
+	// PreFlight may register protective cleanups (the .creating marker
+	// removal in real backends); the mock simulates one to exercise
+	// the early-stage unwind path.
+	c.Register("remove creating marker", b.makeCleanup("remove creating marker"))
 	return mockPreFlight{}, nil
-}
-
-func (b *mockBackend) AllocateUpper(ctx context.Context, req config.CreateShedRequest, pre PreFlightResult, c *backend.Cleanup) (UpperInfo, error) {
-	b.record("AllocateUpper")
-	if err := b.failAt["AllocateUpper"]; err != nil {
-		return nil, err
-	}
-	c.Register("delete upper", b.makeCleanup("delete upper"))
-	return mockUpper{path: "/tmp/test-upper", size: 1 << 30}, nil
 }
 
 func (b *mockBackend) AllocateNetwork(ctx context.Context, req config.CreateShedRequest, c *backend.Cleanup) (NetworkResources, error) {
@@ -100,13 +89,23 @@ func (b *mockBackend) AllocateNetwork(ctx context.Context, req config.CreateShed
 		return nil, err
 	}
 	c.Register("release network", b.makeCleanup("release network"))
-	return mockNet{summary: "mock-net"}, nil
+	return mockNet{}, nil
+}
+
+func (b *mockBackend) AllocateUpper(ctx context.Context, req config.CreateShedRequest, pre PreFlightResult, c *backend.Cleanup) (UpperInfo, error) {
+	b.record("AllocateUpper")
+	if err := b.failAt["AllocateUpper"]; err != nil {
+		return nil, err
+	}
+	c.Register("delete upper", b.makeCleanup("delete upper"))
+	return mockUpper{}, nil
 }
 
 func (b *mockBackend) BuildAndPersistMetadata(ctx context.Context, req config.CreateShedRequest, pre PreFlightResult, upper UpperInfo, net NetworkResources, c *backend.Cleanup) (MetadataHandle, error) {
 	b.record("BuildAndPersistMetadata")
-	// Register BEFORE the "save would create a partial dir" — same
-	// invariant as the real backends (see PR #137 review).
+	// Register BEFORE the simulated meta.Save — same invariant as the
+	// real backends (see PR #137 review): MkdirAll can leave a partial
+	// dir behind that LIFO must still unwind.
 	c.Register("delete instance dir", b.makeCleanup("delete instance dir"))
 	if err := b.failAt["BuildAndPersistMetadata"]; err != nil {
 		return nil, err
@@ -120,30 +119,29 @@ func (b *mockBackend) StartVM(ctx context.Context, meta MetadataHandle, upper Up
 		return nil, err
 	}
 	c.Register("stop VM", b.makeCleanup("stop VM"))
-	return mockVM{backend: config.BackendVZ}, nil
+	return mockVM{}, nil
 }
 
-func (b *mockBackend) FinalizeVM(ctx context.Context, meta MetadataHandle, vm VMHandle, c *backend.Cleanup) error {
-	b.record("FinalizeVM")
-	if err := b.failAt["FinalizeVM"]; err != nil {
+func (b *mockBackend) FinalizeStartedVM(ctx context.Context, meta MetadataHandle, vm VMHandle, c *backend.Cleanup) error {
+	b.record("FinalizeStartedVM")
+	if err := b.failAt["FinalizeStartedVM"]; err != nil {
 		return err
 	}
 	c.Register("remove from vms map", b.makeCleanup("remove from vms map"))
 	return nil
 }
 
-func (b *mockBackend) MountWorkspace(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) error {
-	b.record("MountWorkspace")
-	return b.failAt["MountWorkspace"]
+func (b *mockBackend) MountLocalDir(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) error {
+	b.record("MountLocalDir")
+	return b.failAt["MountLocalDir"]
 }
 
 func (b *mockBackend) SetupCredentials(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) {
 	b.record("SetupCredentials")
 }
 
-func (b *mockBackend) CloneRepo(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) error {
+func (b *mockBackend) CloneRepo(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) {
 	b.record("CloneRepo")
-	return b.failAt["CloneRepo"]
 }
 
 func (b *mockBackend) RunProvisioning(ctx context.Context, req config.CreateShedRequest, meta MetadataHandle, vm VMHandle) {
@@ -173,12 +171,12 @@ func TestCreateShed_HappyPathOrder(t *testing.T) {
 
 	want := []string{
 		"PreFlight",
-		"AllocateUpper",
 		"AllocateNetwork",
+		"AllocateUpper",
 		"BuildAndPersistMetadata",
 		"StartVM",
-		"FinalizeVM",
-		"MountWorkspace",
+		"FinalizeStartedVM",
+		"MountLocalDir",
 		"SetupCredentials",
 		"CloneRepo",
 		"RunProvisioning",
@@ -197,6 +195,9 @@ func TestCreateShed_HappyPathOrder(t *testing.T) {
 // TestCreateShed_FailureUnwindLIFO injects a failure at each hook that
 // returns an error and asserts the registered cleanups unwind in
 // reverse order. The test name in the table identifies the failure point.
+//
+// Hooks that DON'T return an error (SetupCredentials, CloneRepo,
+// RunProvisioning) are best-effort by design and not failable here.
 func TestCreateShed_FailureUnwindLIFO(t *testing.T) {
 	cases := []struct {
 		failAt       string
@@ -206,51 +207,43 @@ func TestCreateShed_FailureUnwindLIFO(t *testing.T) {
 		{
 			failAt:       "PreFlight",
 			wantCalled:   []string{"PreFlight"},
-			wantCleanups: nil, // nothing registered yet
-		},
-		{
-			failAt:       "AllocateUpper",
-			wantCalled:   []string{"PreFlight", "AllocateUpper"},
-			wantCleanups: nil, // AllocateUpper failed before registering
+			wantCleanups: nil, // PreFlight failed before registering anything (mock registers AFTER fail check)
 		},
 		{
 			failAt:       "AllocateNetwork",
-			wantCalled:   []string{"PreFlight", "AllocateUpper", "AllocateNetwork"},
-			wantCleanups: []string{"delete upper"},
+			wantCalled:   []string{"PreFlight", "AllocateNetwork"},
+			wantCleanups: []string{"remove creating marker"},
+		},
+		{
+			failAt:       "AllocateUpper",
+			wantCalled:   []string{"PreFlight", "AllocateNetwork", "AllocateUpper"},
+			wantCleanups: []string{"release network", "remove creating marker"},
 		},
 		{
 			failAt:     "BuildAndPersistMetadata",
-			wantCalled: []string{"PreFlight", "AllocateUpper", "AllocateNetwork", "BuildAndPersistMetadata"},
-			// Cleanup for delete-instance-dir IS registered before the
-			// fail-injection point (mock mirrors the real backend's
-			// "register before Save" invariant from PR #137).
-			wantCleanups: []string{"delete instance dir", "release network", "delete upper"},
+			wantCalled: []string{"PreFlight", "AllocateNetwork", "AllocateUpper", "BuildAndPersistMetadata"},
+			// "delete instance dir" IS registered before the simulated
+			// save (mock mirrors the real backend's "register before
+			// Save" invariant from PR #137).
+			wantCleanups: []string{"delete instance dir", "delete upper", "release network", "remove creating marker"},
 		},
 		{
 			failAt:       "StartVM",
-			wantCalled:   []string{"PreFlight", "AllocateUpper", "AllocateNetwork", "BuildAndPersistMetadata", "StartVM"},
-			wantCleanups: []string{"delete instance dir", "release network", "delete upper"},
+			wantCalled:   []string{"PreFlight", "AllocateNetwork", "AllocateUpper", "BuildAndPersistMetadata", "StartVM"},
+			wantCleanups: []string{"delete instance dir", "delete upper", "release network", "remove creating marker"},
 		},
 		{
-			failAt:       "FinalizeVM",
-			wantCalled:   []string{"PreFlight", "AllocateUpper", "AllocateNetwork", "BuildAndPersistMetadata", "StartVM", "FinalizeVM"},
-			wantCleanups: []string{"stop VM", "delete instance dir", "release network", "delete upper"},
+			failAt:       "FinalizeStartedVM",
+			wantCalled:   []string{"PreFlight", "AllocateNetwork", "AllocateUpper", "BuildAndPersistMetadata", "StartVM", "FinalizeStartedVM"},
+			wantCleanups: []string{"stop VM", "delete instance dir", "delete upper", "release network", "remove creating marker"},
 		},
 		{
-			failAt: "MountWorkspace",
+			failAt: "MountLocalDir",
 			wantCalled: []string{
-				"PreFlight", "AllocateUpper", "AllocateNetwork", "BuildAndPersistMetadata",
-				"StartVM", "FinalizeVM", "MountWorkspace",
+				"PreFlight", "AllocateNetwork", "AllocateUpper", "BuildAndPersistMetadata",
+				"StartVM", "FinalizeStartedVM", "MountLocalDir",
 			},
-			wantCleanups: []string{"remove from vms map", "stop VM", "delete instance dir", "release network", "delete upper"},
-		},
-		{
-			failAt: "CloneRepo",
-			wantCalled: []string{
-				"PreFlight", "AllocateUpper", "AllocateNetwork", "BuildAndPersistMetadata",
-				"StartVM", "FinalizeVM", "MountWorkspace", "SetupCredentials", "CloneRepo",
-			},
-			wantCleanups: []string{"remove from vms map", "stop VM", "delete instance dir", "release network", "delete upper"},
+			wantCleanups: []string{"remove from vms map", "stop VM", "delete instance dir", "delete upper", "release network", "remove creating marker"},
 		},
 	}
 
@@ -272,6 +265,28 @@ func TestCreateShed_FailureUnwindLIFO(t *testing.T) {
 				t.Errorf("cleanup unwind order =\n  %v\nwant (LIFO)\n  %v", b.cleanupsRun, tc.wantCleanups)
 			}
 		})
+	}
+}
+
+// TestCreateShed_BestEffortHooksDoNotAbort verifies that hooks marked
+// best-effort (SetupCredentials, CloneRepo, RunProvisioning) cannot
+// abort the create. The mock's best-effort hooks don't return errors
+// to inject — this test would catch a regression where someone made
+// them return error AND the orchestrator started propagating.
+func TestCreateShed_BestEffortHooksDoNotAbort(t *testing.T) {
+	b := newMockBackend()
+	got, err := CreateShed(context.Background(), b, config.CreateShedRequest{Name: "best-effort"})
+	if err != nil {
+		t.Fatalf("CreateShed returned error from best-effort path: %v", err)
+	}
+	if got == nil || got.Name != "best-effort" {
+		t.Fatalf("ToShedResult returned %v; want a Shed", got)
+	}
+	// All three best-effort hooks must have been called.
+	wantTail := []string{"SetupCredentials", "CloneRepo", "RunProvisioning", "ToShedResult"}
+	gotTail := b.calls[len(b.calls)-len(wantTail):]
+	if !sliceEqual(gotTail, wantTail) {
+		t.Errorf("best-effort tail = %v, want %v", gotTail, wantTail)
 	}
 }
 


### PR DESCRIPTION
§15 Phase 2 PR 2b — scaffolding only. New \`internal/backend/orchestrator/\` package with the \`BackendCreator\` interface + a CreateShed orchestrator + a mock-backed test suite. **VZ and FC continue using their existing CreateShed implementations**; 2c migrates VZ to the orchestrator, 2d migrates FC.

## The BackendCreator interface (11 methods)

| Method | Role |
|---|---|
| \`PreFlight\` | Early validation + image/snapshot resolution |
| \`AllocateUpper\` | Writable upper layer; Registers delete-upper |
| \`AllocateNetwork\` | FC: CID/IP/TAP; VZ: no-op; Registers per-resource cleanups |
| \`BuildAndPersistMetadata\` | meta struct + Save; Registers delete-instance |
| \`StartVM\` | Boot guest; Registers stop-VM |
| \`FinalizeVM\` | Status=Running, PID; Registers remove-from-vms |
| \`MountWorkspace\` | VirtioFS or 9P \`--local-dir\` mount |
| \`SetupCredentials\` | Best-effort credential mounts |
| \`CloneRepo\` | Best-effort \`--repo\` clone |
| \`RunProvisioning\` | Best-effort provisioning hooks |
| \`ToShedResult\` | Return-value materialization |

Plus four opaque handle types so the orchestrator never depends on either backend's concrete metadata / VM / upper shape: \`PreFlightResult\`, \`UpperInfo\`, \`NetworkResources\`, \`MetadataHandle\`, \`VMHandle\`.

## Orchestrator behavior

\`CreateShed\` sets up a \`*backend.Cleanup\` and \`defer cleanup.Run()\` (so any error-return unwinds in LIFO), calls each hook in the documented order, emits the \`rootfs\` and \`vm\` PhaseTimer boundaries at the same points the real backends do today, and calls \`cleanup.Commit()\` before returning on success.

## Test coverage (mock backend)

- **\`TestCreateShed_HappyPathOrder\`** pins the full 11-hook call sequence and asserts NO cleanups run on the success path (\`cleanup.Commit\` zeroes the stack).
- **\`TestCreateShed_FailureUnwindLIFO\`** injects an error at each failable hook (8 cases: PreFlight, AllocateUpper, AllocateNetwork, BuildAndPersistMetadata, StartVM, FinalizeVM, MountWorkspace, CloneRepo) and asserts the registered cleanups unwind in LIFO order matching what each real backend will do.

The mock mirrors the real backends' \`Cleanup.Register\` invariants from PR #137 — including registering \"delete instance dir\" BEFORE the simulated meta.Save, so the \"BuildAndPersistMetadata fails\" case correctly unwinds the dir a real backend's MkdirAll-then-Write would have left behind.

## Open design questions that 2c/2d will pressure-test

- VZ's \`preserveConsoleLog\` step is currently bundled INTO the delete-instance-dir cleanup closure. Whether that bundle survives the orchestrator migration cleanly (or whether \`preserveConsoleLog\` deserves its own interface hook) is a 2c discovery.
- FC's \`c.RegisterInstance\` call after meta.Save is currently redundant (\`AllocateCID\`/\`AllocateNetwork\` already populate the same maps). 2c can simplify or remove it.
- \`CloneRepo\` / \`RunProvisioning\` are interface hooks so each backend CAN supply its own implementation, but in practice they're shared via \`vmutil\`. The interface keeps the door open for backend-specific overrides without forcing them.

## Validation

- \`make build\` clean (host + Linux cross-compile).
- \`make test\` clean — orchestrator tests (1 happy-path + 8 LIFO-unwind subtests) pass; rest of the repo unaffected.
- \`make lint\` clean.

## Per the §15 mandatory process

- **No live integration test in this PR.** Neither backend has migrated to the orchestrator; the happy-path against a mock IS the contract test. 2c is where the orchestrator gets its first real shipping-path validation against VZ.
- **No release** from this PR. Foundation for 2c (migrate VZ to orchestrator) and 2d (migrate FC, kill duplicate lifecycle code in both backends).

## Files

\`internal/backend/orchestrator/create.go\` (+~200 lines: interface + CreateShed)
\`internal/backend/orchestrator/create_test.go\` (+~250 lines: mock + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized orchestration for Shed creation with ordered lifecycle phases, automatic rollback on failure, and best-effort post-start steps that do not abort a successful creation.

* **Tests**
  * Added tests verifying precise phase ordering, LIFO cleanup/unwind behavior on failures, and that non-failable post-start hooks run without aborting creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->