### PR TITLE
vz: migrate CreateShed to the orchestrator (§15 2c)

### DIFF
--- a/internal/backend/orchestrator/create.go
+++ b/internal/backend/orchestrator/create.go
@@ -71,16 +71,23 @@ type PreFlightResult interface {
 }
 
 // UpperInfo is the orchestrator-opaque handle to a just-allocated
-// writable upper layer. Backends type-assert back to their concrete
-// type when they need the host-side path or size.
-type UpperInfo interface{ isUpperInfo() }
+// writable upper layer. The orchestrator threads it from
+// AllocateUpper through BuildAndPersistMetadata and StartVM as an
+// `any`-shaped token; backends type-assert to their concrete value
+// when they need the host-side path or size.
+//
+// (Empty interface by design — see the package doc-comment. The
+// orchestrator does not introspect the value; the marker pattern was
+// rejected because Go requires unexported markers to be implemented
+// in the same package as the interface.)
+type UpperInfo any
 
 // NetworkResources is the orchestrator-opaque handle to the per-shed
 // network resources acquired by the backend. Backends without
 // per-shed network allocation (VZ uses Apple's vmnet shared NAT)
-// return a zero-value NetworkResources that satisfies the interface
-// and registers no cleanups.
-type NetworkResources interface{ isNetworkResources() }
+// return a zero-value value of any type that satisfies `any` and
+// registers no cleanups. Same opacity rationale as `UpperInfo`.
+type NetworkResources any
 
 // MetadataHandle is the orchestrator-opaque handle to the persisted
 // per-shed Metadata record. Each backend has its own Metadata type
@@ -98,8 +105,9 @@ type MetadataHandle interface {
 // orchestrator threads it from StartVM through FinalizeStartedVM,
 // MountLocalDir, SetupCredentials, CloneRepo, and RunProvisioning
 // so backends can pass their concrete VM type around without the
-// orchestrator depending on it.
-type VMHandle interface{ isVMHandle() }
+// orchestrator depending on it. Same opacity rationale as
+// `UpperInfo`.
+type VMHandle any
 
 // BackendCreator is the per-backend hook contract used by
 // orchestrator.CreateShed. Methods are listed in the order

--- a/internal/backend/orchestrator/create_test.go
+++ b/internal/backend/orchestrator/create_test.go
@@ -27,19 +27,13 @@ func (p mockPreFlight) IsFromSnapshot() bool { return p.fromSnapshot }
 
 type mockUpper struct{}
 
-func (mockUpper) isUpperInfo() {}
-
 type mockNet struct{}
-
-func (mockNet) isNetworkResources() {}
 
 type mockMeta struct{ name string }
 
 func (m mockMeta) Name() string { return m.name }
 
 type mockVM struct{}
-
-func (mockVM) isVMHandle() {}
 
 // mockBackend records every hook invocation in order and exposes
 // failure-injection knobs so each error-propagation path is testable

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -18,11 +18,11 @@ import (
 	"time"
 
 	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/backend/orchestrator"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/lockmap"
 	"github.com/charliek/shed/internal/plugin"
 	"github.com/charliek/shed/internal/vmimage"
-	"github.com/charliek/shed/internal/vmimage/clone"
 	"github.com/charliek/shed/internal/vmutil"
 )
 
@@ -109,6 +109,13 @@ func (c *Client) preserveConsoleLog(meta *Metadata) {
 }
 
 // CreateShed creates a new VZ-based shed.
+//
+// This wrapper handles the parts the orchestrator does NOT own
+// (per-shed-name locking, existence-check, orphan-upper sweep, the
+// --image vs --from-snapshot exclusivity check). Per-step lifecycle
+// logic lives in vzCreator (see orchestrator.go) and is invoked by
+// orchestrator.CreateShed. See `internal/backend/orchestrator/create.go`
+// for the BackendCreator contract.
 func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error) {
 	if err := config.ValidateShedName(req.Name); err != nil {
 		return nil, err
@@ -127,18 +134,10 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		defer c.acquireSnapshotLock(req.FromSnapshot)()
 	}
 
-	// Serialize CreateShed calls for the same name so the existence check
-	// below and CopyRootfs's os.Remove(dst) can't race two concurrent
-	// creates into corrupting the first caller's rootfs.
+	// Serialize CreateShed calls for the same name so the existence
+	// check below and CopyRootfs's os.Remove(dst) can't race two
+	// concurrent creates into corrupting the first caller's rootfs.
 	defer c.acquireCreateLock(req.Name)()
-
-	// LIFO rollback stack. Each successful resource-acquiring step
-	// `Register`s its teardown; on any error-return the deferred
-	// `cleanup.Run` invokes them in reverse. The success path calls
-	// `cleanup.Commit()` just before `return`, which zeroes the stack so
-	// the defer becomes a no-op. See `internal/backend/cleanup.go`.
-	cleanup := backend.NewCleanup()
-	defer cleanup.Run()
 
 	if _, err := LoadMetadata(c.cfg.InstanceDir, req.Name); err == nil {
 		return nil, fmt.Errorf("%w: %s", config.ErrShedAlreadyExistsSentinel, req.Name)
@@ -158,290 +157,7 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		}
 	}
 
-	cpus := req.CPUs
-	if cpus == 0 {
-		cpus = c.cfg.DefaultCPUs
-	}
-	if cpus < 1 || cpus > config.MaxVZCPUs {
-		return nil, fmt.Errorf("invalid cpus %d: must be between 1 and %d", cpus, config.MaxVZCPUs)
-	}
-	memoryMB := req.MemoryMB
-	if memoryMB == 0 {
-		memoryMB = c.cfg.DefaultMemoryMB
-	}
-	if memoryMB < 128 || memoryMB > config.MaxVZMemoryMB {
-		return nil, fmt.Errorf("invalid memory_mb %d: must be between 128 and %d", memoryMB, config.MaxVZMemoryMB)
-	}
-
-	upperSizeBytes := req.UpperSizeBytes
-	if upperSizeBytes == 0 {
-		sz := c.cfg.UpperSizeDefault
-		if sz == "" {
-			sz = config.DefaultUpperSize
-		}
-		parsed, perr := config.ParseUpperSize(sz)
-		if perr != nil {
-			return nil, fmt.Errorf("invalid upper_size_default: %w", perr)
-		}
-		upperSizeBytes = parsed
-	} else {
-		if upperSizeBytes < config.MinUpperSizeBytes || upperSizeBytes > config.MaxUpperSizeBytes {
-			return nil, fmt.Errorf("upper size out of range: must be between %dG and %dG",
-				config.MinUpperSizeBytes/(1024*1024*1024), config.MaxUpperSizeBytes/(1024*1024*1024))
-		}
-	}
-
-	var snapshotUpperSource, lowerDigest, lowerImageTag string
-	if req.FromSnapshot != "" {
-		snap, err := loadSnapshot(c.cfg.SnapshotsDir, req.FromSnapshot)
-		if err != nil {
-			return nil, err
-		}
-		if snap.Backend != config.BackendVZ {
-			return nil, fmt.Errorf("%w: snapshot %q is for backend %q, server is %q",
-				config.ErrSnapshotBackendMismatchSentinel, req.FromSnapshot, snap.Backend, config.BackendVZ)
-		}
-		if snap.LowerDigest == "" {
-			return nil, fmt.Errorf("snapshot %q is missing lower_digest; recreate the snapshot from a current shed", req.FromSnapshot)
-		}
-		if !vmimage.BlobExists(c.cfg.ImagesDir, snap.LowerDigest) {
-			ref := snap.SourceImage
-			if ref == "" {
-				ref = "(unknown)"
-			}
-			return nil, fmt.Errorf("snapshot %q references lower digest %s which is no longer cached; pull the original image (%s) first",
-				req.FromSnapshot, vmimage.ShortDigest(snap.LowerDigest), ref)
-		}
-		snapshotUpperSource = SnapshotRootfsPath(c.cfg.SnapshotsDir, req.FromSnapshot)
-		lowerDigest = snap.LowerDigest
-		lowerImageTag = snap.SourceImage
-	} else {
-		var resolved config.ResolvedImage
-		if req.Image != "" {
-			var err error
-			resolved, err = c.cfg.ResolveImage(req.Image)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			if c.cfg.BaseRootfs == "" {
-				return nil, fmt.Errorf("%w: no --image specified and no base_rootfs configured in vz.base_rootfs; pass --image <tag> or set base_rootfs in server.yaml", config.ErrInvalidShedRequestSentinel)
-			}
-			resolved = c.cfg.ResolveBaseRootfs()
-		}
-
-		// Ensure image is available locally (pulls + converts Docker refs if needed).
-		// We only need the digest — the rootfs path is rederived per-boot inside vm.go.
-		backend.Phase(ctx, "image")
-		backend.Status(ctx, "Resolving image...")
-		_, ldigest, err := c.EnsureImage(ctx, resolved)
-		if err != nil {
-			return nil, err
-		}
-		if ldigest == "" {
-			return nil, fmt.Errorf("image %q resolved to a path outside the blob store; the overlay model requires content-addressed images", resolved.Name)
-		}
-		lowerDigest = ldigest
-		lowerImageTag = resolved.Name
-	}
-
-	// Drop a `.creating` marker so a concurrent `shed image prune`
-	// can't sweep the blob between here and meta.Save. See the
-	// matching block in firecracker/client.go for rationale.
-	if lowerDigest != "" && req.FromSnapshot == "" {
-		if err := writeCreatingMarker(c.cfg.InstanceDir, req.Name, lowerDigest); err != nil {
-			return nil, fmt.Errorf("failed to write creating marker: %w", err)
-		}
-		defer removeCreatingMarker(c.cfg.InstanceDir, req.Name)
-	}
-
-	backend.Phase(ctx, "rootfs")
-	backend.Status(ctx, "Allocating writable upper layer...")
-	upperPath, err := EnsureUpper(c.cfg.UppersDir, req.Name, upperSizeBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create upper: %w", err)
-	}
-	cleanup.Register("delete upper layer", func() error {
-		return DeleteUpper(c.cfg.UppersDir, req.Name)
-	})
-
-	if snapshotUpperSource != "" {
-		// Replace the freshly allocated empty upper with a clone of the
-		// snapshot's stored upper so the new shed inherits its parent's
-		// writable contents.
-		if err := os.Remove(upperPath); err != nil && !os.IsNotExist(err) {
-			return nil, fmt.Errorf("failed to clear upper for snapshot clone: %w", err)
-		}
-		if _, err := clone.CloneFile(snapshotUpperSource, upperPath); err != nil {
-			return nil, fmt.Errorf("failed to clone snapshot upper: %w", err)
-		}
-		if err := os.Chmod(upperPath, 0o644); err != nil {
-			return nil, fmt.Errorf("failed to chmod cloned upper: %w", err)
-		}
-		// The metadata's UpperSizeBytes must reflect the *cloned* file's
-		// actual size, not the freshly-allocated sparse size — otherwise
-		// `shed system df` and reset/snapshot bookkeeping report the
-		// pre-snapshot size for what is now a different file.
-		if fi, statErr := os.Stat(upperPath); statErr == nil {
-			upperSizeBytes = fi.Size()
-		}
-	} else {
-		// Clone a pre-formatted ext4 template into the upper so the guest
-		// mounts it directly and skips the multi-second in-guest mkfs on
-		// first boot. Best-effort: any failure leaves the freshly-allocated
-		// signature upper in place (formatted in-guest), so create never
-		// regresses.
-		if tmpl, terr := EnsureUpperTemplate(ctx, c.templatesDir(), resolveBuildToolsRef(), upperSizeBytes, ""); terr != nil {
-			// A canceled/timed-out request must abort, not silently fall
-			// back and keep mutating resources past the deadline.
-			if errors.Is(terr, context.Canceled) || errors.Is(terr, context.DeadlineExceeded) {
-				return nil, fmt.Errorf("upper template provisioning canceled: %w", terr)
-			}
-			log.Printf("[%s] upper template unavailable (%v); formatting in guest", req.Name, terr)
-		} else if perr := provisionUpperFromTemplate(upperPath, tmpl); perr != nil {
-			if errors.Is(perr, context.Canceled) || errors.Is(perr, context.DeadlineExceeded) {
-				return nil, fmt.Errorf("upper template provisioning canceled: %w", perr)
-			}
-			log.Printf("[%s] upper template clone failed (%v); formatting in guest", req.Name, perr)
-		} else {
-			backend.Phase(ctx, "rootfs")
-			backend.Status(ctx, "Provisioned upper from template (skips in-guest mkfs)")
-		}
-	}
-	rootfsPath := upperPath
-
-	meta := &Metadata{
-		Name:           req.Name,
-		Status:         config.StatusStopped,
-		CreatedAt:      time.Now(),
-		Backend:        config.BackendVZ,
-		CPUs:           cpus,
-		MemoryMB:       memoryMB,
-		RootfsPath:     rootfsPath,
-		UpperPath:      upperPath,
-		UpperSizeBytes: upperSizeBytes,
-		Repo:           req.Repo,
-		LocalDir:       req.LocalDir,
-		Image:          req.Image,
-		LowerDigest:    lowerDigest,
-		LowerImageTag:  lowerImageTag,
-		FromSnapshot:   req.FromSnapshot,
-	}
-
-	// Register the instance-dir cleanup BEFORE calling Save. Save's
-	// `os.MkdirAll` runs first; if any subsequent write fails partway
-	// through, the directory it created is left behind. `meta.Delete`
-	// is `os.RemoveAll`, so it's safe to register against a not-yet-
-	// existent path (the cleanup is a no-op if the dir was never
-	// created). `preserveConsoleLog` is also safe pre-Start (it skips
-	// when console.log is absent — see vz/metadata.go).
-	cleanup.Register("preserve console log + delete instance dir", func() error {
-		c.preserveConsoleLog(meta)
-		return meta.Delete(c.cfg.InstanceDir)
-	})
-	if err := meta.Save(c.cfg.InstanceDir); err != nil {
-		return nil, fmt.Errorf("failed to save metadata: %w", err)
-	}
-
-	// Filter credentials to those with existing source directories.
-	// Non-existent sources are skipped to avoid vfkit VirtioFS failures.
-	dirCreds := vmutil.FilterExistingCredentials(c.serverCfg)
-
-	vm := CreateVM(meta, c.cfg)
-	vm.credentialShares = buildCredentialShares(dirCreds)
-
-	backend.Phase(ctx, "vm")
-	backend.Status(ctx, "Starting virtual machine...")
-	if err := vm.Start(ctx); err != nil {
-		return nil, fmt.Errorf("failed to start VM: %w", err)
-	}
-	cleanup.Register("stop VM", func() error {
-		return vm.Stop(context.Background())
-	})
-
-	meta.Status = config.StatusRunning
-	meta.PID = vm.meta.PID
-	if err := meta.Save(c.cfg.InstanceDir); err != nil {
-		return nil, fmt.Errorf("failed to save metadata: %w", err)
-	}
-
-	c.mu.Lock()
-	c.vms[req.Name] = vm
-	c.mu.Unlock()
-	cleanup.Register("remove from vms map", func() error {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-		delete(c.vms, req.Name)
-		return nil
-	})
-
-	agent := c.newAgentClient(meta.Name)
-
-	// Mount VirtioFS workspace if local dir is configured
-	if req.LocalDir != "" {
-		backend.Phase(ctx, "mount")
-		backend.Status(ctx, "Mounting local directory via VirtioFS...")
-		if err := c.mountVirtioFSShare(ctx, agent, config.VirtioFSMountTag, config.WorkspacePath, false); err != nil {
-			// VirtioFS mount is essential for --local-dir; fail the
-			// create. The deferred cleanup now fully unwinds: vms
-			// map entry, VM, instance dir, upper — previously only
-			// `vm.Stop` ran here, leaking the rest.
-			return nil, fmt.Errorf("VirtioFS mount failed for local dir %s: %w", req.LocalDir, err)
-		}
-	}
-
-	// Mount credentials
-	c.credMgr.SetupCredentials(ctx, agent, req.Name, dirCreds, c.mountVirtioFSCredential)
-
-	// Clone repo if specified (skip when using local dir or spawning from snapshot;
-	// snapshot rootfs is already provisioned).
-	if req.Repo != "" && req.LocalDir == "" && req.FromSnapshot == "" {
-		backend.Phase(ctx, "repo")
-		backend.Status(ctx, "Cloning repository...")
-		if err := vmutil.CloneRepo(ctx, agent, c.serverCfg, req.Repo); err != nil {
-			log.Printf("Warning: failed to clone repo %s: %v", config.SanitizeRepoURL(req.Repo), err)
-			// Generic SSE message by design: req.Repo can carry credentials
-			// (e.g., https://user:pw@host/...) and the wrapped err from
-			// git/ssh may include the URL too. Full detail is in the server
-			// log above; SSE consumers get a stable, sanitized signal.
-			//
-			// Deliberately no `backend.Phase(ctx, "repo")` here: the
-			// preceding `vmutil.CloneRepo` already advanced the timer
-			// to "clone", and re-entering "repo" just to attach a
-			// status would split the timer line into the
-			// `repo=N clone=M repo=K` triple shape documented in §14
-			// and Codex's review of #132. The user still sees the
-			// status message (SSE consumes Status events regardless of
-			// the current phase).
-			backend.StatusWarning(ctx, "Failed to clone repository (see server logs for details)")
-		} else {
-			backend.Status(ctx, "Repository cloned")
-		}
-	}
-
-	// Run provisioning. When spawning from a snapshot the rootfs is already
-	// provisioned, so we skip the one-shot install hook but still run the
-	// startup hook on every boot — matching StartShed's behavior. This means
-	// a snapshot-spawned shed gets the same first-boot startup hook as if
-	// the operator had started it manually.
-	if !req.NoProvision {
-		provisioner := vmutil.NewProvisioner(agent, req.Name)
-		provisioner.SetOutput(os.Stdout, os.Stderr)
-		cfg, err := provisioner.LoadConfig(ctx)
-		if err != nil {
-			log.Printf("Warning: failed to load provisioning config: %v", err)
-		} else {
-			runInstall := req.FromSnapshot == ""
-			if err := provisioner.RunProvisioning(ctx, cfg, runInstall); err != nil {
-				log.Printf("Warning: provisioning failed: %v", err)
-			}
-		}
-	}
-
-	// Happy path: zero out the cleanup stack so the deferred `Run` is a
-	// no-op. From here on the shed is the caller's responsibility.
-	cleanup.Commit()
-	return metadataToShed(meta, "127.0.0.1"), nil
+	return orchestrator.CreateShed(ctx, &vzCreator{c: c}, req)
 }
 
 // GetShed returns a shed by name.

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -141,6 +141,13 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 
 	if _, err := LoadMetadata(c.cfg.InstanceDir, req.Name); err == nil {
 		return nil, fmt.Errorf("%w: %s", config.ErrShedAlreadyExistsSentinel, req.Name)
+	} else if !errors.Is(err, ErrInstanceNotFound) {
+		// Non-not-found errors (corrupt metadata, I/O, permission)
+		// must propagate — falling through here would sweep the
+		// existing upper and overwrite a possibly-real shed. The
+		// pre-orchestrator code silently fell through; CodeRabbit's
+		// review of PR #139 flagged this. Loud failure is correct.
+		return nil, fmt.Errorf("failed to read metadata for %s: %w", req.Name, err)
 	}
 
 	// Sweep an orphan upper from a previously crashed create. We're

--- a/internal/vz/orchestrator.go
+++ b/internal/vz/orchestrator.go
@@ -1,0 +1,417 @@
+//go:build darwin
+
+// This file implements `orchestrator.BackendCreator` for the VZ
+// backend. It carries the per-step platform logic that used to live
+// inline in CreateShed; the orchestrator now owns the call ordering,
+// the cleanup-stack scaffolding, and the success/failure return
+// contract. See `internal/backend/orchestrator/create.go` for the
+// contract and `internal/vz/client.go:CreateShed` for the wrapper.
+
+package vz
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/backend/orchestrator"
+	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/vmimage"
+	"github.com/charliek/shed/internal/vmimage/clone"
+	"github.com/charliek/shed/internal/vmutil"
+)
+
+// vzCreator is VZ's implementation of `orchestrator.BackendCreator`.
+// It wraps a *Client and carries the per-create resolved values
+// (cpus / memory / upper-size) inside `vzPreFlight` so subsequent
+// hooks don't re-derive them.
+type vzCreator struct{ c *Client }
+
+// vzPreFlight is the per-create resolved-input bundle handed from
+// PreFlight to the rest of the lifecycle. Tracks `snapshotUpperSource`
+// (set when --from-snapshot is in play) and the resolved cpus /
+// memory / upper-size — values the old inline CreateShed computed
+// once and used in three places.
+type vzPreFlight struct {
+	snapshotUpperSource string
+	lowerDigest         string
+	lowerImageTag       string
+	cpus                int
+	memoryMB            int
+	upperSizeBytes      int64
+	hasCreatingMarker   bool
+}
+
+func (p *vzPreFlight) IsFromSnapshot() bool { return p.snapshotUpperSource != "" }
+
+type vzUpper struct {
+	path string
+	size int64
+}
+
+// vzNet is a placeholder satisfying NetworkResources. VZ does not
+// allocate per-shed network state (Apple's vmnet is shared NAT).
+type vzNet struct{}
+
+// vzMetaHandle carries the persisted *Metadata between hooks. Only
+// Name() is exported via the orchestrator contract; the VM-build
+// hook type-asserts back to access the rest of the fields.
+type vzMetaHandle struct{ meta *Metadata }
+
+func (h *vzMetaHandle) Name() string { return h.meta.Name }
+
+// vzVMHandle carries the running VM between hooks.
+type vzVMHandle struct{ vm *VM }
+
+// ---------------------------------------------------------------------------
+// BackendCreator implementation
+// ---------------------------------------------------------------------------
+
+// PreFlight resolves the image-source (or snapshot-source) for the
+// requested create, derives cpus/memory/upper-size from the request +
+// config defaults, and writes the `.creating` marker that protects
+// the lower-digest blob from a concurrent `shed image prune`.
+//
+// The marker-removal cleanup is registered on the orchestrator's
+// `cleanup` stack so a subsequent failure unwinds it.
+func (b *vzCreator) PreFlight(ctx context.Context, req config.CreateShedRequest, cleanup *backend.Cleanup) (orchestrator.PreFlightResult, error) {
+	pre := &vzPreFlight{}
+
+	// Resolve cpus / memory / upper-size with the same bounds checks
+	// the old inline CreateShed used.
+	cpus := req.CPUs
+	if cpus == 0 {
+		cpus = b.c.cfg.DefaultCPUs
+	}
+	if cpus < 1 || cpus > config.MaxVZCPUs {
+		return nil, fmt.Errorf("invalid cpus %d: must be between 1 and %d", cpus, config.MaxVZCPUs)
+	}
+	memoryMB := req.MemoryMB
+	if memoryMB == 0 {
+		memoryMB = b.c.cfg.DefaultMemoryMB
+	}
+	if memoryMB < 128 || memoryMB > config.MaxVZMemoryMB {
+		return nil, fmt.Errorf("invalid memory_mb %d: must be between 128 and %d", memoryMB, config.MaxVZMemoryMB)
+	}
+	upperSizeBytes := req.UpperSizeBytes
+	if upperSizeBytes == 0 {
+		sz := b.c.cfg.UpperSizeDefault
+		if sz == "" {
+			sz = config.DefaultUpperSize
+		}
+		parsed, perr := config.ParseUpperSize(sz)
+		if perr != nil {
+			return nil, fmt.Errorf("invalid upper_size_default: %w", perr)
+		}
+		upperSizeBytes = parsed
+	} else {
+		if upperSizeBytes < config.MinUpperSizeBytes || upperSizeBytes > config.MaxUpperSizeBytes {
+			return nil, fmt.Errorf("upper size out of range: must be between %dG and %dG",
+				config.MinUpperSizeBytes/(1024*1024*1024), config.MaxUpperSizeBytes/(1024*1024*1024))
+		}
+	}
+	pre.cpus = cpus
+	pre.memoryMB = memoryMB
+	pre.upperSizeBytes = upperSizeBytes
+
+	// Resolve image or snapshot source.
+	if req.FromSnapshot != "" {
+		snap, err := loadSnapshot(b.c.cfg.SnapshotsDir, req.FromSnapshot)
+		if err != nil {
+			return nil, err
+		}
+		if snap.Backend != config.BackendVZ {
+			return nil, fmt.Errorf("%w: snapshot %q is for backend %q, server is %q",
+				config.ErrSnapshotBackendMismatchSentinel, req.FromSnapshot, snap.Backend, config.BackendVZ)
+		}
+		if snap.LowerDigest == "" {
+			return nil, fmt.Errorf("snapshot %q is missing lower_digest; recreate the snapshot from a current shed", req.FromSnapshot)
+		}
+		if !vmimage.BlobExists(b.c.cfg.ImagesDir, snap.LowerDigest) {
+			ref := snap.SourceImage
+			if ref == "" {
+				ref = "(unknown)"
+			}
+			return nil, fmt.Errorf("snapshot %q references lower digest %s which is no longer cached; pull the original image (%s) first",
+				req.FromSnapshot, vmimage.ShortDigest(snap.LowerDigest), ref)
+		}
+		pre.snapshotUpperSource = SnapshotRootfsPath(b.c.cfg.SnapshotsDir, req.FromSnapshot)
+		pre.lowerDigest = snap.LowerDigest
+		pre.lowerImageTag = snap.SourceImage
+	} else {
+		var resolved config.ResolvedImage
+		if req.Image != "" {
+			var err error
+			resolved, err = b.c.cfg.ResolveImage(req.Image)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			if b.c.cfg.BaseRootfs == "" {
+				return nil, fmt.Errorf("%w: no --image specified and no base_rootfs configured in vz.base_rootfs; pass --image <tag> or set base_rootfs in server.yaml", config.ErrInvalidShedRequestSentinel)
+			}
+			resolved = b.c.cfg.ResolveBaseRootfs()
+		}
+		backend.Phase(ctx, "image")
+		backend.Status(ctx, "Resolving image...")
+		_, ldigest, err := b.c.EnsureImage(ctx, resolved)
+		if err != nil {
+			return nil, err
+		}
+		if ldigest == "" {
+			return nil, fmt.Errorf("image %q resolved to a path outside the blob store; the overlay model requires content-addressed images", resolved.Name)
+		}
+		pre.lowerDigest = ldigest
+		pre.lowerImageTag = resolved.Name
+	}
+
+	// Drop a `.creating` marker so a concurrent `shed image prune`
+	// can't sweep the blob between here and meta.Save. The marker
+	// counts as a Pending protective ref in the refscanner. Skip
+	// for from-snapshot: the snapshot already pins the digest via
+	// its own LowerDigest field.
+	if pre.lowerDigest != "" && req.FromSnapshot == "" {
+		if err := writeCreatingMarker(b.c.cfg.InstanceDir, req.Name, pre.lowerDigest); err != nil {
+			return nil, fmt.Errorf("failed to write creating marker: %w", err)
+		}
+		pre.hasCreatingMarker = true
+		shedName := req.Name
+		cleanup.Register("remove creating marker", func() error {
+			removeCreatingMarker(b.c.cfg.InstanceDir, shedName)
+			return nil
+		})
+	}
+
+	return pre, nil
+}
+
+// AllocateNetwork is a no-op for VZ — Apple's vmnet provides shared
+// NAT with no per-shed allocation.
+func (b *vzCreator) AllocateNetwork(ctx context.Context, req config.CreateShedRequest, cleanup *backend.Cleanup) (orchestrator.NetworkResources, error) {
+	return vzNet{}, nil
+}
+
+// AllocateUpper provisions the writable upper layer. Includes the
+// snapshot-clone branch (when spawning from a snapshot) and the
+// best-effort template-mint branch (otherwise) — both used to live
+// inline in CreateShed.
+func (b *vzCreator) AllocateUpper(ctx context.Context, req config.CreateShedRequest, preRaw orchestrator.PreFlightResult, cleanup *backend.Cleanup) (orchestrator.UpperInfo, error) {
+	pre := preRaw.(*vzPreFlight)
+
+	upperPath, err := EnsureUpper(b.c.cfg.UppersDir, req.Name, pre.upperSizeBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create upper: %w", err)
+	}
+	shedName := req.Name
+	cleanup.Register("delete upper layer", func() error {
+		return DeleteUpper(b.c.cfg.UppersDir, shedName)
+	})
+
+	if pre.snapshotUpperSource != "" {
+		// Replace the freshly allocated empty upper with a clone of
+		// the snapshot's stored upper so the new shed inherits its
+		// parent's writable contents.
+		if err := os.Remove(upperPath); err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to clear upper for snapshot clone: %w", err)
+		}
+		if _, err := clone.CloneFile(pre.snapshotUpperSource, upperPath); err != nil {
+			return nil, fmt.Errorf("failed to clone snapshot upper: %w", err)
+		}
+		if err := os.Chmod(upperPath, 0o644); err != nil {
+			return nil, fmt.Errorf("failed to chmod cloned upper: %w", err)
+		}
+		// The metadata's UpperSizeBytes must reflect the *cloned*
+		// file's actual size; mutate pre so BuildAndPersistMetadata
+		// sees the corrected value.
+		if fi, statErr := os.Stat(upperPath); statErr == nil {
+			pre.upperSizeBytes = fi.Size()
+		}
+	} else {
+		// Clone a pre-formatted ext4 template into the upper so the
+		// guest mounts it directly and skips the multi-second
+		// in-guest mkfs on first boot. Best-effort: any failure
+		// leaves the freshly-allocated signature upper in place
+		// (formatted in-guest), so create never regresses.
+		if tmpl, terr := EnsureUpperTemplate(ctx, b.c.templatesDir(), resolveBuildToolsRef(), pre.upperSizeBytes, ""); terr != nil {
+			if errors.Is(terr, context.Canceled) || errors.Is(terr, context.DeadlineExceeded) {
+				return nil, fmt.Errorf("upper template provisioning canceled: %w", terr)
+			}
+			log.Printf("[%s] upper template unavailable (%v); formatting in guest", req.Name, terr)
+		} else if perr := provisionUpperFromTemplate(upperPath, tmpl); perr != nil {
+			if errors.Is(perr, context.Canceled) || errors.Is(perr, context.DeadlineExceeded) {
+				return nil, fmt.Errorf("upper template provisioning canceled: %w", perr)
+			}
+			log.Printf("[%s] upper template clone failed (%v); formatting in guest", req.Name, perr)
+		} else {
+			backend.Phase(ctx, "rootfs")
+			backend.Status(ctx, "Provisioned upper from template (skips in-guest mkfs)")
+		}
+	}
+	return vzUpper{path: upperPath, size: pre.upperSizeBytes}, nil
+}
+
+// BuildAndPersistMetadata builds the VZ Metadata struct and saves it.
+// Registers the "delete instance dir" cleanup BEFORE Save (see
+// PR #137 review for the partial-MkdirAll regression history).
+func (b *vzCreator) BuildAndPersistMetadata(ctx context.Context, req config.CreateShedRequest, preRaw orchestrator.PreFlightResult, upperRaw orchestrator.UpperInfo, _ orchestrator.NetworkResources, cleanup *backend.Cleanup) (orchestrator.MetadataHandle, error) {
+	pre := preRaw.(*vzPreFlight)
+	upper := upperRaw.(vzUpper)
+
+	meta := &Metadata{
+		Name:           req.Name,
+		Status:         config.StatusStopped,
+		CreatedAt:      time.Now(),
+		Backend:        config.BackendVZ,
+		CPUs:           pre.cpus,
+		MemoryMB:       pre.memoryMB,
+		RootfsPath:     upper.path,
+		UpperPath:      upper.path,
+		UpperSizeBytes: pre.upperSizeBytes,
+		Repo:           req.Repo,
+		LocalDir:       req.LocalDir,
+		Image:          req.Image,
+		LowerDigest:    pre.lowerDigest,
+		LowerImageTag:  pre.lowerImageTag,
+		FromSnapshot:   req.FromSnapshot,
+	}
+
+	// Register BEFORE Save: Save's `os.MkdirAll` runs first, so a
+	// partial-write failure could leave the dir behind.
+	// `preserveConsoleLog` is safe pre-Start (no console.log yet —
+	// see vz/metadata.go:PreserveConsoleLog).
+	cleanup.Register("preserve console log + delete instance dir", func() error {
+		b.c.preserveConsoleLog(meta)
+		return meta.Delete(b.c.cfg.InstanceDir)
+	})
+	if err := meta.Save(b.c.cfg.InstanceDir); err != nil {
+		return nil, fmt.Errorf("failed to save metadata: %w", err)
+	}
+	return &vzMetaHandle{meta: meta}, nil
+}
+
+// StartVM constructs and starts the VM (including the per-shed
+// VirtioFS credential-share pre-computation that VZ requires before
+// the VM boots — the existing inline CreateShed did this between
+// meta.Save and CreateVM).
+func (b *vzCreator) StartVM(ctx context.Context, metaRaw orchestrator.MetadataHandle, _ orchestrator.UpperInfo, _ orchestrator.NetworkResources, cleanup *backend.Cleanup) (orchestrator.VMHandle, error) {
+	meta := metaRaw.(*vzMetaHandle).meta
+
+	// vfkit needs every VirtioFS share declared up front before the
+	// VM boots; SetupCredentials post-Start only handles the guest-
+	// side mount. Filter to creds whose source exists to avoid vfkit
+	// rejecting the share.
+	dirCreds := vmutil.FilterExistingCredentials(b.c.serverCfg)
+	vm := CreateVM(meta, b.c.cfg)
+	vm.credentialShares = buildCredentialShares(dirCreds)
+
+	if err := vm.Start(ctx); err != nil {
+		return nil, fmt.Errorf("failed to start VM: %w", err)
+	}
+	cleanup.Register("stop VM", func() error {
+		return vm.Stop(context.Background())
+	})
+	return vzVMHandle{vm: vm}, nil
+}
+
+// FinalizeStartedVM bumps the metadata's Status/PID, re-saves, and
+// registers the c.vms map entry's removal cleanup.
+func (b *vzCreator) FinalizeStartedVM(ctx context.Context, metaRaw orchestrator.MetadataHandle, vmRaw orchestrator.VMHandle, cleanup *backend.Cleanup) error {
+	meta := metaRaw.(*vzMetaHandle).meta
+	vm := vmRaw.(vzVMHandle).vm
+
+	meta.Status = config.StatusRunning
+	meta.PID = vm.meta.PID
+	if err := meta.Save(b.c.cfg.InstanceDir); err != nil {
+		return fmt.Errorf("failed to save metadata: %w", err)
+	}
+
+	b.c.mu.Lock()
+	b.c.vms[meta.Name] = vm
+	b.c.mu.Unlock()
+	shedName := meta.Name
+	cleanup.Register("remove from vms map", func() error {
+		b.c.mu.Lock()
+		defer b.c.mu.Unlock()
+		delete(b.c.vms, shedName)
+		return nil
+	})
+	return nil
+}
+
+// MountLocalDir mounts `--local-dir` via VirtioFS when set; no-op otherwise.
+func (b *vzCreator) MountLocalDir(ctx context.Context, req config.CreateShedRequest, metaRaw orchestrator.MetadataHandle, _ orchestrator.VMHandle) error {
+	if req.LocalDir == "" {
+		return nil
+	}
+	meta := metaRaw.(*vzMetaHandle).meta
+	agent := b.c.newAgentClient(meta.Name)
+	backend.Phase(ctx, "mount")
+	backend.Status(ctx, "Mounting local directory via VirtioFS...")
+	if err := b.c.mountVirtioFSShare(ctx, agent, config.VirtioFSMountTag, config.WorkspacePath, false); err != nil {
+		return fmt.Errorf("VirtioFS mount failed for local dir %s: %w", req.LocalDir, err)
+	}
+	return nil
+}
+
+// SetupCredentials mounts configured credentials post-Start. Best-effort.
+func (b *vzCreator) SetupCredentials(ctx context.Context, req config.CreateShedRequest, metaRaw orchestrator.MetadataHandle, _ orchestrator.VMHandle) {
+	meta := metaRaw.(*vzMetaHandle).meta
+	dirCreds := vmutil.FilterExistingCredentials(b.c.serverCfg)
+	agent := b.c.newAgentClient(meta.Name)
+	b.c.credMgr.SetupCredentials(ctx, agent, req.Name, dirCreds, b.c.mountVirtioFSCredential)
+}
+
+// CloneRepo runs `git clone` inside the guest when --repo is set
+// (and not overridden by --local-dir / --from-snapshot). Best-effort:
+// failures emit a sanitized StatusWarning and the create still
+// completes — matching today's behavior.
+func (b *vzCreator) CloneRepo(ctx context.Context, req config.CreateShedRequest, metaRaw orchestrator.MetadataHandle, _ orchestrator.VMHandle) {
+	if req.Repo == "" || req.LocalDir != "" || req.FromSnapshot != "" {
+		return
+	}
+	meta := metaRaw.(*vzMetaHandle).meta
+	agent := b.c.newAgentClient(meta.Name)
+	backend.Phase(ctx, "repo")
+	backend.Status(ctx, "Cloning repository...")
+	if err := vmutil.CloneRepo(ctx, agent, b.c.serverCfg, req.Repo); err != nil {
+		log.Printf("Warning: failed to clone repo %s: %v", config.SanitizeRepoURL(req.Repo), err)
+		// Status attaches to the current ("clone") phase — see
+		// PR #135's opportunistic cleanup that removed the
+		// `repo=N clone=M repo=K` triple shape.
+		backend.StatusWarning(ctx, "Failed to clone repository (see server logs for details)")
+	} else {
+		backend.Status(ctx, "Repository cloned")
+	}
+}
+
+// RunProvisioning loads the per-shed provisioning config and runs
+// any hooks it declares (unless the request opted out via
+// NoProvision). Best-effort.
+func (b *vzCreator) RunProvisioning(ctx context.Context, req config.CreateShedRequest, metaRaw orchestrator.MetadataHandle, _ orchestrator.VMHandle) {
+	if req.NoProvision {
+		return
+	}
+	meta := metaRaw.(*vzMetaHandle).meta
+	agent := b.c.newAgentClient(meta.Name)
+	provisioner := vmutil.NewProvisioner(agent, req.Name)
+	provisioner.SetOutput(os.Stdout, os.Stderr)
+	cfg, err := provisioner.LoadConfig(ctx)
+	if err != nil {
+		log.Printf("Warning: failed to load provisioning config: %v", err)
+		return
+	}
+	runInstall := req.FromSnapshot == ""
+	if err := provisioner.RunProvisioning(ctx, cfg, runInstall); err != nil {
+		log.Printf("Warning: provisioning failed: %v", err)
+	}
+}
+
+// ToShedResult returns the *config.Shed value the orchestrator hands
+// back to the per-backend CreateShed wrapper's caller.
+func (b *vzCreator) ToShedResult(metaRaw orchestrator.MetadataHandle) *config.Shed {
+	return metadataToShed(metaRaw.(*vzMetaHandle).meta, "127.0.0.1")
+}


### PR DESCRIPTION
§15 Phase 2 PR 2c. VZ's \`CreateShed\` is now a thin **43-line wrapper** over \`orchestrator.CreateShed\`. The per-step platform logic moved into \`internal/vz/orchestrator.go\` as \`*vzCreator\` (implementing the \`BackendCreator\` interface from #138).

## Diff scale

| | Before (#137 main) | After (this PR) |
|---|---|---|
| \`internal/vz/client.go\` \`CreateShed\` body | ~330 lines | **43 lines** |
| \`internal/vz/orchestrator.go\` | — | +370 lines (vzCreator + handles + all 11 hooks) |

The wrapper still owns the things the orchestrator's caller-contract requires (per-shed locks, name-exists check, orphan-upper sweep, --from-snapshot vs --image/--repo exclusivity). Everything else delegates.

## Hook-by-hook responsibility map

| Hook | What it does (was inline in CreateShed) |
|---|---|
| \`PreFlight\` | cpus/memory/upper-size resolution, image OR snapshot source, .creating marker + cleanup |
| \`AllocateNetwork\` | no-op (VZ uses vmnet shared NAT) |
| \`AllocateUpper\` | EnsureUpper + snapshot-clone OR template-mint + delete-upper cleanup |
| \`BuildAndPersistMetadata\` | Metadata struct + delete-instance cleanup BEFORE Save (PR #137 invariant), Save |
| \`StartVM\` | vfkit credential-share build (the VZ-specific pre-Start work), CreateVM, Start, stop-VM cleanup |
| \`FinalizeStartedVM\` | Status=Running + PID + Save, c.vms insert, remove-from-vms cleanup |
| \`MountLocalDir\` | VirtioFS mount when \`--local-dir\` |
| \`SetupCredentials\` | c.credMgr.SetupCredentials |
| \`CloneRepo\` | vmutil.CloneRepo wrapped in best-effort log + StatusWarning |
| \`RunProvisioning\` | provisioner.LoadConfig + RunProvisioning, best-effort |
| \`ToShedResult\` | metadataToShed |

## Interface design adjustment (rolled into this PR)

The handle types \`UpperInfo\`, \`NetworkResources\`, \`VMHandle\` from PR #138 had unexported marker methods (\`isUpperInfo()\` etc.). Go requires unexported markers to be implemented in the **same package** as the interface, so VZ's concrete types couldn't satisfy them from \`internal/vz/\`. Per Codex's review of #138 (concern 8) — *\"make handles opaque backend-owned types... expect backend hooks to type-assert internally\"* — switched the three handle types to \`any\`. Backends type-assert at use. \`MetadataHandle\` retains its \`Name()\` method because the orchestrator genuinely uses it.

## Validation chain

- \`make build\` clean (host + Linux cross-compile).
- \`make test\` clean (Go unit tests, including the 12 orchestrator mock-backed cases from PR #138).
- \`make lint\` clean.
- \`make test-integration\` against dev v0.5.6 server with VZ routed through the orchestrator: **18 passed + 2 cleanly-skipped** (FC PhaseTimer-dependent; mini3 v0.5.3). Identical shape to PR #133/#135/#137's baselines — behavior is fully preserved end-to-end.
- PR #127's locked ordering invariants remain green.
- PR #133's healthPollInterval cut preserved.
- Brew server restored at session end.

## What 2d will do

Same migration for Firecracker (a longer file because of CID/IP/TAP allocation + .creating marker + RegisterInstance + 9P). Once FC also goes through the orchestrator, the duplicate lifecycle code in both backends' \`client.go\` can be deleted (the 2d \"kill duplicate code\" step).

## Per the §15 mandatory process

**No release** from this PR. Bundle with the rest of Phase 2 into a single Phase-2 release discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal backend orchestrator refactored to improve code organization and streamline VM creation lifecycle management across platform-specific implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->