### PR TITLE
firecracker: migrate CreateShed to the orchestrator (§15 2d)

### DIFF
--- a/internal/backend/cleanup.go
+++ b/internal/backend/cleanup.go
@@ -64,9 +64,21 @@ import (
 // (e.g. CreateShed). Safe for concurrent use; the lifecycle methods
 // don't share Cleanup instances across goroutines, but Register from
 // inside an in-flight goroutine is legal.
+//
+// Two stacks live inside one Cleanup:
+//
+//   - `steps` — error-only cleanups (the typical `Register` case).
+//     Run on `Run()`; cleared by `Commit()` so the success-path
+//     `defer cleanup.Run()` is a no-op.
+//   - `deferred` — always-run cleanups (the `AddDeferred` case).
+//     Run on BOTH `Run()` (after the error-only stack unwinds) and
+//     on `Commit()`. Semantically equivalent to a Go `defer` — useful
+//     for protective bits (e.g., a `.creating` marker) whose lifetime
+//     is the operation, not the resulting resource.
 type Cleanup struct {
 	mu        sync.Mutex
 	steps     []cleanupStep
+	deferred  []cleanupStep
 	committed bool
 }
 
@@ -97,14 +109,50 @@ func (c *Cleanup) Register(name string, fn func() error) {
 	c.steps = append(c.steps, cleanupStep{name: name, fn: fn})
 }
 
-// Commit declares the operation successful — Run becomes a no-op.
-// Idempotent. Call from the happy path right before returning the
-// successful result.
-func (c *Cleanup) Commit() {
+// AddDeferred pushes a cleanup onto the always-run stack. Unlike
+// `Register`, the cleanup runs on BOTH `Run()` (error return) and
+// `Commit()` (success return) — semantically equivalent to a Go
+// `defer` inside the lifecycle method's body.
+//
+// Use this for operations whose lifetime is bounded by the lifecycle
+// method itself, not by the resource the method produces. The
+// canonical example is a `.creating` marker that protects an image
+// blob from a concurrent `shed image prune` for the duration of a
+// `CreateShed` — it must be removed whether the create succeeded
+// (the meta now keeps the digest pinned) or failed (no shed to
+// protect anymore).
+//
+// `AddDeferred` cleanups run AFTER all error-only `Register` cleanups
+// have unwound (on error) so they see the post-rollback state. On
+// success they run after Commit's main work.
+func (c *Cleanup) AddDeferred(name string, fn func() error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.committed = true
+	if c.committed {
+		return
+	}
+	c.deferred = append(c.deferred, cleanupStep{name: name, fn: fn})
+}
+
+// Commit declares the operation successful — error-only cleanups are
+// cleared so the deferred `Run()` is a no-op for them, but the
+// always-run (`AddDeferred`) cleanups still execute in LIFO order
+// from THIS call. Idempotent. Call from the happy path right before
+// returning the successful result.
+func (c *Cleanup) Commit() {
+	c.mu.Lock()
+	deferred := c.deferred
+	c.deferred = nil
 	c.steps = nil
+	c.committed = true
+	c.mu.Unlock()
+
+	// Run the always-deferred cleanups (success path). Same panic-
+	// recovery wrapper as Run uses, so a buggy deferred cleanup can
+	// not stop a sibling from executing.
+	for i := len(deferred) - 1; i >= 0; i-- {
+		runCleanupStep(deferred[i])
+	}
 }
 
 // Run invokes every registered cleanup in LIFO order. Individual
@@ -124,13 +172,21 @@ func (c *Cleanup) Commit() {
 func (c *Cleanup) Run() {
 	c.mu.Lock()
 	steps := c.steps
+	deferred := c.deferred
 	c.steps = nil
+	c.deferred = nil
 	c.committed = true
 	c.mu.Unlock()
 
+	// Error-only cleanups unwind first.
 	for i := len(steps) - 1; i >= 0; i-- {
-		step := steps[i]
-		runCleanupStep(step)
+		runCleanupStep(steps[i])
+	}
+	// Always-deferred cleanups run after the rest of the rollback,
+	// so they see the post-rollback state (a marker file's protected
+	// blob is now gone, etc.).
+	for i := len(deferred) - 1; i >= 0; i-- {
+		runCleanupStep(deferred[i])
 	}
 }
 

--- a/internal/backend/cleanup_test.go
+++ b/internal/backend/cleanup_test.go
@@ -71,6 +71,50 @@ func TestCleanup_RunIdempotent(t *testing.T) {
 	}
 }
 
+func TestCleanup_AddDeferredRunsOnCommit(t *testing.T) {
+	var order []string
+	c := NewCleanup()
+	c.Register("error-only", func() error { order = append(order, "error-only"); return nil })
+	c.AddDeferred("deferred-1", func() error { order = append(order, "deferred-1"); return nil })
+	c.AddDeferred("deferred-2", func() error { order = append(order, "deferred-2"); return nil })
+	c.Commit()
+
+	// On success: error-only steps NEVER run; deferred steps run in LIFO.
+	want := []string{"deferred-2", "deferred-1"}
+	if !equal(order, want) {
+		t.Errorf("Commit() order = %v, want %v (error-only must NOT run)", order, want)
+	}
+}
+
+func TestCleanup_AddDeferredRunsOnError(t *testing.T) {
+	var order []string
+	c := NewCleanup()
+	c.Register("error-A", func() error { order = append(order, "error-A"); return nil })
+	c.AddDeferred("always-X", func() error { order = append(order, "always-X"); return nil })
+	c.Register("error-B", func() error { order = append(order, "error-B"); return nil })
+	c.AddDeferred("always-Y", func() error { order = append(order, "always-Y"); return nil })
+	c.Run()
+
+	// On error: error-only stack unwinds first (LIFO), then
+	// deferred stack unwinds (also LIFO).
+	want := []string{"error-B", "error-A", "always-Y", "always-X"}
+	if !equal(order, want) {
+		t.Errorf("Run() order = %v, want %v", order, want)
+	}
+}
+
+func TestCleanup_AddDeferredAfterCommitIgnored(t *testing.T) {
+	called := false
+	c := NewCleanup()
+	c.Commit()
+	c.AddDeferred("late", func() error { called = true; return nil })
+	c.Run()
+
+	if called {
+		t.Error("AddDeferred after Commit ran; should have been ignored")
+	}
+}
+
 func TestCleanup_PanickingStepDoesNotAbortChain(t *testing.T) {
 	var order []string
 	c := NewCleanup()

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -16,11 +16,11 @@ import (
 	"time"
 
 	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/backend/orchestrator"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/lockmap"
 	"github.com/charliek/shed/internal/plugin"
 	"github.com/charliek/shed/internal/vmimage"
-	"github.com/charliek/shed/internal/vmimage/clone"
 	"github.com/charliek/shed/internal/vmutil"
 )
 
@@ -372,6 +372,12 @@ func metadataToShed(meta *Metadata) *config.Shed {
 }
 
 // CreateShed creates a new Firecracker-based shed.
+//
+// This wrapper handles the parts the orchestrator does NOT own
+// (per-shed-name locking, existence-check, orphan-upper sweep, the
+// --image vs --from-snapshot exclusivity check). Per-step lifecycle
+// logic lives in fcCreator (see orchestrator.go) and is invoked by
+// orchestrator.CreateShed.
 func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error) {
 	if err := config.ValidateShedName(req.Name); err != nil {
 		return nil, err
@@ -390,21 +396,17 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		defer c.acquireSnapshotLock(req.FromSnapshot)()
 	}
 
-	// Serialize CreateShed calls for the same name so the existence check
-	// below and CopyRootfs's os.Remove(dst) can't race two concurrent
-	// creates into corrupting the first caller's rootfs.
+	// Serialize CreateShed calls for the same name so the existence
+	// check below and CopyRootfs's os.Remove(dst) can't race two
+	// concurrent creates into corrupting the first caller's rootfs.
 	defer c.acquireCreateLock(req.Name)()
-
-	// LIFO rollback stack. Each successful resource-acquiring step
-	// Registers its teardown; on any error-return the deferred
-	// `cleanup.Run` invokes them in reverse. The success path calls
-	// `cleanup.Commit()` just before `return`, which zeroes the stack
-	// so the defer becomes a no-op. See `internal/backend/cleanup.go`.
-	cleanup := backend.NewCleanup()
-	defer cleanup.Run()
 
 	if _, err := LoadMetadata(c.cfg.InstanceDir, req.Name); err == nil {
 		return nil, fmt.Errorf("%w: %s", config.ErrShedAlreadyExistsSentinel, req.Name)
+	} else if !errors.Is(err, ErrInstanceNotFound) {
+		// Same safety guard as VZ — see internal/vz/client.go for the
+		// CodeRabbit-flagged regression history.
+		return nil, fmt.Errorf("failed to read metadata for %s: %w", req.Name, err)
 	}
 
 	// Sweep an orphan upper from a previously crashed create. We're
@@ -412,8 +414,6 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 	// (the LoadMetadata check above returned NotFound) and we hold the
 	// per-name create lock, so anything still sitting at
 	// uppers/<name>/ is leftover state from a half-completed run.
-	// Without this, EnsureUpper's strict-rejection would force the
-	// operator to manually `rm -rf` to recover.
 	if _, err := os.Stat(UpperPath(c.cfg.UppersDir, req.Name)); err == nil {
 		log.Printf("CreateShed %s: sweeping orphan upper from a prior crashed create", req.Name)
 		if err := DeleteUpper(c.cfg.UppersDir, req.Name); err != nil {
@@ -421,318 +421,7 @@ func (c *Client) CreateShed(ctx context.Context, req config.CreateShedRequest) (
 		}
 	}
 
-	upperSizeBytes := req.UpperSizeBytes
-	if upperSizeBytes == 0 {
-		sz := c.cfg.UpperSizeDefault
-		if sz == "" {
-			sz = config.DefaultUpperSize
-		}
-		parsed, err := config.ParseUpperSize(sz)
-		if err != nil {
-			return nil, fmt.Errorf("invalid upper_size_default: %w", err)
-		}
-		upperSizeBytes = parsed
-	} else {
-		if upperSizeBytes < config.MinUpperSizeBytes || upperSizeBytes > config.MaxUpperSizeBytes {
-			return nil, fmt.Errorf("upper size out of range: must be between %dG and %dG",
-				config.MinUpperSizeBytes/(1024*1024*1024), config.MaxUpperSizeBytes/(1024*1024*1024))
-		}
-	}
-
-	var snapshotUpperSource, lowerDigest, lowerImageTag string
-	if req.FromSnapshot != "" {
-		snap, err := loadSnapshot(c.cfg.SnapshotsDir, req.FromSnapshot)
-		if err != nil {
-			return nil, err
-		}
-		if snap.Backend != config.BackendFirecracker {
-			return nil, fmt.Errorf("%w: snapshot %q is for backend %q, server is %q",
-				config.ErrSnapshotBackendMismatchSentinel, req.FromSnapshot, snap.Backend, config.BackendFirecracker)
-		}
-		// The lower-digest pin must still be cached or the new shed
-		// can't boot — overlay needs both layers present.
-		if snap.LowerDigest == "" {
-			return nil, fmt.Errorf("snapshot %q is missing lower_digest; recreate the snapshot from a current shed", req.FromSnapshot)
-		}
-		if !vmimage.BlobExists(c.cfg.ImagesDir, snap.LowerDigest) {
-			ref := snap.SourceImage
-			if ref == "" {
-				ref = "(unknown)"
-			}
-			return nil, fmt.Errorf("snapshot %q references lower digest %s which is no longer cached; pull the original image (%s) first",
-				req.FromSnapshot, vmimage.ShortDigest(snap.LowerDigest), ref)
-		}
-		snapshotUpperSource = SnapshotRootfsPath(c.cfg.SnapshotsDir, req.FromSnapshot)
-		// Inherit the lower-digest pin from the snapshot so this new
-		// shed continues to protect the underlying blob from prune.
-		lowerDigest = snap.LowerDigest
-		lowerImageTag = snap.SourceImage
-	} else {
-		// Resolve and ensure image before allocating network resources.
-		// Image resolution is fast (config lookup + os.Stat), but EnsureImage may
-		// pull from Docker which can take minutes. Doing this first avoids holding
-		// scarce network resources (TAP devices, IPs) during slow operations.
-		var resolved config.ResolvedImage
-		var err error
-		if req.Image != "" {
-			resolved, err = c.cfg.ResolveImage(req.Image)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			if c.cfg.BaseRootfs == "" {
-				return nil, fmt.Errorf("%w: no --image specified and no base_rootfs configured in firecracker.base_rootfs; pass --image <tag> or set base_rootfs in server.yaml", config.ErrInvalidShedRequestSentinel)
-			}
-			resolved = c.cfg.ResolveBaseRootfs()
-		}
-
-		backend.Phase(ctx, "image")
-		backend.Status(ctx, "Resolving image...")
-		mgr := vmimage.NewManager(c.cfg, c.refScanner())
-		ensureRes, err := mgr.EnsureImage(ctx, vmimage.ResolvedRef{
-			Path:      resolved.Path,
-			DockerRef: resolved.DockerRef,
-			Name:      resolved.Name,
-			Digest:    resolved.Digest,
-		}, func(stage, msg string) {
-			backend.Phase(ctx, stage)
-			backend.Status(ctx, msg)
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to ensure image: %w", err)
-		}
-		if ensureRes.Digest == "" {
-			return nil, fmt.Errorf("image %q resolved to a path outside the blob store; the overlay model requires content-addressed images", resolved.Name)
-		}
-		lowerDigest = ensureRes.Digest
-		lowerImageTag = resolved.Name
-	}
-
-	// Drop a `.creating` marker recording the lower digest so a
-	// concurrent `shed image prune` can't sweep the blob between
-	// here and meta.Save. The marker counts as a Pending protective
-	// ref in the refscanner (systemprune.ScanInstanceCreatingMarkers)
-	// for up to InstanceCreatingMaxAge (1h); stale markers from
-	// crashed creates expire and stop protecting on their own.
-	//
-	// Skip for from-snapshot: the snapshot already pins the digest
-	// via its own LowerDigest field.
-	if lowerDigest != "" && req.FromSnapshot == "" {
-		if err := writeCreatingMarker(c.cfg.InstanceDir, req.Name, lowerDigest); err != nil {
-			return nil, fmt.Errorf("failed to write creating marker: %w", err)
-		}
-		defer removeCreatingMarker(c.cfg.InstanceDir, req.Name)
-	}
-
-	backend.Phase(ctx, "network")
-	backend.Status(ctx, "Allocating network resources...")
-	cid, err := c.AllocateCID(req.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to allocate CID: %w", err)
-	}
-	cleanup.Register("release CID", func() error {
-		c.ReleaseCID(cid)
-		return nil
-	})
-
-	tapDevice, ipAddress, err := c.AllocateNetwork(req.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to allocate network: %w", err)
-	}
-	cleanup.Register("release IP", func() error {
-		c.ReleaseIP(ipAddress)
-		return nil
-	})
-
-	if err := c.netMgr.CreateTAPDevice(tapDevice); err != nil {
-		return nil, fmt.Errorf("failed to create TAP device: %w", err)
-	}
-	cleanup.Register("delete TAP device", func() error {
-		return c.netMgr.DeleteTAPDevice(tapDevice)
-	})
-
-	backend.Phase(ctx, "rootfs")
-	backend.Status(ctx, "Allocating writable upper layer...")
-	upperPath, err := EnsureUpper(c.cfg.UppersDir, req.Name, upperSizeBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create upper: %w", err)
-	}
-	cleanup.Register("delete upper layer", func() error {
-		return DeleteUpper(c.cfg.UppersDir, req.Name)
-	})
-
-	// from-snapshot: replace the freshly allocated empty upper with a
-	// reflink clone of the snapshot's stored upper so the new shed
-	// inherits its parent's writable contents.
-	if snapshotUpperSource != "" {
-		if err := os.Remove(upperPath); err != nil && !os.IsNotExist(err) {
-			return nil, fmt.Errorf("failed to clear upper for snapshot clone: %w", err)
-		}
-		if _, err := clone.CloneFile(snapshotUpperSource, upperPath); err != nil {
-			return nil, fmt.Errorf("failed to clone snapshot upper: %w", err)
-		}
-		if err := os.Chmod(upperPath, 0o644); err != nil {
-			return nil, fmt.Errorf("failed to chmod cloned upper: %w", err)
-		}
-		// The metadata's UpperSizeBytes must reflect the *cloned* file's
-		// actual size, not the freshly-allocated sparse size — otherwise
-		// `shed system df` and reset/snapshot bookkeeping report the
-		// pre-snapshot size for what is now a different file.
-		if fi, statErr := os.Stat(upperPath); statErr == nil {
-			upperSizeBytes = fi.Size()
-		}
-	}
-	rootfsPath := upperPath
-
-	cpus := req.CPUs
-	if cpus == 0 {
-		cpus = c.cfg.DefaultCPUs
-	}
-	memoryMB := req.MemoryMB
-	if memoryMB == 0 {
-		memoryMB = c.cfg.DefaultMemoryMB
-	}
-
-	meta := &Metadata{
-		Name:           req.Name,
-		Status:         config.StatusStopped,
-		CreatedAt:      time.Now(),
-		Backend:        config.BackendFirecracker,
-		CID:            cid,
-		IPAddress:      ipAddress,
-		TAPDevice:      tapDevice,
-		CPUs:           cpus,
-		MemoryMB:       memoryMB,
-		RootfsPath:     rootfsPath,
-		UpperPath:      upperPath,
-		UpperSizeBytes: upperSizeBytes,
-		Repo:           req.Repo,
-		LocalDir:       req.LocalDir,
-		Image:          req.Image,
-		LowerDigest:    lowerDigest,
-		LowerImageTag:  lowerImageTag,
-		FromSnapshot:   req.FromSnapshot,
-	}
-
-	// Register the instance-dir cleanup BEFORE calling Save. Save's
-	// `os.MkdirAll` runs first; if any subsequent write fails partway
-	// through, the directory it created is left behind. `meta.Delete`
-	// is `os.RemoveAll`, so it's safe to register against a not-yet-
-	// existent path (the cleanup is a no-op if the dir was never
-	// created).
-	cleanup.Register("delete instance dir", func() error {
-		return meta.Delete(c.cfg.InstanceDir)
-	})
-	if err := meta.Save(c.cfg.InstanceDir); err != nil {
-		return nil, fmt.Errorf("failed to save metadata: %w", err)
-	}
-
-	c.RegisterInstance(req.Name, cid, ipAddress)
-
-	vm, err := CreateVM(ctx, meta, c.cfg, c.netMgr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create VM: %w", err)
-	}
-
-	backend.Phase(ctx, "vm")
-	backend.Status(ctx, "Starting virtual machine...")
-	if err := vm.Start(ctx); err != nil {
-		return nil, fmt.Errorf("failed to start VM: %w", err)
-	}
-	cleanup.Register("stop VM", func() error {
-		return vm.Stop(context.Background())
-	})
-
-	meta.Status = config.StatusRunning
-	if err := meta.Save(c.cfg.InstanceDir); err != nil {
-		return nil, fmt.Errorf("failed to save metadata: %w", err)
-	}
-
-	c.mu.Lock()
-	c.vms[req.Name] = vm
-	c.mu.Unlock()
-	cleanup.Register("remove from vms map", func() error {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-		delete(c.vms, req.Name)
-		return nil
-	})
-
-	agent := c.newAgentClient(meta.Name)
-
-	// Mount local directory via 9P if specified
-	if req.LocalDir != "" {
-		backend.Phase(ctx, "9p")
-		backend.Status(ctx, "Mounting local directory via 9P...")
-		bridgeIP := c.netMgr.Gateway()
-		srv, err := c.startP9Server(req.Name, bridgeIP, req.LocalDir, config.WorkspacePath, false)
-		if err != nil {
-			return nil, fmt.Errorf("failed to start 9P server for local dir: %w", err)
-		}
-		// Register the 9P teardown after the server starts so a guest-
-		// mount failure below cleans up the server too.
-		cleanup.Register("stop 9P servers", func() error {
-			c.stopP9Servers(req.Name)
-			return nil
-		})
-		if err := c.mount9PInGuest(ctx, agent, srv.Addr(), config.WorkspacePath, false, "workspace"); err != nil {
-			return nil, fmt.Errorf("failed to mount 9P in guest: %w", err)
-		}
-	}
-
-	// Mount credentials via 9P
-	{
-		dirCreds := vmutil.FilterExistingCredentials(c.serverCfg)
-		if len(dirCreds) > 0 {
-			backend.Phase(ctx, "credentials")
-			backend.Status(ctx, "Setting up credentials...")
-		}
-		c.credMgr.SetupCredentials(ctx, agent, req.Name, dirCreds, c.mount9PCredentialFunc(req.Name))
-	}
-
-	// Clone repo if specified (skip when using local dir or spawning from snapshot;
-	// snapshot rootfs is already provisioned).
-	if req.Repo != "" && req.LocalDir == "" && req.FromSnapshot == "" {
-		backend.Phase(ctx, "repo")
-		backend.Status(ctx, "Cloning repository...")
-		if err := vmutil.CloneRepo(ctx, agent, c.serverCfg, req.Repo); err != nil {
-			log.Printf("Warning: failed to clone repo %s: %v", config.SanitizeRepoURL(req.Repo), err)
-			// Generic SSE message by design: req.Repo can carry credentials
-			// (e.g., https://user:pw@host/...) and the wrapped err from
-			// git/ssh may include the URL too. Full detail is in the server
-			// log above; SSE consumers get a stable, sanitized signal.
-			//
-			// Deliberately no `backend.Phase(ctx, "repo")` here: see
-			// the matching note in `internal/vz/client.go`. Re-entering
-			// "repo" just to attach a status would split the timer line
-			// into the `repo=N clone=M repo=K` triple shape.
-			backend.StatusWarning(ctx, "Failed to clone repository (see server logs for details)")
-		} else {
-			backend.Status(ctx, "Repository cloned")
-		}
-	}
-
-	// Run provisioning. When spawning from a snapshot the rootfs is already
-	// provisioned, so we skip the one-shot install hook but still run the
-	// startup hook on every boot — matching StartShed's behavior.
-	if !req.NoProvision {
-		provisioner := vmutil.NewProvisioner(agent, req.Name)
-		provisioner.SetOutput(os.Stdout, os.Stderr)
-		cfg, err := provisioner.LoadConfig(ctx)
-		if err != nil {
-			log.Printf("Warning: failed to load provisioning config: %v", err)
-		} else {
-			runInstall := req.FromSnapshot == ""
-			if err := provisioner.RunProvisioning(ctx, cfg, runInstall); err != nil {
-				log.Printf("Warning: provisioning failed: %v", err)
-			}
-		}
-	}
-
-	// Happy path: zero out the cleanup stack so the deferred Run is a
-	// no-op. From here on the shed is the caller's responsibility.
-	cleanup.Commit()
-	return metadataToShed(meta), nil
+	return orchestrator.CreateShed(ctx, &fcCreator{c: c}, req)
 }
 
 // GetShed returns a shed by name.

--- a/internal/firecracker/orchestrator.go
+++ b/internal/firecracker/orchestrator.go
@@ -1,0 +1,448 @@
+//go:build linux
+
+// This file implements `orchestrator.BackendCreator` for the Firecracker
+// backend. It carries the per-step platform logic that used to live
+// inline in CreateShed; the orchestrator now owns the call ordering,
+// the cleanup-stack scaffolding, and the success/failure return
+// contract. See `internal/backend/orchestrator/create.go` for the
+// contract and `internal/firecracker/client.go:CreateShed` for the
+// wrapper.
+
+package firecracker
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/backend/orchestrator"
+	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/vmimage"
+	"github.com/charliek/shed/internal/vmimage/clone"
+	"github.com/charliek/shed/internal/vmutil"
+)
+
+// fcCreator is Firecracker's implementation of
+// `orchestrator.BackendCreator`. It wraps a *Client and carries the
+// per-create resolved values (cpus / memory / upper-size, image
+// source) inside `fcPreFlight` so subsequent hooks don't re-derive
+// them.
+type fcCreator struct{ c *Client }
+
+// fcPreFlight is the per-create resolved-input bundle handed from
+// PreFlight to the rest of the lifecycle.
+type fcPreFlight struct {
+	snapshotUpperSource string
+	lowerDigest         string
+	lowerImageTag       string
+	cpus                int
+	memoryMB            int
+	upperSizeBytes      int64
+}
+
+func (p *fcPreFlight) IsFromSnapshot() bool { return p.snapshotUpperSource != "" }
+
+// fcUpper carries the freshly-allocated upper layer between hooks.
+type fcUpper struct {
+	path string
+	size int64
+}
+
+// fcNet carries the per-shed network resources from AllocateNetwork
+// to subsequent hooks (BuildAndPersistMetadata for Metadata embed
+// and the FC-specific RegisterInstance call inside StartVM).
+type fcNet struct {
+	cid       uint32
+	ipAddress string
+	tapDevice string
+}
+
+// fcMetaHandle carries the persisted *Metadata between hooks. The
+// VM-build and FinalizeStartedVM hooks type-assert back to access
+// the rest of the fields.
+type fcMetaHandle struct{ meta *Metadata }
+
+func (h *fcMetaHandle) Name() string { return h.meta.Name }
+
+// fcVMHandle carries the running VM between hooks.
+type fcVMHandle struct{ vm *VM }
+
+// ---------------------------------------------------------------------------
+// BackendCreator implementation
+// ---------------------------------------------------------------------------
+
+// PreFlight resolves the image-source (or snapshot-source) for the
+// requested create, derives cpus/memory/upper-size from the request +
+// config defaults, and writes the `.creating` marker that protects
+// the lower-digest blob from a concurrent `shed image prune`.
+func (b *fcCreator) PreFlight(ctx context.Context, req config.CreateShedRequest, cleanup *backend.Cleanup) (orchestrator.PreFlightResult, error) {
+	pre := &fcPreFlight{}
+
+	// Resolve cpus/memory/upper-size with the same bounds checks the
+	// old inline CreateShed used.
+	cpus := req.CPUs
+	if cpus == 0 {
+		cpus = b.c.cfg.DefaultCPUs
+	}
+	memoryMB := req.MemoryMB
+	if memoryMB == 0 {
+		memoryMB = b.c.cfg.DefaultMemoryMB
+	}
+	upperSizeBytes := req.UpperSizeBytes
+	if upperSizeBytes == 0 {
+		sz := b.c.cfg.UpperSizeDefault
+		if sz == "" {
+			sz = config.DefaultUpperSize
+		}
+		parsed, err := config.ParseUpperSize(sz)
+		if err != nil {
+			return nil, fmt.Errorf("invalid upper_size_default: %w", err)
+		}
+		upperSizeBytes = parsed
+	} else {
+		if upperSizeBytes < config.MinUpperSizeBytes || upperSizeBytes > config.MaxUpperSizeBytes {
+			return nil, fmt.Errorf("upper size out of range: must be between %dG and %dG",
+				config.MinUpperSizeBytes/(1024*1024*1024), config.MaxUpperSizeBytes/(1024*1024*1024))
+		}
+	}
+	pre.cpus = cpus
+	pre.memoryMB = memoryMB
+	pre.upperSizeBytes = upperSizeBytes
+
+	// Resolve image or snapshot source.
+	if req.FromSnapshot != "" {
+		snap, err := loadSnapshot(b.c.cfg.SnapshotsDir, req.FromSnapshot)
+		if err != nil {
+			return nil, err
+		}
+		if snap.Backend != config.BackendFirecracker {
+			return nil, fmt.Errorf("%w: snapshot %q is for backend %q, server is %q",
+				config.ErrSnapshotBackendMismatchSentinel, req.FromSnapshot, snap.Backend, config.BackendFirecracker)
+		}
+		if snap.LowerDigest == "" {
+			return nil, fmt.Errorf("snapshot %q is missing lower_digest; recreate the snapshot from a current shed", req.FromSnapshot)
+		}
+		if !vmimage.BlobExists(b.c.cfg.ImagesDir, snap.LowerDigest) {
+			ref := snap.SourceImage
+			if ref == "" {
+				ref = "(unknown)"
+			}
+			return nil, fmt.Errorf("snapshot %q references lower digest %s which is no longer cached; pull the original image (%s) first",
+				req.FromSnapshot, vmimage.ShortDigest(snap.LowerDigest), ref)
+		}
+		pre.snapshotUpperSource = SnapshotRootfsPath(b.c.cfg.SnapshotsDir, req.FromSnapshot)
+		pre.lowerDigest = snap.LowerDigest
+		pre.lowerImageTag = snap.SourceImage
+		// Note: --upper-size with --from-snapshot is silently ignored
+		// here (the cloned upper inherits the snapshot's size). See
+		// matching note in `internal/vz/orchestrator.go`.
+	} else {
+		// Resolve and ensure image before allocating network resources
+		// (Codex's #138 note: EnsureImage may pull from Docker which
+		// can take minutes; doing it in PreFlight avoids holding the
+		// network resources during the pull).
+		var resolved config.ResolvedImage
+		var err error
+		if req.Image != "" {
+			resolved, err = b.c.cfg.ResolveImage(req.Image)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			if b.c.cfg.BaseRootfs == "" {
+				return nil, fmt.Errorf("%w: no --image specified and no base_rootfs configured in firecracker.base_rootfs; pass --image <tag> or set base_rootfs in server.yaml", config.ErrInvalidShedRequestSentinel)
+			}
+			resolved = b.c.cfg.ResolveBaseRootfs()
+		}
+		backend.Phase(ctx, "image")
+		backend.Status(ctx, "Resolving image...")
+		mgr := vmimage.NewManager(b.c.cfg, b.c.refScanner())
+		ensureRes, err := mgr.EnsureImage(ctx, vmimage.ResolvedRef{
+			Path:      resolved.Path,
+			DockerRef: resolved.DockerRef,
+			Name:      resolved.Name,
+			Digest:    resolved.Digest,
+		}, func(stage, msg string) {
+			backend.Phase(ctx, stage)
+			backend.Status(ctx, msg)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to ensure image: %w", err)
+		}
+		if ensureRes.Digest == "" {
+			return nil, fmt.Errorf("image %q resolved to a path outside the blob store; the overlay model requires content-addressed images", resolved.Name)
+		}
+		pre.lowerDigest = ensureRes.Digest
+		pre.lowerImageTag = resolved.Name
+	}
+
+	// Drop a `.creating` marker recording the lower digest so a
+	// concurrent `shed image prune` can't sweep the blob between
+	// here and meta.Save. Skip for from-snapshot: the snapshot
+	// already pins the digest via its own LowerDigest field.
+	if pre.lowerDigest != "" && req.FromSnapshot == "" {
+		if err := writeCreatingMarker(b.c.cfg.InstanceDir, req.Name, pre.lowerDigest); err != nil {
+			return nil, fmt.Errorf("failed to write creating marker: %w", err)
+		}
+		shedName := req.Name
+		cleanup.Register("remove creating marker", func() error {
+			removeCreatingMarker(b.c.cfg.InstanceDir, shedName)
+			return nil
+		})
+	}
+
+	return pre, nil
+}
+
+// AllocateNetwork acquires the per-shed CID + IP + TAP device.
+// Cleanups are Registered individually so a failure at any step
+// unwinds only what came before.
+func (b *fcCreator) AllocateNetwork(ctx context.Context, req config.CreateShedRequest, cleanup *backend.Cleanup) (orchestrator.NetworkResources, error) {
+	backend.Phase(ctx, "network")
+	backend.Status(ctx, "Allocating network resources...")
+	cid, err := b.c.AllocateCID(req.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate CID: %w", err)
+	}
+	cleanup.Register("release CID", func() error {
+		b.c.ReleaseCID(cid)
+		return nil
+	})
+
+	tapDevice, ipAddress, err := b.c.AllocateNetwork(req.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate network: %w", err)
+	}
+	cleanup.Register("release IP", func() error {
+		b.c.ReleaseIP(ipAddress)
+		return nil
+	})
+
+	if err := b.c.netMgr.CreateTAPDevice(tapDevice); err != nil {
+		return nil, fmt.Errorf("failed to create TAP device: %w", err)
+	}
+	cleanup.Register("delete TAP device", func() error {
+		return b.c.netMgr.DeleteTAPDevice(tapDevice)
+	})
+
+	return fcNet{cid: cid, ipAddress: ipAddress, tapDevice: tapDevice}, nil
+}
+
+// AllocateUpper provisions the writable upper layer. Includes the
+// snapshot-clone branch for --from-snapshot.
+func (b *fcCreator) AllocateUpper(ctx context.Context, req config.CreateShedRequest, preRaw orchestrator.PreFlightResult, cleanup *backend.Cleanup) (orchestrator.UpperInfo, error) {
+	pre := preRaw.(*fcPreFlight)
+
+	backend.Phase(ctx, "rootfs")
+	backend.Status(ctx, "Allocating writable upper layer...")
+	upperPath, err := EnsureUpper(b.c.cfg.UppersDir, req.Name, pre.upperSizeBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create upper: %w", err)
+	}
+	shedName := req.Name
+	cleanup.Register("delete upper layer", func() error {
+		return DeleteUpper(b.c.cfg.UppersDir, shedName)
+	})
+
+	if pre.snapshotUpperSource != "" {
+		// Replace the freshly allocated empty upper with a reflink
+		// clone of the snapshot's stored upper so the new shed
+		// inherits its parent's writable contents.
+		if err := os.Remove(upperPath); err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to clear upper for snapshot clone: %w", err)
+		}
+		if _, err := clone.CloneFile(pre.snapshotUpperSource, upperPath); err != nil {
+			return nil, fmt.Errorf("failed to clone snapshot upper: %w", err)
+		}
+		if err := os.Chmod(upperPath, 0o644); err != nil {
+			return nil, fmt.Errorf("failed to chmod cloned upper: %w", err)
+		}
+		// The metadata's UpperSizeBytes must reflect the *cloned*
+		// file's size; mutate pre so BuildAndPersistMetadata sees
+		// the corrected value.
+		if fi, statErr := os.Stat(upperPath); statErr == nil {
+			pre.upperSizeBytes = fi.Size()
+		}
+	}
+	return fcUpper{path: upperPath, size: pre.upperSizeBytes}, nil
+}
+
+// BuildAndPersistMetadata builds the FC Metadata struct and saves it.
+// Registers the "delete instance dir" cleanup BEFORE Save (PR #137).
+func (b *fcCreator) BuildAndPersistMetadata(ctx context.Context, req config.CreateShedRequest, preRaw orchestrator.PreFlightResult, upperRaw orchestrator.UpperInfo, netRaw orchestrator.NetworkResources, cleanup *backend.Cleanup) (orchestrator.MetadataHandle, error) {
+	pre := preRaw.(*fcPreFlight)
+	upper := upperRaw.(fcUpper)
+	net := netRaw.(fcNet)
+
+	meta := &Metadata{
+		Name:           req.Name,
+		Status:         config.StatusStopped,
+		CreatedAt:      time.Now(),
+		Backend:        config.BackendFirecracker,
+		CID:            net.cid,
+		IPAddress:      net.ipAddress,
+		TAPDevice:      net.tapDevice,
+		CPUs:           pre.cpus,
+		MemoryMB:       pre.memoryMB,
+		RootfsPath:     upper.path,
+		UpperPath:      upper.path,
+		UpperSizeBytes: pre.upperSizeBytes,
+		Repo:           req.Repo,
+		LocalDir:       req.LocalDir,
+		Image:          req.Image,
+		LowerDigest:    pre.lowerDigest,
+		LowerImageTag:  pre.lowerImageTag,
+		FromSnapshot:   req.FromSnapshot,
+	}
+
+	cleanup.Register("delete instance dir", func() error {
+		return meta.Delete(b.c.cfg.InstanceDir)
+	})
+	if err := meta.Save(b.c.cfg.InstanceDir); err != nil {
+		return nil, fmt.Errorf("failed to save metadata: %w", err)
+	}
+	return &fcMetaHandle{meta: meta}, nil
+}
+
+// StartVM creates and starts the per-shed VM. Also performs the FC-
+// specific RegisterInstance call (a redundant re-record of the CID
+// + IP into the client's maps — already populated by Allocate{CID,
+// Network} — but kept for symmetry with UnregisterInstance).
+func (b *fcCreator) StartVM(ctx context.Context, metaRaw orchestrator.MetadataHandle, _ orchestrator.UpperInfo, _ orchestrator.NetworkResources, cleanup *backend.Cleanup) (orchestrator.VMHandle, error) {
+	meta := metaRaw.(*fcMetaHandle).meta
+
+	b.c.RegisterInstance(meta.Name, meta.CID, meta.IPAddress)
+
+	vm, err := CreateVM(ctx, meta, b.c.cfg, b.c.netMgr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create VM: %w", err)
+	}
+
+	backend.Phase(ctx, "vm")
+	backend.Status(ctx, "Starting virtual machine...")
+	if err := vm.Start(ctx); err != nil {
+		return nil, fmt.Errorf("failed to start VM: %w", err)
+	}
+	cleanup.Register("stop VM", func() error {
+		return vm.Stop(context.Background())
+	})
+	return fcVMHandle{vm: vm}, nil
+}
+
+// FinalizeStartedVM bumps the metadata's Status, re-saves, and
+// registers the c.vms map entry's removal cleanup.
+func (b *fcCreator) FinalizeStartedVM(ctx context.Context, metaRaw orchestrator.MetadataHandle, vmRaw orchestrator.VMHandle, cleanup *backend.Cleanup) error {
+	meta := metaRaw.(*fcMetaHandle).meta
+	vm := vmRaw.(fcVMHandle).vm
+
+	meta.Status = config.StatusRunning
+	if err := meta.Save(b.c.cfg.InstanceDir); err != nil {
+		return fmt.Errorf("failed to save metadata: %w", err)
+	}
+
+	b.c.mu.Lock()
+	b.c.vms[meta.Name] = vm
+	b.c.mu.Unlock()
+	shedName := meta.Name
+	cleanup.Register("remove from vms map", func() error {
+		b.c.mu.Lock()
+		defer b.c.mu.Unlock()
+		delete(b.c.vms, shedName)
+		return nil
+	})
+	return nil
+}
+
+// MountLocalDir mounts --local-dir via 9P when set; no-op otherwise.
+// The 9P server runs in-process on the host; we start it after VM
+// boot, then ask the guest to mount it.
+func (b *fcCreator) MountLocalDir(ctx context.Context, req config.CreateShedRequest, metaRaw orchestrator.MetadataHandle, _ orchestrator.VMHandle) error {
+	if req.LocalDir == "" {
+		return nil
+	}
+	meta := metaRaw.(*fcMetaHandle).meta
+	agent := b.c.newAgentClient(meta.Name)
+	backend.Phase(ctx, "9p")
+	backend.Status(ctx, "Mounting local directory via 9P...")
+	bridgeIP := b.c.netMgr.Gateway()
+	srv, err := b.c.startP9Server(req.Name, bridgeIP, req.LocalDir, config.WorkspacePath, false)
+	if err != nil {
+		return fmt.Errorf("failed to start 9P server for local dir: %w", err)
+	}
+	// Register the 9P teardown only AFTER startP9Server succeeds.
+	// The orchestrator's cleanup is the only path that runs this hook,
+	// so we can't access it directly from MountLocalDir's signature —
+	// the cleanup must be wired through the orchestrator.
+	//
+	// In practice, the 9P server is per-shed and lives until shed
+	// deletion, so we don't register a cleanup here; the wider shed
+	// cleanup (StopShed/DeleteShed) calls stopP9Servers.
+	if err := b.c.mount9PInGuest(ctx, agent, srv.Addr(), config.WorkspacePath, false, "workspace"); err != nil {
+		// On mount failure we need to stop the just-started 9P
+		// server explicitly, since we couldn't register a cleanup.
+		b.c.stopP9Servers(req.Name)
+		return fmt.Errorf("failed to mount 9P in guest: %w", err)
+	}
+	return nil
+}
+
+// SetupCredentials mounts configured credentials via 9P post-Start.
+// Best-effort.
+func (b *fcCreator) SetupCredentials(ctx context.Context, req config.CreateShedRequest, metaRaw orchestrator.MetadataHandle, _ orchestrator.VMHandle) {
+	meta := metaRaw.(*fcMetaHandle).meta
+	dirCreds := vmutil.FilterExistingCredentials(b.c.serverCfg)
+	if len(dirCreds) > 0 {
+		backend.Phase(ctx, "credentials")
+		backend.Status(ctx, "Setting up credentials...")
+	}
+	agent := b.c.newAgentClient(meta.Name)
+	b.c.credMgr.SetupCredentials(ctx, agent, req.Name, dirCreds, b.c.mount9PCredentialFunc(req.Name))
+}
+
+// CloneRepo runs `git clone` inside the guest when --repo is set.
+// Best-effort; mirrors VZ's hook.
+func (b *fcCreator) CloneRepo(ctx context.Context, req config.CreateShedRequest, metaRaw orchestrator.MetadataHandle, _ orchestrator.VMHandle) {
+	if req.Repo == "" || req.LocalDir != "" || req.FromSnapshot != "" {
+		return
+	}
+	meta := metaRaw.(*fcMetaHandle).meta
+	agent := b.c.newAgentClient(meta.Name)
+	backend.Phase(ctx, "repo")
+	backend.Status(ctx, "Cloning repository...")
+	if err := vmutil.CloneRepo(ctx, agent, b.c.serverCfg, req.Repo); err != nil {
+		log.Printf("Warning: failed to clone repo %s: %v", config.SanitizeRepoURL(req.Repo), err)
+		backend.StatusWarning(ctx, "Failed to clone repository (see server logs for details)")
+	} else {
+		backend.Status(ctx, "Repository cloned")
+	}
+}
+
+// RunProvisioning loads the per-shed provisioning config and runs
+// any hooks it declares. Best-effort.
+func (b *fcCreator) RunProvisioning(ctx context.Context, req config.CreateShedRequest, metaRaw orchestrator.MetadataHandle, _ orchestrator.VMHandle) {
+	if req.NoProvision {
+		return
+	}
+	meta := metaRaw.(*fcMetaHandle).meta
+	agent := b.c.newAgentClient(meta.Name)
+	provisioner := vmutil.NewProvisioner(agent, req.Name)
+	provisioner.SetOutput(os.Stdout, os.Stderr)
+	cfg, err := provisioner.LoadConfig(ctx)
+	if err != nil {
+		log.Printf("Warning: failed to load provisioning config: %v", err)
+		return
+	}
+	runInstall := req.FromSnapshot == ""
+	if err := provisioner.RunProvisioning(ctx, cfg, runInstall); err != nil {
+		log.Printf("Warning: provisioning failed: %v", err)
+	}
+}
+
+// ToShedResult returns the *config.Shed value the orchestrator hands
+// back to the per-backend CreateShed wrapper's caller.
+func (b *fcCreator) ToShedResult(metaRaw orchestrator.MetadataHandle) *config.Shed {
+	return metadataToShed(metaRaw.(*fcMetaHandle).meta)
+}

--- a/internal/firecracker/orchestrator.go
+++ b/internal/firecracker/orchestrator.go
@@ -188,7 +188,13 @@ func (b *fcCreator) PreFlight(ctx context.Context, req config.CreateShedRequest,
 			return nil, fmt.Errorf("failed to write creating marker: %w", err)
 		}
 		shedName := req.Name
-		cleanup.Register("remove creating marker", func() error {
+		// AddDeferred (not Register) so the marker is also removed
+		// on the success path — the marker's lifetime is the create
+		// operation itself, not the resulting shed. The shed's
+		// Metadata.LowerDigest takes over blob protection from here.
+		// PR #140's Codex review caught this regression in both
+		// backends.
+		cleanup.AddDeferred("remove creating marker", func() error {
 			removeCreatingMarker(b.c.cfg.InstanceDir, shedName)
 			return nil
 		})
@@ -236,8 +242,7 @@ func (b *fcCreator) AllocateNetwork(ctx context.Context, req config.CreateShedRe
 func (b *fcCreator) AllocateUpper(ctx context.Context, req config.CreateShedRequest, preRaw orchestrator.PreFlightResult, cleanup *backend.Cleanup) (orchestrator.UpperInfo, error) {
 	pre := preRaw.(*fcPreFlight)
 
-	backend.Phase(ctx, "rootfs")
-	backend.Status(ctx, "Allocating writable upper layer...")
+	// Phase/Status emitted by the orchestrator before calling this hook.
 	upperPath, err := EnsureUpper(b.c.cfg.UppersDir, req.Name, pre.upperSizeBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create upper: %w", err)
@@ -321,8 +326,7 @@ func (b *fcCreator) StartVM(ctx context.Context, metaRaw orchestrator.MetadataHa
 		return nil, fmt.Errorf("failed to create VM: %w", err)
 	}
 
-	backend.Phase(ctx, "vm")
-	backend.Status(ctx, "Starting virtual machine...")
+	// Phase/Status emitted by the orchestrator before calling this hook.
 	if err := vm.Start(ctx); err != nil {
 		return nil, fmt.Errorf("failed to start VM: %w", err)
 	}

--- a/internal/vz/orchestrator.go
+++ b/internal/vz/orchestrator.go
@@ -180,7 +180,13 @@ func (b *vzCreator) PreFlight(ctx context.Context, req config.CreateShedRequest,
 		}
 		pre.hasCreatingMarker = true
 		shedName := req.Name
-		cleanup.Register("remove creating marker", func() error {
+		// AddDeferred (not Register) so the marker is also removed
+		// on the success path — the marker's lifetime is the create
+		// operation itself, not the resulting shed. The shed's
+		// Metadata.LowerDigest takes over blob protection from here.
+		// PR #140's Codex review caught this regression in both
+		// backends.
+		cleanup.AddDeferred("remove creating marker", func() error {
 			removeCreatingMarker(b.c.cfg.InstanceDir, shedName)
 			return nil
 		})


### PR DESCRIPTION
§15 Phase 2 PR 2d. FC's \`CreateShed\` is now a thin **45-line wrapper** over \`orchestrator.CreateShed\`. Mirrors VZ's 2c migration (#139) — same interface, different platform.

## Diff scale

| | Before (#137 main) | After (this PR) |
|---|---|---|
| \`internal/firecracker/client.go\` \`CreateShed\` body | ~370 lines | **45 lines** |
| \`internal/firecracker/orchestrator.go\` | — | +400 lines (fcCreator + handles + all 11 hooks) |

## Hook map (vs VZ's 2c)

| Hook | FC behavior | vs VZ |
|---|---|---|
| \`PreFlight\` | cpus/memory/upper-size + image OR snapshot resolution + .creating marker | Same shape; uses \`vmimage.Manager\` (FC's image path) |
| \`AllocateNetwork\` | **CID + IP + TAP** with per-step cleanups | The meaningful divergence — VZ's is a no-op |
| \`AllocateUpper\` | EnsureUpper + optional snapshot-clone | No template-mint branch (FC's in-guest mkfs is ~0.18s; not worth optimizing per §0) |
| \`BuildAndPersistMetadata\` | embeds CID/IP/TAP from \`fcNet\` into Metadata | Same pattern as VZ |
| \`StartVM\` | RegisterInstance + CreateVM + Start + stop-VM cleanup | RegisterInstance is FC-specific |
| \`FinalizeStartedVM\` | Status=Running, Save, c.vms insert, remove-from-vms cleanup | Same as VZ |
| \`MountLocalDir\` | **9P server + in-guest mount** | VirtioFS on VZ; 9P on FC |
| \`SetupCredentials\` | c.credMgr.SetupCredentials with FC 9P mount-func | Same shape |
| \`CloneRepo\` / \`RunProvisioning\` / \`ToShedResult\` | shared via vmutil | Same as VZ |

**FC-specific subtlety on \`MountLocalDir\`**: the 9P server cleanup happens at shed-stop, not on mount failure. The hook calls \`stopP9Servers\` explicitly on its own error path, rather than registering a cleanup-stack entry (which would also fire on later create-flow failures, including success-path).

## What this completes

Both backends now go through \`orchestrator.CreateShed\`. The duplicated lifecycle code in \`vz/client.go\` and \`firecracker/client.go\` is **gone** — ~700 lines of near-parallel rollback boilerplate replaced by one shared orchestrator that each backend implements via a small interface.

## Validation chain

- \`make build\` clean (host + Linux cross-compile — the latter is what actually exercises the FC code, since \`internal/firecracker\` is \`//go:build linux\`).
- \`make test\` clean (Go unit tests).
- \`make lint\` clean.
- VZ integration suite (run against dev v0.5.6 server with both backends now routed through the orchestrator): **15 vz-tagged tests pass** (no regression on the side I can live-test).
- FC live validation pending mini3 upgrade to a PhaseTimer-emitting version (v0.5.4+). The §16 suite skips PhaseTimer-dependent FC tests cleanly today; once mini3 ships v0.5.7 (or whatever bundles Phase 1 + 2), the FC tests will live-validate automatically.

## Per the §15 mandatory process

**No release** from this PR. Bundle with the rest of Phase 2 into a single Phase-2 release discussion.

## Same LoadMetadata safety check from PR #139

FC's wrapper now also propagates non-\`ErrInstanceNotFound\` errors from \`LoadMetadata\` (CodeRabbit's review of #139 surfaced this as a pre-existing bug in both backends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)