### PR TITLE
docs: integration test suite in CLAUDE.md + Development → Testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,15 +9,43 @@ Shed is a CLI tool for managing persistent, VM-based development environments ac
 ## Build & Test
 
 ```bash
-make build          # Build all binaries (shed, shed-server, shed-agent) into bin/
-make test           # Run all unit tests
-make lint           # Run golangci-lint
-make fmt            # Format code with gofmt
-make check          # Run lint + test
-make coverage       # Tests with coverage report
+make build              # Build all binaries (shed, shed-server, shed-agent) into bin/
+make test               # Run all unit tests
+make lint               # Run golangci-lint
+make fmt                # Format code with gofmt
+make check              # Run lint + test
+make coverage           # Tests with coverage report
+make test-integration   # Run the pytest-based integration suite (see below)
 ```
 
 Tools are managed via [mise](https://mise.jdx.dev/) — run `mise install` to set up Go and golangci-lint.
+
+### Integration test suite (`tests/integration/`)
+
+Live create-cycle tests that drive a running `shed-server` via the `shed` CLI. Pytest + subprocess (Fabric reserved for the few remote-orchestration tasks that need it), managed with `uv`. Complements the Go unit tests — those catch logic / file-shape regressions on every PR; the integration suite catches live boot-path / SSE / timing regressions that need a real VM.
+
+```bash
+# One-time: install uv (https://docs.astral.sh/uv/getting-started/installation/)
+brew install uv
+
+# Run the suite (auto-installs Python deps into a managed venv on first run)
+make test-integration
+```
+
+The suite is **parameterized over `["vz", "fc"]`** and skips cleanly when a backend is unreachable from this host. On a Mac with the brew-installed `shed-server`, VZ tests run against `shed -s my-server`; FC tests target the entry named by `$SHED_FC_HOST` (default `mini3`) over SSH.
+
+**FC live tests require the remote `shed-server` to emit `PhaseTimer` log lines** (added in v0.5.4 via PR #118). Two tests (`test_phase_timer_emitted[fc]`, `test_plain_create_timing[fc]`) skip cleanly with a clear message if the remote is older — the other three FC tests work against any shed-server version. Once the remote upgrades to v0.5.4+, the suite picks up the FC tests automatically with no config change.
+
+Environment overrides (full list in `tests/integration/README.md`):
+
+| Variable | Default | Effect |
+|---|---|---|
+| `SHED_VZ_SERVER` | `my-server` | `~/.shed/config.yaml` entry for the local VZ server |
+| `SHED_VZ_LOG_PATH` | `/opt/homebrew/var/log/shed-server.log` | brew log path (override for Intel-Mac homebrew prefix or custom installs) |
+| `SHED_FC_HOST` | `mini3` | SSH host for FC live tests |
+| `SHED_FC_SERVER` | same as host | `~/.shed/config.yaml` entry name when it differs from the SSH host |
+
+See `docs/development/testing.md` (Development → Testing on the docs site) for the full operator guide — adding a test, the per-backend timing ceilings, the fixture conventions, the mini3 upgrade procedure for FC e2e, etc.
 
 ## Project Structure
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -4,10 +4,13 @@ This document covers Shed's testing strategy, how to run each tier of tests, and
 
 ## Test Tiers
 
-| Tier | Scope | Build Tags | Requirements | CI |
-|------|-------|------------|--------------|-----|
-| Unit | Pure logic, no external deps | None (or `linux` for Firecracker) | Go toolchain | Yes |
-| E2E (Firecracker) | Full VM lifecycle via API | `e2e` | KVM, root, Firecracker assets | No |
+| Tier | Scope | Tool | Requirements | CI |
+|------|-------|------|--------------|-----|
+| Unit | Pure logic, file-shape, ordering invariants | `go test` | Go toolchain | Yes |
+| Integration suite | Live create-cycle via `shed` CLI (both backends) | `pytest` + subprocess (uv-managed) | Reachable shed-server (local or remote); for FC: SSH to the host | No (locally + bare-metal release-validation) |
+| E2E (Firecracker, legacy) | Full VM lifecycle via API directly | `go test -tags=e2e` | KVM, root, Firecracker assets | No |
+
+The **integration suite** (PR #132) is the recommended path for live create-cycle verification on both backends. The Go-tagged FC e2e tests predate it and remain available for low-level API exercise.
 
 ## Running Tests
 
@@ -31,7 +34,130 @@ Firecracker unit tests (metadata, rootfs, networking) use the `linux` build tag 
 go test ./internal/firecracker/...
 ```
 
-### E2E (Firecracker)
+### Integration Suite (pytest)
+
+Live create-cycle tests that drive a running `shed-server` via the `shed` CLI. The suite lives at `tests/integration/` and is the recommended path for verifying that the host-side and guest-side pieces actually fit together — boot timing, SSE events, `--repo` clone, `shed exec` round-trip, etc.
+
+Architecture: pytest + subprocess (+ Fabric reserved for remote-orchestration tasks like deploying a dev binary), managed with [`uv`](https://docs.astral.sh/uv/). The decision rationale + the full architecture is captured in `docs/discovery/platform-runtime-optimization.md` §16.
+
+#### Running the suite
+
+```bash
+# One-time: install uv (or `brew install uv`)
+# https://docs.astral.sh/uv/getting-started/installation/
+
+# From repo root:
+make test-integration
+```
+
+That target verifies `uv` is on `PATH`, runs `uv sync` into a managed venv (gitignored), and invokes pytest with `-v`. Each test is parameterized over `["vz", "fc"]` and skips cleanly when its target backend isn't reachable from this host.
+
+#### Per-backend requirements
+
+**VZ (Apple Silicon mac):**
+
+- A reachable shed-server, e.g., `brew services start shed`.
+- `shed -s my-server list` succeeds. The entry comes from `~/.shed/config.yaml`.
+- Server log at `/opt/homebrew/var/log/shed-server.log` (Homebrew default). Override with `SHED_VZ_LOG_PATH` for Intel-Mac (`/usr/local/...`) or custom install paths.
+
+**Firecracker (default: `mini3` over SSH):**
+
+- SSH access to the host with `BatchMode=yes` (no interactive prompt). Override the hostname with `SHED_FC_HOST`.
+- `shed -s mini3 list` succeeds (the entry exists in `~/.shed/config.yaml` and the server responds).
+- Passwordless `sudo -n journalctl -u shed-server` on the remote, for the PhaseTimer log-line fetch. Two tests skip cleanly if it's unavailable (you still get the other three FC tests).
+- **The remote shed-server must be v0.5.4 or newer** for the PhaseTimer-dependent assertions (`test_phase_timer_emitted`, `test_plain_create_timing`). PhaseTimer was added in PR #118 / v0.5.4; older servers cause those two tests to skip with a clear reason while the rest of the suite still runs.
+
+#### Enabling FC e2e on `mini3` (or any remote host)
+
+The suite picks up FC tests automatically once the remote server emits PhaseTimer. The procedure to enable end-to-end FC verification on `mini3`:
+
+1. **Upgrade the remote shed-server to v0.5.4 or newer.** The simplest path is to install the latest release's `.deb` — every v0.5.4+ release publishes `shed-server_<version>_amd64.deb` and `shed-server_<version>_arm64.deb` to GitHub Releases. On `mini3`:
+
+   ```bash
+   # On the remote host
+   curl -L -o /tmp/shed-server.deb \
+     https://github.com/charliek/shed/releases/download/v<VERSION>/shed-server_<VERSION>_amd64.deb
+   sudo dpkg -i /tmp/shed-server.deb
+   sudo systemctl restart shed-server
+   systemctl is-active shed-server     # active
+   /usr/local/bin/shed-server --version
+   ```
+
+2. **Verify passwordless sudo for journalctl** (one-time per remote):
+
+   ```bash
+   sudo -n journalctl -u shed-server --since "1 minute ago" --no-pager
+   ```
+
+   If this prompts for a password, the suite's PhaseTimer-dependent FC tests can't fetch logs. Either keep your sudo cache warm during the run or add a NOPASSWD rule for the `journalctl -u shed-server` invocation.
+
+3. **Run the suite from the dev mac**:
+
+   ```bash
+   make test-integration
+   ```
+
+   All ten tests (5 × 2 backends) should now run live. Plain-create timing thresholds are in `tests/integration/fixtures/server.py:DEFAULT_AGENT_P50_MS` — tighten as future PRs land.
+
+#### Environment overrides
+
+| Variable | Default | Effect |
+|---|---|---|
+| `SHED_VZ_SERVER` | `my-server` | `~/.shed/config.yaml` entry for the local VZ server. |
+| `SHED_VZ_LOG_PATH` | `/opt/homebrew/var/log/shed-server.log` | Where the local VZ server writes its log file. |
+| `SHED_FC_HOST` | `mini3` | SSH hostname for the FC server (used for journald log fetch). |
+| `SHED_FC_SERVER` | same as `SHED_FC_HOST` | `~/.shed/config.yaml` entry name when it differs from the SSH host. |
+
+#### Adding a test
+
+Tests live in `test_smoke.py`. Use the `shed_server` fixture (parameterized over `["vz", "fc"]`) and `test_shed_name` (unique per-test name with autoteardown):
+
+```python
+def test_my_thing(shed_server, test_shed_name):
+    shed_server.create(test_shed_name, image="base")
+    r = shed_server.exec(test_shed_name, ["uname", "-r"])
+    assert r.returncode == 0
+    assert "Linux" in r.stdout
+```
+
+For a backend-specific test, mark it explicitly:
+
+```python
+@pytest.mark.fc
+def test_only_on_fc(fc_server, ...):
+    ...
+```
+
+(Markers are declared in `pyproject.toml` under `[tool.pytest.ini_options].markers` — keep them in sync.)
+
+#### Suite layout
+
+```
+tests/integration/
+  pyproject.toml          # uv-managed Python project + pytest config
+  uv.lock                 # committed for reproducibility (gitignore exception)
+  README.md               # operator notes; same content as this section, in-tree
+  conftest.py             # vz_server, fc_server, shed_server, test_shed_name
+  test_smoke.py           # 5 MVP tests × 2 backends
+  test_timing_parser.py   # 8 PhaseTimer parser unit tests (no live server)
+  fixtures/
+    server.py             # LocalServer + RemoteServer + ShedHandle
+    timing.py             # PhaseTimer log-line parser
+```
+
+The five MVP tests:
+
+| Test | What it asserts |
+|---|---|
+| `test_create_delete_lifecycle` | `shed create` succeeds; the shed appears in `shed list`; explicit `shed delete` removes it; absence verified. |
+| `test_phase_timer_emitted` | Server log contains a `timing: create …` line with the expected phase keys. |
+| `test_repo_clone_https` | `--repo` with an HTTPS URL clones the pinned octocat/Hello-World HEAD; `git rev-parse HEAD` in the guest matches. |
+| `test_plain_create_timing` | `agent` phase p50 (5 samples) stays under a per-backend ceiling. The **dynamic perf-regression gate** PR-time CI can't be (no `/dev/kvm` on GHA). |
+| `test_shed_exec_smoke` | `shed exec <name> -- echo hello` returns `hello`. |
+
+Plus 8 parser unit tests in `test_timing_parser.py` covering the PhaseTimer log shape (real captured lines, duplicate-phase summation, "no keys after err=" guard).
+
+### E2E (Firecracker, legacy)
 
 Firecracker e2e tests exercise the full VM lifecycle: create, start, exec, stop, delete. They require KVM access, root privileges, and pre-built Firecracker assets.
 


### PR DESCRIPTION
Per the user message during PR #140's session — document the §16 integration test suite for both operators and contributors, including the enable-FC-e2e-on-mini3 procedure.

## What's changed

### \`CLAUDE.md\` (project instructions, loaded into every Claude Code session)

- \`make test-integration\` added to the build/test summary at the top.
- New "Integration test suite" subsection explaining:
  - Architecture (pytest + subprocess + uv).
  - What it tests vs the Go unit tier.
  - Per-backend availability rule (skip cleanly when unreachable).
  - The FC v0.5.4+ PhaseTimer precondition + which two tests skip on older servers.
  - Environment-override table.
  - Pointer to the full operator guide in the docs site.

### \`docs/development/testing.md\`

- **Test-tiers table** now lists the integration suite alongside Unit and the legacy FC e2e tier, with refreshed comparison columns (Tool / Requirements / CI).
- **New "Integration Suite (pytest)" section** between Unit and E2E (Firecracker, legacy) covering:
  - One-line \`make test-integration\` invocation.
  - Per-backend requirements (VZ on this mac; FC remote, default mini3).
  - **Concrete "Enabling FC e2e on \`mini3\`" procedure**: download the latest \`.deb\` from GitHub Releases, install with dpkg, restart shed-server, verify passwordless \`sudo -n journalctl\`, then run \`make test-integration\` — all 10 tests live.
  - Environment-override table.
  - "Adding a test" example with the \`shed_server\` + \`test_shed_name\` fixtures.
  - Suite layout (file tree).
  - Per-test summary table for the 5 MVP tests.
- Pre-existing "E2E (Firecracker)" tier renamed to **(legacy)** so the integration suite is recommended for new live tests.

## Why this matters now

§16 (the suite's design doc) lives in \`discovery/platform-runtime-optimization.md\` which is implementation-trail prose, not operator-facing. \`tests/integration/README.md\` covers the same content but lives in-tree where less casual contributors find it. CLAUDE.md + the Development docs site section are where the audience actually looks — operators running tests + contributors adding them.

## Doesn't change

- No code touched.
- No Makefile change beyond what \`test-integration\` already did.
- No new dependency.
- \`make build\` / \`make test\` / \`make lint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)