### PR TITLE
feat(images): add zip to both base images (#129)

### DIFF
--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -100,7 +100,7 @@ RUN printf '%s\n' \
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        systemd systemd-sysv dbus \
-       sudo unzip ca-certificates hostname \
+       sudo zip unzip ca-certificates hostname \
        tmux git curl wget neovim jq ncurses-term ripgrep tree \
        openssh-server \
        iproute2 iputils-ping dnsutils netcat-openbsd \

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -75,7 +75,7 @@ RUN printf '%s\n' \
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        systemd systemd-sysv systemd-resolved dbus \
-       sudo unzip ca-certificates hostname \
+       sudo zip unzip ca-certificates hostname \
        tmux git gh curl wget neovim jq ncurses-term ripgrep tree \
        openssh-server \
        iproute2 iputils-ping dnsutils netcat-openbsd \


### PR DESCRIPTION
Trivial parity add. Both `vz/Dockerfile` and `firecracker/Dockerfile`
already install `unzip` but not `zip`; sdkman, gradle wrappers, and
other common build tools that *create* zip archives need it.

## Diff

```diff
- sudo unzip ca-certificates hostname \
+ sudo zip unzip ca-certificates hostname \
```

Same single-word add in both Dockerfiles, in the base apt-install
layer so it propagates to all three image variants (base /
extensions / full).

Image size cost: ~110 KB installed (`zip` is tiny). Symmetry with
`unzip` is the win.

No CHANGELOG edit — deferred to the v0.5.7 release commit per project
convention (this PR is being bundled with #131 and the
shed-extensions v0.3.2 bump for the release).

Closes #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)