### PR TITLE
chore(images): bump shed-extensions v0.3.1 → v0.3.2 + add extensions smoke

### DIFF
--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -24,7 +24,7 @@
 
 # Bump this when shed-extensions releases a new version.
 # The extensions and full variants pull binaries from this tag.
-ARG SHED_EXT_VERSION=v0.3.1
+ARG SHED_EXT_VERSION=v0.3.2
 FROM ghcr.io/charliek/shed-extensions:${SHED_EXT_VERSION} AS shed-extensions
 
 # Note: the shed initramfs (overlay-on-the-guest init) is built from

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -193,3 +193,66 @@ def test_shed_exec_smoke(shed_server, test_shed_name):
     r = shed_server.exec(test_shed_name, ["echo", "hello"])
     assert r.returncode == 0, f"shed exec echo failed: stderr={r.stderr!r}"
     assert "hello" in r.stdout, f"unexpected stdout: {r.stdout!r}"
+
+
+# ---------------------------------------------------------------------------
+# 6. Extensions image smoke (the shed-extensions layer is wired up)
+# ---------------------------------------------------------------------------
+
+
+# Binaries shipped by the upstream ghcr.io/charliek/shed-extensions image
+# and copied into the `extensions` (and transitively `full`) rootfs layer
+# by the Dockerfile's COPY-via-bind RUN. If a bump regresses any of them
+# (missing binary, wrong path, lost +x bit, arch mismatch), this test
+# catches it before the bump ships.
+#
+# Keep this list aligned with the install statements in
+# vz/Dockerfile + firecracker/Dockerfile's `shed-vz-extensions` /
+# `shed-fc-extensions` stage.
+_SHED_EXTENSIONS_BINARIES = (
+    "/usr/local/bin/shed-ext-ssh-agent",
+    "/usr/local/bin/shed-ext-aws-credentials",
+    "/usr/local/bin/docker-credential-shed",
+)
+
+
+def test_extensions_image_smoke(shed_server, test_shed_name):
+    """The `extensions` image variant carries the shed-extensions binaries.
+
+    Smoke test for the `extensions` (and transitively `full`) image
+    variants — verifies that the Dockerfile's
+    `COPY --from=ghcr.io/charliek/shed-extensions:vX.Y.Z` resolved
+    cleanly at image-build time, every documented binary is present in
+    the booted rootfs at the documented path, and each binary has the
+    executable bit. This is the gate future shed-extensions bumps need
+    to survive — added with the v0.3.1 → v0.3.2 bump so the existing
+    `image="base"` tests don't carry the burden.
+
+    Skips with a clear message if the server has no `extensions` tag
+    configured (e.g. a dev box pulling only `base`); the test isn't a
+    regression for that environment, it just doesn't apply.
+    """
+    try:
+        shed_server.create(test_shed_name, image="extensions")
+    except AssertionError as e:
+        msg = str(e)
+        if "extensions" in msg and (
+            "no image tag" in msg or "not found" in msg or "unknown image" in msg
+        ):
+            pytest.skip(
+                "server has no `extensions` image tag configured; this "
+                "smoke gate only applies where the extensions variant is "
+                "installed. Configure one with `shed image tag …` or pull "
+                "ghcr.io/charliek/shed-{vz,fc}-extensions:vX.Y.Z."
+            )
+        raise
+
+    for binary in _SHED_EXTENSIONS_BINARIES:
+        r = shed_server.exec(test_shed_name, ["test", "-x", binary])
+        assert r.returncode == 0, (
+            f"{binary!r} missing or not executable in the booted shed: "
+            f"exit={r.returncode} stdout={r.stdout!r} stderr={r.stderr!r}. "
+            f"The Dockerfile's `COPY --from=shed-extensions` likely failed "
+            f"to install this binary (check the COPY RUN in "
+            f"vz/Dockerfile / firecracker/Dockerfile's extensions stage)."
+        )

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -24,7 +24,7 @@
 
 # Bump this when shed-extensions releases a new version.
 # The extensions and full variants pull binaries from this tag.
-ARG SHED_EXT_VERSION=v0.3.1
+ARG SHED_EXT_VERSION=v0.3.2
 FROM ghcr.io/charliek/shed-extensions:${SHED_EXT_VERSION} AS shed-extensions
 
 # Note: the shed initramfs (overlay-on-the-guest init) is built from


### PR DESCRIPTION
Upstream [shed-extensions v0.3.2](https://github.com/charliek/shed-extensions/releases/tag/v0.3.2)
just shipped with bug fixes (Touch ID approval in clamshell mode,
Docker credential helper PATH under launchd, plus docs / Homebrew
quality-of-life). Bumps the `SHED_EXT_VERSION` ARG in both `vz/Dockerfile`
and `firecracker/Dockerfile`; affects the `extensions` and `full`
image variants (the `base` variant doesn't layer shed-extensions).

## Diff

```diff
-ARG SHED_EXT_VERSION=v0.3.1
+ARG SHED_EXT_VERSION=v0.3.2
```

— same single-token bump in both Dockerfiles.

## New: integration test for the extensions image

`tests/integration/test_smoke.py::test_extensions_image_smoke`,
parameterized over `["vz", "fc"]`. Creates with `image="extensions"`,
then asserts each documented shed-extensions binary
(`shed-ext-ssh-agent`, `shed-ext-aws-credentials`,
`docker-credential-shed`) is present at `/usr/local/bin/` and has the
executable bit. **This is the gate future shed-extensions bumps need
to survive** — without it, the existing `image="base"` tests can't
catch a regression in the layered binaries (lost +x, wrong arch,
missing path, etc.). Skips cleanly if the server has no `extensions`
tag configured.

## Pre-PR validation

- ✅ Upstream OCI image v0.3.2 published and pullable
  (`docker manifest inspect ghcr.io/charliek/shed-extensions:v0.3.2`
  shows both `linux/arm64` and `linux/amd64` manifests).
- ✅ New smoke test passes on both backends against the
  currently-shipping v0.3.1 extensions image (validates the test
  logic — `test_extensions_image_smoke[vz]` and `[fc]` both PASS).
- ✅ Full `make test-integration` clean on VZ (mac) and FC (mini3
  v0.5.6) with the new test added.
- ✅ `make check` clean.

## Validation caveat

Local-build rebuild validation *of v0.3.2 specifically* was blocked
by a pre-existing kernel/initramfs module-version mismatch on freshly
rebuilt rootfs — the `base` variant rebuilds with the same
`erofs.ko` insmod failure (`libcrc32c: disagrees about version of
symbol module_layout` → `mount /dev/vdb on /lower failed: No such
device` → `agent health check failed: context deadline exceeded`).
This is a pre-existing local-build environment issue independent of
this bump; the bump itself is a 2-character ARG value change and the
`COPY --from=shed-extensions` paths are unchanged. CI's image-build
job validates the v0.3.2 OCI image resolves end-to-end.

The local-build kernel/initramfs issue is worth a separate
investigation; logging it here so it's not lost (the broken boot
behavior is the same whether you build `base` or `extensions`
locally — see the `shed-initramfs PANIC [SHED-INIT-03]` in
`~/Library/Application Support/shed/vz/logs/`).

## No CHANGELOG edit

Deferred to the v0.5.7 release commit (this PR bundles with #143,
#144, and the upcoming SSH-wrap PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added smoke test to verify extensions image contains required binaries.

* **Chores**
  * Updated shed-extensions dependency to v0.3.2 in Firecracker and virtualization build configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->