### PR TITLE
feat(sshd): wrap SSH command channel in bash -lc (#131)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,17 +73,19 @@ See `docs/development/testing.md` (Development → Testing on the docs site) for
 - **Workspace path**: `/workspace` inside VMs (see `config.WorkspacePath`)
 - **VM user**: `shed` (UID 1000) with passwordless sudo
 
-## `shed exec` semantics
+## `shed exec` semantics and the SSH command channel
 
-`shed exec` runs `argv[0]` with `argv[1:]` directly inside the shed — like `docker exec` / `kubectl exec`. There is **no implicit shell wrapping**, so pipes, redirects, semicolons, `$VAR`, command substitution, etc. only fire when the user explicitly invokes a shell. The CLI single-quotes each argv element before handing to `ssh` so the SSH server's `shlex.Split` recovers the original argv intact.
+`shed exec` ships argv literally. The CLI single-quote-wraps each argv element before SSH (`cmd/shed/console.go:shellQuoteArgs`), and the server reparses the SSH command through `bash -lc` (`internal/sshd/wrap.go:wrapCommand`). Because bash treats single-quoted text as literal data, `shed exec name -- echo '$HOME'` echoes the literal `$HOME` — argv is preserved, shell metacharacters in user-supplied data don't escape.
+
+Raw SSH (`ssh shed-name 'cmd | pipe'`) gets the full shell, because the client sends a raw command string and the server's `bash -lc` wrap interprets it. This matches Docker, Codespaces, devcontainers, and every other hosted-shell product, and is what Zed Remote-SSH, VS Code Remote-SSH, JetBrains Gateway, raw `ssh`, and `rsync` assume.
 
 Implications when writing code or docs:
 
-- `shed exec <name> -- mytool` is direct-exec; tools must already be on the agent's `PATH` (`/etc/environment.d/` defaults).
-- Anything needing shell features goes through `bash -c '…'`: `shed exec <name> -- bash -c 'a | b > c'`.
-- Login-shell init (`/etc/profile.d`, `~/.profile`) is opt-in via `bash -lc '…'`.
-- Provisioning hooks are a separate path (`internal/vmutil/provisioning.go`) — they still run as `bash --login -c` and source profile scripts.
-- The legacy idiom `shed exec name "cmd | with | pipes"` no longer works; rewrite as `shed exec name -- bash -c 'cmd | with | pipes'`.
+- `shed exec <name> -- mytool` runs `mytool` direct-argv via `bash -lc "'mytool'"` server-side — `mytool` must be on the shed user's login PATH (`/etc/profile.d/*.sh` and `/etc/environment.d/` defaults are sourced by the `-l`).
+- Anything needing shell features inside `shed exec` still goes through `bash -c '…'` explicitly, as before; the difference is that `bash` is now also implicit on the SSH-server side, so direct argv elements get the same login-shell PATH treatment.
+- Provisioning hooks are a separate path (`internal/vmutil/provisioning.go`) — they still run as `bash --login -c` and bypass the sshd wrap entirely.
+- The CLI quoter (`cmd/shed/console.go:validateAndQuoteArgs`) is the **security gate**. It single-quotes each argv element and rejects empty elements + NUL bytes. The Go-level bash round-trip test (`cmd/shed/console_test.go:TestShellQuoteBashRoundTrip`) is the unit audit; the integration suite (`tests/integration/test_exec_shell.py`) is the live wire audit.
+- The legacy idiom `shed exec name "cmd | with | pipes"` still doesn't work — the CLI strips the pipe by single-quoting; rewrite as `shed exec name -- bash -c 'cmd | with | pipes'`.
 
 This convention is documented end-user-style in `docs/reference/cli.md` under `shed exec`.
 

--- a/cmd/shed/console.go
+++ b/cmd/shed/console.go
@@ -101,14 +101,29 @@ func shellQuoteArgs(args []string) []string {
 }
 
 // validateAndQuoteArgs single-quotes each argv element (so shell metacharacters
-// survive the SSH wire) and rejects empty elements. The gliderlabs/ssh server
-// uses anmitsu/go-shlex in posix mode, which drops empty quoted tokens — so
-// without this guard, an empty argv element would silently shift the rest of
-// argv on the server side.
+// survive the SSH wire) and rejects argv elements that the SSH/bash downstream
+// can't safely round-trip.
+//
+// Rejected:
+//   - Empty elements — the gliderlabs/ssh server uses anmitsu/go-shlex in posix
+//     mode, which drops empty quoted tokens; without this guard an empty argv
+//     element would silently shift the rest of argv on the server side.
+//   - NUL bytes — bash and Go's os/exec both reject embedded NUL with confusing
+//     errors; reject early at the CLI so the user sees a clear message. NUL is
+//     also the one byte single-quote wrapping can't safely carry through SSH
+//     and the server-side `bash -lc` reparse (see internal/sshd/wrap.go).
+//
+// The single-quote wrap itself survives the server-side `bash -lc` reparse
+// because bash treats single-quoted text as literal data — that is the
+// security gate that lets `shed exec` preserve argv literally while raw SSH
+// gains shell semantics.
 func validateAndQuoteArgs(args []string) ([]string, error) {
 	for i, a := range args {
 		if a == "" {
 			return nil, fmt.Errorf("argv[%d] is empty; the SSH transport cannot represent empty arguments (posix shlex drops '' tokens)", i)
+		}
+		if strings.ContainsRune(a, 0) {
+			return nil, fmt.Errorf("argv[%d] contains a NUL byte; not representable over SSH or in POSIX argv", i)
 		}
 	}
 	return shellQuoteArgs(args), nil

--- a/cmd/shed/console_test.go
+++ b/cmd/shed/console_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -137,4 +139,134 @@ func TestValidateAndQuoteArgs(t *testing.T) {
 			t.Errorf("got %d args, want 0", len(got))
 		}
 	})
+}
+
+// TestValidateAndQuoteArgsNULRejection verifies that argv elements containing
+// a NUL byte are rejected with a clear error. NUL is the one byte that
+// single-quote wrapping can't safely round-trip: Go's os/exec rejects it with
+// a confusing error, and the server-side `bash -lc` reparse can't carry it
+// either. Reject early at the CLI so the user sees the failure pointed at the
+// offending argv index.
+func TestValidateAndQuoteArgsNULRejection(t *testing.T) {
+	t.Run("NUL in argv[0]", func(t *testing.T) {
+		_, err := validateAndQuoteArgs([]string{"echo\x00", "hello"})
+		if err == nil {
+			t.Fatal("expected error for NUL in argv[0], got nil")
+		}
+		if !strings.Contains(err.Error(), "argv[0]") || !strings.Contains(err.Error(), "NUL") {
+			t.Errorf("error = %q, want it to mention argv[0] and NUL", err.Error())
+		}
+	})
+
+	t.Run("NUL in middle argv", func(t *testing.T) {
+		_, err := validateAndQuoteArgs([]string{"echo", "a\x00b", "hello"})
+		if err == nil {
+			t.Fatal("expected error for NUL in argv[1], got nil")
+		}
+		if !strings.Contains(err.Error(), "argv[1]") || !strings.Contains(err.Error(), "NUL") {
+			t.Errorf("error = %q, want it to mention argv[1] and NUL", err.Error())
+		}
+	})
+
+	t.Run("NUL at end of argv", func(t *testing.T) {
+		_, err := validateAndQuoteArgs([]string{"echo", "hello", "\x00"})
+		if err == nil {
+			t.Fatal("expected error for NUL in last argv, got nil")
+		}
+		if !strings.Contains(err.Error(), "argv[2]") || !strings.Contains(err.Error(), "NUL") {
+			t.Errorf("error = %q, want it to mention argv[2] and NUL", err.Error())
+		}
+	})
+}
+
+// TestShellQuoteBashRoundTrip is the load-bearing security audit: it proves
+// that single-quote-wrapped argv survives a real bash reparse with argv
+// preserved literally, even when individual elements contain shell
+// metacharacters (`$(…)`, backticks, `${…}`, semicolons, pipes, mixed
+// quotes, backslashes, newlines, UTF-8).
+//
+// The PR-D contract: the server-side `bash -lc <raw>` wrap interprets shell
+// metacharacters in raw SSH commands, but bash treats single-quoted text as
+// LITERAL data — so `shed exec`'s single-quote-wrapped argv stays argv after
+// bash sees it. If that invariant ever broke, raw SSH could no longer be
+// trusted to wrap with bash safely.
+//
+// This test invokes the real /bin/bash (skips cleanly when bash isn't on
+// PATH) using a NUL-separated printf marker pattern, then splits stdout on
+// NUL to recover argv. Each case below is a string bash would normally
+// expand or interpret if not single-quoted; the assertion is that the
+// recovered string equals the input.
+func TestShellQuoteBashRoundTrip(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not on PATH; skipping round-trip test")
+	}
+
+	cases := []struct {
+		name string
+		argv []string
+	}{
+		{"command substitution literal", []string{"echo", "$(rm -rf /)"}},
+		{"backtick literal", []string{"echo", "`whoami`"}},
+		{"parameter expansion literal", []string{"echo", "${HOME}"}},
+		{"mixed quotes", []string{"echo", `it's a "test"`}},
+		{"backslash before newline (line continuation)", []string{"echo", "a\\\nb"}},
+		{"embedded newline", []string{"echo", "a\nb"}},
+		{"UTF-8", []string{"echo", "héllo 🎉"}},
+		{"semicolons and pipes", []string{"echo", "a;b|c"}},
+		{"dollar var literal", []string{"echo", "$HOME"}},
+		{"plain ASCII", []string{"echo", "hello"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			quoted, err := validateAndQuoteArgs(tc.argv)
+			if err != nil {
+				t.Fatalf("validateAndQuoteArgs(%#v): %v", tc.argv, err)
+			}
+
+			// Construct a bash script that takes the quoted argv as a
+			// space-joined string of literal-single-quoted tokens, then
+			// runs `for a in <quoted-tokens>; do printf '%s\0' "$a"; done`
+			// so we get a NUL-separated stream of literal argv elements
+			// from bash's own parser. This is the exact path `bash -lc`
+			// will take server-side: parse the joined string as a shell
+			// command, with single-quoted tokens preserved as literal
+			// data.
+			joined := strings.Join(quoted, " ")
+			script := "for a in " + joined + "; do printf '%s\\0' \"$a\"; done"
+
+			cmd := exec.Command(bash, "-c", script)
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("bash -c failed: %v\nscript: %s\nstderr: %s", err, script, stderr.String())
+			}
+
+			out := stdout.Bytes()
+			// printf '%s\0' emits a trailing NUL after each element; the
+			// final byte is NUL, so split and drop the empty trailing
+			// element rather than counting NULs.
+			if len(out) == 0 || out[len(out)-1] != 0 {
+				t.Fatalf("expected NUL-terminated stream; got %q", out)
+			}
+			parts := bytes.Split(out[:len(out)-1], []byte{0})
+			recovered := make([]string, 0, len(parts))
+			for _, p := range parts {
+				recovered = append(recovered, string(p))
+			}
+
+			if len(recovered) != len(tc.argv) {
+				t.Fatalf("recovered %d argv, want %d\n  argv:      %#v\n  quoted:    %s\n  recovered: %#v\n  stderr:    %s",
+					len(recovered), len(tc.argv), tc.argv, joined, recovered, stderr.String())
+			}
+			for i := range tc.argv {
+				if recovered[i] != tc.argv[i] {
+					t.Errorf("argv[%d] = %q, want %q (joined=%q)",
+						i, recovered[i], tc.argv[i], joined)
+				}
+			}
+		})
+	}
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -653,25 +653,24 @@ shed exec <name> <command...>
 |------|-------|---------|-------------|
 | `--session` | `-S` | None | Run in tmux session context |
 
-**Execution model.** `shed exec` runs `argv[0]` with `argv[1:]` directly inside the shed (matching `docker exec` / `kubectl exec` semantics). There is **no implicit shell wrapping** — pipes, redirects, semicolons, `$VAR` expansion, command substitution, and other shell metacharacters only take effect when *you* explicitly invoke a shell as part of the command (e.g. `bash -c '...'`). The CLI shell-quotes each argv element before transmission so nested quotes, spaces, and metacharacters survive the SSH wire intact.
+**Execution model.** `shed exec` ships argv literally. The CLI single-quote-wraps each argv element before transmission so nested quotes, spaces, and shell metacharacters in *your* data survive the SSH wire intact and reach the guest as argv, not as shell code. The server-side SSH command channel does run those quoted tokens through `bash -lc` (so login PATH adjustments — `/etc/profile.d/*.sh`, `~/.profile`, mise, nvm, rustup — are in effect), but bash treats single-quoted text as literal data, so argv stays argv. End result: `shed exec name -- mytool` just works for tools installed via login-shell PATH managers, and `shed exec name -- echo '$HOME'` still prints the literal `$HOME` — no expansion, no command splitting.
 
-The agent provides a reasonable baseline environment for direct exec — `PATH`, `HOME`, `USER`, `SHELL`, `LANG` defaults plus anything written to `/etc/environment.d/` — but **does not source `/etc/profile` or `~/.profile`**. Tools installed via rustup, mise, nvm, asdf, or any other manager that adds itself to `PATH` from `~/.profile` will not be on `PATH` unless you opt into a login shell.
+This is the same model Docker, devcontainers, Codespaces, and Coder follow on their `exec` path. Pipes, redirects, semicolons, `$VAR` expansion, command substitution, and other shell metacharacters only take effect when *you* explicitly invoke a shell as part of the command (e.g. `bash -c '...'`).
 
-**Login-shell workaround.** If you need `/etc/profile.d/*.sh` and `~/.profile` sourced before your command runs, invoke `bash -lc` explicitly — the same idiom Docker users use daily:
-
-```bash
-shed exec codelens -- bash -lc 'rustc --version'
-shed exec codelens -- bash -lc 'mise current && which node'
-```
+**Raw SSH gets the full shell.** If you connect with raw `ssh shed-name 'cmd | pipe'` (the path Zed Remote-SSH, VS Code Remote-SSH, JetBrains Gateway, and `rsync` take), the SSH server runs your command string through `bash -lc <raw>` — so the pipe runs as a shell pipeline on the shed, exactly like a normal dev VM. The `shed exec` CLI is the path that preserves argv literally; raw SSH is the path that runs a shell.
 
 **Examples:**
 
 ```bash
-# Direct argv — no shell involved
+# Direct argv — bash on the server side, but argv stays argv because of
+# the single-quote wrap. Tools installed via login PATH (mise, nvm, rustup,
+# etc.) just work because `bash -lc` sources profile scripts.
 shed exec codelens git status
 shed exec codelens ls -la /workspace
+shed exec codelens rustc --version
+shed exec codelens mise current
 
-# Explicit shell for pipes, redirects, multi-statements
+# Explicit shell when YOU want pipes/redirects/multi-statements
 shed exec codelens -- bash -c 'echo hello | wc -c'
 shed exec codelens -- bash -c 'cd /workspace && npm test'
 shed exec codelens -- bash -c 'for f in *.go; do gofmt -l $f; done'
@@ -679,8 +678,13 @@ shed exec codelens -- bash -c 'for f in *.go; do gofmt -l $f; done'
 # Nested quotes survive intact
 shed exec codelens -- bash -c 'bun -e "console.log(1+1)"'
 
-# Login shell (sources /etc/profile + ~/.profile)
-shed exec codelens -- bash -lc 'rustup show'
+# Variables in argv are LITERAL — no expansion (security gate)
+shed exec codelens -- echo '$HOME'      # prints literal '$HOME'
+shed exec codelens -- echo 'a;b;c'      # prints literal 'a;b;c'
+
+# Raw SSH from any other client gets the full shell (Zed, VS Code, etc.)
+ssh codelens 'echo $HOME'               # prints /home/shed
+ssh codelens 'cat file | wc -l'         # pipe runs server-side
 
 # Run in an existing tmux session
 shed exec codelens --session default -- git status

--- a/internal/firecracker/backend.go
+++ b/internal/firecracker/backend.go
@@ -169,12 +169,17 @@ func (b *FirecrackerBackend) Exec(ctx context.Context, shedName string, opts bac
 	}
 
 	// Non-empty argv is passed through verbatim: the agent execs argv[0] with
-	// argv[1:] directly (matching docker exec / kubectl exec semantics). This
-	// avoids a second layer of shell parsing that previously mangled pipes,
-	// redirects, and nested quotes (issues #44 and #48). Users wanting
-	// login-shell sourcing of /etc/profile or ~/.profile invoke
-	// `bash -lc 'cmd'` explicitly. Empty argv still defaults to an
-	// interactive login shell for `shed console`.
+	// argv[1:] directly. The caller decides whether opts.Cmd is direct argv
+	// or a shell wrapper. Today's callers:
+	//   - SSH session path (internal/sshd/session.go) wraps in `bash -lc <raw>`
+	//     so raw SSH from IDE clients gets POSIX-shell semantics and login PATH
+	//     (#131). `shed exec`'s argv-literal contract is preserved because the
+	//     CLI single-quote-wraps each argv element before SSH (single-quoted
+	//     text is literal under bash reparse — that is the security gate; see
+	//     cmd/shed/console.go:validateAndQuoteArgs).
+	//   - Provisioning hooks (internal/vmutil/provisioning.go) build their own
+	//     `bash --login -c <script>` argv directly and bypass sshd entirely.
+	// Empty argv still defaults to an interactive login shell for `shed console`.
 	if len(opts.Cmd) == 0 {
 		opts.Cmd = []string{"/bin/bash", "--login"}
 	}

--- a/internal/sshd/session.go
+++ b/internal/sshd/session.go
@@ -151,8 +151,13 @@ func (s *Server) waitForReady(ctx context.Context, shedName string) error {
 
 // execInContainer executes a command or shell in the shed.
 func (s *Server) execInContainer(ctx context.Context, sess ssh.Session, shed *config.Shed) error {
-	// Get the command to execute.
-	cmd := sess.Command()
+	// Wrap whatever the client sent into `bash -lc <raw>` so the SSH
+	// command channel runs as a POSIX shell (Docker / Codespaces /
+	// devcontainers / Zed / VS Code / JetBrains Gateway behavior).
+	// `shed exec`'s argv-literal semantics are preserved because the
+	// CLI single-quote-wraps each argv element before SSH (see
+	// cmd/shed/console.go:shellQuoteArgs and wrapCommand's doc).
+	cmd := wrapCommand(sess.RawCommand())
 
 	// Check if we have a PTY request.
 	ptyReq, winCh, isPTY := sess.Pty()

--- a/internal/sshd/wrap.go
+++ b/internal/sshd/wrap.go
@@ -1,0 +1,29 @@
+package sshd
+
+// wrapCommand maps the raw SSH command string from the client into the
+// argv the agent will exec.
+//
+// Empty raw → nil so the agent's interactive login-shell default fires
+// (cmd/shed-agent runs `{/bin/bash, --login}` when opts.Cmd is empty).
+// Non-empty raw → `bash -lc <raw>`, preserving every shell metacharacter
+// the client wrote and sourcing /etc/profile + /etc/profile.d/*.sh +
+// ~/.profile so mise, nvm, rustup, and similar PATH-mutating tools take
+// effect for SSH-driven commands.
+//
+// This matches what Docker, Codespaces, Coder, devcontainers, and every
+// other hosted-shell product does, and it is what Zed Remote-SSH,
+// VS Code Remote-SSH, JetBrains Gateway, raw `ssh host 'cmd | pipe'`,
+// and `rsync` assume.
+//
+// The CLI side (cmd/shed/console.go shellQuoteArgs) wraps each argv
+// element in single quotes before sending, so `shed exec`'s
+// argv-literal semantics survive the bash reparse (bash treats
+// single-quoted text as literal data — that is the security gate).
+// See CLAUDE.md's "shed exec semantics and the SSH command channel"
+// for the full contract.
+func wrapCommand(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	return []string{"bash", "-lc", raw}
+}

--- a/internal/sshd/wrap_test.go
+++ b/internal/sshd/wrap_test.go
@@ -1,0 +1,87 @@
+package sshd
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestWrapCommand locks the contract `wrapCommand` exposes: empty raw
+// returns nil (agent boots into its default `{bash, --login}`), every
+// non-empty raw is fed verbatim to `bash -lc` with no transformation,
+// because every shell-metacharacter interpretation belongs to bash.
+//
+// What this test *does not* exercise: bash's own parse of the resulting
+// `-lc` argument. That happens guest-side and is covered by the
+// integration suite (tests/integration/test_exec_shell.py).
+func TestWrapCommand(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{
+			name: "empty raw → nil (agent default login shell fires)",
+			raw:  "",
+			want: nil,
+		},
+		{
+			name: "plain command preserved verbatim",
+			raw:  "echo hi",
+			want: []string{"bash", "-lc", "echo hi"},
+		},
+		{
+			name: "dollar-var preserved literally for bash to expand",
+			raw:  "echo $HOME",
+			want: []string{"bash", "-lc", "echo $HOME"},
+		},
+		{
+			name: "embedded single quote preserved",
+			raw:  `echo 'it'\''s'`,
+			want: []string{"bash", "-lc", `echo 'it'\''s'`},
+		},
+		{
+			name: "leading and trailing whitespace preserved",
+			raw:  "   echo hi   ",
+			want: []string{"bash", "-lc", "   echo hi   "},
+		},
+		{
+			name: "embedded newline preserved",
+			raw:  "echo a\necho b",
+			want: []string{"bash", "-lc", "echo a\necho b"},
+		},
+		{
+			name: "command substitution preserved",
+			raw:  "echo $(hostname)",
+			want: []string{"bash", "-lc", "echo $(hostname)"},
+		},
+		{
+			name: "backtick substitution preserved",
+			raw:  "echo `hostname`",
+			want: []string{"bash", "-lc", "echo `hostname`"},
+		},
+		{
+			name: "parameter expansion preserved",
+			raw:  "echo ${FOO:-default}",
+			want: []string{"bash", "-lc", "echo ${FOO:-default}"},
+		},
+		{
+			name: "literal NUL passes through wrap (CLI quoter rejects upstream)",
+			raw:  "echo \x00",
+			want: []string{"bash", "-lc", "echo \x00"},
+		},
+		{
+			name: "pipes and semicolons preserved",
+			raw:  "a; b | c && d",
+			want: []string{"bash", "-lc", "a; b | c && d"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := wrapCommand(tc.raw)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("wrapCommand(%q) = %#v, want %#v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/vz/backend.go
+++ b/internal/vz/backend.go
@@ -174,12 +174,17 @@ func (b *VZBackend) Exec(ctx context.Context, shedName string, opts backend.Exec
 	}
 
 	// Non-empty argv is passed through verbatim: the agent execs argv[0] with
-	// argv[1:] directly (matching docker exec / kubectl exec semantics). This
-	// avoids a second layer of shell parsing that previously mangled pipes,
-	// redirects, and nested quotes (issues #44 and #48). Users wanting
-	// login-shell sourcing of /etc/profile or ~/.profile invoke
-	// `bash -lc 'cmd'` explicitly. Empty argv still defaults to an
-	// interactive login shell for `shed console`.
+	// argv[1:] directly. The caller decides whether opts.Cmd is direct argv
+	// or a shell wrapper. Today's callers:
+	//   - SSH session path (internal/sshd/session.go) wraps in `bash -lc <raw>`
+	//     so raw SSH from IDE clients gets POSIX-shell semantics and login PATH
+	//     (#131). `shed exec`'s argv-literal contract is preserved because the
+	//     CLI single-quote-wraps each argv element before SSH (single-quoted
+	//     text is literal under bash reparse — that is the security gate; see
+	//     cmd/shed/console.go:validateAndQuoteArgs).
+	//   - Provisioning hooks (internal/vmutil/provisioning.go) build their own
+	//     `bash --login -c <script>` argv directly and bypass sshd entirely.
+	// Empty argv still defaults to an interactive login shell for `shed console`.
 	if len(opts.Cmd) == 0 {
 		opts.Cmd = []string{"/bin/bash", "--login"}
 	}

--- a/tests/integration/fixtures/server.py
+++ b/tests/integration/fixtures/server.py
@@ -201,13 +201,13 @@ class LocalServer:
         the server side.
 
         Resolves connection params (host, SSH port, known-hosts file)
-        through the running shed's own connection metadata via
-        `shed --json -s <server> get-host <shed>` so we line up with
-        whatever the CLI would have used (StrictHostKeyChecking=yes
-        against the known-hosts populated at create-time). Falls back
-        to the server's plain `ssh_port` from config and -o
-        StrictHostKeyChecking=no when the metadata isn't surfaced —
-        the integration suite only ever talks to known-good test sheds.
+        via `shed --json server list` so we line up with whatever the
+        CLI would have used. Uses `~/.shed/known_hosts` with
+        StrictHostKeyChecking=yes when it exists (the file the CLI
+        populates at create-time); falls back to
+        StrictHostKeyChecking=no for fresh test environments. The
+        integration suite only ever talks to known-good test sheds, so
+        the fallback is safe.
         """
         host, port, known_hosts = self._ssh_connect_params()
         ssh_argv = [

--- a/tests/integration/fixtures/server.py
+++ b/tests/integration/fixtures/server.py
@@ -184,6 +184,94 @@ class LocalServer:
         full = ["shed", "-s", self.name, "exec", name, "--"] + cmd
         return subprocess.run(full, capture_output=True, text=True, timeout=timeout)
 
+    def ssh_exec(
+        self,
+        name: str,
+        raw_command: str,
+        timeout: int = 60,
+    ) -> subprocess.CompletedProcess:
+        """Drive the SSH wire directly with a raw command string,
+        bypassing the `shed exec` CLI's argv quoter.
+
+        This exercises the server-side `bash -lc` wrap on the same path
+        OpenSSH, Zed Remote-SSH, VS Code Remote-SSH, and JetBrains
+        Gateway take. The `shed exec` CLI path is covered by
+        `exec(...)` above; use *this* helper when you want to assert
+        that shell metacharacters in the raw command actually fire on
+        the server side.
+
+        Resolves connection params (host, SSH port, known-hosts file)
+        through the running shed's own connection metadata via
+        `shed --json -s <server> get-host <shed>` so we line up with
+        whatever the CLI would have used (StrictHostKeyChecking=yes
+        against the known-hosts populated at create-time). Falls back
+        to the server's plain `ssh_port` from config and -o
+        StrictHostKeyChecking=no when the metadata isn't surfaced —
+        the integration suite only ever talks to known-good test sheds.
+        """
+        host, port, known_hosts = self._ssh_connect_params()
+        ssh_argv = [
+            "ssh",
+            "-p", str(port),
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=5",
+        ]
+        if known_hosts is not None:
+            ssh_argv += [
+                "-o", f"UserKnownHostsFile={known_hosts}",
+                "-o", "StrictHostKeyChecking=yes",
+            ]
+        else:
+            ssh_argv += ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null"]
+        ssh_argv += [f"{name}@{host}", raw_command]
+        return subprocess.run(
+            ssh_argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    def _ssh_connect_params(self) -> tuple[str, int, Optional[Path]]:
+        """Return (host, ssh_port, known_hosts) for raw `ssh` invocations.
+
+        For LocalServer the host is the localhost-mapped ssh_port from
+        `~/.shed/config.yaml`. Subclasses (RemoteServer) override to
+        return the remote host's address. Known-hosts path is
+        ~/.shed/known_hosts (per `config.GetKnownHostsPath` — the same
+        file `shed console` uses), or None if it doesn't exist yet.
+        """
+        # The CLI's known-hosts default; only set if it exists so a
+        # fresh test environment skips StrictHostKeyChecking rather than
+        # failing with "no known-hosts file."
+        kh = Path.home() / ".shed" / "known_hosts"
+        if not kh.exists():
+            kh = None
+        host, port = self._resolve_ssh_endpoint()
+        return host, port, kh
+
+    def _resolve_ssh_endpoint(self) -> tuple[str, int]:
+        """LocalServer: assume the server hosts the shed on localhost.
+
+        Reads the SSH port from the server's config via the `shed`
+        CLI's view of the server entry; falls back to 2222 (the brew
+        default).
+        """
+        try:
+            r = subprocess.run(
+                ["shed", "--json", "server", "list"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if r.returncode == 0:
+                entries = json.loads(r.stdout) or []
+                for e in entries:
+                    if isinstance(e, dict) and e.get("name") == self.name:
+                        host = e.get("host", "localhost")
+                        port = int(e.get("ssh_port", 2222))
+                        return host, port
+        except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError, ValueError):
+            pass
+        return "localhost", 2222
+
     def delete(self, name: str, ignore_missing: bool = False) -> None:
         """Delete a shed.
 

--- a/tests/integration/test_exec_shell.py
+++ b/tests/integration/test_exec_shell.py
@@ -113,8 +113,11 @@ def test_ssh_exec_login_profile_sourced(shed_server, test_shed_name):
     sourced and PATH-mutating tools (mise, nvm, rustup) wouldn't take
     effect for SSH-driven commands.
 
-    Uses `shed_server.exec` (argv-literal path) to drop the script in
-    place, then raw `ssh_exec` to read it back.
+    Uses raw `ssh_exec` for both the seed and the read-back: the seed
+    relies on a here-doc + `sudo tee`, which needs shell features the
+    argv-literal `exec()` path doesn't provide. Same wire, symmetric
+    semantics — and any wrap-related regression would surface on both
+    halves uniformly.
     """
     shed_server.create(test_shed_name, image="base")
 

--- a/tests/integration/test_exec_shell.py
+++ b/tests/integration/test_exec_shell.py
@@ -1,0 +1,221 @@
+"""Exec-and-shell semantics tests for the SSH command channel (§ #131).
+
+Eight tests, parameterized over `["vz", "fc"]`. They split into two halves
+that together encode the security model of #131's POSIX-shell SSH wrap:
+
+1. **Raw SSH gets the full shell** — five tests drive raw `ssh host '<cmd>'`
+   through `LocalServer.ssh_exec` to prove that pipes, `$VAR`, `$(…)`, bash
+   builtins, and `/etc/profile.d/*.sh` PATH adjustments all fire on the
+   guest. This is the new behavior gained by wrapping the server-side
+   command in `bash -lc <raw>`.
+
+2. **`shed exec` argv stays literal** — three tests drive
+   `LocalServer.exec(name, [argv...])` (the CLI quoter path) to prove
+   that even though raw SSH now runs through bash, the CLI's single-quote
+   wrap keeps argv literal across the bash reparse. That is the security
+   gate: shell metacharacters in user-supplied argv data do NOT escape.
+
+The CLI quoter is now load-bearing: every regression in
+`cmd/shed/console.go:validateAndQuoteArgs` would let a metacharacter
+expand into shell semantics on the SSH server side. The Go-level
+`TestShellQuoteBashRoundTrip` (cmd/shed/console_test.go) is the unit
+audit; this file is the live wire audit.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Raw-SSH path (server-side `bash -lc <raw>` wrap fires)
+# ---------------------------------------------------------------------------
+
+
+def test_ssh_exec_pipes(shed_server, test_shed_name):
+    """`ssh host 'echo a | wc -c'` returns `2` (one byte + newline).
+
+    Proves the server-side `bash -lc` wrap interprets the pipe. Without
+    the wrap the agent would try to exec `echo` with `a | wc -c` as
+    a literal argv element and bash semantics wouldn't fire.
+    """
+    shed_server.create(test_shed_name, image="base")
+    r = shed_server.ssh_exec(test_shed_name, "echo a | wc -c")
+    assert r.returncode == 0, (
+        f"ssh exec with pipe failed: exit={r.returncode} stderr={r.stderr!r}"
+    )
+    assert r.stdout.strip() == "2", (
+        f"expected '2' (one char + newline counted by wc), got {r.stdout!r}"
+    )
+
+
+def test_ssh_exec_dollar_var(shed_server, test_shed_name):
+    """`ssh host 'echo "$HOME"'` expands `$HOME` to `/home/shed`.
+
+    Proves env expansion happens server-side. The shed user is `shed`
+    (UID 1000) per CLAUDE.md / config.WorkspacePath; the login shell's
+    `$HOME` is `/home/shed`.
+    """
+    shed_server.create(test_shed_name, image="base")
+    r = shed_server.ssh_exec(test_shed_name, 'echo "$HOME"')
+    assert r.returncode == 0, (
+        f"ssh exec with $HOME failed: exit={r.returncode} stderr={r.stderr!r}"
+    )
+    assert r.stdout.strip() == "/home/shed", (
+        f"expected '/home/shed', got {r.stdout!r}"
+    )
+
+
+def test_ssh_exec_command_substitution(shed_server, test_shed_name):
+    """`ssh host 'echo "$(hostname)"'` returns the guest hostname.
+
+    Proves `$(…)` command substitution fires. The hostname is set
+    per-shed at provisioning so we don't pin a specific value; we only
+    require a non-empty result.
+    """
+    shed_server.create(test_shed_name, image="base")
+    r = shed_server.ssh_exec(test_shed_name, 'echo "$(hostname)"')
+    assert r.returncode == 0, (
+        f"ssh exec with $(hostname) failed: exit={r.returncode} stderr={r.stderr!r}"
+    )
+    hostname = r.stdout.strip()
+    assert hostname, f"expected non-empty hostname from $(hostname), got {r.stdout!r}"
+
+
+def test_ssh_exec_bash_builtin(shed_server, test_shed_name):
+    """`ssh host 'type cd && cd /tmp && pwd'` shows `cd is a shell builtin`
+    and ends with `/tmp`.
+
+    Proves bash builtins are available (vs the old direct-argv path where
+    `type` and `cd` would resolve to whatever was on PATH and `cd` would
+    have nothing to chain off of). This is also a strong signal that the
+    -lc wrap covers compound statements (`&&`).
+    """
+    shed_server.create(test_shed_name, image="base")
+    r = shed_server.ssh_exec(test_shed_name, "type cd && cd /tmp && pwd")
+    assert r.returncode == 0, (
+        f"ssh exec with builtin failed: exit={r.returncode} stderr={r.stderr!r}"
+    )
+    assert "shell builtin" in r.stdout, (
+        f"expected 'shell builtin' in stdout (type cd output), got {r.stdout!r}"
+    )
+    assert r.stdout.strip().endswith("/tmp"), (
+        f"expected stdout to end with '/tmp' (cd /tmp && pwd), got {r.stdout!r}"
+    )
+
+
+def test_ssh_exec_login_profile_sourced(shed_server, test_shed_name):
+    """Seeding `/etc/profile.d/shedtest.sh` and then reading
+    `$SHEDTEST` over raw SSH returns `ok`.
+
+    Proves the `-l` in `bash -lc` actually fires (login-shell init runs
+    `/etc/profile.d/*.sh`). Without `-l`, profile scripts wouldn't be
+    sourced and PATH-mutating tools (mise, nvm, rustup) wouldn't take
+    effect for SSH-driven commands.
+
+    Uses `shed_server.exec` (argv-literal path) to drop the script in
+    place, then raw `ssh_exec` to read it back.
+    """
+    shed_server.create(test_shed_name, image="base")
+
+    # Seed the profile snippet server-side via raw ssh + a here-doc so
+    # the write happens in one shot. Direct-argv `shed exec` can't drive
+    # sudo+tee+stdin in a single call (no stdin pipe through the
+    # fixture), and raw ssh_exec is the same path that will read the
+    # value back below — same wire, symmetric semantics. The shed user
+    # has passwordless sudo per CLAUDE.md.
+    seed = shed_server.ssh_exec(
+        test_shed_name,
+        "sudo tee /etc/profile.d/shedtest.sh > /dev/null <<'EOF'\n"
+        "export SHEDTEST=ok\n"
+        "EOF",
+    )
+    assert seed.returncode == 0, (
+        f"failed to seed /etc/profile.d/shedtest.sh: "
+        f"exit={seed.returncode} stderr={seed.stderr!r}"
+    )
+
+    # Now read $SHEDTEST back. The login-shell init sources
+    # /etc/profile.d/*.sh, so $SHEDTEST should be `ok`.
+    r = shed_server.ssh_exec(test_shed_name, 'echo "$SHEDTEST"')
+    assert r.returncode == 0, (
+        f"ssh exec of echo $SHEDTEST failed: "
+        f"exit={r.returncode} stderr={r.stderr!r}"
+    )
+    assert r.stdout.strip() == "ok", (
+        f"expected 'ok' (from seeded /etc/profile.d/shedtest.sh), "
+        f"got {r.stdout!r}; this means `bash -lc` is NOT sourcing "
+        f"profile scripts (the `-l` is missing or not effective)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI-quoter path (`shed exec` argv stays literal — the security gate)
+# ---------------------------------------------------------------------------
+
+
+def test_shed_exec_still_direct_argv(shed_server, test_shed_name):
+    """`shed exec name -- echo 'hello $USER'` echoes literal `hello $USER`.
+
+    The security gate: even though raw SSH now runs through `bash -lc`,
+    `shed exec` single-quote-wraps each argv element before sending. Bash
+    treats single-quoted text as literal, so the `$USER` reaches `echo`
+    as the literal token `$USER` and gets echoed back unexpanded.
+
+    If this test ever flips to expanding `$USER`, the CLI quoter is
+    broken and the SSH server side is reparsing argv data as shell
+    metacharacters — that's the regression path #131 explicitly guards.
+    """
+    shed_server.create(test_shed_name, image="base")
+    r = shed_server.exec(test_shed_name, ["echo", "hello $USER"])
+    assert r.returncode == 0, (
+        f"shed exec failed: exit={r.returncode} stderr={r.stderr!r}"
+    )
+    assert r.stdout.strip() == "hello $USER", (
+        f"expected literal 'hello $USER' (CLI quoter MUST keep $USER literal), "
+        f"got {r.stdout!r}. The CLI single-quote wrap is broken — the "
+        f"server-side bash reparse expanded the variable, which means "
+        f"user-supplied argv data is being reinterpreted as shell."
+    )
+
+
+def test_shed_exec_metachar_safety(shed_server, test_shed_name):
+    """`shed exec name -- echo 'a;b;c'` echoes literal `a;b;c`.
+
+    Security regression gate for command-splitting metacharacters. A
+    leak here would let `shed exec name -- mytool "$(rm -rf /)"` style
+    invocations execute the substitution server-side — exactly the
+    scenario the single-quote wrap is designed to prevent.
+    """
+    shed_server.create(test_shed_name, image="base")
+    r = shed_server.exec(test_shed_name, ["echo", "a;b;c"])
+    assert r.returncode == 0, (
+        f"shed exec failed: exit={r.returncode} stderr={r.stderr!r}"
+    )
+    assert r.stdout.strip() == "a;b;c", (
+        f"expected literal 'a;b;c' (CLI quoter MUST escape semicolons), "
+        f"got {r.stdout!r}. Semicolon expansion = command injection vector."
+    )
+
+
+def test_shed_exec_with_explicit_bash_lc(shed_server, test_shed_name):
+    """`shed exec name -- bash -lc 'echo $HOME'` works.
+
+    Proves the user-driven shell escape — when the operator *wants*
+    shell semantics inside `shed exec`, they explicitly invoke a shell.
+    This is the documented pattern (CLAUDE.md / docs/reference/cli.md).
+
+    Doubles as a sanity check that login-shell expansion is symmetric
+    between the raw SSH path and the user-driven bash path — both
+    should resolve `$HOME` to `/home/shed`.
+    """
+    shed_server.create(test_shed_name, image="base")
+    r = shed_server.exec(test_shed_name, ["bash", "-lc", "echo $HOME"])
+    assert r.returncode == 0, (
+        f"shed exec with bash -lc failed: "
+        f"exit={r.returncode} stderr={r.stderr!r}"
+    )
+    assert r.stdout.strip() == "/home/shed", (
+        f"expected '/home/shed' (explicit bash -lc expands $HOME), "
+        f"got {r.stdout!r}"
+    )


### PR DESCRIPTION
Closes #131.

## Summary

Wrap the SSH command channel server-side in `bash -lc <raw>` so raw
`ssh shed 'cmd | pipe'` Just Works like every other dev VM — Docker,
Codespaces, Coder, devcontainers, Zed Remote-SSH, VS Code Remote-SSH,
JetBrains Gateway, `rsync`. `shed exec`'s argv-literal semantics are
preserved because the CLI single-quote-wraps each argv element before
SSH and bash treats single-quoted text as literal data — that is the
security gate.

## Before / after

```bash
# Before (today, v0.5.6 and earlier)
ssh shed 'echo $HOME'           # prints literal '$HOME'
ssh shed 'a | wc -c'            # tries to exec `a` with `| wc -c` as argv
ssh shed 'type cd'              # `cd` not on PATH; fails

# After (this PR, v0.5.7)
ssh shed 'echo $HOME'           # prints /home/shed
ssh shed 'a | wc -c'            # pipe runs as a shell pipeline
ssh shed 'type cd'              # 'cd is a shell builtin'

# shed exec semantics: argv stays literal across the bash reparse
shed exec name -- echo '$HOME'  # prints literal '$HOME' (unchanged)
shed exec name -- echo 'a;b'    # prints literal 'a;b' (unchanged)
shed exec name -- mytool        # mytool runs from login PATH (mise/nvm/rustup work)
```

## What changes

| File | Change |
|---|---|
| `internal/sshd/wrap.go` (new) | Pure function `wrapCommand(raw)` — empty → nil; non-empty → `{bash, -lc, raw}`. |
| `internal/sshd/wrap_test.go` (new) | 11 table-driven cases locking the contract. |
| `internal/sshd/session.go:155` | `sess.Command()` → `wrapCommand(sess.RawCommand())`. One-line semantic swap. |
| `cmd/shed/console.go:validateAndQuoteArgs` | NUL byte rejection alongside empty-arg rejection. Docstring rewritten to explain the security model. |
| `cmd/shed/console_test.go` | `TestValidateAndQuoteArgsNULRejection` + `TestShellQuoteBashRoundTrip` (the load-bearing security audit — runs real /bin/bash on 10 metacharacter cases). |
| `tests/integration/fixtures/server.py` | New `ssh_exec()` helper drives raw `ssh -p <port> shed@host <raw>`. |
| `tests/integration/test_exec_shell.py` (new) | 8 tests × 2 backends — 5 raw-SSH (pipes, $HOME, $(hostname), bash builtins, /etc/profile.d sourcing) + 3 CLI-quoter (argv stays literal, semicolons stay literal, explicit `bash -lc` works). |
| `CLAUDE.md` "shed exec semantics" | Rewritten to reflect the new contract. |
| `docs/reference/cli.md` "shed exec" | Execution model rewritten; "Login-shell workaround" section dropped (login PATH is now default); "Raw SSH gets the full shell" note added for IDE integrations. |

## Security model

**The CLI quoter is now load-bearing.** Bash treats single-quoted text
as literal data, so:

- Raw `ssh host 'cmd'` interprets shell metacharacters — that's the new
  POSIX-shell wrap, intended.
- `shed exec name -- echo '$HOME'` echoes the literal `$HOME` even
  though the server runs through `bash -lc` — because the CLI quoter
  wraps each argv element in single quotes before SSH, and bash
  preserves single-quoted text verbatim.

`TestShellQuoteBashRoundTrip` is the audit: real /bin/bash, 10
metacharacter cases (`$(rm -rf /)`, backticks, `${HOME}`, mixed quotes,
backslash-newline, embedded newline, UTF-8, semicolons + pipes, dollar
var literal, plain ASCII), every recovered argv must equal input. Any
regression in `validateAndQuoteArgs` / `shellQuoteArgs` would let
user-supplied argv data reinterpret as shell on the server side; that
test prevents it.

NUL byte rejection was added because NUL is the one byte single-quote
wrapping can't safely carry through SSH and the bash reparse — Go's
`os/exec` rejects it with a confusing error; the CLI now rejects it
early with a clear message pointed at the offending argv index.

## Pre-PR validation

- ✅ `make check` clean (lint + test, both arches).
- ✅ `GOOS=linux GOARCH=arm64 go build ./internal/firecracker/` clean.
- ✅ New Go unit tests pass (`TestWrapCommand` 11 cases,
  `TestValidateAndQuoteArgsNULRejection` 3 cases,
  `TestShellQuoteBashRoundTrip` 10 cases).
- ✅ Full integration suite green on VZ against a locally-built patched
  shed-server binary: 8/8 `test_exec_shell.py` tests pass; existing
  `test_smoke.py` also clean.

### FC integration caveat

The FC half of the new integration tests couldn't run against a
patched binary in this PR's pre-merge window — the auto-mode classifier
declined to scp a custom dev binary to mini3 (correct posture for
shared infrastructure). FC raw-SSH tests will validate post-merge once
v0.5.7 ships to mini3 via the normal `.deb` update path. The
CLI-quoter tests (the security gate half) pass against mini3 v0.5.6
because the quoter behavior is symmetric across server versions —
single-quoted argv has always stayed literal at the SSH wire.

## Non-goals

- No opt-in/opt-out flag (rejected in the issue body).
- No guest agent changes — the agent's direct-argv exec path
  (`cmd/shed-agent/exec.go`) is kept; it's used by provisioning hooks
  (`internal/vmutil/provisioning.go`), `tmux list-sessions`, and `shed
  exec` argv. The wrap lives only in `internal/sshd/`.

## What does NOT change

- `cmd/shed-agent/exec.go` direct-argv exec — kept.
- `internal/vmutil/provisioning.go` — still `bash --login -c`, bypasses sshd.
- `internal/vz/backend.go` / `internal/firecracker/backend.go` `Exec` — backend
  doesn't care that the argv it now receives is `["bash", "-lc", raw]` instead
  of the user's shlex'd argv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)