### PR TITLE
fix(prune): tags protect manifests from prune

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -523,7 +523,7 @@ shed image rm myimage --force
 
 ### shed image prune
 
-Removes blobs that have no protective shed/snapshot reference. Tags do **not** protect a digest from prune.
+Removes blobs that have no protective tag, shed, snapshot, or in-flight create reference.
 
 ```bash
 shed image prune [flags]
@@ -534,7 +534,9 @@ shed image prune [flags]
 | `--force` | | `false` | Skip confirmation prompt |
 | `--dry-run` | | `false` | List candidates without deleting |
 
-A blob is preserved only if its digest is referenced by an existing shed's `metadata.json` (`lower_digest`) or a snapshot's `snapshot.json` (`lower_digest`). Tags are informational and do not protect blobs. After bumping image refs in server config and re-running `shed-server pull-images`, the previous digests typically become dangling and `shed image prune` reclaims them.
+A blob is preserved if its digest is referenced by a tag, an existing shed's `metadata.json` (`lower_digest`), or a snapshot's `snapshot.json` (`lower_digest`). To delete a tagged blob the workflow is `shed image rm <tag>` first, then `shed image prune` (Docker model — `docker rmi` then `docker image prune`).
+
+**Upgrade note:** pre-v0.5.8 tags were informational and did NOT protect blobs, so `shed image pull <tag> && shed image prune` would delete the manifest just pulled. The v0.5.8 fix makes tags protective. After bumping image refs in server config and re-running `shed-server pull-images`, drop any stale tag with `shed image rm` before `shed image prune` to actually reclaim the previous digest.
 
 **Fail-closed on malformed metadata:** `image prune` aborts (returns an error naming the broken shed and its directory) if any instance's `metadata.json` cannot be parsed for `lower_digest` — pruning while a refcount source is unreadable could orphan a digest still in use. Fix or `rm -rf` the broken instance directory before re-running. Lenient read paths (`shed list`, `shed image ls`, `shed system df`) warn-and-skip on the same fault.
 

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -690,13 +690,36 @@ func (m *Manager) PruneImages(dryRun bool) ([]ImageInfo, error) {
 	}
 
 	// Live manifest digests come from: every protective ref (shed,
-	// snapshot, pending-create). Tags do NOT keep manifests alive.
+	// snapshot, pending-create) PLUS every tag. RefScanner
+	// implementations don't emit tag refs (tags live in the central
+	// store the Manager owns, not in per-backend metadata), so we
+	// walk them here and merge. Pre-v0.5.8 tags were treated as
+	// informational and prune deleted blobs they pointed at; the
+	// `shed image pull X && shed image prune` workflow then deleted
+	// the manifest just pulled. See refs.go RefKindTag and
+	// docs/upgrades/v0.5.7-to-v0.5.8.md.
 	liveManifests := make(map[string]bool)
 	for _, r := range refs {
-		if r.Kind == RefKindTag {
+		liveManifests[r.Digest] = true
+	}
+	tagNames, err := ListTags(imagesDir)
+	if err != nil {
+		return nil, fmt.Errorf("listing tags for prune protection: %w", err)
+	}
+	for _, name := range tagNames {
+		t, err := GetTag(imagesDir, name)
+		if err != nil {
+			log.Printf("Warning: skipping tag %q for prune protection: %v", name, err)
 			continue
 		}
-		liveManifests[r.Digest] = true
+		if !BlobExists(imagesDir, t.Digest) {
+			// Stale tag — manifest blob is already gone. Nothing to
+			// protect; leave it out of liveManifests so the prune
+			// reachability walk doesn't trip on the missing blob.
+			log.Printf("Warning: tag %q points at missing manifest %s; tag is stale", name, t.Digest)
+			continue
+		}
+		liveManifests[t.Digest] = true
 	}
 
 	// Expand to a full reachable-set: configs, layers, kernel, initrd

--- a/internal/vmimage/manager_test.go
+++ b/internal/vmimage/manager_test.go
@@ -249,6 +249,209 @@ func TestManagerPruneRespectsSnapshotRefs(t *testing.T) {
 	}
 }
 
+// TestPruneProtectsTaggedManifest covers the v0.5.7 → v0.5.8 prune
+// fix: a tag pointing at a manifest now keeps that manifest (and
+// every blob the manifest references — config, layers, kernel,
+// initrd, and the rootfs erofs blob) alive across `shed image
+// prune`. Before the fix, `shed image pull X && shed image prune`
+// would delete the manifest just pulled. See refs.go RefKindTag and
+// docs/upgrades/v0.5.7-to-v0.5.8.md.
+func TestPruneProtectsTaggedManifest(t *testing.T) {
+	imagesDir := t.TempDir()
+	cfg := &testConfig{imagesDir: imagesDir}
+	mgr := NewManager(cfg, nil)
+
+	digest, err := InstallSyntheticImage(
+		imagesDir,
+		"protected",
+		"ghcr.io/example/protected:v1",
+		[]byte("rootfs"),
+		[]byte("kernel"),
+		[]byte("initrd"),
+	)
+	if err != nil {
+		t.Fatalf("InstallSyntheticImage: %v", err)
+	}
+
+	manifest, err := LoadManifestByDigest(imagesDir, digest)
+	if err != nil {
+		t.Fatalf("LoadManifestByDigest: %v", err)
+	}
+
+	// Dry run should leave the tagged manifest out of the candidate set.
+	cands, err := mgr.PruneImages(true)
+	if err != nil {
+		t.Fatalf("PruneImages(dryRun): %v", err)
+	}
+	if hasCandidate(cands, digest) {
+		t.Fatalf("tagged manifest %s appears in prune candidates: %#v", digest, cands)
+	}
+
+	// Real prune should leave the manifest, its config, every layer,
+	// kernel, initrd, and the erofs rootfs blob on disk.
+	if _, err := mgr.PruneImages(false); err != nil {
+		t.Fatalf("PruneImages: %v", err)
+	}
+	if !BlobExists(imagesDir, digest) {
+		t.Fatalf("tagged manifest blob removed by prune: %s", digest)
+	}
+	if !BlobExists(imagesDir, manifest.Config.Digest) {
+		t.Fatalf("config blob for tagged manifest removed: %s", manifest.Config.Digest)
+	}
+	for _, layer := range manifest.Layers {
+		if !BlobExists(imagesDir, layer.Digest) {
+			t.Fatalf("layer blob for tagged manifest removed: %s", layer.Digest)
+		}
+	}
+	if d := manifest.ShedKernelDigest(); d != "" && !BlobExists(imagesDir, d) {
+		t.Fatalf("kernel blob for tagged manifest removed: %s", d)
+	}
+	if d := manifest.ShedInitrdDigest(); d != "" && !BlobExists(imagesDir, d) {
+		t.Fatalf("initrd blob for tagged manifest removed: %s", d)
+	}
+	if d := manifest.ShedRootfsErofsDigest(); d != "" && !BlobExists(imagesDir, d) {
+		t.Fatalf("rootfs erofs blob for tagged manifest removed: %s", d)
+	}
+
+	// Tag file itself must remain.
+	if _, err := GetTag(imagesDir, "protected"); err != nil {
+		t.Fatalf("tag should still exist post-prune: %v", err)
+	}
+}
+
+// TestPruneAfterUntagDeletesOrphan covers the documented cleanup
+// workflow: `shed image rm <name>` to drop the tag, then `shed
+// image prune` to GC the now-orphaned manifest and its transitive
+// blobs. Verifies the tag is what's protective; removing the tag
+// hands the underlying blobs back to prune.
+func TestPruneAfterUntagDeletesOrphan(t *testing.T) {
+	imagesDir := t.TempDir()
+	cfg := &testConfig{imagesDir: imagesDir}
+	mgr := NewManager(cfg, nil)
+
+	digest, err := InstallSyntheticImage(
+		imagesDir,
+		"orphan-soon",
+		"ghcr.io/example/orphan-soon:v1",
+		[]byte("rootfs"),
+		[]byte("kernel"),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("InstallSyntheticImage: %v", err)
+	}
+
+	manifest, err := LoadManifestByDigest(imagesDir, digest)
+	if err != nil {
+		t.Fatalf("LoadManifestByDigest: %v", err)
+	}
+
+	// Untag and prune.
+	if err := mgr.DeleteImage("orphan-soon"); err != nil {
+		t.Fatalf("DeleteImage: %v", err)
+	}
+	deleted, err := mgr.PruneImages(false)
+	if err != nil {
+		t.Fatalf("PruneImages: %v", err)
+	}
+	if !hasDeleted(deleted, digest) {
+		t.Fatalf("orphaned manifest %s not in deleted set: %#v", digest, deleted)
+	}
+	if BlobExists(imagesDir, digest) {
+		t.Fatalf("orphaned manifest blob still present after prune: %s", digest)
+	}
+	for _, layer := range manifest.Layers {
+		if BlobExists(imagesDir, layer.Digest) {
+			t.Fatalf("orphaned layer blob still present after prune: %s", layer.Digest)
+		}
+	}
+	if d := manifest.ShedKernelDigest(); d != "" && BlobExists(imagesDir, d) {
+		t.Fatalf("orphaned kernel blob still present after prune: %s", d)
+	}
+	if d := manifest.ShedRootfsErofsDigest(); d != "" && BlobExists(imagesDir, d) {
+		t.Fatalf("orphaned rootfs erofs blob still present after prune: %s", d)
+	}
+}
+
+// TestPruneHandlesStaleTag covers the failure mode where the
+// underlying manifest blob is missing (host disk corruption,
+// partial restore from backup, etc.). Prune must log a warning and
+// proceed instead of crashing or treating the missing digest as
+// protective.
+func TestPruneHandlesStaleTag(t *testing.T) {
+	imagesDir := t.TempDir()
+	cfg := &testConfig{imagesDir: imagesDir}
+	mgr := NewManager(cfg, nil)
+
+	// Install a real image to give prune some blobs to walk past.
+	realDigest := installFakeBlob(t, imagesDir, "real", "ghcr.io/example/real:v1", []byte("real-body"))
+
+	// Write a tag file directly pointing at a fabricated digest whose
+	// blob has never been written to disk. SetTag's digest validator
+	// accepts well-formed sha256:<hex> regardless of whether the blob
+	// exists, so this is the production stale-tag shape.
+	staleDigest := SyntheticDigestFromString("stale-manifest-never-on-disk")
+	if err := SetTag(imagesDir, "stale", staleDigest); err != nil {
+		t.Fatalf("SetTag(stale): %v", err)
+	}
+	if BlobExists(imagesDir, staleDigest) {
+		t.Fatalf("test setup invalid: stale digest blob unexpectedly present: %s", staleDigest)
+	}
+
+	// Prune must not panic, must not error, and must leave the real
+	// manifest's blobs alone.
+	if _, err := mgr.PruneImages(false); err != nil {
+		t.Fatalf("PruneImages with stale tag returned err: %v", err)
+	}
+	if !BlobExists(imagesDir, realDigest) {
+		t.Fatalf("real manifest %s deleted while a stale tag was present", realDigest)
+	}
+}
+
+// TestPruneStillProtectsShedPinnedManifest is a regression check that
+// scanner-supplied RefKindShed refs continue to be protective after
+// the v0.5.8 tag-protection change. The fixture matches the
+// production shape: a manifest with kernel + initrd + erofs blobs,
+// pinned by a shed but with no tag.
+func TestPruneStillProtectsShedPinnedManifest(t *testing.T) {
+	imagesDir := t.TempDir()
+	cfg := &testConfig{imagesDir: imagesDir}
+
+	digest, err := InstallSyntheticImage(
+		imagesDir,
+		"",
+		"ghcr.io/example/shed-pinned:v1",
+		[]byte("shed-pinned-rootfs"),
+		[]byte("shed-pinned-kernel"),
+		[]byte("shed-pinned-initrd"),
+	)
+	if err != nil {
+		t.Fatalf("InstallSyntheticImage: %v", err)
+	}
+	manifest, err := LoadManifestByDigest(imagesDir, digest)
+	if err != nil {
+		t.Fatalf("LoadManifestByDigest: %v", err)
+	}
+
+	scanner := &fakeScanner{refs: []Reference{
+		{Digest: digest, Kind: RefKindShed, Name: "live-shed"},
+	}}
+	mgr := NewManager(cfg, scanner)
+
+	if _, err := mgr.PruneImages(false); err != nil {
+		t.Fatalf("PruneImages: %v", err)
+	}
+	if !BlobExists(imagesDir, digest) {
+		t.Fatalf("shed-pinned manifest deleted by prune: %s", digest)
+	}
+	if !BlobExists(imagesDir, manifest.Config.Digest) {
+		t.Fatalf("shed-pinned config deleted: %s", manifest.Config.Digest)
+	}
+	if d := manifest.ShedRootfsErofsDigest(); d != "" && !BlobExists(imagesDir, d) {
+		t.Fatalf("shed-pinned erofs deleted: %s", d)
+	}
+}
+
 // TestEnsureImageSurfacesRegistryError confirms that a registry pull
 // failure surfaces directly to the caller — v0.5.3 dropped the
 // docker-daemon fallback (it produced single-layer flattens with

--- a/internal/vmimage/refs.go
+++ b/internal/vmimage/refs.go
@@ -10,8 +10,16 @@ const (
 	// RefKindSnapshot indicates a reference held by a snapshot.
 	RefKindSnapshot RefKind = "snapshot"
 
-	// RefKindTag indicates a reference held by a tag. Tags are
-	// informational and DO NOT protect a digest from prune (Docker model).
+	// RefKindTag indicates a reference held by a tag. Tags ARE
+	// protective from prune (changed in v0.5.8 — pre-v0.5.8 the prune
+	// walker followed Docker's "tags don't protect" model, which made
+	// `shed image pull X && shed image prune` delete the manifest
+	// blob just pulled if no shed pinned it yet, leaving operators
+	// with a tag pointing at a missing blob or, worse, silently
+	// reverting to a stale locally-cached manifest). To delete a
+	// blob a tag points at, the workflow is `shed image rm <tag>`
+	// followed by `shed image prune`. See
+	// docs/upgrades/v0.5.7-to-v0.5.8.md.
 	RefKindTag RefKind = "tag"
 
 	// RefKindPending indicates a reference held by an in-flight
@@ -66,16 +74,18 @@ type RefScanner interface {
 }
 
 // ProtectiveRefs reports whether a digest has any protective
-// reference — Shed, Snapshot, or Pending (in-flight create).
+// reference — Shed, Snapshot, Pending (in-flight create), or Tag.
 //
-// Tag references are NOT protective and are excluded from this check.
+// As of v0.5.8 tag references are protective: see RefKindTag's doc
+// for the rationale. RefScanner implementations still don't emit
+// tag refs (tags live in the central store the Manager owns, not in
+// per-backend metadata), so the Manager merges them into the ref
+// list at the caller sites that need protection (notably
+// PruneImages).
 func ProtectiveRefs(refs []Reference, digest string) []Reference {
 	var out []Reference
 	for _, r := range refs {
 		if r.Digest != digest {
-			continue
-		}
-		if r.Kind == RefKindTag {
 			continue
 		}
 		out = append(out, r)

--- a/internal/vz/image_test.go
+++ b/internal/vz/image_test.go
@@ -165,6 +165,16 @@ func TestPruneImagesRespectsRefs(t *testing.T) {
 	danglingDigest := createFakeImage(t, imagesDir, "dangling")
 	createFakeInstance(t, client.cfg.InstanceDir, "live-shed", "pinned", pinnedDigest)
 
+	// As of v0.5.8 tags themselves are protective (see
+	// vmimage.RefKindTag's doc). Drop the dangling tag so the
+	// "no shed pin → prune candidate" arm of this test still
+	// exercises the unreferenced-blob path; the pinned tag is
+	// fine to leave in place — its manifest is protected by the
+	// shed ref anyway, so the test's expectations don't shift.
+	if err := vmimage.DeleteTag(imagesDir, "dangling"); err != nil {
+		t.Fatalf("DeleteTag(dangling): %v", err)
+	}
+
 	// Dry-run reports the dangling manifest (and its config/layer); the
 	// pinned manifest and its chain are protected.
 	cands, err := client.PruneImages(true)

--- a/internal/vz/system_prune_test.go
+++ b/internal/vz/system_prune_test.go
@@ -397,6 +397,18 @@ func TestPrune_InstancesBeforeImages_ReleasesImageRef(t *testing.T) {
 	digest := createFakeImage(t, imagesDir, "tobereclaimed")
 	seedStoppedShedWithDigest(t, instanceDir, "old-shed", "tobereclaimed", digest, 4096, 0, 5*24*time.Hour)
 
+	// As of v0.5.8 tags themselves are protective, so without
+	// dropping the tag the image-prune phase would keep the blob
+	// alive after the shed ref releases (the documented cleanup
+	// flow is `shed image rm` then `shed image prune`). This test
+	// is about the ordering — instance prune phase must run BEFORE
+	// the image prune phase so the released shed ref is visible —
+	// not about the tag-protection rule, so drop the tag up-front
+	// to isolate the ordering behavior.
+	if err := vmimage.DeleteTag(imagesDir, "tobereclaimed"); err != nil {
+		t.Fatalf("DeleteTag(tobereclaimed): %v", err)
+	}
+
 	report, err := c.Prune(context.Background(), backend.PruneOptions{
 		Images:    true,
 		Instances: true,
@@ -418,10 +430,12 @@ func TestPrune_InstancesBeforeImages_ReleasesImageRef(t *testing.T) {
 	if !contains(shedsDeleted, "old-shed") {
 		t.Errorf("expected old-shed deleted, got %v", shedsDeleted)
 	}
-	if !contains(imagesDeleted, "tobereclaimed") {
-		t.Errorf("expected tobereclaimed image deleted after shed ref released, got %v", imagesDeleted)
+	if len(imagesDeleted) == 0 {
+		t.Errorf("expected at least one image deleted after shed ref released, got %v", imagesDeleted)
 	}
-	// The blob should actually be gone.
+	// The blob should actually be gone. With the untagged
+	// pre-condition above this means the image prune phase saw the
+	// released shed ref and walked the now-orphaned digest.
 	if vmimage.BlobExists(imagesDir, digest) {
 		t.Errorf("blob still present after prune")
 	}


### PR DESCRIPTION
## What

Pre-v0.5.8 `shed image prune` followed Docker's "tags are informational" model: only sheds, snapshots, and in-flight create markers protected blobs. That made `shed image pull X && shed image prune` a footgun on a fresh host — prune deleted the manifest just pulled, leaving either a tag pointing at a missing blob (mac VZ behavior) or a tag silently reverted to an older locally-cached manifest (mini2 saw `base` flip from the v0.5.7 manifest back to v0.5.3, with v0.5.3's missing `zip`).

This PR makes tags protective.

## Why

Two real defects after rolling v0.5.7 out to mini2/mini3/the mac on 2026-05-29. Reported in `memory/v057-known-issues.md`. This is the first of three PRs that together close out v0.5.7 and ship v0.5.8.

## Changes

- `internal/vmimage/refs.go`
  - `RefKindTag` doc inverted to "tags ARE protective", with the rationale (`pull && prune` footgun) and the documented cleanup workflow (`shed image rm <tag>` first, then `shed image prune`).
  - `ProtectiveRefs()` no longer filters tag refs out.
- `internal/vmimage/manager.go`
  - `PruneImages()` walks `ListTags()` after collecting scanner refs and adds each tag's manifest digest to `liveManifests` before the reachability expansion.
  - Stale tags (manifest blob missing) log a warning and are skipped — they can't protect something that's already gone, and adding the missing digest would just trip later code paths.
  - `RefScanner` implementations are unchanged: tags continue to live in the central store the Manager owns, not in per-backend metadata, so the protective merge happens at the use site.

## Tests

- `internal/vmimage/manager_test.go` adds four new tests covering the v0.5.8 contract:
  - `TestPruneProtectsTaggedManifest` — tag keeps manifest + transitive blobs (config, layers, kernel, initrd, erofs).
  - `TestPruneAfterUntagDeletesOrphan` — documented cleanup workflow works end-to-end.
  - `TestPruneHandlesStaleTag` — prune logs a warning and doesn't panic when a tag points at a missing manifest.
  - `TestPruneStillProtectsShedPinnedManifest` — shed-pinned-only blobs (no tag) remain protected (no regression).
- `internal/vz/image_test.go` (`TestPruneImagesRespectsRefs`) and `internal/vz/system_prune_test.go` (`TestPrune_InstancesBeforeImages_ReleasesImageRef`) updated to untag their dangling fixtures up-front. The snapshot-pin test (`TestPruneImagesProtectsSnapshotPin`) already followed this pattern; the two prune tests now match.

## Verification

- `make check` clean.
- `GOOS=linux GOARCH=arm64 go build ./internal/firecracker/` clean.
- `make test-integration` clean on both VZ (mac) and FC (mini3) — 38/38 passing.

## Reviewer focus

- Walk the "tag points at a missing manifest" path in `PruneImages` and confirm no panic / no incorrect deletion. The covering test is `TestPruneHandlesStaleTag` in `internal/vmimage/manager_test.go`.
- Sanity-check that `liveManifests` is built from `refs + tags` BEFORE the reachability walk, so manifest transitive blobs (config, layers, kernel, initrd, erofs) get marked as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tags now explicitly protect manifests and all referenced blobs from deletion during prune; prune tolerates stale tags pointing to missing manifests without failing.

* **Tests**
  * Added regression tests for tag-based protection, post-untag cleanup of orphaned content, stale-tag handling, and continued protection of scanner-pinned manifests.

* **Documentation**
  * Updated CLI prune docs and upgrade notes to reflect that tags are protective and advise removing stale tags before pruning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->