### PR TITLE
fix(images): pin Ubuntu kernel package across initramfs + vz Dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-cli build-server build-agent build-firstboot build-tools test test-integration release clean dev-server dev-cli check coverage lint-all docs docs-serve firecracker-rootfs download-firecracker vz-rootfs vz-rootfs-base vz-rootfs-all
+.PHONY: build build-cli build-server build-agent build-firstboot build-tools test test-integration release clean dev-server dev-cli check check-kernel-pin coverage lint-all docs docs-serve firecracker-rootfs download-firecracker vz-rootfs vz-rootfs-base vz-rootfs-all
 
 GOARCH ?= $(shell go env GOARCH)
 
@@ -86,8 +86,40 @@ tidy:
 	go mod tidy
 	cd sdk && go mod tidy
 
-# Run all checks (lint + test)
-check: lint test
+# Verify the LINUX_IMAGE_VERSION pin stays in lockstep across the two
+# Dockerfiles that install the Ubuntu kernel package. Pre-v0.5.8 the
+# initramfs and vz/base each installed `linux-image-virtual` without
+# pinning, and a Docker BuildKit cache split between stages produced
+# initramfs .ko files targeting a different kernel than the rootfs
+# vmlinuz — booting the resulting VZ image panicked in the
+# shed-initramfs with SHED-INIT-03. The two Dockerfiles must declare
+# the same ARG value; this target fails fast if they drift.
+#
+# firecracker/Dockerfile is intentionally skipped: the FC rootfs uses
+# the custom KERNEL_TAG-built kernel and does not install
+# linux-image-virtual at all. FC's initramfs is the SAME initramfs
+# initramfs/Dockerfile produces, so pinning that one file covers the
+# FC initramfs path as well.
+check-kernel-pin:
+	@vz=$$(awk '/^ARG LINUX_IMAGE_VERSION=/ { print; exit }' vz/Dockerfile) ; \
+	 ir=$$(awk '/^ARG LINUX_IMAGE_VERSION=/ { print; exit }' initramfs/Dockerfile) ; \
+	 if [ -z "$$vz" ] || [ -z "$$ir" ]; then \
+	   echo "ERROR: LINUX_IMAGE_VERSION ARG missing:" ; \
+	   echo "  vz/Dockerfile:        $$vz" ; \
+	   echo "  initramfs/Dockerfile: $$ir" ; \
+	   exit 1 ; \
+	 fi ; \
+	 if [ "$$vz" != "$$ir" ]; then \
+	   echo "ERROR: LINUX_IMAGE_VERSION ARG drifted across Dockerfiles:" ; \
+	   echo "  vz/Dockerfile:        $$vz" ; \
+	   echo "  initramfs/Dockerfile: $$ir" ; \
+	   echo "Bump in lockstep (see docs/reference/images.md)." ; \
+	   exit 1 ; \
+	 fi ; \
+	 echo "kernel pin OK: $$vz"
+
+# Run all checks (lint + test + kernel pin)
+check: check-kernel-pin lint test
 
 # Run tests with coverage
 coverage:

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -405,6 +405,59 @@ for the workflow.
 [`go-containerregistry`](https://github.com/google/go-containerregistry)
 directly.
 
+### Kernel version pinning
+
+`initramfs/Dockerfile` and `vz/Dockerfile` both install an Ubuntu
+kernel package — the initramfs to stage `erofs.ko` + `libcrc32c.ko`,
+the VZ rootfs to ship the `vmlinuz` shed extracts at image-publish
+time. The two must target the **same** kernel version: VZ kernels
+don't have erofs built-in, so the initramfs's staged `.ko` files
+must match the booted `vmlinuz` ABI exactly or the in-guest
+overlay mount fails with `SHED-INIT-03`.
+
+Pre-v0.5.8 both stages installed the `linux-image-virtual`
+metapackage without pinning. GitHub Actions builds were safe (each
+runner has a fresh BuildKit cache, so both stages see the same apt
+snapshot), but iterative local builds via `./scripts/build-vz-rootfs.sh`
+could pull two different apt snapshots out of BuildKit's cache and
+produce an unbootable image with kernel-version skew between the
+initramfs and the rootfs.
+
+v0.5.8+ pins via `ARG LINUX_IMAGE_VERSION` in both Dockerfiles:
+
+| File | What the ARG controls |
+|---|---|
+| `initramfs/Dockerfile` | Package the initramfs stages `erofs.ko` + `libcrc32c.ko` from. |
+| `vz/Dockerfile` | Package the VZ rootfs installs as the in-guest kernel. |
+
+`make check-kernel-pin` (wired into `make check`) fails the build
+if the two values drift apart. Bump both in lockstep when picking
+up a new Ubuntu kernel:
+
+```bash
+# Both lines must declare the same package version.
+grep '^ARG LINUX_IMAGE_VERSION=' initramfs/Dockerfile vz/Dockerfile
+```
+
+Firecracker's rootfs uses the custom `KERNEL_TAG`-built kernel
+(`firecracker/Dockerfile` `kernel-builder` stage) and does **not**
+install `linux-image-virtual` — so it's not covered by this pin.
+FC's initramfs IS the same artifact `initramfs/Dockerfile` builds,
+so the FC initramfs path is covered by `LINUX_IMAGE_VERSION`
+automatically; FC's custom kernel has erofs built-in, so the .ko
+load is non-load-bearing on FC anyway.
+
+After bumping the pin, validate locally:
+
+```bash
+docker buildx prune --all --force
+./scripts/build-vz-rootfs.sh --variant base
+# Then boot a shed against the rebuilt blob and verify uname -r.
+```
+
+See `docs/upgrades/v0.5.7-to-v0.5.8.md` for the original SHED-INIT-03
+incident report.
+
 ## Image Caching
 
 Pull / save / load / build all land manifests and blobs in the OCI

--- a/initramfs/Dockerfile
+++ b/initramfs/Dockerfile
@@ -12,15 +12,30 @@
 #     --target shed-initramfs \
 #     --output type=local,dest=./out .
 
-# Stage: pull Ubuntu's linux-image-virtual kernel modules so the
-# initramfs can insmod erofs.ko before mounting the single read-only
-# erofs lower. Ubuntu ships erofs as a *module* (=m) in
-# linux-image-virtual, not built-in, and overlay.ko alone isn't enough
-# — without erofs loaded, the lower mount fails with EINVAL.
+# Stage: pull Ubuntu's linux-image kernel modules so the initramfs can
+# insmod erofs.ko before mounting the single read-only erofs lower.
+# Ubuntu ships erofs as a *module* (=m), not built-in, and overlay.ko
+# alone isn't enough — without erofs loaded, the lower mount fails
+# with EINVAL.
 FROM ubuntu:24.04 AS ubuntu-modules
 
+# LINUX_IMAGE_VERSION pins the apt kernel package the initramfs's
+# erofs.ko + libcrc32c.ko are staged from. Pre-v0.5.8 this stage and
+# vz/Dockerfile each installed the linux-image-virtual metapackage
+# independently; if Docker BuildKit's layer cache held an older apt
+# snapshot for one stage and a fresher one for the other, the staged
+# .ko files targeted a different kernel than the booted vmlinuz and
+# the VZ guest panicked in shed-initramfs with SHED-INIT-03 ("failed
+# to mount /dev/vdb at /lower (erofs)"). Pinning the specific image
+# package across both Dockerfiles closes that drift window.
+#
+# MUST match vz/Dockerfile's ARG of the same name; Makefile's
+# `check-kernel-pin` target enforces parity. See
+# docs/upgrades/v0.5.7-to-v0.5.8.md for the rationale.
+ARG LINUX_IMAGE_VERSION=6.8.0-124
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        linux-image-virtual \
+        "linux-image-${LINUX_IMAGE_VERSION}-generic" \
     && rm -rf /var/lib/apt/lists/*
 
 # Stage erofs.ko AND its dependency libcrc32c.ko (erofs uses crc32c for
@@ -32,14 +47,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # load them in sorted order (libcrc32c=10, erofs=20). Without this,
 # erofs.ko's "Unknown symbol crc32c" fails the load and erofs mounts
 # return EINVAL.
+#
+# Scope the find to /lib/modules/${LINUX_IMAGE_VERSION}-generic
+# explicitly. If the pin ARG is wrong (e.g. operator forgot to bump
+# both Dockerfiles in lockstep), the find returns nothing and the
+# build fails fast with a clear error rather than silently grabbing
+# a module from a different kernel that happens to be present.
 RUN mkdir -p /stage \
-    && erofs_ko=$(find /lib/modules -name 'erofs.ko*' 2>/dev/null | tail -1) \
-    && crc32c_ko=$(find /lib/modules -name 'libcrc32c.ko*' 2>/dev/null | tail -1) \
-    && if [ -z "$erofs_ko" ]; then echo "ERROR: erofs.ko not found in linux-image-virtual" >&2; exit 1; fi \
-    && if [ -z "$crc32c_ko" ]; then echo "ERROR: libcrc32c.ko not found" >&2; exit 1; fi \
+    && kver="${LINUX_IMAGE_VERSION}-generic" \
+    && mod_root="/lib/modules/${kver}" \
+    && [ -d "$mod_root" ] || { echo "ERROR: ${mod_root} not present — LINUX_IMAGE_VERSION=${LINUX_IMAGE_VERSION} did not install the expected kernel" >&2; exit 1; } \
+    && erofs_ko=$(find "$mod_root" -name 'erofs.ko*' 2>/dev/null | tail -1) \
+    && crc32c_ko=$(find "$mod_root" -name 'libcrc32c.ko*' 2>/dev/null | tail -1) \
+    && if [ -z "$erofs_ko" ]; then echo "ERROR: erofs.ko not found under ${mod_root}" >&2; exit 1; fi \
+    && if [ -z "$crc32c_ko" ]; then echo "ERROR: libcrc32c.ko not found under ${mod_root}" >&2; exit 1; fi \
     && cp "$crc32c_ko" "/stage/10-$(basename "$crc32c_ko")" \
     && cp "$erofs_ko"  "/stage/20-$(basename "$erofs_ko")" \
-    && kver=$(basename "$(dirname "$(dirname "$(dirname "$(dirname "$erofs_ko")")")")") \
     && echo "$kver" > /stage/kver.txt \
     && echo "Staged: 10-$(basename "$crc32c_ko"), 20-$(basename "$erofs_ko") for kver $kver"
 

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -44,6 +44,21 @@ LABEL org.opencontainers.image.source="https://github.com/charliek/shed"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
+# LINUX_IMAGE_VERSION pins the apt kernel package the VZ rootfs and the
+# shed initramfs share. Pre-v0.5.8 both stages installed the
+# linux-image-virtual metapackage independently; if Docker BuildKit's
+# layer cache held an older apt snapshot for one stage and a fresher
+# one for the other, the initramfs's staged erofs.ko / libcrc32c.ko
+# targeted a different kernel than this stage's booted vmlinuz and
+# the VZ guest panicked in shed-initramfs with SHED-INIT-03 ("failed
+# to mount /dev/vdb at /lower (erofs)"). VZ kernels lack erofs as
+# built-in, so the .ko load is load-bearing.
+#
+# MUST match initramfs/Dockerfile's ARG of the same name; Makefile's
+# `check-kernel-pin` target enforces parity. See
+# docs/upgrades/v0.5.7-to-v0.5.8.md for the rationale.
+ARG LINUX_IMAGE_VERSION=6.8.0-124
+
 # Strip man pages, docs, and non-English locales from every subsequent
 # dpkg/apt operation. Must come BEFORE the first apt-get install so the
 # excludes apply to all packages. Keep en/en_US locales — many tools
@@ -57,19 +72,19 @@ RUN printf '%s\n' \
     > /etc/dpkg/dpkg.cfg.d/01-shed-strip
 
 # Layer 1: APT-installed system + dev tools + Docker CE in one go.
-# linux-image-virtual + initramfs-tools provide the in-VM kernel
-# (extracted at image-build time by shed image build for VZ booting).
-# linux-image-virtual is ~100 MB smaller than linux-image-generic because
-# it ships a minimal recommended-modules set: virtio_blk, virtio_net,
-# virtio_pci, 9p, 9pnet_virtio, loop, overlay. It does NOT ship the
-# vsock guest-transport modules (vmw_vsock_virtio_transport[_common]);
-# those live in linux-modules-extra-$KVERS-generic, which Noble does
-# NOT expose as a -virtual metapackage (only kernel-flavor-specific
-# aliases like -extra-aws/-azure/-gcp exist). We derive the exact
-# kernel version from the linux-image-*-generic package the
-# linux-image-virtual metapackage pulled in and install the matching
-# -extra package by name. Without it, shed-agent.service can't open
-# its vsock listener and host health checks time out.
+# linux-image-${LINUX_IMAGE_VERSION}-generic + initramfs-tools provide
+# the in-VM kernel (extracted at image-build time by shed image build
+# for VZ booting). Pre-v0.5.8 this stage installed the
+# linux-image-virtual metapackage; we install the specific generic
+# kernel image directly so the kernel version matches the initramfs's
+# .ko staging (see the ARG comment above). The -generic flavor is
+# ~100 MB larger than -virtual but ships the same recommended
+# virtio_* / overlay modules, so the boot path is unchanged. The
+# vsock guest-transport modules
+# (vmw_vsock_virtio_transport[_common]) still live in
+# linux-modules-extra-$KVERS-generic; we install that by name too.
+# Without it, shed-agent.service can't open its vsock listener and
+# host health checks time out.
 # Editor lineup: neovim only. vim/nano/jed/htop dropped to save ~80 MB;
 # users who need them can `apt install` inside a shed.
 RUN apt-get update \
@@ -80,10 +95,11 @@ RUN apt-get update \
        openssh-server \
        iproute2 iputils-ping dnsutils netcat-openbsd \
        build-essential bubblewrap \
-       linux-image-virtual initramfs-tools \
-    && KVERS=$(dpkg-query -W -f='${Package}\n' 'linux-image-*-generic' | head -1 | sed 's/linux-image-//') \
-    && [ -n "$KVERS" ] || { echo "ERROR: could not derive kernel version from linux-image-*-generic"; exit 1; } \
-    && apt-get install -y --no-install-recommends "linux-modules-extra-$KVERS" \
+       "linux-image-${LINUX_IMAGE_VERSION}-generic" \
+       "linux-modules-extra-${LINUX_IMAGE_VERSION}-generic" \
+       initramfs-tools \
+    && [ -d "/lib/modules/${LINUX_IMAGE_VERSION}-generic" ] \
+       || { echo "ERROR: /lib/modules/${LINUX_IMAGE_VERSION}-generic not present after install — LINUX_IMAGE_VERSION ARG is wrong" >&2; exit 1; } \
     && rm -rf /var/lib/apt/lists/*
 
 # Layer 2: stage shed-built binaries + service files from the build


### PR DESCRIPTION
## What

Pin the Ubuntu kernel package across `initramfs/Dockerfile` and `vz/Dockerfile` via `ARG LINUX_IMAGE_VERSION=6.8.0-124`. Closes the v0.5.7 `SHED-INIT-03` panic that operators hit when iteratively rebuilding VZ images locally.

## Why

Pre-v0.5.8 both stages installed the `linux-image-virtual` metapackage independently. The two installs run in separate `docker buildx build` invocations with their own BuildKit cache; when their apt snapshots drift (common in iterative local builds), the initramfs's staged `erofs.ko` + `libcrc32c.ko` target a different kernel than the booted `vmlinuz` and the VZ guest panics in `shed-initramfs` because the .ko load fails ("disagrees about version of symbol module_layout"). VZ kernels don't have erofs built-in, so the .ko load is load-bearing.

GitHub Actions doesn't hit this — each runner has a fresh BuildKit cache — but every operator iterating on the image scripts does.

## Changes

- `initramfs/Dockerfile` — new `ARG LINUX_IMAGE_VERSION=6.8.0-124`. Installs `linux-image-${LINUX_IMAGE_VERSION}-generic` directly instead of the `linux-image-virtual` metapackage. Scopes the `erofs.ko*` / `libcrc32c.ko*` `find` to `/lib/modules/${kver}` explicitly so the build fails fast if the pin is wrong.
- `vz/Dockerfile` — same ARG, same `linux-image-${LINUX_IMAGE_VERSION}-generic` swap, plus `linux-modules-extra-${LINUX_IMAGE_VERSION}-generic` (replaces the dynamic `KVERS=$(dpkg-query …)` block with a hard `[ -d /lib/modules/${kver} ]` check).
- `Makefile` — new `check-kernel-pin` target wired into `make check`. Compares the ARG values across both Dockerfiles and fails the build with a clear diff if they drift.
- `docs/reference/images.md` — new "Kernel version pinning" section under "Builder backend" explaining the ARG, why both files must declare the same value, the `check-kernel-pin` enforcement, the FC carve-out (see below), and the bump procedure.

## Deviation from the original plan

The plan listed `firecracker/Dockerfile` as a third file to touch. After reading the file, the FC rootfs **does not install `linux-image-virtual` at all** — it uses the custom `KERNEL_TAG`-built kernel from the `kernel-builder` stage. The FC initramfs IS the same artifact `initramfs/Dockerfile` produces, so pinning that one file covers the FC initramfs path automatically. Adding a never-referenced ARG to `firecracker/Dockerfile` would be dead code that drifts independently. Documented in the Makefile target's comment and the new docs section.

FC's custom kernel has erofs built-in anyway, so this whole class of panic is VZ-only.

## Verification

- `make check` clean (includes `check-kernel-pin`).
- `make check-kernel-pin` correctly catches drift (tested by hand-mismatching one ARG and confirming the target fails with a clear diff).
- `GOOS=linux GOARCH=arm64 go build ./internal/firecracker/` clean.
- `make test-integration` clean on both VZ and FC backends (38/38).
- **End-to-end local rebuild** — the failure case from the v0.5.7 session:
  ```bash
  docker buildx prune --all --force
  ./scripts/build-vz-rootfs.sh --variant base
  shed -s my-server create v058-pin-smoke --image base
  shed -s my-server exec v058-pin-smoke -- bash -lc 'uname -r'
  # → 6.8.0-124-generic, clean boot, no SHED-INIT-03 panic.
  shed -s my-server delete v058-pin-smoke -f
  ```

## Reviewer focus

- Walk both `apt-get install linux-image-${LINUX_IMAGE_VERSION}-generic` invocations. The metapackage-to-specific-package swap is the load-bearing change; confirm the package name is correct for Ubuntu 24.04 noble (`linux-image-6.8.0-124-generic` resolves; verified locally).
- Sanity-check the FC carve-out reasoning in the Makefile / docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Kernel version pinning" section explaining how kernel versions are kept synchronized across builds to prevent compatibility issues.

* **Chores**
  * Added build-time validation to enforce kernel version consistency across container images.
  * Updated container images to pin specific Ubuntu kernel versions, preventing version mismatches in staged modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->