### PR TITLE
fix(packaging): .deb postinst try-restart on upgrade

### DIFF
--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -1,16 +1,57 @@
 #!/bin/bash
+# nfpm-generated postinst for shed-server.
+#
+# dpkg invokes this with:
+#   $1 = action  ("configure" on install/upgrade; abort-* on rollback)
+#   $2 = previous package version, empty on a fresh install
+#
+# Convention: a fresh install enables (but does NOT start) the unit and
+# prints the "edit config then start" hint, because the operator needs
+# to fill in /etc/shed/server.yaml first. An upgrade try-restarts the
+# unit so the new binary actually replaces the running old one — pre-
+# v0.5.9 the postinst skipped the restart, leaving operators with a
+# 0.5.x-1 binary still serving while `dpkg-query` reported 0.5.x. See
+# docs/upgrades/v0.5.7-to-v0.5.8.md for the original incident.
 set -e
 
-# Guard against non-systemd environments (chroots, container builds)
-if command -v systemctl >/dev/null 2>&1 && systemctl --system 2>/dev/null; then
-    systemctl daemon-reload
-    systemctl enable shed-server.service || true
+# Guard against non-systemd environments (chroots, container builds).
+# `systemctl --system` returns nonzero outside a real systemd host.
+if ! command -v systemctl >/dev/null 2>&1 || ! systemctl --system 2>/dev/null; then
+    exit 0
 fi
 
-echo ""
-echo "shed-server has been installed and enabled."
-echo ""
-echo "Next steps:"
-echo "  1. Edit /etc/shed/server.yaml"
-echo "  2. Run: sudo shed-server setup"
-echo "  3. Run: sudo systemctl start shed-server"
+systemctl daemon-reload || true
+systemctl enable shed-server.service || true
+
+if [ -n "${2:-}" ]; then
+    # Upgrade path. `try-restart` is the Debian-standard primitive for
+    # "restart only if the unit is already active". If the operator had
+    # stopped the service deliberately (maintenance window, config
+    # debugging) we don't surprise them by auto-starting it; we just
+    # swap binaries and leave activation state alone.
+    if command -v deb-systemd-invoke >/dev/null 2>&1; then
+        deb-systemd-invoke try-restart shed-server.service || true
+    else
+        # Fallback for systems missing the dh-systemd helper (rare on
+        # modern Debian/Ubuntu but possible on stripped derivatives).
+        if systemctl is-active --quiet shed-server.service; then
+            systemctl restart shed-server.service || true
+        fi
+    fi
+
+    echo ""
+    if systemctl is-active --quiet shed-server.service; then
+        echo "shed-server has been upgraded and restarted (was running)."
+    else
+        echo "shed-server has been upgraded; unit was inactive so it was left stopped."
+        echo "Start it with: sudo systemctl start shed-server"
+    fi
+else
+    echo ""
+    echo "shed-server has been installed and enabled."
+    echo ""
+    echo "Next steps:"
+    echo "  1. Edit /etc/shed/server.yaml"
+    echo "  2. Run: sudo shed-server setup"
+    echo "  3. Run: sudo systemctl start shed-server"
+fi

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -16,7 +16,10 @@ set -e
 
 # Guard against non-systemd environments (chroots, container builds).
 # `systemctl --system` returns nonzero outside a real systemd host.
-if ! command -v systemctl >/dev/null 2>&1 || ! systemctl --system 2>/dev/null; then
+# Redirect both stdout (which would otherwise dump the full unit list
+# into dpkg's install output — caught by CodeRabbit on PR #150) and
+# stderr.
+if ! command -v systemctl >/dev/null 2>&1 || ! systemctl --system >/dev/null 2>&1; then
     exit 0
 fi
 


### PR DESCRIPTION
## What

`packaging/postinstall.sh` now `try-restart`s the `shed-server.service` when invoked on a .deb upgrade, instead of leaving the running 0.5.x-1 process serving while `dpkg-query` reports 0.5.x. Fresh installs preserve the existing "edit `server.yaml`, then start" contract — no auto-start.

This is the follow-up from `docs/upgrades/v0.5.7-to-v0.5.8.md`'s `.deb`-restart gap callout.

## Why

Reproduced on mini2 and mini3 during the v0.5.7 → v0.5.8 rollout (full notes in the PR thread for #149). After `sudo dpkg -i shed-server_0.5.8_amd64.deb` over a 0.5.7 install:

```
$ dpkg-query -W shed-server        # → 0.5.8 (package upgraded)
$ systemctl is-active shed-server  # → active
$ curl /api/info                   # → "version":"0.5.7"  ← old binary still running!
```

The operator-visible symptom is the worst kind of footgun: nothing is wrong, all the obvious checks say "yes, you upgraded," but the new code never ran. The current upgrade doc warns about it explicitly with an admonition, but that's a documentation patch over a packaging defect.

## Changes

- `packaging/postinstall.sh` — branch on `$2` (the previous version dpkg passes to the postinst):
  - **Upgrade ($2 nonempty)**: `deb-systemd-invoke try-restart shed-server.service`. The `try-restart` primitive is the Debian-standard "restart only if the unit is already active" semantics. If the operator had stopped the service deliberately (maintenance, config debugging) the upgrade swaps the binary but leaves activation alone.
  - **Fresh install ($2 empty)**: unchanged — `enable` but don't start; print the "1. edit yaml 2. setup 3. start" hint as today.
  - Fallback when `deb-systemd-invoke` is missing (rare on modern Debian/Ubuntu, possible on stripped derivatives): `systemctl is-active --quiet` + raw `systemctl restart`.
  - Hint output mirrors which branch ran so the operator gets a one-line confirmation.

No other files touched. No CHANGELOG entry — **no release**; the next release picks this up.

## Validation (pre-PR, on mini2)

Built a snapshot .deb locally with `nfpm pkg` at version `0.5.8+postinstfix1` from this branch and `dpkg -i`-ed it over the released v0.5.8 .deb on mini2:

### Arm 1 — was running (the common upgrade path)

```
=== PRE-install state ===
shed-server	0.5.8
active
{"version":"0.5.8", ...}

=== Installing v0.5.8+postinstfix1 ===
shed-server has been upgraded and restarted (was running).

=== POST-install state (NO manual restart) ===
shed-server	0.5.8+postinstfix1
active
{"version":"0.5.8+postinstfix1", ...}
```

`try-restart` fired, the running binary swapped, and `curl /api/info` reported the new version immediately.

### Arm 2 — was stopped (operator stopped it for maintenance)

```
=== Stopping service ===
inactive

=== Installing +postinstfix2 (service stopped) ===
shed-server has been upgraded; unit was inactive so it was left stopped.
Start it with: sudo systemctl start shed-server

=== POST-install state ===
shed-server	0.5.8+postinstfix2
inactive
```

`try-restart` correctly did NOT start the stopped unit. Operator gets a clear hint and the choice of when to start it. Binary on disk is the new one (per `dpkg-query`).

mini2 has been restored to the released v0.5.8 .deb and restarted; mini3 + mac are untouched and continue to run the released v0.5.8 binaries.

## Reviewer focus

- The `try-restart` choice vs. always-restart. The user picked try-restart explicitly — preserves the "operator deliberately stopped it" semantics. Alternative is documented in the source comment.
- The `command -v deb-systemd-invoke` fallback. The helper has been in `init-system-helpers` since `wheezy`, so the fallback is almost dead code on Debian/Ubuntu, but it makes the postinst safe on the stripped derivatives where it isn't.
- `shellcheck packaging/postinstall.sh` is clean.
- Tests intentionally absent — postinst behavior is best validated against a real `dpkg -i`, which is what the mini2 validation above is. The next release will pick this up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced post-installation flow with distinct behavior for fresh installs vs upgrades.
  * Fresh installs now prompt users to configure the service before starting it.
  * Upgrades will attempt to restart the service only when appropriate to avoid unnecessary restarts.
  * Better handling and clearer messaging on systems without modern service management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->