### PR TITLE
fix(lifecycle): verify VMM exit before flipping status; PID-reuse guard on FC

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -61,6 +61,21 @@ var (
 	// field-conflict cases (e.g., --from-snapshot combined with --image or --repo)
 	// under this sentinel rather than minting per-conflict sentinels.
 	ErrInvalidShedRequestSentinel = errors.New("invalid create-shed request")
+
+	// ErrStopIncompleteSentinel is returned when StopShed asked the VMM to
+	// terminate but the recorded PID is still alive after the stop
+	// sequence (vm.Stop returned without error). Surfacing this prevents
+	// the metadata from advertising status=stopped while a zombie VMM
+	// still holds the workspace upper / vsock sockets.
+	ErrStopIncompleteSentinel = errors.New("VMM did not exit after stop sequence")
+
+	// ErrZombiePresentSentinel is returned when StartShed sees a non-zero
+	// PID in metadata whose process is still alive AND looks like the
+	// expected VMM binary (vfkit / firecracker). This protects against
+	// silently spawning a second VMM under the same name when metadata
+	// got out of sync (partial save / external tampering / server crash
+	// between vm.Start and metadata.Save).
+	ErrZombiePresentSentinel = errors.New("recorded VMM pid is still alive; refusing to spawn a second instance")
 )
 
 // shedNameRegex validates shed names: lowercase alphanumeric and hyphens, starting with a letter.

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -567,6 +567,18 @@ func (c *Client) StartShed(ctx context.Context, name string) (*config.Shed, erro
 		meta.PID = 0
 	}
 
+	// Defensive zombie-pid check. Even when status reads "stopped" we
+	// can still hold a stale pid (server crash between vm.Stop() and
+	// the metadata save, hand-edited metadata.json, etc). Refuse to
+	// spawn a second firecracker under the same name when the recorded
+	// pid is still alive AND still looks like firecracker. Plain
+	// liveness without the binary check would false-positive across
+	// PID reuse.
+	if meta.PID > 0 && vmutil.IsProcessAlive(meta.PID) && isFirecrackerProcess(meta.PID) {
+		return nil, fmt.Errorf("%w: %s (pid %d)", config.ErrZombiePresentSentinel, name, meta.PID)
+	}
+	meta.PID = 0
+
 	vm, err := CreateVM(ctx, meta, c.cfg, c.netMgr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create VM: %w", err)
@@ -688,6 +700,15 @@ func (c *Client) stopShedLocked(ctx context.Context, meta *Metadata) (*config.Sh
 
 	if err := vm.Stop(ctx); err != nil {
 		return nil, fmt.Errorf("failed to stop VM: %w", err)
+	}
+
+	// vm.Stop's post-SIGKILL waitForProcessExit swallows its timeout
+	// and returns nil even when firecracker refused to die. Verify
+	// before flipping status — otherwise the next StartShed would find
+	// PID=0 in metadata and silently spawn a second firecracker under
+	// the same name.
+	if meta.PID > 0 && vmutil.IsProcessAlive(meta.PID) && isFirecrackerProcess(meta.PID) {
+		return nil, fmt.Errorf("%w: %s (pid %d)", config.ErrStopIncompleteSentinel, meta.Name, meta.PID)
 	}
 
 	meta.Status = config.StatusStopped

--- a/internal/firecracker/vm.go
+++ b/internal/firecracker/vm.go
@@ -383,7 +383,15 @@ func (vm *VM) IsRunning() bool {
 	// Send signal 0 to check if process exists.
 	// EPERM means the process exists but we lack permission to signal it.
 	err = process.Signal(syscall.Signal(0))
-	return err == nil || errors.Is(err, syscall.EPERM)
+	if err != nil && !errors.Is(err, syscall.EPERM) {
+		return false
+	}
+
+	// Guard against PID reuse: verify the process is actually
+	// firecracker. Matches VZ's vfkit check in vz/vm.go:IsRunning.
+	// Without this, a recycled PID (host reboot + churn) could keep
+	// shed reporting status=running indefinitely.
+	return isFirecrackerProcess(vm.meta.PID)
 }
 
 // isFirecrackerProcess checks if the given PID belongs to a Firecracker process

--- a/internal/firecracker/vm_test.go
+++ b/internal/firecracker/vm_test.go
@@ -51,75 +51,73 @@ func TestGenerateMACAddress(t *testing.T) {
 	}
 }
 
-func TestIsRunning_LivePIDButNotFirecracker(t *testing.T) {
-	// A live PID that isn't firecracker must report not-running. Before
-	// the PID-reuse guard was added, this returned true and shed list
-	// would silently advertise a recycled pid as a running VMM.
-	//
-	// We can't use os.Getpid() here: the test binary's /proc/PID/cmdline
-	// is `/path/to/firecracker.test` and substring-matches "firecracker".
-	// Spawn a sleep child so the cmdline is definitively not firecracker.
-	cmd := exec.Command("sleep", "30")
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start sleep child: %v", err)
+func TestIsRunning(t *testing.T) {
+	// spawnSleepChild returns a non-firecracker live pid the caller
+	// owns for the duration of the case (cleanup kills + reaps it).
+	// os.Getpid() can't substitute here: the test binary's
+	// /proc/PID/cmdline ends in `firecracker.test` and substring-
+	// matches "firecracker", which would defeat the PID-reuse guard
+	// we're trying to test.
+	spawnSleepChild := func(t *testing.T) int {
+		t.Helper()
+		cmd := exec.Command("sleep", "30")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start sleep child: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		})
+		return cmd.Process.Pid
 	}
-	t.Cleanup(func() {
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
-	})
 
-	dir := mustTempDir(t, "vm-test")
-	cfg := testFirecrackerConfig(dir)
-	meta := testMetadata("test-vm")
-	meta.PID = cmd.Process.Pid
-
-	vm := &VM{meta: meta, cfg: cfg}
-
-	if vm.IsRunning() {
-		t.Error("IsRunning() = true for non-firecracker PID, want false (PID-reuse guard)")
-	}
-}
-
-func TestIsRunning_InvalidPID(t *testing.T) {
-	dir := mustTempDir(t, "vm-test")
-	cfg := testFirecrackerConfig(dir)
-	meta := testMetadata("test-vm")
-
-	tests := []struct {
-		name string
-		pid  int
+	cases := []struct {
+		name       string
+		setupPID   func(t *testing.T) int
+		wantRunning bool
 	}{
-		{"zero PID", 0},
-		{"negative PID", -1},
+		{
+			name:        "zero PID",
+			setupPID:    func(*testing.T) int { return 0 },
+			wantRunning: false,
+		},
+		{
+			name:        "negative PID",
+			setupPID:    func(*testing.T) int { return -1 },
+			wantRunning: false,
+		},
+		{
+			// Tightens the contract added by the PID-reuse guard: a
+			// live PID that isn't firecracker must report not-running.
+			// Before the guard, this returned true and `shed list`
+			// would silently advertise a recycled pid as a running VMM.
+			name:        "live PID but not firecracker",
+			setupPID:    spawnSleepChild,
+			wantRunning: false,
+		},
+		{
+			// 2,000,000,000 is above default Linux pid_max (4,194,304)
+			// but well within int32 — kernels return ESRCH.
+			name:        "impossibly-large PID",
+			setupPID:    func(*testing.T) int { return 2000000000 },
+			wantRunning: false,
+		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			meta.PID = tt.pid
+	dir := mustTempDir(t, "vm-test")
+	cfg := testFirecrackerConfig(dir)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := testMetadata("test-vm")
+			meta.PID = tc.setupPID(t)
 			vm := &VM{meta: meta, cfg: cfg}
 
-			if vm.IsRunning() {
-				t.Errorf("IsRunning() = true for PID %d, want false", tt.pid)
+			if got := vm.IsRunning(); got != tc.wantRunning {
+				t.Errorf("IsRunning() = %v, want %v (pid=%d)", got, tc.wantRunning, meta.PID)
 			}
 		})
 	}
-}
-
-func TestIsRunning_NonexistentPID(t *testing.T) {
-	// Use a very high PID that's unlikely to exist
-	// Note: This test may be flaky on systems with very high PIDs
-	highPID := 2000000000 // Very high, unlikely to exist (fits 32-bit int)
-
-	dir := mustTempDir(t, "vm-test")
-	cfg := testFirecrackerConfig(dir)
-	meta := testMetadata("test-vm")
-	meta.PID = highPID
-
-	vm := &VM{meta: meta, cfg: cfg}
-
-	// On most systems, this should return false
-	// The test verifies the logic handles non-running processes
-	_ = vm.IsRunning() // Just verify it doesn't panic
 }
 
 func TestMACAddressFormat(t *testing.T) {

--- a/internal/firecracker/vm_test.go
+++ b/internal/firecracker/vm_test.go
@@ -4,7 +4,7 @@
 package firecracker
 
 import (
-	"os"
+	"os/exec"
 	"testing"
 )
 
@@ -55,12 +55,23 @@ func TestIsRunning_LivePIDButNotFirecracker(t *testing.T) {
 	// A live PID that isn't firecracker must report not-running. Before
 	// the PID-reuse guard was added, this returned true and shed list
 	// would silently advertise a recycled pid as a running VMM.
-	currentPID := os.Getpid()
+	//
+	// We can't use os.Getpid() here: the test binary's /proc/PID/cmdline
+	// is `/path/to/firecracker.test` and substring-matches "firecracker".
+	// Spawn a sleep child so the cmdline is definitively not firecracker.
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep child: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
 
 	dir := mustTempDir(t, "vm-test")
 	cfg := testFirecrackerConfig(dir)
 	meta := testMetadata("test-vm")
-	meta.PID = currentPID
+	meta.PID = cmd.Process.Pid
 
 	vm := &VM{meta: meta, cfg: cfg}
 

--- a/internal/firecracker/vm_test.go
+++ b/internal/firecracker/vm_test.go
@@ -51,8 +51,10 @@ func TestGenerateMACAddress(t *testing.T) {
 	}
 }
 
-func TestIsRunning_CurrentPID(t *testing.T) {
-	// Use current process PID which is definitely running
+func TestIsRunning_LivePIDButNotFirecracker(t *testing.T) {
+	// A live PID that isn't firecracker must report not-running. Before
+	// the PID-reuse guard was added, this returned true and shed list
+	// would silently advertise a recycled pid as a running VMM.
 	currentPID := os.Getpid()
 
 	dir := mustTempDir(t, "vm-test")
@@ -62,8 +64,8 @@ func TestIsRunning_CurrentPID(t *testing.T) {
 
 	vm := &VM{meta: meta, cfg: cfg}
 
-	if !vm.IsRunning() {
-		t.Error("IsRunning() = false for current process, want true")
+	if vm.IsRunning() {
+		t.Error("IsRunning() = true for non-firecracker PID, want false (PID-reuse guard)")
 	}
 }
 

--- a/internal/firecracker/vm_test.go
+++ b/internal/firecracker/vm_test.go
@@ -72,8 +72,8 @@ func TestIsRunning(t *testing.T) {
 	}
 
 	cases := []struct {
-		name       string
-		setupPID   func(t *testing.T) int
+		name        string
+		setupPID    func(t *testing.T) int
 		wantRunning bool
 	}{
 		{

--- a/internal/vmutil/process.go
+++ b/internal/vmutil/process.go
@@ -1,0 +1,42 @@
+package vmutil
+
+import (
+	"errors"
+	"syscall"
+)
+
+// IsProcessAlive reports whether the given pid refers to a process the
+// caller can signal (i.e., a live process that may or may not be owned
+// by the caller).
+//
+// The check uses signal 0, which performs the kernel's send-signal
+// permission validation but does not actually deliver a signal:
+//   - nil  → process exists and the caller may signal it.
+//   - EPERM → process exists but the caller lacks permission; treated
+//     as alive (the process is still there).
+//   - ESRCH → no such process; treated as dead.
+//   - anything else → conservatively treated as dead so callers don't
+//     loop on transient kernel errors.
+//
+// pid <= 0 is treated as not-alive: 0 means "the current process group"
+// to syscall.Kill on Unix and is never a real VMM pid in our metadata;
+// negatives are likewise invalid.
+//
+// This helper is intended for "did the VMM actually exit?" liveness
+// checks at stop/start boundaries. It does NOT verify that the pid
+// belongs to the expected program — callers concerned about PID reuse
+// should follow up with the backend-specific check (isVfkitProcess /
+// isFirecrackerProcess).
+func IsProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, syscall.EPERM) {
+		return true
+	}
+	return false
+}

--- a/internal/vmutil/process_test.go
+++ b/internal/vmutil/process_test.go
@@ -7,49 +7,80 @@ import (
 )
 
 func TestIsProcessAlive(t *testing.T) {
-	t.Run("invalid pid is not alive", func(t *testing.T) {
-		if IsProcessAlive(0) {
-			t.Errorf("IsProcessAlive(0) = true, want false")
-		}
-		if IsProcessAlive(-1) {
-			t.Errorf("IsProcessAlive(-1) = true, want false")
-		}
-	})
-
-	t.Run("own pid is alive", func(t *testing.T) {
-		if !IsProcessAlive(os.Getpid()) {
-			t.Errorf("IsProcessAlive(self) = false, want true")
-		}
-	})
-
-	t.Run("live child is alive, reaped child is not", func(t *testing.T) {
-		// Spawn a short-lived child we can observe both alive and dead.
+	// startSleepChild spawns a sleep process the caller owns for the
+	// duration of the test. Returns the pid + a cleanup that kills and
+	// reaps the child so subsequent cases don't see a stray sleep.
+	startSleepChild := func(t *testing.T) (*exec.Cmd, int) {
+		t.Helper()
 		cmd := exec.Command("sleep", "30")
 		if err := cmd.Start(); err != nil {
 			t.Fatalf("start sleep: %v", err)
 		}
-		pid := cmd.Process.Pid
-		if !IsProcessAlive(pid) {
-			t.Errorf("IsProcessAlive(live child) = false, want true")
-		}
-		if err := cmd.Process.Kill(); err != nil {
-			t.Fatalf("kill child: %v", err)
-		}
-		if err := cmd.Wait(); err == nil {
-			// Wait returns *exec.ExitError when killed; either way, child is reaped.
-			t.Logf("child Wait returned nil after Kill (unusual but acceptable)")
-		}
-		if IsProcessAlive(pid) {
-			t.Errorf("IsProcessAlive(reaped child) = true, want false")
-		}
-	})
+		return cmd, cmd.Process.Pid
+	}
 
-	t.Run("definitely-dead pid is not alive", func(t *testing.T) {
-		// PID 1 always exists on Unix, so use a clearly out-of-range pid.
-		// On Linux pid_max defaults to 4194304; on macOS it's 99998.
-		// 0x7fffffff is above both. ESRCH expected.
-		if IsProcessAlive(0x7fffffff) {
-			t.Errorf("IsProcessAlive(impossibly-large pid) = true, want false")
-		}
-	})
+	cases := []struct {
+		name      string
+		setup     func(t *testing.T) int // returns pid to check
+		wantAlive bool
+	}{
+		{
+			name:      "pid zero is not alive",
+			setup:     func(*testing.T) int { return 0 },
+			wantAlive: false,
+		},
+		{
+			name:      "negative pid is not alive",
+			setup:     func(*testing.T) int { return -1 },
+			wantAlive: false,
+		},
+		{
+			name:      "own pid is alive",
+			setup:     func(*testing.T) int { return os.Getpid() },
+			wantAlive: true,
+		},
+		{
+			name: "live child is alive",
+			setup: func(t *testing.T) int {
+				cmd, pid := startSleepChild(t)
+				t.Cleanup(func() {
+					_ = cmd.Process.Kill()
+					_ = cmd.Wait()
+				})
+				return pid
+			},
+			wantAlive: true,
+		},
+		{
+			name: "reaped child is not alive",
+			setup: func(t *testing.T) int {
+				cmd, pid := startSleepChild(t)
+				if err := cmd.Process.Kill(); err != nil {
+					t.Fatalf("kill child: %v", err)
+				}
+				// Wait returns *exec.ExitError when killed; either way,
+				// the child is reaped after this returns.
+				_ = cmd.Wait()
+				return pid
+			},
+			wantAlive: false,
+		},
+		{
+			name: "impossibly-large pid is not alive",
+			// Above Linux pid_max (default 4194304) and macOS pid_max
+			// (99998); syscall.Kill returns ESRCH.
+			setup:     func(*testing.T) int { return 0x7fffffff },
+			wantAlive: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pid := tc.setup(t)
+			got := IsProcessAlive(pid)
+			if got != tc.wantAlive {
+				t.Errorf("IsProcessAlive(%d) = %v, want %v", pid, got, tc.wantAlive)
+			}
+		})
+	}
 }

--- a/internal/vmutil/process_test.go
+++ b/internal/vmutil/process_test.go
@@ -1,0 +1,55 @@
+package vmutil
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestIsProcessAlive(t *testing.T) {
+	t.Run("invalid pid is not alive", func(t *testing.T) {
+		if IsProcessAlive(0) {
+			t.Errorf("IsProcessAlive(0) = true, want false")
+		}
+		if IsProcessAlive(-1) {
+			t.Errorf("IsProcessAlive(-1) = true, want false")
+		}
+	})
+
+	t.Run("own pid is alive", func(t *testing.T) {
+		if !IsProcessAlive(os.Getpid()) {
+			t.Errorf("IsProcessAlive(self) = false, want true")
+		}
+	})
+
+	t.Run("live child is alive, reaped child is not", func(t *testing.T) {
+		// Spawn a short-lived child we can observe both alive and dead.
+		cmd := exec.Command("sleep", "30")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start sleep: %v", err)
+		}
+		pid := cmd.Process.Pid
+		if !IsProcessAlive(pid) {
+			t.Errorf("IsProcessAlive(live child) = false, want true")
+		}
+		if err := cmd.Process.Kill(); err != nil {
+			t.Fatalf("kill child: %v", err)
+		}
+		if err := cmd.Wait(); err == nil {
+			// Wait returns *exec.ExitError when killed; either way, child is reaped.
+			t.Logf("child Wait returned nil after Kill (unusual but acceptable)")
+		}
+		if IsProcessAlive(pid) {
+			t.Errorf("IsProcessAlive(reaped child) = true, want false")
+		}
+	})
+
+	t.Run("definitely-dead pid is not alive", func(t *testing.T) {
+		// PID 1 always exists on Unix, so use a clearly out-of-range pid.
+		// On Linux pid_max defaults to 4194304; on macOS it's 99998.
+		// 0x7fffffff is above both. ESRCH expected.
+		if IsProcessAlive(0x7fffffff) {
+			t.Errorf("IsProcessAlive(impossibly-large pid) = true, want false")
+		}
+	})
+}

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -308,6 +308,17 @@ func (c *Client) StartShed(ctx context.Context, name string) (*config.Shed, erro
 		meta.PID = 0
 	}
 
+	// Defensive zombie-pid check. Even when status reads "stopped" we
+	// can still hold a stale pid (server crash between vm.Stop() and
+	// the metadata save, hand-edited metadata.json, etc). Refuse to
+	// spawn a second vfkit under the same name when the recorded pid
+	// is still alive AND still looks like a vfkit. Plain liveness
+	// without the binary check would false-positive across PID reuse.
+	if meta.PID > 0 && vmutil.IsProcessAlive(meta.PID) && isVfkitProcess(meta.PID) {
+		return nil, fmt.Errorf("%w: %s (pid %d)", config.ErrZombiePresentSentinel, name, meta.PID)
+	}
+	meta.PID = 0
+
 	// Filter credentials to those with existing source directories.
 	dirCreds := vmutil.FilterExistingCredentials(c.serverCfg)
 
@@ -410,6 +421,15 @@ func (c *Client) stopShedLocked(ctx context.Context, meta *Metadata) (*config.Sh
 
 	if err := vm.Stop(ctx); err != nil {
 		return nil, fmt.Errorf("failed to stop VM: %w", err)
+	}
+
+	// vm.Stop's post-SIGKILL waitForProcessExit swallows its timeout
+	// and returns nil even when vfkit refused to die (uninterruptible
+	// I/O, kernel hang, etc). Verify before flipping status — otherwise
+	// the next StartShed would find PID=0 in metadata and silently
+	// spawn a second vfkit under the same name.
+	if meta.PID > 0 && vmutil.IsProcessAlive(meta.PID) && isVfkitProcess(meta.PID) {
+		return nil, fmt.Errorf("%w: %s (pid %d)", config.ErrStopIncompleteSentinel, meta.Name, meta.PID)
 	}
 
 	meta.Status = config.StatusStopped


### PR DESCRIPTION
## Summary

Tightens stop/start lifecycle so shed can't silently spawn a second VMM under the same name when the previous process didn't actually die, and so FC's `IsRunning()` doesn't false-positive on PID reuse.

### The three gaps

1. **stopShedLocked** previously flipped `meta.Status=stopped`/`PID=0` after `vm.Stop()` returned `nil`, even when the post-SIGKILL `waitForProcessExit` swallowed its 2 s timeout. Result: "dead-on-paper, alive-in-fact" window; next `StartShed` sees `PID=0` and spawns a second VMM.
2. **StartShed** only checked `IsRunning()` when `meta.Status=Running`. A stale-PID-in-Stopped-metadata scenario (server crash between `vm.Stop` and metadata save, hand-edited `metadata.json`) walked straight through.
3. **FC `IsRunning()`** lacked the `isFirecrackerProcess(PID)` PID-reuse guard that VZ already has — a recycled PID kept reporting `status=running` forever.

### Changes

- `internal/vmutil/process.go`: new `IsProcessAlive(pid)` helper using `syscall.Kill(pid, 0)`. EPERM=alive, ESRCH/other=dead. Unit tests cover invalid/own/live/reaped/impossibly-large pids.
- `internal/config/types.go`: `ErrStopIncompleteSentinel`, `ErrZombiePresentSentinel`.
- `internal/{vz,firecracker}/client.go:stopShedLocked`: verify the recorded PID is gone after `vm.Stop`; if alive → `ErrStopIncomplete`.
- `internal/{vz,firecracker}/client.go:StartShed`: defensive zombie check before clearing PID; if alive AND looks like the expected VMM → `ErrZombiePresent`.
- `internal/firecracker/vm.go:IsRunning`: chain on `isFirecrackerProcess` (mirrors VZ).

### Validation findings vs. plan

Plan made three assumptions; ran them through current code:

- ✅ Reap goroutine only `log.Printf`s (valid). But lazy staleness in `GetShed` already flips status=stopped on next read, so end users don't see ghost VMs in `shed list`. Left the reap goroutine alone — adding a "crashed" status was scoped out (UX-affecting; would need CLI/docs updates beyond this PR).
- ⚠️ StartShed already had an `IsRunning()` guard for `Status=Running` (partial invalidation). The new defensive check covers the remaining stale-PID-in-Stopped case.
- ✅ stopShedLocked unconditional write valid; FC `IsRunning` PID-reuse gap (not in original plan) discovered during validation and fixed inline.

### Test plan

- `make check` clean.
- `GOOS=linux GOARCH=arm64 go build ./internal/firecracker/` clean.
- `make test-integration`: 38/38 pass on both VZ (my-server) and FC (mini3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced lifecycle management to detect and prevent duplicate VM instances from lingering zombie processes.
  * Improved shutdown verification to ensure complete termination before operations are considered finished.
  * Strengthened process identification to validate PIDs belong to the correct process type, preventing errors from PID reuse.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->