### PR TITLE
fix(mount): retry workspace VirtioFS/9P mount on transient failures

### DIFF
--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -20,9 +20,18 @@ import (
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/lockmap"
 	"github.com/charliek/shed/internal/plugin"
+	"github.com/charliek/shed/internal/retry"
 	"github.com/charliek/shed/internal/vmimage"
 	"github.com/charliek/shed/internal/vmutil"
 )
+
+// mountRetryBackoffs is the per-attempt wait schedule wrapping the
+// in-guest 9P mount call. 3 attempts total, max ~2.5 s of added
+// latency on the worst failure path — far cheaper than killing a
+// 10 s create over a single transient agent RPC blip. Tighter than
+// the registry-pull schedule (1s/4s) because mount errors fail fast
+// and a slow retry just wastes wall-clock.
+var mountRetryBackoffs = []time.Duration{500 * time.Millisecond, 2 * time.Second}
 
 // Client manages Firecracker VM instances.
 type Client struct {
@@ -316,6 +325,19 @@ func (c *Client) mount9PInGuest(ctx context.Context, agent *vmutil.AgentClient, 
 		return fmt.Errorf("mount-9p exec failed for %s at %s: %w", serverAddr, target, err)
 	}
 	return nil
+}
+
+// mount9PInGuestWithRetry wraps mount9PInGuest in a bounded retry
+// envelope. Used by the create/start paths where a transient agent
+// RPC blip during the mount would otherwise kill an entire 10-second
+// VM bring-up. Credential mounts (mount9PCredentialFunc) don't go
+// through here because the credential manager already
+// log-and-continues on failure — extra latency before that log isn't
+// a useful tradeoff.
+func (c *Client) mount9PInGuestWithRetry(ctx context.Context, agent *vmutil.AgentClient, serverAddr, target string, readOnly bool, tag string) error {
+	return retry.Do(ctx, "mount 9p "+tag, mountRetryBackoffs, nil, func() error {
+		return c.mount9PInGuest(ctx, agent, serverAddr, target, readOnly, tag)
+	})
 }
 
 // metadataToShed converts Firecracker metadata to a config.Shed.
@@ -616,7 +638,7 @@ func (c *Client) StartShed(ctx context.Context, name string) (*config.Shed, erro
 			_ = meta.Save(c.cfg.InstanceDir)
 			return nil, fmt.Errorf("failed to start 9P server on start: %w", err)
 		}
-		if err := c.mount9PInGuest(ctx, agent, srv.Addr(), config.WorkspacePath, false, "workspace"); err != nil {
+		if err := c.mount9PInGuestWithRetry(ctx, agent, srv.Addr(), config.WorkspacePath, false, "workspace"); err != nil {
 			c.stopP9Servers(name)
 			if stopErr := vm.Stop(context.Background()); stopErr != nil {
 				log.Printf("Warning: failed to stop VM: %v", stopErr)

--- a/internal/firecracker/orchestrator.go
+++ b/internal/firecracker/orchestrator.go
@@ -384,7 +384,7 @@ func (b *fcCreator) MountLocalDir(ctx context.Context, req config.CreateShedRequ
 	// In practice, the 9P server is per-shed and lives until shed
 	// deletion, so we don't register a cleanup here; the wider shed
 	// cleanup (StopShed/DeleteShed) calls stopP9Servers.
-	if err := b.c.mount9PInGuest(ctx, agent, srv.Addr(), config.WorkspacePath, false, "workspace"); err != nil {
+	if err := b.c.mount9PInGuestWithRetry(ctx, agent, srv.Addr(), config.WorkspacePath, false, "workspace"); err != nil {
 		// On mount failure we need to stop the just-started 9P
 		// server explicitly, since we couldn't register a cleanup.
 		b.c.stopP9Servers(req.Name)

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,76 @@
+// Package retry is the shared "call this, back off, try again" loop
+// for transient-failure-prone operations across the codebase.
+//
+// Originally just the registry-pull wrapper in internal/vmimage, the
+// loop was lifted here so the in-guest mount call sites (VZ VirtioFS,
+// FC 9P) could share the same backoff and cancellation contract
+// without a cycle through vmutil/config/vmimage. The HTTP-specific
+// retryable classifier stays in vmimage; this package owns only the
+// loop + a permissive default classifier suitable for opaque RPC
+// failures.
+package retry
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+)
+
+// Do calls fn with the supplied backoff schedule. After fn returns a
+// non-nil error, Do consults isRetryable(err):
+//
+//   - true  → wait the next backoff (or return ctx.Err() if the caller
+//     cancelled in the meantime) and call fn again.
+//   - false → return the error verbatim.
+//
+// Total attempts = 1 + len(backoffs). The first attempt runs
+// immediately; backoff[i] is the wait BEFORE attempt i+2.
+//
+// opName is included in the retry log line emitted on each retry so
+// the operator can see which call is stuttering. The final error is
+// returned without wrapping so callers that pattern-match on a
+// sentinel still see it.
+//
+// If isRetryable is nil, Do uses [DefaultIsRetryable], which retries
+// any non-context-cancellation error.
+func Do(ctx context.Context, opName string, backoffs []time.Duration, isRetryable func(error) bool, fn func() error) error {
+	if isRetryable == nil {
+		isRetryable = DefaultIsRetryable
+	}
+	err := fn()
+	if err == nil || !isRetryable(err) {
+		return err
+	}
+	totalAttempts := len(backoffs) + 1
+	for i, backoff := range backoffs {
+		log.Printf("retrying %s after transient error (attempt %d/%d in %v): %v", opName, i+2, totalAttempts, backoff, err)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+		err = fn()
+		if err == nil || !isRetryable(err) {
+			return err
+		}
+	}
+	return err
+}
+
+// DefaultIsRetryable treats any non-nil error that isn't a context
+// cancellation or deadline as retryable. Appropriate for in-guest RPC
+// calls (mounts, agent exec) where the failure shapes are
+// unpredictable but most short blips are worth one more attempt.
+//
+// Callers with a tighter classification (e.g., HTTP 4xx is permanent)
+// pass their own classifier to [Do].
+func DefaultIsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	return true
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,133 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDo(t *testing.T) {
+	t.Run("succeeds on first try", func(t *testing.T) {
+		calls := 0
+		err := Do(context.Background(), "op", []time.Duration{0, 0}, nil, func() error {
+			calls++
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1", calls)
+		}
+	})
+
+	t.Run("succeeds after transient failure", func(t *testing.T) {
+		calls := 0
+		err := Do(context.Background(), "op", []time.Duration{0, 0}, nil, func() error {
+			calls++
+			if calls == 1 {
+				return errors.New("transient")
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		if calls != 2 {
+			t.Errorf("calls = %d, want 2 (one failure + one success)", calls)
+		}
+	})
+
+	t.Run("exhausts attempts and returns last error", func(t *testing.T) {
+		sentinel := errors.New("persistent")
+		calls := 0
+		err := Do(context.Background(), "op", []time.Duration{0, 0}, nil, func() error {
+			calls++
+			return sentinel
+		})
+		if !errors.Is(err, sentinel) {
+			t.Errorf("Do: got %v, want %v", err, sentinel)
+		}
+		if calls != 3 {
+			t.Errorf("calls = %d, want 3 (1 + len(backoffs))", calls)
+		}
+	})
+
+	t.Run("non-retryable short-circuits", func(t *testing.T) {
+		sentinel := errors.New("hard fail")
+		calls := 0
+		err := Do(context.Background(), "op",
+			[]time.Duration{0, 0},
+			func(err error) bool { return !errors.Is(err, sentinel) },
+			func() error {
+				calls++
+				return sentinel
+			})
+		if !errors.Is(err, sentinel) {
+			t.Errorf("Do: got %v, want %v", err, sentinel)
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (non-retryable should not retry)", calls)
+		}
+	})
+
+	t.Run("context cancellation aborts during backoff", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- Do(ctx, "op", []time.Duration{1 * time.Second, 1 * time.Second}, nil, func() error {
+				calls++
+				return errors.New("transient")
+			})
+		}()
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("Do: got %v, want context.Canceled", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("Do did not return after context cancel")
+		}
+		if calls < 1 {
+			t.Errorf("calls = %d, want at least 1", calls)
+		}
+	})
+
+	t.Run("default classifier treats context.Canceled as non-retryable", func(t *testing.T) {
+		calls := 0
+		err := Do(context.Background(), "op", []time.Duration{0, 0}, nil, func() error {
+			calls++
+			return context.Canceled
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("Do: got %v, want context.Canceled", err)
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (context.Canceled is non-retryable)", calls)
+		}
+	})
+}
+
+func TestDefaultIsRetryable(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is not retryable", nil, false},
+		{"context.Canceled is not retryable", context.Canceled, false},
+		{"context.DeadlineExceeded is not retryable", context.DeadlineExceeded, false},
+		{"plain error is retryable", errors.New("oops"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DefaultIsRetryable(tc.err); got != tc.want {
+				t.Errorf("DefaultIsRetryable(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/vmimage/registry_retry.go
+++ b/internal/vmimage/registry_retry.go
@@ -15,12 +15,13 @@ import (
 	"context"
 	"errors"
 	"io"
-	"log"
 	"net"
 	"strings"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+
+	"github.com/charliek/shed/internal/retry"
 )
 
 // retryAttempts and retryBackoffs configure the retry envelope.
@@ -35,30 +36,12 @@ import (
 // etc.).
 var retryBackoffs = []time.Duration{1 * time.Second, 4 * time.Second}
 
-// withRetry calls fn, and on transient failure waits + retries
-// according to retryBackoffs. opName is included in the log line
-// emitted on each retry so the user can see which fetch is
-// stuttering. Returns the last attempt's error verbatim — no
-// wrapping that would hide retry semantics from a caller that
-// pattern-matches on the original error.
+// withRetry is a registry-flavoured wrapper around retry.Do: same
+// loop and cancellation contract, paired with the HTTP/network
+// classifier below. Mount-side callers in the VZ/FC clients use
+// retry.Do directly with the permissive default classifier.
 func withRetry(ctx context.Context, opName string, fn func() error) error {
-	err := fn()
-	if err == nil || !isRetryablePullErr(err) {
-		return err
-	}
-	for i, backoff := range retryBackoffs {
-		log.Printf("retrying %s after transient error (attempt %d/%d in %v): %v", opName, i+2, len(retryBackoffs)+1, backoff, err)
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(backoff):
-		}
-		err = fn()
-		if err == nil || !isRetryablePullErr(err) {
-			return err
-		}
-	}
-	return err
+	return retry.Do(ctx, opName, retryBackoffs, isRetryablePullErr, fn)
 }
 
 // isRetryablePullErr returns true for the error shapes a brief

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -22,9 +22,16 @@ import (
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/lockmap"
 	"github.com/charliek/shed/internal/plugin"
+	"github.com/charliek/shed/internal/retry"
 	"github.com/charliek/shed/internal/vmimage"
 	"github.com/charliek/shed/internal/vmutil"
 )
+
+// mountRetryBackoffs is the per-attempt wait schedule wrapping the
+// VirtioFS mount call. 3 attempts total, max ~2.5 s of added latency
+// on the worst failure path — far cheaper than killing a 10 s create
+// over a single transient agent RPC blip.
+var mountRetryBackoffs = []time.Duration{500 * time.Millisecond, 2 * time.Second}
 
 // Client manages VZ VM instances.
 type Client struct {
@@ -345,7 +352,7 @@ func (c *Client) StartShed(ctx context.Context, name string) (*config.Shed, erro
 
 	// Re-mount VirtioFS workspace on start (mount doesn't persist across reboots)
 	if meta.LocalDir != "" {
-		if err := c.mountVirtioFSShare(ctx, agent, config.VirtioFSMountTag, config.WorkspacePath, false); err != nil {
+		if err := c.mountVirtioFSShareWithRetry(ctx, agent, config.VirtioFSMountTag, config.WorkspacePath, false); err != nil {
 			// VirtioFS mount is essential for --local-dir; stop the VM and fail
 			if stopErr := vm.Stop(context.Background()); stopErr != nil {
 				log.Printf("Warning: failed to stop VM after mount failure: %v", stopErr)
@@ -516,6 +523,19 @@ func (c *Client) mountVirtioFSShare(ctx context.Context, agent *vmutil.AgentClie
 		return fmt.Errorf("virtiofs mount failed for %s at %s: %w", mountTag, target, err)
 	}
 	return nil
+}
+
+// mountVirtioFSShareWithRetry wraps mountVirtioFSShare in a bounded
+// retry envelope. Used by the create/start paths where a transient
+// agent RPC blip during the mount would otherwise kill an entire
+// 10-second VM bring-up. Credential mounts (mountVirtioFSCredential)
+// don't go through here because the credential manager already
+// log-and-continues on failure — extra latency before that log isn't
+// a useful tradeoff.
+func (c *Client) mountVirtioFSShareWithRetry(ctx context.Context, agent *vmutil.AgentClient, mountTag, target string, readOnly bool) error {
+	return retry.Do(ctx, "mount virtiofs "+mountTag, mountRetryBackoffs, nil, func() error {
+		return c.mountVirtioFSShare(ctx, agent, mountTag, target, readOnly)
+	})
 }
 
 // buildCredentialShares creates VirtioFS share entries from classified credentials.

--- a/internal/vz/orchestrator.go
+++ b/internal/vz/orchestrator.go
@@ -357,7 +357,7 @@ func (b *vzCreator) MountLocalDir(ctx context.Context, req config.CreateShedRequ
 	agent := b.c.newAgentClient(meta.Name)
 	backend.Phase(ctx, "mount")
 	backend.Status(ctx, "Mounting local directory via VirtioFS...")
-	if err := b.c.mountVirtioFSShare(ctx, agent, config.VirtioFSMountTag, config.WorkspacePath, false); err != nil {
+	if err := b.c.mountVirtioFSShareWithRetry(ctx, agent, config.VirtioFSMountTag, config.WorkspacePath, false); err != nil {
 		return fmt.Errorf("VirtioFS mount failed for local dir %s: %w", req.LocalDir, err)
 	}
 	return nil


### PR DESCRIPTION
## Summary

A single transient agent-RPC blip during the workspace mount used to kill an entire 10-second VM bring-up; the only recovery was `shed delete` + recreate. This wraps the VZ VirtioFS mount and FC 9P mount in a small bounded retry envelope so brief flakes don't escalate to a full failure.

### Why a leaf package, not vmutil

The plan called for promoting `withRetry` to `internal/vmutil/retry.go`. Implementing that hit an import cycle (`config → vmimage` already exists; `vmimage → vmutil → config` would close it). Put the loop in a new leaf package `internal/retry/` instead — same effect, no cycle. Documented in the package doc comment.

### What this PR does

- `internal/retry/retry.go` — new leaf package with `Do(ctx, opName, backoffs, isRetryable, fn)`. Default classifier (when `nil`) is permissive: retries any non-context-cancellation error, which is right for opaque in-guest RPC failures.
- `internal/vmimage/registry_retry.go` — `withRetry` becomes a thin wrapper around `retry.Do`, keeping the HTTP-specific `isRetryablePullErr` classifier next to the registry callers that need it. No behavior change on the pull path.
- `internal/{vz,firecracker}/client.go` — new `mount{VirtioFSShare,9PInGuest}WithRetry` helpers. Backoffs: `500ms / 2s` = 3 attempts, max ~2.5 s added on the failure path. Tighter than the registry-pull schedule because mount errors fail fast.
- Wrap the four real workspace-mount call sites on both backends (StartShed + CreateShed orchestrator hook). Credential mounts intentionally don't go through the retry helpers — `SetupCredentials` already log-and-continues on failure.

### Validation findings vs. plan

- ✅ `withRetry` shape valid and structurally reusable.
- ⚠️ Plan suggested promoting to `vmutil`. Build broke with an import cycle — used a leaf package instead. Same effect.
- ✅ `isRetryablePullErr` is HTTP-specific (transport.Error, net.OpError). Mount sites pass `nil` and use the permissive default.
- ✅ Marked "defensive, not directly motivated by an observed failure" per plan.

### Test plan

- `make check` clean.
- `GOOS=linux GOARCH=arm64 go build ./internal/firecracker/` clean.
- `make test-integration`: 38/38 pass on both VZ (my-server) and FC (mini3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace mount operations now automatically retry on transient failures, improving reliability of local directory mounting and workspace initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->