### PR TITLE
refactor(vz): migrate StartShed to orchestrator BackendStarter

### DIFF
--- a/internal/backend/orchestrator/start.go
+++ b/internal/backend/orchestrator/start.go
@@ -1,0 +1,157 @@
+// This file extends the orchestrator with the backend-agnostic
+// StartShed lifecycle that mirrors CreateShed's late half (StartVM →
+// FinalizeStartedVM → MountLocalDir → SetupCredentials →
+// RunProvisioning) without the early-half steps (image pull, network
+// alloc, rootfs alloc, metadata create) which a stopped shed already
+// has on disk.
+//
+// Why a separate sub-interface (BackendStarter) and not a method
+// suffix on BackendCreator?
+//
+//   - CreateShed and StartShed take genuinely different inputs:
+//     CreateShed gets a CreateShedRequest, StartShed gets a name +
+//     loads metadata. Squeezing both into one interface forces every
+//     hook to know which mode it's running in.
+//   - The StartShed-specific hooks (LoadMetadata, CheckNotRunning,
+//     PersistRunningState, RunStartupHook) have no natural place in
+//     CreateShed's flow.
+//   - The shared hooks (MountLocalDir, SetupCredentials,
+//     ToShedResult) reuse the same closed-over Client state via the
+//     backend's per-create wrapper type implementing both interfaces.
+//     Each backend's *Starter type wraps the same *Client as the
+//     *Creator and delegates to the shared helpers underneath.
+//
+// Per PR-B1 the migration is VZ-only; PR-B2 mirrors for Firecracker
+// and removes the inline StartShed code from both backend clients.
+
+package orchestrator
+
+import (
+	"context"
+
+	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/config"
+)
+
+// StartRequest is the orchestrator-side input for StartShed. Kept as
+// its own type rather than reusing CreateShedRequest because the
+// stop→start hot path takes only a name and the rest of the request
+// shape is loaded from persisted metadata. Carrying a half-populated
+// CreateShedRequest would invite "did the caller forget to set X?"
+// bugs in the hooks.
+type StartRequest struct {
+	Name string
+}
+
+// BackendStarter is the per-backend hook contract used by
+// orchestrator.StartShed. Methods are listed in the order StartShed
+// calls them.
+//
+// Same cleanup-stack contract as BackendCreator: hooks that acquire
+// rollback-able state Register on the passed *backend.Cleanup; the
+// orchestrator runs cleanup on failure and commits on success.
+type BackendStarter interface {
+	// LoadMetadata reads the persisted per-shed metadata from disk
+	// and returns it as an orchestrator-opaque handle. Returning the
+	// canonical ErrShedNotFoundSentinel from internal/config is the
+	// API-level contract for "no such shed."
+	LoadMetadata(ctx context.Context, req StartRequest) (MetadataHandle, error)
+
+	// CheckNotRunning verifies the shed isn't already up. Two error
+	// paths matter:
+	//
+	//   - ErrShedAlreadyRunningSentinel: status=Running AND the
+	//     recorded PID is genuinely a live VMM. Caller's StartShed
+	//     was a no-op against a running shed.
+	//   - ErrZombiePresentSentinel: status=Stopped (or stale Running)
+	//     but the recorded PID is alive + matches the VMM binary.
+	//     We refuse to spawn a second VMM under the same name.
+	//
+	// If neither fires (PID dead, or status=Stopped with PID=0),
+	// returns nil. Implementations are expected to clear stale
+	// status/PID fields on the in-memory metadata before returning
+	// — those changes ride along the rest of the lifecycle and are
+	// persisted by PersistRunningState.
+	CheckNotRunning(ctx context.Context, meta MetadataHandle) error
+
+	// StartVM constructs and starts the per-shed VM from the existing
+	// metadata. Implementations MUST Register a "stop VM" cleanup on
+	// cleanup so a downstream failure unwinds it. The orchestrator
+	// emits the "vm" PhaseTimer boundary before calling.
+	StartVM(ctx context.Context, meta MetadataHandle, cleanup *backend.Cleanup) (VMHandle, error)
+
+	// PersistRunningState updates the persisted metadata with
+	// post-Start state (Status=Running, PID, ...) and registers the
+	// "remove from vms map" cleanup so a downstream failure unwinds
+	// it. Mirrors BackendCreator.FinalizeStartedVM.
+	PersistRunningState(ctx context.Context, meta MetadataHandle, vm VMHandle, cleanup *backend.Cleanup) error
+
+	// MountLocalDir re-mounts the configured `--local-dir` via the
+	// backend's transport (VirtioFS on VZ, 9P on FC). Mount state
+	// does not persist across VMM restarts, so this runs on every
+	// start even when CreateShed already mounted at create time.
+	// No-op when the metadata has no local-dir.
+	MountLocalDir(ctx context.Context, meta MetadataHandle, vm VMHandle) error
+
+	// SetupCredentials re-mounts any configured credentials into the
+	// guest. Best-effort (matches CreateShed's contract).
+	SetupCredentials(ctx context.Context, meta MetadataHandle, vm VMHandle)
+
+	// RunStartupHook runs only the `startup` provisioning hook —
+	// NOT `install`, which is create-time only. Loads the per-shed
+	// provision.yaml inside the guest workspace. Best-effort.
+	RunStartupHook(ctx context.Context, meta MetadataHandle, vm VMHandle)
+
+	// ToShedResult returns the *config.Shed value to hand back to
+	// the orchestrator's caller. Called once the start is fully
+	// committed.
+	ToShedResult(meta MetadataHandle) *config.Shed
+}
+
+// StartShed runs the backend-agnostic shed-start lifecycle. Each
+// backend supplies its platform-specific behavior via `b`.
+//
+// Caller contract (what the per-backend StartShed wrapper must do
+// BEFORE calling orchestrator.StartShed):
+//
+//   - Acquire the per-shed create-lock (same lock that serializes
+//     CreateShed/StopShed/DeleteShed for this name). The
+//     orchestrator does not own it.
+//
+// On any error from a hook, the deferred cleanup.Run unwinds every
+// cleanup the hook chain has registered so far, in LIFO order. On
+// success, cleanup.Commit zeroes the stack so the defer is a no-op.
+func StartShed(ctx context.Context, b BackendStarter, req StartRequest) (*config.Shed, error) {
+	cleanup := backend.NewCleanup()
+	defer cleanup.Run()
+
+	meta, err := b.LoadMetadata(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := b.CheckNotRunning(ctx, meta); err != nil {
+		return nil, err
+	}
+
+	backend.Phase(ctx, "vm")
+	backend.Status(ctx, "Starting virtual machine...")
+	vm, err := b.StartVM(ctx, meta, cleanup)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := b.PersistRunningState(ctx, meta, vm, cleanup); err != nil {
+		return nil, err
+	}
+
+	if err := b.MountLocalDir(ctx, meta, vm); err != nil {
+		return nil, err
+	}
+
+	b.SetupCredentials(ctx, meta, vm)
+	b.RunStartupHook(ctx, meta, vm)
+
+	cleanup.Commit()
+	return b.ToShedResult(meta), nil
+}

--- a/internal/backend/orchestrator/start_test.go
+++ b/internal/backend/orchestrator/start_test.go
@@ -1,0 +1,197 @@
+// Mock-backed tests for orchestrator.StartShed. Mirrors create_test.go
+// in shape (mockStarter + happy/failure/best-effort tables) and pins
+// the StartShed-specific contract: hook call order, LIFO unwind on
+// failure, best-effort hooks cannot abort the start.
+
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/config"
+)
+
+// mockStarter mirrors mockBackend's shape but implements
+// BackendStarter. Reuses mockMeta + mockVM from create_test.go since
+// they're already orchestrator-opaque.
+type mockStarter struct {
+	calls       []string
+	failAt      map[string]error
+	cleanupsRun []string
+}
+
+func newMockStarter() *mockStarter {
+	return &mockStarter{failAt: map[string]error{}}
+}
+
+func (b *mockStarter) record(name string) { b.calls = append(b.calls, name) }
+
+func (b *mockStarter) makeCleanup(name string) func() error {
+	return func() error {
+		b.cleanupsRun = append(b.cleanupsRun, name)
+		return nil
+	}
+}
+
+func (b *mockStarter) LoadMetadata(ctx context.Context, req StartRequest) (MetadataHandle, error) {
+	b.record("LoadMetadata")
+	if err := b.failAt["LoadMetadata"]; err != nil {
+		return nil, err
+	}
+	return mockMeta{name: req.Name}, nil
+}
+
+func (b *mockStarter) CheckNotRunning(ctx context.Context, meta MetadataHandle) error {
+	b.record("CheckNotRunning")
+	return b.failAt["CheckNotRunning"]
+}
+
+func (b *mockStarter) StartVM(ctx context.Context, meta MetadataHandle, c *backend.Cleanup) (VMHandle, error) {
+	b.record("StartVM")
+	if err := b.failAt["StartVM"]; err != nil {
+		return nil, err
+	}
+	c.Register("stop VM", b.makeCleanup("stop VM"))
+	return mockVM{}, nil
+}
+
+func (b *mockStarter) PersistRunningState(ctx context.Context, meta MetadataHandle, vm VMHandle, c *backend.Cleanup) error {
+	b.record("PersistRunningState")
+	if err := b.failAt["PersistRunningState"]; err != nil {
+		return err
+	}
+	c.Register("remove from vms map", b.makeCleanup("remove from vms map"))
+	return nil
+}
+
+func (b *mockStarter) MountLocalDir(ctx context.Context, meta MetadataHandle, vm VMHandle) error {
+	b.record("MountLocalDir")
+	return b.failAt["MountLocalDir"]
+}
+
+func (b *mockStarter) SetupCredentials(ctx context.Context, meta MetadataHandle, vm VMHandle) {
+	b.record("SetupCredentials")
+}
+
+func (b *mockStarter) RunStartupHook(ctx context.Context, meta MetadataHandle, vm VMHandle) {
+	b.record("RunStartupHook")
+}
+
+func (b *mockStarter) ToShedResult(meta MetadataHandle) *config.Shed {
+	b.record("ToShedResult")
+	return &config.Shed{Name: meta.Name(), Backend: config.BackendVZ}
+}
+
+// TestStartShed_HappyPathOrder pins the hook call sequence.
+func TestStartShed_HappyPathOrder(t *testing.T) {
+	b := newMockStarter()
+	got, err := StartShed(context.Background(), b, StartRequest{Name: "x"})
+	if err != nil {
+		t.Fatalf("happy-path StartShed returned error: %v", err)
+	}
+	if got == nil || got.Name != "x" {
+		t.Fatalf("ToShedResult returned %v; want a Shed named x", got)
+	}
+
+	want := []string{
+		"LoadMetadata",
+		"CheckNotRunning",
+		"StartVM",
+		"PersistRunningState",
+		"MountLocalDir",
+		"SetupCredentials",
+		"RunStartupHook",
+		"ToShedResult",
+	}
+	if !sliceEqual(b.calls, want) {
+		t.Errorf("hook call order =\n  %v\nwant\n  %v", b.calls, want)
+	}
+
+	if len(b.cleanupsRun) != 0 {
+		t.Errorf("cleanups ran on success path: %v", b.cleanupsRun)
+	}
+}
+
+// TestStartShed_FailureUnwindLIFO injects a failure at each
+// error-returning hook and verifies the cleanup stack unwinds in
+// reverse-registration order.
+func TestStartShed_FailureUnwindLIFO(t *testing.T) {
+	cases := []struct {
+		failAt       string
+		wantCalled   []string
+		wantCleanups []string
+	}{
+		{
+			failAt:       "LoadMetadata",
+			wantCalled:   []string{"LoadMetadata"},
+			wantCleanups: nil,
+		},
+		{
+			failAt:       "CheckNotRunning",
+			wantCalled:   []string{"LoadMetadata", "CheckNotRunning"},
+			wantCleanups: nil,
+		},
+		{
+			failAt:       "StartVM",
+			wantCalled:   []string{"LoadMetadata", "CheckNotRunning", "StartVM"},
+			wantCleanups: nil,
+		},
+		{
+			failAt:       "PersistRunningState",
+			wantCalled:   []string{"LoadMetadata", "CheckNotRunning", "StartVM", "PersistRunningState"},
+			wantCleanups: []string{"stop VM"},
+		},
+		{
+			failAt: "MountLocalDir",
+			wantCalled: []string{
+				"LoadMetadata", "CheckNotRunning", "StartVM", "PersistRunningState",
+				"MountLocalDir",
+			},
+			wantCleanups: []string{"remove from vms map", "stop VM"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.failAt, func(t *testing.T) {
+			b := newMockStarter()
+			b.failAt[tc.failAt] = errors.New("injected failure")
+			_, err := StartShed(context.Background(), b, StartRequest{Name: "fail-" + tc.failAt})
+			if err == nil {
+				t.Fatal("expected error from injected failure")
+			}
+			if !strings.Contains(err.Error(), "injected failure") {
+				t.Errorf("error %q does not contain the injected message", err)
+			}
+			if !sliceEqual(b.calls, tc.wantCalled) {
+				t.Errorf("hook calls =\n  %v\nwant\n  %v", b.calls, tc.wantCalled)
+			}
+			if !sliceEqual(b.cleanupsRun, tc.wantCleanups) {
+				t.Errorf("cleanup unwind order =\n  %v\nwant (LIFO)\n  %v", b.cleanupsRun, tc.wantCleanups)
+			}
+		})
+	}
+}
+
+// TestStartShed_BestEffortHooksDoNotAbort verifies that the best-effort
+// post-mount hooks (SetupCredentials, RunStartupHook) cannot abort the
+// start — would catch a regression that made them return error AND
+// the orchestrator started propagating it.
+func TestStartShed_BestEffortHooksDoNotAbort(t *testing.T) {
+	b := newMockStarter()
+	got, err := StartShed(context.Background(), b, StartRequest{Name: "best-effort"})
+	if err != nil {
+		t.Fatalf("StartShed returned error from best-effort path: %v", err)
+	}
+	if got == nil || got.Name != "best-effort" {
+		t.Fatalf("ToShedResult returned %v; want a Shed", got)
+	}
+	wantTail := []string{"SetupCredentials", "RunStartupHook", "ToShedResult"}
+	gotTail := b.calls[len(b.calls)-len(wantTail):]
+	if !sliceEqual(gotTail, wantTail) {
+		t.Errorf("best-effort tail = %v, want %v", gotTail, wantTail)
+	}
+}

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -294,89 +294,14 @@ func (c *Client) DeleteShed(ctx context.Context, name string, keepVolume bool) e
 	return nil
 }
 
-// StartShed starts a stopped shed.
+// StartShed starts a stopped shed via the BackendStarter orchestrator.
+// The per-shed create lock is acquired here (the orchestrator does
+// not own it — same contract as CreateShed). All platform-specific
+// behavior lives in vzStarter; see internal/backend/orchestrator/
+// start.go for the lifecycle contract.
 func (c *Client) StartShed(ctx context.Context, name string) (*config.Shed, error) {
 	defer c.acquireCreateLock(name)()
-
-	meta, err := LoadMetadata(c.cfg.InstanceDir, name)
-	if err != nil {
-		if errors.Is(err, ErrInstanceNotFound) {
-			return nil, fmt.Errorf("%w: %s", config.ErrShedNotFoundSentinel, name)
-		}
-		return nil, err
-	}
-
-	if meta.Status == config.StatusRunning {
-		vm := &VM{meta: meta, cfg: c.cfg}
-		if vm.IsRunning() {
-			return nil, fmt.Errorf("%w: %s", config.ErrShedAlreadyRunningSentinel, name)
-		}
-		meta.Status = config.StatusStopped
-		meta.PID = 0
-	}
-
-	// Defensive zombie-pid check. Even when status reads "stopped" we
-	// can still hold a stale pid (server crash between vm.Stop() and
-	// the metadata save, hand-edited metadata.json, etc). Refuse to
-	// spawn a second vfkit under the same name when the recorded pid
-	// is still alive AND still looks like a vfkit. Plain liveness
-	// without the binary check would false-positive across PID reuse.
-	if meta.PID > 0 && vmutil.IsProcessAlive(meta.PID) && isVfkitProcess(meta.PID) {
-		return nil, fmt.Errorf("%w: %s (pid %d)", config.ErrZombiePresentSentinel, name, meta.PID)
-	}
-	meta.PID = 0
-
-	// Filter credentials to those with existing source directories.
-	dirCreds := vmutil.FilterExistingCredentials(c.serverCfg)
-
-	vm := CreateVM(meta, c.cfg)
-	vm.credentialShares = buildCredentialShares(dirCreds)
-
-	if err := vm.Start(ctx); err != nil {
-		return nil, fmt.Errorf("failed to start VM: %w", err)
-	}
-
-	meta.Status = config.StatusRunning
-	if err := meta.Save(c.cfg.InstanceDir); err != nil {
-		if stopErr := vm.Stop(context.Background()); stopErr != nil {
-			log.Printf("Warning: failed to stop VM: %v", stopErr)
-		}
-		return nil, fmt.Errorf("failed to save metadata: %w", err)
-	}
-
-	c.mu.Lock()
-	c.vms[name] = vm
-	c.mu.Unlock()
-
-	agent := c.newAgentClient(meta.Name)
-
-	// Re-mount VirtioFS workspace on start (mount doesn't persist across reboots)
-	if meta.LocalDir != "" {
-		if err := c.mountVirtioFSShareWithRetry(ctx, agent, config.VirtioFSMountTag, config.WorkspacePath, false); err != nil {
-			// VirtioFS mount is essential for --local-dir; stop the VM and fail
-			if stopErr := vm.Stop(context.Background()); stopErr != nil {
-				log.Printf("Warning: failed to stop VM after mount failure: %v", stopErr)
-			}
-			return nil, fmt.Errorf("VirtioFS mount failed on start for local dir %s: %w", meta.LocalDir, err)
-		}
-	}
-
-	// Mount credentials
-	c.credMgr.SetupCredentials(ctx, agent, name, dirCreds, c.mountVirtioFSCredential)
-
-	// Run startup hook only (not install)
-	provisioner := vmutil.NewProvisioner(agent, name)
-	provisioner.SetOutput(os.Stdout, os.Stderr)
-	cfg, err := provisioner.LoadConfig(ctx)
-	if err != nil {
-		log.Printf("Warning: failed to load provisioning config: %v", err)
-	} else {
-		if err := provisioner.RunProvisioning(ctx, cfg, false); err != nil {
-			log.Printf("Warning: startup hook failed: %v", err)
-		}
-	}
-
-	return metadataToShed(meta, "127.0.0.1"), nil
+	return orchestrator.StartShed(ctx, &vzStarter{c: c}, orchestrator.StartRequest{Name: name})
 }
 
 // StopShed stops a running shed.

--- a/internal/vz/orchestrator.go
+++ b/internal/vz/orchestrator.go
@@ -421,3 +421,151 @@ func (b *vzCreator) RunProvisioning(ctx context.Context, req config.CreateShedRe
 func (b *vzCreator) ToShedResult(metaRaw orchestrator.MetadataHandle) *config.Shed {
 	return metadataToShed(metaRaw.(*vzMetaHandle).meta, "127.0.0.1")
 }
+
+// ---------------------------------------------------------------------------
+// BackendStarter implementation (orchestrator.StartShed lifecycle)
+//
+// vzStarter wraps the same *Client as vzCreator. Hooks that overlap
+// with vzCreator (mount, credentials, ToShedResult) reuse the
+// underlying Client helpers directly rather than delegating to the
+// vzCreator methods — the contracts diverge on input shape
+// (CreateShedRequest vs persisted metadata) and keeping the codepaths
+// distinct makes the start-only behaviors easier to follow.
+// ---------------------------------------------------------------------------
+
+type vzStarter struct{ c *Client }
+
+// LoadMetadata reads the per-shed metadata and wraps the canonical
+// NotFound error with the API-level sentinel.
+func (b *vzStarter) LoadMetadata(_ context.Context, req orchestrator.StartRequest) (orchestrator.MetadataHandle, error) {
+	meta, err := LoadMetadata(b.c.cfg.InstanceDir, req.Name)
+	if err != nil {
+		if errors.Is(err, ErrInstanceNotFound) {
+			return nil, fmt.Errorf("%w: %s", config.ErrShedNotFoundSentinel, req.Name)
+		}
+		return nil, err
+	}
+	return &vzMetaHandle{meta: meta}, nil
+}
+
+// CheckNotRunning enforces the same two-sentinel contract documented
+// on BackendStarter: ErrShedAlreadyRunningSentinel for a live VMM,
+// ErrZombiePresentSentinel for a stale-PID alive process. Falls
+// through clearing meta.Status / meta.PID when the recorded state
+// turns out to be stale (status=Running but no live vfkit).
+func (b *vzStarter) CheckNotRunning(_ context.Context, metaRaw orchestrator.MetadataHandle) error {
+	meta := metaRaw.(*vzMetaHandle).meta
+
+	if meta.Status == config.StatusRunning {
+		vm := &VM{meta: meta, cfg: b.c.cfg}
+		if vm.IsRunning() {
+			return fmt.Errorf("%w: %s", config.ErrShedAlreadyRunningSentinel, meta.Name)
+		}
+		meta.Status = config.StatusStopped
+		meta.PID = 0
+	}
+
+	// Defensive zombie-pid check — same shape as client.go:StartShed
+	// before the orchestrator migration. Refuse to double-spawn even
+	// if status reads "stopped" but the recorded PID is still a live
+	// vfkit (server crash mid-Save, hand-edited metadata, etc).
+	if meta.PID > 0 && vmutil.IsProcessAlive(meta.PID) && isVfkitProcess(meta.PID) {
+		return fmt.Errorf("%w: %s (pid %d)", config.ErrZombiePresentSentinel, meta.Name, meta.PID)
+	}
+	meta.PID = 0
+
+	return nil
+}
+
+// StartVM builds the credential-share list (vfkit needs every share
+// declared before boot) and starts the VM. Registers the "stop VM"
+// cleanup. Mirrors vzCreator.StartVM but takes no UpperInfo/
+// NetworkResources (StartShed loads everything from metadata).
+func (b *vzStarter) StartVM(ctx context.Context, metaRaw orchestrator.MetadataHandle, cleanup *backend.Cleanup) (orchestrator.VMHandle, error) {
+	meta := metaRaw.(*vzMetaHandle).meta
+
+	dirCreds := vmutil.FilterExistingCredentials(b.c.serverCfg)
+	vm := CreateVM(meta, b.c.cfg)
+	vm.credentialShares = buildCredentialShares(dirCreds)
+
+	if err := vm.Start(ctx); err != nil {
+		return nil, fmt.Errorf("failed to start VM: %w", err)
+	}
+	cleanup.Register("stop VM", func() error {
+		return vm.Stop(context.Background())
+	})
+	return vzVMHandle{vm: vm}, nil
+}
+
+// PersistRunningState flips the metadata to Running, re-saves, and
+// registers the c.vms map entry's removal cleanup. Mirrors
+// vzCreator.FinalizeStartedVM.
+func (b *vzStarter) PersistRunningState(_ context.Context, metaRaw orchestrator.MetadataHandle, vmRaw orchestrator.VMHandle, cleanup *backend.Cleanup) error {
+	meta := metaRaw.(*vzMetaHandle).meta
+	vm := vmRaw.(vzVMHandle).vm
+
+	meta.Status = config.StatusRunning
+	if err := meta.Save(b.c.cfg.InstanceDir); err != nil {
+		return fmt.Errorf("failed to save metadata: %w", err)
+	}
+
+	b.c.mu.Lock()
+	b.c.vms[meta.Name] = vm
+	b.c.mu.Unlock()
+	shedName := meta.Name
+	cleanup.Register("remove from vms map", func() error {
+		b.c.mu.Lock()
+		defer b.c.mu.Unlock()
+		delete(b.c.vms, shedName)
+		return nil
+	})
+	return nil
+}
+
+// MountLocalDir re-mounts the workspace VirtioFS share when
+// meta.LocalDir is set. VirtioFS mounts don't persist across vfkit
+// restarts; this is the start-time refresh.
+func (b *vzStarter) MountLocalDir(ctx context.Context, metaRaw orchestrator.MetadataHandle, _ orchestrator.VMHandle) error {
+	meta := metaRaw.(*vzMetaHandle).meta
+	if meta.LocalDir == "" {
+		return nil
+	}
+	agent := b.c.newAgentClient(meta.Name)
+	if err := b.c.mountVirtioFSShareWithRetry(ctx, agent, config.VirtioFSMountTag, config.WorkspacePath, false); err != nil {
+		return fmt.Errorf("VirtioFS mount failed on start for local dir %s: %w", meta.LocalDir, err)
+	}
+	return nil
+}
+
+// SetupCredentials re-mounts configured credentials. Best-effort
+// (the credentials manager itself log-and-continues per credential).
+func (b *vzStarter) SetupCredentials(ctx context.Context, metaRaw orchestrator.MetadataHandle, _ orchestrator.VMHandle) {
+	meta := metaRaw.(*vzMetaHandle).meta
+	dirCreds := vmutil.FilterExistingCredentials(b.c.serverCfg)
+	agent := b.c.newAgentClient(meta.Name)
+	b.c.credMgr.SetupCredentials(ctx, agent, meta.Name, dirCreds, b.c.mountVirtioFSCredential)
+}
+
+// RunStartupHook runs ONLY the `startup` hook from provision.yaml
+// (runInstall=false). Best-effort: a failure logs but doesn't fail
+// the start (matches the pre-migration inline behavior).
+func (b *vzStarter) RunStartupHook(ctx context.Context, metaRaw orchestrator.MetadataHandle, _ orchestrator.VMHandle) {
+	meta := metaRaw.(*vzMetaHandle).meta
+	agent := b.c.newAgentClient(meta.Name)
+	provisioner := vmutil.NewProvisioner(agent, meta.Name)
+	provisioner.SetOutput(os.Stdout, os.Stderr)
+	cfg, err := provisioner.LoadConfig(ctx)
+	if err != nil {
+		log.Printf("Warning: failed to load provisioning config: %v", err)
+		return
+	}
+	if err := provisioner.RunProvisioning(ctx, cfg, false); err != nil {
+		log.Printf("Warning: startup hook failed: %v", err)
+	}
+}
+
+// ToShedResult mirrors vzCreator.ToShedResult — VZ's endpoint is the
+// shared-NAT localhost.
+func (b *vzStarter) ToShedResult(metaRaw orchestrator.MetadataHandle) *config.Shed {
+	return metadataToShed(metaRaw.(*vzMetaHandle).meta, "127.0.0.1")
+}

--- a/internal/vz/orchestrator.go
+++ b/internal/vz/orchestrator.go
@@ -504,7 +504,13 @@ func (b *vzStarter) PersistRunningState(_ context.Context, metaRaw orchestrator.
 	meta := metaRaw.(*vzMetaHandle).meta
 	vm := vmRaw.(vzVMHandle).vm
 
+	// vm.meta aliases the same *Metadata as meta (CreateVM stores the
+	// pointer), so vm.Start's `vm.meta.PID = cmd.Process.Pid` write
+	// already lands here. The explicit assignment mirrors
+	// vzCreator.FinalizeStartedVM — keeps the PID transfer visible at
+	// the persistence boundary in case the aliasing changes later.
 	meta.Status = config.StatusRunning
+	meta.PID = vm.meta.PID
 	if err := meta.Save(b.c.cfg.InstanceDir); err != nil {
 		return fmt.Errorf("failed to save metadata: %w", err)
 	}

--- a/tests/integration/fixtures/server.py
+++ b/tests/integration/fixtures/server.py
@@ -184,6 +184,30 @@ class LocalServer:
         full = ["shed", "-s", self.name, "exec", name, "--"] + cmd
         return subprocess.run(full, capture_output=True, text=True, timeout=timeout)
 
+    def stop(self, name: str, timeout: int = 60) -> None:
+        """Stop a running shed via `shed stop` (fail-loud)."""
+        r = subprocess.run(
+            ["shed", "-s", self.name, "stop", name],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        if r.returncode != 0:
+            raise AssertionError(
+                f"shed stop failed (exit {r.returncode}) on {self.name}: "
+                f"stdout={r.stdout!r} stderr={r.stderr!r}"
+            )
+
+    def start(self, name: str, timeout: int = 120) -> None:
+        """Start a stopped shed via `shed start` (fail-loud)."""
+        r = subprocess.run(
+            ["shed", "-s", self.name, "start", name],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        if r.returncode != 0:
+            raise AssertionError(
+                f"shed start failed (exit {r.returncode}) on {self.name}: "
+                f"stdout={r.stdout!r} stderr={r.stderr!r}"
+            )
+
     def ssh_exec(
         self,
         name: str,

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -1,0 +1,40 @@
+"""Lifecycle tests: create → stop → start → exec → delete.
+
+Catches regressions in the StartShed-after-StopShed path that the
+plain create/delete smoke can't see. Lands with the §15 Phase 2
+StartShed orchestrator migration (PR-B1/B2) so future churn in that
+codepath has a live signal beyond the orchestrator unit tests.
+"""
+
+from __future__ import annotations
+
+
+def test_lifecycle_plain(shed_server, test_shed_name):
+    """create → stop → start → exec → delete on the plain image."""
+    shed_server.create(test_shed_name, image="base")
+
+    # First exec proves the shed boots cleanly out of CreateShed.
+    r = shed_server.exec(test_shed_name, ["echo", "before-stop"])
+    assert r.returncode == 0, f"pre-stop exec failed: stderr={r.stderr!r}"
+    assert "before-stop" in r.stdout
+
+    shed_server.stop(test_shed_name)
+
+    # Re-list MUST show the shed in stopped state (`shed list` flips
+    # a crashed/missing VM to stopped lazily; an explicit stop should
+    # land at stopped immediately).
+    names = shed_server.list_shed_names()
+    assert test_shed_name in names, (
+        f"shed {test_shed_name!r} disappeared after stop; got {names}"
+    )
+
+    shed_server.start(test_shed_name)
+
+    # Exec after start proves the post-start hooks (workspace mount,
+    # credential mount, agent re-attach) re-armed correctly.
+    r = shed_server.exec(test_shed_name, ["echo", "after-start"])
+    assert r.returncode == 0, f"post-start exec failed: stderr={r.stderr!r}"
+    assert "after-start" in r.stdout
+
+    shed_server.delete(test_shed_name, ignore_missing=False)
+    assert test_shed_name not in shed_server.list_shed_names()

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -20,9 +20,10 @@ def test_lifecycle_plain(shed_server, test_shed_name):
 
     shed_server.stop(test_shed_name)
 
-    # Re-list MUST show the shed in stopped state (`shed list` flips
-    # a crashed/missing VM to stopped lazily; an explicit stop should
-    # land at stopped immediately).
+    # Re-list must still include the shed — `shed stop` only halts
+    # the VMM, it doesn't delete the shed. (`list_shed_names()` only
+    # returns names, not per-shed status; that's covered by the
+    # implicit "shed_server.start succeeded" assertion below.)
     names = shed_server.list_shed_names()
     assert test_shed_name in names, (
         f"shed {test_shed_name!r} disappeared after stop; got {names}"


### PR DESCRIPTION
## Summary

§15 Phase 2 finish (VZ half). Replaces 83 lines of inline VZ `StartShed` with a 3-line orchestrator call. The orchestrator (`internal/backend/orchestrator/start.go`) owns the call ordering, PhaseTimer boundaries, and cleanup-stack scaffolding; `vzStarter` in `internal/vz/orchestrator.go` carries the per-step platform logic.

### Why a separate sub-interface, not a flag on BackendCreator

- CreateShed and StartShed take different inputs (`CreateShedRequest` vs. persisted metadata loaded from disk). Squeezing both into one interface forces every hook to know which mode.
- The start-specific hooks (`LoadMetadata`, `CheckNotRunning`, `PersistRunningState`, `RunStartupHook`) have no natural place in the create flow.
- Shared hooks (`MountLocalDir`, `SetupCredentials`, `ToShedResult`) reuse the underlying `Client` helpers directly; each backend's `*Starter` wraps the same `*Client`.

### Changes

- `internal/backend/orchestrator/start.go` (new): `BackendStarter` interface + `StartShed(ctx, b, req)` function. Same cleanup-stack contract as `CreateShed` (Register on cleanup, LIFO unwind on failure, Commit on success).
- `internal/backend/orchestrator/start_test.go` (new): mock-backed happy-path order + failure-LIFO-unwind table + best-effort hooks-don't-abort tests, mirroring `create_test.go`'s shape.
- `internal/vz/orchestrator.go`: extended with `vzStarter`. Reuses existing `vzMetaHandle`, `vzVMHandle`, `buildCredentialShares`, `CreateVM`, `mountVirtioFSShareWithRetry`, `newAgentClient`, `credMgr.SetupCredentials`, `metadataToShed`. `CheckNotRunning` bundles the IsRunning/zombie guards PR-A1 added inline.
- `internal/vz/client.go:StartShed` shrinks 83 → 3 lines. The per-shed createLock acquisition stays here (orchestrator doesn't own it).
- `tests/integration/fixtures/server.py`: new `LocalServer.stop()` + `start()` methods (fail-loud, matching `create()`).
- `tests/integration/test_lifecycle.py` (new): create → stop → start → exec → delete on both backends.

### Validation

- `make check` clean.
- `GOOS=linux GOARCH=arm64 go build ./internal/firecracker/` clean.
- `make test-integration`: 40/40 pass on both VZ (my-server, brew binary swapped for the locally-built shed-server to exercise the new server-side code) and FC (mini3 — still inline-StartShed there; covered by PR-B2).
- Manual VZ create → stop → start → exec → delete works end-to-end.
- PhaseTimer regression check: agent phase ~1.7s on my-build with `SHED_BUILD_TOOLS_REF` set, matching v0.5.8 brew baseline.

### A note on dev-build agent timing

While validating this PR I hit the timing-regression gate fire at agent p50 ~5800ms vs 2200ms ceiling. Bisected to `make build` binaries (clean v0.5.8 source also regresses). Root cause: `internal/version/buildtools.go:BuildToolsRefForTag` returns `""` for dev-version strings (`-dirty` / `-N-g<hash>` suffixes), so dev builds skip the pre-formatted upper-template fast path and `mkfs.ext4` in-guest (+4s). Release binaries from goreleaser embed clean tags and aren't affected. PR-A1 + PR-A2 do not carry a runtime regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added start and stop operations for shed instances, enabling pause and resume workflows without deletion and recreation.
  * Full lifecycle management now supported: create, stop, start, and delete operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->