### PR TITLE
refactor: delete GetNetworkEndpoint (vestigial; DialService is the contract)

### DIFF
--- a/docs/getting-started/vz-setup.md
+++ b/docs/getting-started/vz-setup.md
@@ -279,7 +279,7 @@ See [VZ Configuration](../reference/configuration.md#vz-configuration) for all a
 
 The VZ backend launches each VM as a `vfkit` subprocess. Communication with the guest uses vsock over per-port Unix sockets (one socket per port, named `<name>-<port>.sock`). This differs from Firecracker, which uses a single multiplexed socket with a CONNECT/OK handshake.
 
-Networking uses NAT provided by Virtualization.framework. The guest obtains an IP via DHCP through `systemd-networkd`. From the host's perspective, `GetNetworkEndpoint` always returns `127.0.0.1`.
+Networking uses NAT provided by Virtualization.framework. The guest obtains an IP via DHCP through `systemd-networkd`. From the host's perspective, the guest IP isn't routable; service traffic from the host goes through `DialService`'s vsock TCP-proxy hop. `shed list` and the API report `127.0.0.1` as the shed's IP so the field has a sensible value, but no host code dials that address.
 
 The rootfs is a standard ext4 image, same as Firecracker. Each instance gets its own copy.
 

--- a/docs/reference/vz-operations.md
+++ b/docs/reference/vz-operations.md
@@ -109,7 +109,7 @@ ls ~/.shed/vz/sockets/
 
 VZ uses NAT networking provided by Apple's Virtualization.framework. The guest obtains an IP address via DHCP through `systemd-networkd`.
 
-From the host, `shed` commands communicate with the VM over vsock (Unix sockets), not TCP. The `GetNetworkEndpoint` API returns `127.0.0.1`.
+From the host, `shed` commands communicate with the VM over vsock (Unix sockets), not TCP. `shed list` and the API still report a `127.0.0.1` IP for running VZ sheds (so the field has a sensible value in JSON output), but service traffic itself routes through `DialService`'s vsock TCP-proxy hop rather than that IP.
 
 ## Docker Inside VZ
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -220,9 +220,6 @@ func (f *createShedFakeBackend) KillSession(_ context.Context, _, _ string) erro
 func (f *createShedFakeBackend) Exec(_ context.Context, _ string, _ backend.ExecOptions) error {
 	panic("unexpected")
 }
-func (f *createShedFakeBackend) GetNetworkEndpoint(_ context.Context, _ string) (string, error) {
-	panic("unexpected")
-}
 func (f *createShedFakeBackend) DialService(_ context.Context, _ string, _ uint16) (net.Conn, error) {
 	panic("unexpected")
 }

--- a/internal/api/routes_test.go
+++ b/internal/api/routes_test.go
@@ -48,9 +48,6 @@ func (routesFakeBackend) KillSession(_ context.Context, _, _ string) error { ret
 func (routesFakeBackend) Exec(_ context.Context, _ string, _ backend.ExecOptions) error {
 	return nil
 }
-func (routesFakeBackend) GetNetworkEndpoint(_ context.Context, _ string) (string, error) {
-	return "", config.ErrShedNotFoundSentinel
-}
 func (routesFakeBackend) DialService(_ context.Context, _ string, _ uint16) (net.Conn, error) {
 	return nil, config.ErrShedNotFoundSentinel
 }

--- a/internal/api/snapshot_handlers_test.go
+++ b/internal/api/snapshot_handlers_test.go
@@ -66,9 +66,6 @@ func (f *snapshotFakeBackend) KillSession(_ context.Context, _, _ string) error 
 func (f *snapshotFakeBackend) Exec(_ context.Context, _ string, _ backend.ExecOptions) error {
 	panic("unexpected")
 }
-func (f *snapshotFakeBackend) GetNetworkEndpoint(_ context.Context, _ string) (string, error) {
-	panic("unexpected")
-}
 func (f *snapshotFakeBackend) DialService(_ context.Context, _ string, _ uint16) (net.Conn, error) {
 	panic("unexpected")
 }

--- a/internal/api/system_handlers_test.go
+++ b/internal/api/system_handlers_test.go
@@ -56,9 +56,6 @@ func (f *fakeBackend) KillSession(ctx context.Context, shedName, sessionName str
 func (f *fakeBackend) Exec(ctx context.Context, shedName string, opts backend.ExecOptions) error {
 	panic("unexpected")
 }
-func (f *fakeBackend) GetNetworkEndpoint(ctx context.Context, shedName string) (string, error) {
-	panic("unexpected")
-}
 func (f *fakeBackend) DialService(ctx context.Context, shedName string, port uint16) (net.Conn, error) {
 	panic("unexpected")
 }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -69,10 +69,6 @@ type Backend interface {
 
 	// Network
 
-	// GetNetworkEndpoint returns the network endpoint (IP or hostname) for a shed.
-	// This is used for API responses and informational purposes.
-	GetNetworkEndpoint(ctx context.Context, shedName string) (string, error)
-
 	// DialService opens a TCP connection to a port inside a running shed's VM.
 	// For VZ: dials via vsock TCP proxy (port 1028) with CONNECT handshake.
 	// For Firecracker: dials the VM's bridge IP directly over TCP.

--- a/internal/firecracker/backend.go
+++ b/internal/firecracker/backend.go
@@ -188,11 +188,6 @@ func (b *FirecrackerBackend) Exec(ctx context.Context, shedName string, opts bac
 	return agent.Exec(ctx, opts)
 }
 
-// GetNetworkEndpoint returns the network endpoint (IP) for a shed.
-func (b *FirecrackerBackend) GetNetworkEndpoint(ctx context.Context, shedName string) (string, error) {
-	return b.client.GetNetworkEndpoint(ctx, shedName)
-}
-
 // DialService opens a TCP connection to a port inside a running shed's VM.
 func (b *FirecrackerBackend) DialService(ctx context.Context, shedName string, port uint16) (net.Conn, error) {
 	return b.client.DialService(ctx, shedName, port)

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -653,19 +653,6 @@ func (c *Client) stopShedLocked(ctx context.Context, meta *Metadata) (*config.Sh
 	return metadataToShed(meta), nil
 }
 
-// GetNetworkEndpoint returns the IP address for a shed.
-func (c *Client) GetNetworkEndpoint(ctx context.Context, name string) (string, error) {
-	meta, err := LoadMetadata(c.cfg.InstanceDir, name)
-	if err != nil {
-		if errors.Is(err, ErrInstanceNotFound) {
-			return "", fmt.Errorf("%w: %s", config.ErrShedNotFoundSentinel, name)
-		}
-		return "", err
-	}
-
-	return meta.IPAddress, nil
-}
-
 // DialService opens a TCP connection to a service port inside a running Firecracker shed.
 // Firecracker VMs have routable bridge IPs, so this dials directly.
 func (c *Client) DialService(ctx context.Context, name string, port uint16) (net.Conn, error) {

--- a/internal/firecracker/stub_nonlinux.go
+++ b/internal/firecracker/stub_nonlinux.go
@@ -101,11 +101,6 @@ func (b *FirecrackerBackend) Exec(ctx context.Context, shedName string, opts bac
 	return errNonLinux()
 }
 
-// GetNetworkEndpoint returns an error on non-linux platforms.
-func (b *FirecrackerBackend) GetNetworkEndpoint(ctx context.Context, shedName string) (string, error) {
-	return "", errNonLinux()
-}
-
 // DialService returns an error on non-linux platforms.
 func (b *FirecrackerBackend) DialService(ctx context.Context, shedName string, port uint16) (net.Conn, error) {
 	return nil, errNonLinux()

--- a/internal/vz/backend.go
+++ b/internal/vz/backend.go
@@ -193,11 +193,6 @@ func (b *VZBackend) Exec(ctx context.Context, shedName string, opts backend.Exec
 	return agent.Exec(ctx, opts)
 }
 
-// GetNetworkEndpoint returns the network endpoint for a shed.
-func (b *VZBackend) GetNetworkEndpoint(ctx context.Context, shedName string) (string, error) {
-	return b.client.GetNetworkEndpoint(ctx, shedName)
-}
-
 // DialService opens a TCP connection to a port inside a running shed's VM.
 func (b *VZBackend) DialService(ctx context.Context, shedName string, port uint16) (net.Conn, error) {
 	return b.client.DialService(ctx, shedName, port)

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -377,20 +377,6 @@ func (c *Client) stopShedLocked(ctx context.Context, meta *Metadata) (*config.Sh
 	return metadataToShed(meta, ""), nil
 }
 
-// GetNetworkEndpoint returns the network endpoint for a shed.
-// VZ uses NAT, so the endpoint is always localhost.
-func (c *Client) GetNetworkEndpoint(ctx context.Context, name string) (string, error) {
-	_, err := LoadMetadata(c.cfg.InstanceDir, name)
-	if err != nil {
-		if errors.Is(err, ErrInstanceNotFound) {
-			return "", fmt.Errorf("%w: %s", config.ErrShedNotFoundSentinel, name)
-		}
-		return "", err
-	}
-
-	return "127.0.0.1", nil
-}
-
 // DialService opens a TCP connection to a service port inside a running VZ shed.
 // It dials the vsock TCP proxy port and performs a CONNECT handshake.
 func (c *Client) DialService(ctx context.Context, name string, port uint16) (net.Conn, error) {

--- a/internal/vz/client_test.go
+++ b/internal/vz/client_test.go
@@ -66,57 +66,6 @@ func TestBuildEnvForGitNoEnvVars(t *testing.T) {
 	}
 }
 
-func TestGetNetworkEndpoint(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	cfg := &config.VZConfig{
-		InstanceDir: tmpDir,
-	}
-
-	// Create a valid metadata file
-	meta := &Metadata{
-		Name:     "test-vm",
-		Status:   config.StatusRunning,
-		Backend:  config.BackendVZ,
-		CPUs:     2,
-		MemoryMB: 4096,
-	}
-	meta.Save(tmpDir)
-
-	client := &Client{
-		cfg:     cfg,
-		vms:     make(map[string]*VM),
-		credMgr: newTestCredMgr(),
-	}
-
-	endpoint, err := client.GetNetworkEndpoint(context.Background(), "test-vm")
-	if err != nil {
-		t.Fatalf("GetNetworkEndpoint() error = %v", err)
-	}
-	if endpoint != "127.0.0.1" {
-		t.Errorf("GetNetworkEndpoint() = %q, want %q", endpoint, "127.0.0.1")
-	}
-}
-
-func TestGetNetworkEndpointNotFound(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	cfg := &config.VZConfig{
-		InstanceDir: tmpDir,
-	}
-
-	client := &Client{
-		cfg:     cfg,
-		vms:     make(map[string]*VM),
-		credMgr: newTestCredMgr(),
-	}
-
-	_, err := client.GetNetworkEndpoint(context.Background(), "nonexistent")
-	if err == nil {
-		t.Error("GetNetworkEndpoint() expected error for nonexistent shed")
-	}
-}
-
 func TestDialServiceNotFound(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := &config.VZConfig{

--- a/internal/vz/stub_nondarwin.go
+++ b/internal/vz/stub_nondarwin.go
@@ -99,11 +99,6 @@ func (b *VZBackend) Exec(ctx context.Context, shedName string, opts backend.Exec
 	return errNonDarwin
 }
 
-// GetNetworkEndpoint returns an error on non-darwin platforms.
-func (b *VZBackend) GetNetworkEndpoint(ctx context.Context, shedName string) (string, error) {
-	return "", errNonDarwin
-}
-
 // DialService returns an error on non-darwin platforms.
 func (b *VZBackend) DialService(ctx context.Context, shedName string, port uint16) (net.Conn, error) {
 	return nil, errNonDarwin


### PR DESCRIPTION
## Summary

`Backend.GetNetworkEndpoint` had **zero callers** via the interface — the API layer's only network-routing code path (`internal/api/connect.go`) uses `Backend.DialService`, and `Shed.IPAddress` is populated directly in each backend's `metadataToShed`. Discovery doc §7 flagged this method as a "lie" (VZ returns hardcoded `"127.0.0.1"`); two options were on the table:

- **A. Typed `NetworkInfo{Backend, Value}`** — replace the string with a struct.
- **B. Delete entirely** — route everything through `DialService` + `Shed.IPAddress`.

Option B wins on call-site evidence:

```
$ grep -rn '\.GetNetworkEndpoint(' --include='*.go' | grep -v _test
internal/vz/backend.go         (wrapper pass-through)
internal/firecracker/backend.go (wrapper pass-through)
```

No consumer of the returned string exists. Net **−114 LOC**, zero new interface complexity.

### Changes

- `internal/backend/backend.go`: drop the interface method.
- `internal/{vz,firecracker}/backend.go`: drop the wrappers.
- `internal/{vz,firecracker}/client.go`: drop the implementations.
- `internal/{vz,firecracker}/stub_*.go`: drop the non-platform stubs.
- `internal/vz/client_test.go`: drop `TestGetNetworkEndpoint` / `TestGetNetworkEndpointNotFound`.
- `internal/api/{handlers,system_handlers,snapshot_handlers,routes}_test.go`: drop the four `(fakeBackend) GetNetworkEndpoint` interface-satisfaction stubs.

`Shed.IPAddress` remains populated unchanged: VZ writes `"127.0.0.1"` inside `metadataToShed` (StartShed/CreateShed call sites); FC writes `meta.IPAddress` (the real bridge IP). `DialService` remains the single contract for reaching a shed's services.

### Validation

- `make check` clean.
- `GOOS=linux GOARCH=arm64 go build ./internal/firecracker/` clean.
- `make test-integration`: 40/40 pass on both VZ (my-server) and FC (mini3).
- `shed list` continues to show endpoints; `shed connect <name> <port>` continues to work via DialService.

🤖 Generated with [Claude Code](https://claude.com/claude-code)