### PR TITLE
test(integration): split timing gate into agent and rootfs-template

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -68,14 +68,14 @@ tests/integration/
   uv.lock                 # committed for reproducibility (gitignore exception)
   README.md               # this file
   conftest.py             # vz_server, fc_server, shed_server, test_shed_name
-  test_smoke.py           # the MVP five tests
+  test_smoke.py           # the MVP smoke tests
   fixtures/
     __init__.py
     server.py             # LocalServer + RemoteServer + ShedHandle
     timing.py             # PhaseTimer log-line parser
 ```
 
-## The MVP five tests
+## The MVP smoke tests
 
 | Test                                  | What it asserts                                                    |
 |---------------------------------------|--------------------------------------------------------------------|

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -47,8 +47,9 @@ tests they would have run, not the whole session.
   the PhaseTimer log-line fetch in tests 2 and 4. Without it, those two
   tests skip cleanly with a clear reason.
 - The remote shed-server must be **v0.5.4 or newer** for any
-  PhaseTimer-dependent assertion (`test_phase_timer_emitted` and
-  `test_plain_create_timing`). Older servers skip those tests.
+  PhaseTimer-dependent assertion (`test_phase_timer_emitted`,
+  `test_create_agent_p50`, `test_create_rootfs_template_present`).
+  Older servers skip those tests.
 
 ## Environment overrides
 
@@ -76,13 +77,39 @@ tests/integration/
 
 ## The MVP five tests
 
-| Test                              | What it asserts                                                    |
-|-----------------------------------|--------------------------------------------------------------------|
-| `test_create_delete_lifecycle`    | `shed create` succeeds; teardown deletes it cleanly.               |
-| `test_phase_timer_emitted`        | Server log contains a `timing: create` line with the expected keys.|
-| `test_repo_clone_https`           | `--repo <https url>` + `git log` round-trip in the guest works.    |
-| `test_plain_create_timing`        | `agent` phase p50 (5 samples) stays under a per-backend ceiling.   |
-| `test_shed_exec_smoke`            | `shed exec name -- echo hello` returns `hello`.                    |
+| Test                                  | What it asserts                                                    |
+|---------------------------------------|--------------------------------------------------------------------|
+| `test_create_delete_lifecycle`        | `shed create` succeeds; teardown deletes it cleanly.               |
+| `test_phase_timer_emitted`            | Server log contains a `timing: create` line with the expected keys.|
+| `test_repo_clone_https`               | `--repo <https url>` + `git log` round-trip in the guest works.    |
+| `test_create_agent_p50`               | `agent` phase p50 (5 samples) stays under a per-backend ceiling. Skips when the VZ upper-template fast path was unavailable (in-guest mkfs cost inflates `agent_ms` by ~4 s). |
+| `test_create_rootfs_template_present` | VZ-only: the host-side upper-template fast path is active. Skips on FC (no template path) and on VZ dev mode (where the fast path is unavailable by design). |
+| `test_shed_exec_smoke`                | `shed exec name -- echo hello` returns `hello`.                    |
+
+### The split timing gate
+
+`test_create_agent_p50` and `test_create_rootfs_template_present`
+replaced the single `test_plain_create_timing` gate. Both use the
+server log line `[<shed-name>] upper template unavailable (...);
+formatting in guest` (emitted from `internal/vz/orchestrator.go:249`
+when the VZ host-side template clone is unavailable) as their
+"dev-mode active" discriminator, exposed as
+`ShedHandle.template_fallback`:
+
+- `test_create_agent_p50` skips when the fallback was seen on any
+  sample — the in-guest `mkfs.ext4` lands inside the agent phase and
+  inflates `agent_p50` by ~4 s on VZ, which would fire the gate for
+  a structural reason that's not a real regression.
+- `test_create_rootfs_template_present` skips on FC entirely (no
+  host-side template path; FC always uses in-guest mkfs and its
+  agent ceiling already accommodates that cost — see
+  `internal/firecracker/orchestrator.go:AllocateUpper`) and on VZ
+  dev mode. On VZ release mode it asserts `rootfs_ms ≤ 100 ms` as a
+  sanity check that the host-side clone actually happened fast.
+
+This lets the suite run against either binary kind on either backend
+without false-positive timing failures. Background:
+`docs/discovery/integration-suite-server-coverage.md` §7.
 
 ## Per-backend timing ceilings
 

--- a/tests/integration/fixtures/server.py
+++ b/tests/integration/fixtures/server.py
@@ -40,9 +40,27 @@ TIMING_LOOKUP_BUDGET_S = 15.0
 TIMING_LOOKUP_INTERVAL_S = 0.2
 
 
-# Default per-backend ceilings for timing assertions. Calibrated to
-# tolerate normal variance on a moderately-loaded host while still
-# flagging a ~300 ms+ regression on a healthy run.
+# Default per-backend ceilings for the AGENT-phase timing assertion.
+# Calibrated to tolerate normal variance on a moderately-loaded host
+# while still flagging a ~300 ms+ regression on a healthy run.
+#
+# SCOPE: AGENT phase only (vsock dial + healthPoll + first health
+# response). This ceiling is structurally identical between dev and
+# release builds — `make build` and the brew/deb binary share the same
+# agent path. Use `test_create_agent_p50` to gate on regressions here.
+#
+# OUT OF SCOPE: the ROOTFS phase. The upper-allocation path diverges
+# sharply between dev and release builds:
+#   - Release builds: pre-formatted template clone, sub-100 ms.
+#   - Dev builds without SHED_BUILD_TOOLS_REF: in-guest mkfs.ext4, ~4 s.
+# That divergence is intentional — see
+# `internal/version/buildtools.go:BuildToolsRefForTag` returning `""`
+# for non-release version strings. Rootfs is gated by
+# `test_create_rootfs_template_present`, which skips cleanly on dev
+# builds rather than firing as a false-positive against THIS ceiling.
+# The split is what makes it safe to run the integration suite against
+# dev binaries — see `docs/discovery/integration-suite-server-coverage.md`
+# §7 "Locked invariants".
 #
 # Keys are the full backend names as reported by the server's PhaseTimer
 # line (`backend=vz` / `backend=firecracker`), NOT the short pytest-param
@@ -74,10 +92,24 @@ class ShedHandle:
     `timings` is None when the server is too old to emit PhaseTimer lines
     (pre-v0.5.4) or when the log fetch failed. Tests that need timing data
     should check for None and skip with a clear reason.
+
+    `template_fallback` is True if the server logged
+    `[<name>] upper template unavailable ...; formatting in guest` during
+    this create — i.e., the VZ upper-template fast path was inactive and
+    the writable upper was instead created raw, with the in-guest
+    initramfs `mkfs.ext4`'ing it on first boot. This is the canonical
+    "dev binary or `SHED_BUILD_TOOLS_REF` unset" signal and is what
+    `test_create_agent_p50` / `test_create_rootfs_template_present` use
+    to skip cleanly instead of false-positive on the resulting ~4 s
+    cost. FC has no host-side template path; this flag stays False on
+    FC regardless. See `internal/vz/orchestrator.go:249` for the emitter
+    and `docs/discovery/integration-suite-server-coverage.md` §7 for
+    the locked-invariant rationale.
     """
 
     name: str
     timings: Optional[PhaseTimings] = None
+    template_fallback: bool = False
 
 
 class LocalServer:
@@ -171,8 +203,10 @@ class LocalServer:
                 f"shed create failed (exit {r.returncode}) on {self.name}: "
                 f"stdout={r.stdout!r} stderr={r.stderr!r}"
             )
-        timings = self._read_timing(name, offset)
-        return ShedHandle(name=name, timings=timings)
+        timings, template_fallback = self._read_timing(name, offset)
+        return ShedHandle(
+            name=name, timings=timings, template_fallback=template_fallback,
+        )
 
     def exec(
         self,
@@ -394,23 +428,41 @@ class LocalServer:
         self,
         shed_name: str,
         offset: Union[int, str],
-    ) -> Optional[PhaseTimings]:
-        """Find the PhaseTimer line for `shed_name`. Polls briefly because
-        the log line may not have flushed before `shed create` returns.
+    ) -> tuple[Optional[PhaseTimings], bool]:
+        """Find the PhaseTimer line for `shed_name`, plus whether the
+        VZ upper-template fast path fell back to in-guest mkfs.
 
-        Bounded by `TIMING_LOOKUP_BUDGET_S` of wall-clock time, not by
-        an iteration count — that keeps a single slow `_read_log_since`
-        call from blowing past the budget.
+        Returns `(timings, template_fallback)`. `template_fallback` is
+        True if the server emitted the canonical
+        `[<shed_name>] upper template unavailable ...; formatting in
+        guest` line (see `internal/vz/orchestrator.go:249`) during this
+        create. Both signals come from the same log blob so we only
+        pay the journalctl / file-read cost once.
+
+        Polls briefly because the log line may not have flushed before
+        `shed create` returns. Bounded by `TIMING_LOOKUP_BUDGET_S` of
+        wall-clock time, not by an iteration count — that keeps a
+        single slow `_read_log_since` call from blowing past the
+        budget.
         """
         marker = f"name={shed_name} "
+        # Per `internal/vz/orchestrator.go:249` — emitted from the
+        # host-side VZ orchestrator path only. FC has no template
+        # fast path and never emits this line.
+        fallback_marker = f"[{shed_name}] upper template unavailable"
         deadline = time.monotonic() + TIMING_LOOKUP_BUDGET_S
+        # `fallback` is sticky: once we've seen the marker in any blob,
+        # keep it set even if a subsequent re-read window misses it.
+        fallback = False
         while time.monotonic() < deadline:
             blob = self._read_log_since(offset)
+            if fallback_marker in blob:
+                fallback = True
             for line in blob.splitlines():
                 if "timing: create" in line and marker in line:
-                    return parse_timing_line(line)
+                    return parse_timing_line(line), fallback
             time.sleep(TIMING_LOOKUP_INTERVAL_S)
-        return None
+        return None, fallback
 
 
 class RemoteServer(LocalServer):

--- a/tests/integration/fixtures/timing.py
+++ b/tests/integration/fixtures/timing.py
@@ -46,6 +46,12 @@ class PhaseTimings:
 
     @property
     def agent_ms(self) -> Optional[int]:
+        """The `agent` phase duration. Covers vsock dial + healthPoll
+        + first agent health response, plus any in-guest activity that
+        happens before the agent can respond (e.g. the VZ in-guest
+        `mkfs.ext4` fallback when the host-side template clone is
+        unavailable). `test_create_agent_p50` uses this as its
+        regression gate."""
         return self.phases.get("agent")
 
     @property

--- a/tests/integration/fixtures/timing.py
+++ b/tests/integration/fixtures/timing.py
@@ -48,6 +48,18 @@ class PhaseTimings:
     def agent_ms(self) -> Optional[int]:
         return self.phases.get("agent")
 
+    @property
+    def rootfs_ms(self) -> Optional[int]:
+        """The `rootfs` phase duration, used by
+        `test_create_rootfs_template_present` as the fast-path /
+        slow-path discriminator (sub-100 ms = pre-formatted template
+        clone; multi-second = in-guest mkfs.ext4 fallback).
+
+        See `docs/discovery/integration-suite-server-coverage.md` §7
+        "Locked invariants" for why this phase diverges between dev and
+        release builds."""
+        return self.phases.get("rootfs")
+
     def __getitem__(self, key: str) -> int:
         return self.phases[key]
 

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -126,19 +126,68 @@ def test_repo_clone_https(shed_server, test_shed_name):
 
 
 # ---------------------------------------------------------------------------
-# 4. Plain-create timing threshold (the regression gate)
+# 4. Plain-create timing threshold (the regression gate — split)
 # ---------------------------------------------------------------------------
+#
+# Split into two assertions because the per-create boot path has two
+# structurally independent signals that used to share one gate:
+#
+#   - `agent` phase ceiling (`test_create_agent_p50`): vsock dial +
+#     healthPoll + first health response. A genuine regression in
+#     healthPoll, vsock setup, or agent init fires this.
+#   - VZ upper-template fast-path active
+#     (`test_create_rootfs_template_present`): a release-only
+#     invariant — the VZ host-side AllocateUpper clones a
+#     pre-formatted ext4 template instead of writing a raw upper that
+#     the in-guest initramfs has to `mkfs.ext4` on first boot.
+#
+# Empirically the in-guest mkfs cost (~4 s on VZ) lands inside the
+# `agent` phase, NOT the `rootfs` phase — `rootfs_ms` stays sub-100 ms
+# in both modes because that phase only covers host-side allocation,
+# which is fast either way. The original `test_plain_create_timing`
+# couldn't distinguish "dev binary, in-guest mkfs is on the agent
+# critical path" from "genuine agent-phase regression."
+#
+# Discriminator: the server log emits
+# `[<shed-name>] upper template unavailable (...); formatting in guest`
+# from `internal/vz/orchestrator.go:249` whenever the host-side fast
+# path is unavailable (dev build, missing `SHED_BUILD_TOOLS_REF`, or a
+# failed template clone). `ShedHandle.template_fallback` exposes that
+# signal per-create. Both tests use it: `test_create_agent_p50` skips
+# when at least one sample saw the fallback, and
+# `test_create_rootfs_template_present` skips on dev mode and skips
+# on FC entirely (FC has no host-side template fast path —
+# see `internal/firecracker/orchestrator.go:AllocateUpper`).
+#
+# See `docs/discovery/integration-suite-server-coverage.md` §7
+# "Locked invariants" for the dev-build-isolation rationale that makes
+# this divergence intentional.
+
+# Sanity ceiling for the host-side rootfs phase when the fast path is
+# active. Template clone + sibling-swap is ~5-10 ms on a healthy host;
+# 100 ms is generous headroom that would still catch a 10x regression
+# (e.g., a reflink that silently falls back to a full copy).
+ROOTFS_TEMPLATE_FAST_PATH_CEILING_MS = 100
 
 
-def test_plain_create_timing(shed_server):
-    """The `agent` phase p50 (5 samples) stays below the per-backend ceiling.
+def test_create_agent_p50(shed_server):
+    """Boot-path p50 regression gate for the `agent` phase.
 
-    Catches general boot-path regressions across both backends — the
-    dynamic gate that PR-time GHA CI can't be (no /dev/kvm). Names
-    include a per-process hash so a concurrent run against the same
-    server doesn't collide on `itest-perf-{backend}-0`. The suite isn't
-    *designed* for concurrent runs, but failing-closed beats
-    failing-weird.
+    Reads `agent_ms` from PhaseTimer log lines; takes 5 samples
+    (post-warm-up) and asserts the median stays below the per-backend
+    ceiling in `fixtures/server.py:DEFAULT_AGENT_P50_MS`.
+
+    Skips cleanly when ANY sample saw the VZ
+    `template_fallback` signal — on dev binaries the in-guest mkfs.ext4
+    falls inside the agent phase and inflates p50 by ~4 s, which would
+    fire the gate for a structural reason that's NOT a real regression.
+    `test_create_rootfs_template_present` covers the orthogonal "is the
+    fast path active" question; this test focuses on the agent-init
+    path only.
+
+    See `docs/discovery/integration-suite-server-coverage.md` §7
+    "Locked invariants" for why splitting these signals is necessary
+    to make the suite safe to run against dev binaries.
     """
     ceiling = DEFAULT_AGENT_P50_MS[shed_server.backend]
     run_id = hashlib.sha256(
@@ -158,6 +207,7 @@ def test_plain_create_timing(shed_server):
     # store (image pull + erofs conversion) that's irrelevant to
     # boot-time tracking.
     samples: list[int] = []
+    fallback_seen = False
     for i in range(6):  # 1 warm-up + 5 measured
         name = f"itest-perf-{shed_server.backend}-{run_id}-{i}"
         handle = shed_server.create(name, image="base")
@@ -167,6 +217,8 @@ def test_plain_create_timing(shed_server):
                     "PhaseTimer not available; see "
                     "`test_phase_timer_emitted` for the underlying reason."
                 )
+            if handle.template_fallback:
+                fallback_seen = True
             if i > 0:  # skip the warm-up sample
                 samples.append(handle.timings.agent_ms)
         finally:
@@ -175,10 +227,85 @@ def test_plain_create_timing(shed_server):
         # release (vsock CID, TAP device) settles before re-use.
         time.sleep(1)
 
+    if fallback_seen:
+        pytest.skip(
+            f"at least one sample used the VZ in-guest mkfs.ext4 "
+            f"fallback (log marker '[<name>] upper template unavailable' "
+            f"present). agent_p50 is inflated by ~4 s on VZ dev builds "
+            f"because the in-guest mkfs lands inside the agent phase; "
+            f"the gate would fire for a structural reason, not a real "
+            f"regression. Set SHED_BUILD_TOOLS_REF on the shed-server "
+            f"process (e.g. via `launchctl setenv SHED_BUILD_TOOLS_REF "
+            f"ghcr.io/charliek/shed-build-tools:vX.Y.Z` + "
+            f"`brew services restart shed`) or run a release binary "
+            f"to exercise the fast path. samples_collected={samples}"
+        )
+
     p50 = int(statistics.median(samples))
     assert p50 < ceiling, (
         f"agent p50 regressed on {shed_server.backend}: "
         f"{p50}ms >= {ceiling}ms ceiling; samples={samples}"
+    )
+
+
+def test_create_rootfs_template_present(shed_server, test_shed_name):
+    """The VZ upper-template fast-path (pre-formatted template clone) is active.
+
+    Release builds embed a `SHED_BUILD_TOOLS_REF` and the VZ
+    orchestrator's `AllocateUpper` clones a pre-formatted ext4 template
+    on the host — no in-guest mkfs needed. Dev builds (or release
+    builds with the env var unset) fall back to writing a raw upper
+    and letting the in-guest initramfs `mkfs.ext4` on first boot,
+    which costs ~4 s on the agent critical path. The server log line
+    `[<name>] upper template unavailable (...); formatting in guest`
+    (`internal/vz/orchestrator.go:249`) is the canonical "fast path
+    NOT active" signal, surfaced as `ShedHandle.template_fallback`.
+
+    This test:
+      - Skips on FC: `internal/firecracker/orchestrator.go:AllocateUpper`
+        has no template path; FC always uses in-guest mkfs and its
+        agent ceiling already accommodates that cost.
+      - Skips on VZ dev mode: `template_fallback` is True → log says
+        the fast path was unavailable.
+      - On VZ release mode: asserts the host-side host phase
+        (`rootfs_ms`) is sub-100 ms as a sanity check that the
+        template clone actually happened fast.
+
+    See `docs/discovery/integration-suite-server-coverage.md` §7
+    "Locked invariants" for why this divergence is intentional.
+    """
+    if shed_server.backend != "vz":
+        pytest.skip(
+            f"backend={shed_server.backend!r} has no host-side "
+            f"upper-template fast path; only VZ uses it (see "
+            f"`internal/firecracker/orchestrator.go:AllocateUpper`)."
+        )
+    handle = shed_server.create(test_shed_name, image="base")
+    if handle.timings is None or handle.timings.rootfs_ms is None:
+        pytest.skip(
+            "PhaseTimer / rootfs phase not available; see "
+            "`test_phase_timer_emitted` for the underlying reason."
+        )
+    if handle.template_fallback:
+        pytest.skip(
+            "VZ upper-template fast path not active — log emitted "
+            "'upper template unavailable ...; formatting in guest' "
+            "(see `internal/vz/orchestrator.go:249`). Dev binaries "
+            "intentionally don't embed a shed-build-tools image ref "
+            "(see `internal/version/buildtools.go:BuildToolsRefForTag`); "
+            "set SHED_BUILD_TOOLS_REF on the shed-server process or "
+            "run a release binary to exercise the fast path. See "
+            "docs/discovery/integration-suite-server-coverage.md §7."
+        )
+    rootfs_ms = handle.timings.rootfs_ms
+    assert rootfs_ms <= ROOTFS_TEMPLATE_FAST_PATH_CEILING_MS, (
+        f"VZ rootfs fast-path regressed: rootfs={rootfs_ms}ms > "
+        f"{ROOTFS_TEMPLATE_FAST_PATH_CEILING_MS}ms ceiling. The host-side "
+        f"template clone + sibling-swap should be sub-100ms on a healthy "
+        f"reflink-capable FS; a regression here suggests a silent "
+        f"clone-to-full-copy fallback or a slow stat path. Bisect "
+        f"against `internal/vz/uppertemplate.go` and "
+        f"`internal/vz/orchestrator.go:AllocateUpper`."
     )
 
 

--- a/tests/integration/test_timing_parser.py
+++ b/tests/integration/test_timing_parser.py
@@ -98,6 +98,23 @@ def test_agent_ms_convenience_property():
     assert t["agent"] == 7
 
 
+def test_rootfs_ms_convenience_property():
+    """`rootfs_ms` mirrors `agent_ms`: returns the phase value if
+    present, else None. The split timing gate's
+    `test_create_rootfs_template_present` uses it to discriminate the
+    template-clone fast path (sub-100 ms) from the in-guest mkfs
+    fallback (multi-second)."""
+    with_rootfs = "timing: create name=x backend=vz total=10ms rootfs=7ms err=<nil>"
+    t = parse_timing_line(with_rootfs)
+    assert t is not None
+    assert t.rootfs_ms == 7
+
+    without_rootfs = "timing: create name=x backend=vz total=10ms agent=7ms err=<nil>"
+    t2 = parse_timing_line(without_rootfs)
+    assert t2 is not None
+    assert t2.rootfs_ms is None
+
+
 def test_duplicate_phase_keys_are_summed():
     """Duplicate phase keys on the same line SUM, matching the physical
     semantic ("total time spent in this phase"). See timing.py docstring


### PR DESCRIPTION
## What

Replaces the single `test_plain_create_timing` regression gate with two narrower gates that don't false-positive when the suite runs against a dev binary:

| Test | Asserts | Skips when |
|---|---|---|
| `test_create_agent_p50` | `agent` phase p50 (5 samples) ≤ per-backend ceiling | Any sample triggered `template_fallback` (VZ in-guest mkfs cost inflates `agent_ms` by ~4 s, structural not regression). |
| `test_create_rootfs_template_present` | `rootfs_ms ≤ 100 ms` (host-side template-clone sanity) | Backend is FC (no host-side template path), or `template_fallback` is set (VZ dev mode). |

**Discriminator:** the server log line `[<name>] upper template unavailable (...); formatting in guest` emitted from `internal/vz/orchestrator.go:249` whenever the host-side VZ template clone is unavailable. Surfaced as `ShedHandle.template_fallback`; `_read_timing` scans the same log blob it was already reading for the PhaseTimer line — no extra cost.

## Why

`docs/discovery/integration-suite-server-coverage.md` §7 has the full background. Short version: every recent server-side PR (PR-A1 #151, PR-A2 #152, PR-B1 #153, PR-B2 #154, PR #156) shipped with "make test-integration: N/N pass" in its body. That was technically true and structurally meaningless — the suite was running against the OLD brew/deb binary, never exercising the new server code. The old single timing gate fired at agent_p50 ~5800 ms when developers tried to swap in a dev binary for actual validation, so they reverted to "trust the unit tests" instead of fixing the gap.

This is the first of three PRs that close the gap (see plan at `~/.claude/plans/patient-bridging-heron.md`). PR 1 makes the timing gates safe against dev binaries; PRs 2 + 3 add `make test-integration-local` (Mac VZ) and `make test-integration-local-fc` (mini3 FC SSH) targets that automate the binary swap.

## Design correction surfaced during validation

The plan as written hypothesised the in-guest mkfs cost would show up in `rootfs_ms`. Empirical validation (checkpoint c against a dev binary, env var unset) proved it shows up in `agent_ms` instead — `rootfs_ms` stayed 5-8 ms in both modes because that phase only covers host-side allocation. The agent phase doesn't end until the kernel/initramfs finishes mkfs and the agent can dial. I redesigned per the plan's §4.3 "validation reveals the FIX changes the design" clause, using the log marker as the discriminator instead of `rootfs_ms`. The plan at `~/.claude/plans/patient-bridging-heron.md` §1.1 and §1.4 has been updated in-place to reflect the corrected design.

## Validation Results

All 5 checkpoints from plan §1.3 green:

| # | Scenario | Outcome |
|---|---|---|
| a | Brew release v0.5.8 binary | 42 pass, 1 skip (FC template — by design) |
| b | Dev binary (`v0.5.8-9-g97888c1-dirty`) + `SHED_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:v0.5.8` | 42 pass, 1 skip |
| c | Dev binary, `SHED_BUILD_TOOLS_REF` unset | 40 pass, 3 skip (VZ agent_p50 + VZ rootfs_template skip with dev-mode message; FC template skip). `samples_collected=[5853, 5851, 5652, 5653, 6152]` ms — confirms the ~4 s in-guest mkfs cost the plan warned about. |
| d | Restored brew binary | 42 pass, 1 skip |
| e | `SHED_FC_HOST=mini3` against mini3 v0.5.8 deb | Covered by every parameterized run above (FC tests ran fine). |

`make check` clean.

## What's NOT in this PR

- The `make test-integration-local` Makefile target — that's PR 2.
- The `make test-integration-local-fc` Makefile target — that's PR 3.
- Any server-side code change. PR 1 is test-side only.
- Updates to `docs/discovery/integration-suite-server-coverage.md` — those happen in a follow-up session per plan §9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Split a single timing regression check into two focused timing tests (agent latency and template-rootfs timing).
  * Added detection of a template-fallback mode to skip or select appropriate timing assertions.
  * Added a convenience timing property and a parser test to expose rootfs timing when present.

* **Chores**
  * Updated integration test docs and fixtures and raised the minimum test-server version required for certain timing checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->