### PR TITLE
build: add make install-local-server / restore-brew-server / test-integration-local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,12 +130,20 @@ restore-brew-server:
 	  Darwin) ;; \
 	  *) echo "ERROR: restore-brew-server is macOS-only; see install-local-server."; exit 1 ;; \
 	esac
+	@# Always clear the launchctl env var, even in the no-backup branch:
+	@# install-local-server sets the env var ALONGSIDE creating the
+	@# backup, so a stranded env (manual setenv, partial-failure run, or
+	@# a backup that someone rm'd by hand) is the case where "restore"
+	@# is most likely to be invoked. Skipping the unset there would
+	@# leave the dev binary's behavior wired into the brew binary's
+	@# next start.
+	@launchctl unsetenv SHED_BUILD_TOOLS_REF
 	@# Single shell block so the no-op branch can short-circuit cleanly
 	@# (a separate `@if ... exit 0` line only exits its sub-shell, not
 	@# the recipe — make would continue running the restore steps even
 	@# though there's no backup to restore from).
 	@if [ ! -f "$(BACKUP_PATH)" ]; then \
-	  echo "No backup at $(BACKUP_PATH); nothing to restore. (Idempotent: this is OK.)"; \
+	  echo "No backup at $(BACKUP_PATH); nothing to restore (env var cleared anyway). (Idempotent: this is OK.)"; \
 	else \
 	  set -e; \
 	  brew services stop shed; \
@@ -143,18 +151,29 @@ restore-brew-server:
 	  cp -f "$(BACKUP_PATH)" "$(BREW_SHED_BIN)"; \
 	  codesign --force -s - "$(BREW_SHED_BIN)"; \
 	  chmod -w "$(BREW_SHED_BIN)"; \
-	  launchctl unsetenv SHED_BUILD_TOOLS_REF; \
 	  brew services start shed; \
 	  rm -f "$(BACKUP_PATH)"; \
 	  echo "Brew shed-server restored from backup; backup removed."; \
 	fi
 
 # Chain: install dev binary locally, run the integration suite against
-# it, restore the brew binary REGARDLESS of suite outcome. The
-# restore step runs in a sub-make of restore-brew-server so a suite
-# failure doesn't strand the host on the dev binary.
+# it, restore the brew binary REGARDLESS of suite outcome. Captures
+# BOTH the suite and the restore exit codes — a restore failure is at
+# least as serious as a suite failure (it strands the host), so the
+# chain target reports non-zero if either step fails.
 test-integration-local: install-local-server
-	@$(MAKE) test-integration; STATUS=$$?; $(MAKE) restore-brew-server; exit $$STATUS
+	@$(MAKE) test-integration; SUITE=$$?; \
+	 $(MAKE) restore-brew-server; RESTORE=$$?; \
+	 if [ $$SUITE -ne 0 ] && [ $$RESTORE -ne 0 ]; then \
+	   echo "test-integration-local: suite FAILED (exit $$SUITE) AND restore FAILED (exit $$RESTORE); inspect host state"; \
+	   exit $$SUITE; \
+	 elif [ $$SUITE -ne 0 ]; then \
+	   echo "test-integration-local: suite FAILED (exit $$SUITE); restore succeeded"; \
+	   exit $$SUITE; \
+	 elif [ $$RESTORE -ne 0 ]; then \
+	   echo "test-integration-local: suite passed BUT restore FAILED (exit $$RESTORE); inspect host state"; \
+	   exit $$RESTORE; \
+	 fi
 
 # Cross-compile for release
 release:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-cli build-server build-agent build-firstboot build-tools test test-integration release clean dev-server dev-cli check check-kernel-pin coverage lint-all docs docs-serve firecracker-rootfs download-firecracker vz-rootfs vz-rootfs-base vz-rootfs-all
+.PHONY: build build-cli build-server build-agent build-firstboot build-tools test test-integration test-integration-local install-local-server restore-brew-server release clean dev-server dev-cli check check-kernel-pin coverage lint-all docs docs-serve firecracker-rootfs download-firecracker vz-rootfs vz-rootfs-base vz-rootfs-all
 
 GOARCH ?= $(shell go env GOARCH)
 
@@ -44,6 +44,117 @@ test-integration:
 	  exit 1; \
 	}
 	cd tests/integration && uv sync && uv run pytest -v
+
+# Local dev-binary swap + integration suite + restore (Mac VZ only).
+#
+# Closes the integration-suite-server-coverage gap documented in
+# docs/discovery/integration-suite-server-coverage.md: by default
+# `make test-integration` runs against whichever shed-server binary is
+# currently installed (typically the brew release), so server-side PRs
+# can pass the suite without exercising their own code. These targets
+# swap in the just-built dev binary, run the suite against it, and
+# restore the brew binary regardless of suite outcome.
+#
+# Discovery surfaced during PR-B1 (#153) and formalised in
+# ~/.claude/plans/patient-bridging-heron.md §2. The corresponding FC
+# remote (mini3 via SSH) workflow lives in PR 3's
+# `test-integration-local-fc` target.
+
+# Brew install paths. Resolved dynamically because the Cellar version
+# changes per release; we don't want to hardcode a stale path.
+# All three variables collapse to empty when brew shed isn't installed;
+# the install-local-server recipe checks that before doing anything
+# destructive.
+BREW_SHED_PREFIX := $(shell brew --prefix shed 2>/dev/null)
+BREW_VERSION := $(shell test -n "$(BREW_SHED_PREFIX)" && basename "$$(readlink "$(BREW_SHED_PREFIX)" 2>/dev/null)" 2>/dev/null)
+BREW_SHED_BIN := $(BREW_SHED_PREFIX)/bin/shed-server
+BACKUP_PATH := /tmp/shed-server-v$(BREW_VERSION).bak
+
+# shed-build-tools image ref to inject when the dev binary runs.
+# Dev binaries embed Version="vX.Y.Z-N-gHASH-dirty", which
+# BuildToolsRefForTag returns "" for by design (dev-build isolation —
+# see docs/discovery/integration-suite-server-coverage.md §7). Without
+# the env var the dev binary falls back to in-guest mkfs.ext4 on first
+# boot (~4 s on VZ), which the split timing gate (PR #157) skips
+# cleanly but it's still not the path we want when validating server
+# changes against release-shaped behavior. Override with
+# `RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:vX.Y.Z`
+# to pin to a non-latest release.
+RELEASE_BUILD_TOOLS_REF ?= $(shell git tag --list 'v*' --sort=-version:refname | head -1 | sed 's|^|ghcr.io/charliek/shed-build-tools:|')
+
+# Swap the just-built bin/shed-server into the brew Cellar, codesign
+# ad-hoc (launchd SIGKILLs unsigned binaries), set SHED_BUILD_TOOLS_REF
+# in the user's launchd domain, and restart the brew service.
+# Refuses to clobber an existing backup unless FORCE=1, so a developer
+# who runs this twice doesn't lose the original brew binary.
+install-local-server: build
+	@case "$$(uname -s)" in \
+	  Darwin) ;; \
+	  *) echo "ERROR: install-local-server targets the brew-installed shed-server on macOS;"; \
+	     echo "       run this on a Mac. For the FC remote (mini3) workflow see"; \
+	     echo "       'make install-remote-server' (planned for PR 3)."; exit 1 ;; \
+	esac
+	@if [ -z "$(BREW_VERSION)" ]; then \
+	  echo "ERROR: brew shed is not installed (or 'brew --prefix shed' failed)."; \
+	  echo "       Install with 'brew install charliek/shed/shed' and retry."; exit 1; \
+	fi
+	@if [ -f "$(BACKUP_PATH)" ] && [ "$(FORCE)" != "1" ]; then \
+	  echo "ERROR: backup already exists at $(BACKUP_PATH)."; \
+	  echo "       Run 'make restore-brew-server' first, or pass FORCE=1 to overwrite"; \
+	  echo "       (FORCE=1 is destructive — the existing backup is lost)."; exit 1; \
+	fi
+	@cp -f "$(BREW_SHED_BIN)" "$(BACKUP_PATH)"
+	@brew services stop shed
+	@chmod +w "$(BREW_SHED_BIN)"
+	@cp -f bin/shed-server "$(BREW_SHED_BIN)"
+	@# --force lets us re-sign cleanly on subsequent runs without
+	@# tripping codesign's "is already signed" error. macOS launchd
+	@# SIGKILLs unsigned binaries so this step is non-optional.
+	@codesign --force -s - "$(BREW_SHED_BIN)"
+	@chmod -w "$(BREW_SHED_BIN)"
+	@launchctl setenv SHED_BUILD_TOOLS_REF "$(RELEASE_BUILD_TOOLS_REF)"
+	@brew services start shed
+	@echo ""
+	@echo "Dev shed-server installed in brew Cellar at $(BREW_SHED_BIN)."
+	@echo "Build-tools ref: $(RELEASE_BUILD_TOOLS_REF)"
+	@echo "Backup at $(BACKUP_PATH)."
+	@echo "Run 'make restore-brew-server' to revert (or it runs automatically"
+	@echo "at the end of 'make test-integration-local')."
+
+# Reverse of install-local-server: restore the brew binary from the
+# backup, clear the launchctl env var, restart the brew service, and
+# remove the backup file. Idempotent — re-running after a successful
+# restore is a no-op with a clear message.
+restore-brew-server:
+	@case "$$(uname -s)" in \
+	  Darwin) ;; \
+	  *) echo "ERROR: restore-brew-server is macOS-only; see install-local-server."; exit 1 ;; \
+	esac
+	@# Single shell block so the no-op branch can short-circuit cleanly
+	@# (a separate `@if ... exit 0` line only exits its sub-shell, not
+	@# the recipe — make would continue running the restore steps even
+	@# though there's no backup to restore from).
+	@if [ ! -f "$(BACKUP_PATH)" ]; then \
+	  echo "No backup at $(BACKUP_PATH); nothing to restore. (Idempotent: this is OK.)"; \
+	else \
+	  set -e; \
+	  brew services stop shed; \
+	  chmod +w "$(BREW_SHED_BIN)"; \
+	  cp -f "$(BACKUP_PATH)" "$(BREW_SHED_BIN)"; \
+	  codesign --force -s - "$(BREW_SHED_BIN)"; \
+	  chmod -w "$(BREW_SHED_BIN)"; \
+	  launchctl unsetenv SHED_BUILD_TOOLS_REF; \
+	  brew services start shed; \
+	  rm -f "$(BACKUP_PATH)"; \
+	  echo "Brew shed-server restored from backup; backup removed."; \
+	fi
+
+# Chain: install dev binary locally, run the integration suite against
+# it, restore the brew binary REGARDLESS of suite outcome. The
+# restore step runs in a sub-make of restore-brew-server so a suite
+# failure doesn't strand the host on the dev binary.
+test-integration-local: install-local-server
+	@$(MAKE) test-integration; STATUS=$$?; $(MAKE) restore-brew-server; exit $$STATUS
 
 # Cross-compile for release
 release:

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -194,9 +194,13 @@ RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:v0.5.7 \
 ```
 
 The FC remote (mini3 over SSH) sibling — `make
-test-integration-local-fc` — closes the same gap on the Firecracker
-backend. Tracked in
-`docs/discovery/integration-suite-server-coverage.md` §5 Option 1b.
+test-integration-local-fc` — will close the same gap on the
+Firecracker backend. **Planned for a follow-up PR** (not yet in the
+repo); tracked in `docs/discovery/integration-suite-server-coverage.md`
+§5 Option 1b. Until it lands, validate FC server-side changes via the
+manual swap on `$SHED_FC_HOST` (cross-compile +
+`scp` + systemd unit override + restore — see the discovery doc for
+the full sequence).
 
 ## What this suite is *not*
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -145,6 +145,59 @@ def test_only_on_fc(fc_server, ...):
 (Markers are declared in `pyproject.toml` under
 `[tool.pytest.ini_options].markers` — keep them in sync.)
 
+## Validating server-side changes (VZ local)
+
+By default `make test-integration` runs against whichever `shed-server`
+binary is currently *installed* on the host (typically the brew
+release). A server-side-only PR — orchestrator change, lifecycle
+internals, backend handler refactor — can pass that suite without ever
+exercising its own code, because the installed binary is the OLD one.
+
+`make test-integration-local` closes that gap on the local Mac (VZ):
+
+```sh
+make test-integration-local
+```
+
+That target:
+
+1. `install-local-server` — builds `bin/shed-server`, backs up the
+   brew binary to `/tmp/shed-server-vN.M.K.bak`, swaps the dev
+   binary into the brew Cellar, ad-hoc-codesigns it (launchd
+   SIGKILLs unsigned binaries), sets `SHED_BUILD_TOOLS_REF` to the
+   latest release tag (so the dev binary uses the release-shaped
+   pre-formatted-template fast path instead of the in-guest mkfs
+   fallback — see the split-gate explanation above), and restarts
+   the brew service.
+2. `test-integration` — runs the full suite against the dev binary.
+3. `restore-brew-server` — restores the brew binary from the backup,
+   clears the env var, restarts the brew service, removes the
+   backup. Runs unconditionally (even if the suite fails).
+
+Run `make install-local-server` and `make restore-brew-server`
+standalone if you want to drive the suite manually between the swap
+and restore (e.g. for an ad-hoc `shed create` repro against the dev
+binary). Both are macOS-only and idempotent:
+
+- `install-local-server` refuses to overwrite an existing backup
+  without `FORCE=1` (so a developer who runs it twice doesn't lose
+  the original).
+- `restore-brew-server` is a no-op when no backup exists.
+
+`RELEASE_BUILD_TOOLS_REF` defaults to the latest `git tag` matching
+`v*`. Override to pin to an older release if your source has drifted
+from `main`:
+
+```sh
+RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:v0.5.7 \
+  make install-local-server
+```
+
+The FC remote (mini3 over SSH) sibling — `make
+test-integration-local-fc` — closes the same gap on the Firecracker
+backend. Tracked in
+`docs/discovery/integration-suite-server-coverage.md` §5 Option 1b.
+
 ## What this suite is *not*
 
 - Not a replacement for the Go unit tests (`make test`) — those run on


### PR DESCRIPTION
## What

Three new Makefile targets that close the local-Mac half of the integration-suite-server-coverage gap documented in `docs/discovery/integration-suite-server-coverage.md`:

| Target | Mac-only? | Idempotent? | What it does |
|---|---|---|---|
| `install-local-server` | yes | refuses to clobber without `FORCE=1` | builds dev binary, backs up brew binary, swaps + codesigns + sets `SHED_BUILD_TOOLS_REF`, restarts brew |
| `restore-brew-server` | yes | yes (no-op when no backup) | restores brew binary, clears env, restarts brew, removes backup |
| `test-integration-local` | yes (transitively) | yes (chain) | install → suite → restore. Restore runs unconditionally so a suite failure can't strand the host. |

`RELEASE_BUILD_TOOLS_REF` defaults to the latest `git tag` matching `v*`; override to pin: `RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:v0.5.7 make install-local-server`.

Brew paths are detected dynamically (`brew --prefix shed` + `readlink`) so the Cellar version isn't hardcoded.

## Why

By default `make test-integration` runs against whichever `shed-server` binary is currently *installed* on the host — typically the brew release. A server-side-only PR (orchestrator change, lifecycle internals, backend handler refactor) can pass that suite without ever exercising its own code, because the installed binary is the OLD one. PR-A1 (#151), PR-A2 (#152), PR-B1 (#153), PR-B2 (#154), PR #156 all opened with "make test-integration: N/N pass" while structurally not testing their own code.

This is PR 2 of the three-PR plan at `~/.claude/plans/patient-bridging-heron.md`. PR 1 (#157) made the timing gates safe against dev binaries; this PR makes the swap-then-restore-then-run flow one command on Mac VZ; PR 3 will do the same for FC over SSH.

## Implementation notes

Two bugs surfaced during validation and were fixed before push:

1. **`codesign -s -` on an already-signed binary errors with "is already signed".** The restore path copies the backup (which IS the signed brew binary — signature lives in the Mach-O's `__CODE_SIGNATURE` segment, copied byte-for-byte), then tries to codesign it. Fixed by `codesign --force -s -`. Without `--force`, the recipe failed midway and left the host stranded with the brew binary restored but the env var still set and the service stopped.

2. **`@if ... exit 0; fi` only exits its sub-shell, not the recipe.** Each `@command` line in a make recipe is a separate shell invocation. `exit 0` in a sub-shell just exits THAT sub-shell, and make continues to the next line — so `restore-brew-server`'s "no backup, nothing to do" branch was firing `exit 0` *and then* trying to `brew services stop shed` + `cp` a non-existent backup. Fixed by combining the conditional + the body into one shell block.

Per plan §4.3 ("validation reveals the FIX changes the design"), I re-ran the full §2.2 gate from checkpoint a after each fix.

## Validation Results

All 6 checkpoints per plan §2.2 green:

| # | Scenario | Outcome |
|---|---|---|
| a | Cold-state install | Dev binary `v0.5.8-10-g9503ed7-dirty` swapped in; `SHED_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:v0.5.8` set; `/tmp/shed-server-v0.5.8.bak` created. |
| b | Idempotent install guard | Second install errors with `ERROR: backup already exists ... Run 'make restore-brew-server' first, or pass FORCE=1`. |
| c | Restore + idempotent re-run | First restore brings brew `v0.5.8 commit 8f37f58` back, clears env, removes backup. Second restore prints `No backup ...; nothing to restore. (Idempotent: this is OK.)` and exits 0. |
| d | Chained happy path (`make test-integration-local`) | 42 pass + 1 FC-template skip; restore ran cleanly at end; host state clean afterward. |
| e | Chained failure path (conftest.py injection: `raise RuntimeError(...)` at module top) | Pytest exited `Error 4` immediately; chain captured + re-emitted via `Error 2`; restore still ran; backup gone; env cleared; brew binary back. Injection reverted before commit. |
| f | Dogfood against PR #156's `RestoreStoppedMetadata` path | Created `repro-pr2 --local-dir /tmp/repro-dir-pr2`, stopped, `rm -rf` the local-dir, attempted start → failed with `"agent health check failed: context deadline exceeded"`, `shed list` showed `status=stopped` IMMEDIATELY (not stuck at running). Proof that the new infrastructure exercises server-side changes — PR #156's fix was live on the dev binary. |

`make check` clean.

## What's NOT in this PR

- `make test-integration-local-fc` for the FC remote (mini3 over SSH) workflow — that's PR 3.
- Any server-side code change. PR 2 is build-tooling only.
- Updates to `docs/discovery/integration-suite-server-coverage.md` — those happen in a follow-up session per plan §9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local macOS integration testing workflow to run tests against a freshly built development server with automated swap, backup, codesign, and service restart, plus an idempotent restore.

* **Documentation**
  * Added guide for validating server-side changes locally on macOS, including the local test flow and restore behavior.

* **Chores**
  * Added make targets and build config updates to support the local testing and restore workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->