### PR TITLE
build: add make install-remote-server / restore-remote-server / test-integration-local-fc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,13 @@ test-integration:
 # remote (mini3 via SSH) workflow lives in PR 3's
 # `test-integration-local-fc` target.
 
+# Shed CLI entry name for the local VZ server (the entry in
+# `~/.shed/config.yaml`). Mirrors the integration suite's
+# `SHED_VZ_SERVER` env var (see tests/integration/conftest.py); the
+# install-local-server readiness probe uses this so a developer with
+# a non-default VZ entry name still gets a useful ready signal.
+SHED_VZ_SERVER ?= my-server
+
 # Brew install paths. Resolved dynamically because the Cellar version
 # changes per release; we don't want to hardcode a stale path.
 # All three variables collapse to empty when brew shed isn't installed;
@@ -91,8 +98,8 @@ install-local-server: build
 	@case "$$(uname -s)" in \
 	  Darwin) ;; \
 	  *) echo "ERROR: install-local-server targets the brew-installed shed-server on macOS;"; \
-	     echo "       run this on a Mac. For the FC remote (mini3) workflow see"; \
-	     echo "       'make install-remote-server' (planned for PR 3)."; exit 1 ;; \
+	     echo "       run this on a Mac. For the FC remote ($(FC_REMOTE_HOST)) workflow see"; \
+	     echo "       'make install-remote-server'."; exit 1 ;; \
 	esac
 	@if [ -z "$(BREW_VERSION)" ]; then \
 	  echo "ERROR: brew shed is not installed (or 'brew --prefix shed' failed)."; \
@@ -120,11 +127,11 @@ install-local-server: build
 	@# integration suite uses) or 15 s elapses. Without this the suite
 	@# silently skips all VZ tests with "shed-server not reachable."
 	@for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do \
-	  if shed -s my-server list >/dev/null 2>&1; then \
-	    echo "VZ shed-server ready after $${i}s."; break; \
+	  if shed -s $(SHED_VZ_SERVER) list >/dev/null 2>&1; then \
+	    echo "VZ shed-server ($(SHED_VZ_SERVER)) ready after $${i}s."; break; \
 	  fi; \
 	  if [ "$$i" = "15" ]; then \
-	    echo "WARNING: VZ shed-server not reachable after 15 s; integration suite may skip VZ tests."; \
+	    echo "WARNING: VZ shed-server ($(SHED_VZ_SERVER)) not reachable after 15 s; integration suite may skip VZ tests."; \
 	  fi; \
 	  sleep 1; \
 	done
@@ -176,7 +183,7 @@ restore-brew-server:
 # least as serious as a suite failure (it strands the host), so the
 # chain target reports non-zero if either step fails.
 test-integration-local: install-local-server
-	@$(MAKE) test-integration; SUITE=$$?; \
+	@SHED_VZ_SERVER=$(SHED_VZ_SERVER) $(MAKE) test-integration; SUITE=$$?; \
 	 $(MAKE) restore-brew-server; RESTORE=$$?; \
 	 if [ $$SUITE -ne 0 ] && [ $$RESTORE -ne 0 ]; then \
 	   echo "test-integration-local: suite FAILED (exit $$SUITE) AND restore FAILED (exit $$RESTORE); inspect host state"; \
@@ -210,6 +217,14 @@ FC_REMOTE_HOST ?= $(or $(SHED_FC_HOST),mini3)
 FC_REMOTE_BIN_PATH ?= /usr/local/bin/shed-server
 FC_REMOTE_BACKUP := /tmp/shed-server-deb.bak
 FC_REMOTE_ENVOVERRIDE := /etc/systemd/system/shed-server.service.d/dev-override.conf
+
+# Shed CLI entry name for the FC server. Mirrors the integration
+# suite's `SHED_FC_SERVER` env var (see tests/integration/conftest.py):
+# defaults to `$(FC_REMOTE_HOST)` (the same string), but a developer
+# whose `~/.shed/config.yaml` entry differs from the SSH hostname can
+# override with SHED_FC_SERVER=... to align both the readiness probe
+# AND the chain target's suite invocation.
+SHED_FC_SERVER ?= $(FC_REMOTE_HOST)
 
 # Cross-compile shed-server for the remote host's GOARCH. Detects arch
 # at recipe time via `ssh <host> uname -m`; refuses to silently default
@@ -263,11 +278,11 @@ install-remote-server: build-fc-remote-server
 	@# probe) so the chain target's suite invocation doesn't race the
 	@# startup and skip all FC tests.
 	@for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do \
-	  if shed -s $(FC_REMOTE_HOST) list >/dev/null 2>&1; then \
-	    echo "Remote FC shed-server on $(FC_REMOTE_HOST) ready after $${i}s."; break; \
+	  if shed -s $(SHED_FC_SERVER) list >/dev/null 2>&1; then \
+	    echo "Remote FC shed-server ($(SHED_FC_SERVER) on $(FC_REMOTE_HOST)) ready after $${i}s."; break; \
 	  fi; \
 	  if [ "$$i" = "15" ]; then \
-	    echo "WARNING: $(FC_REMOTE_HOST) shed-server not reachable after 15 s; integration suite may skip FC tests."; \
+	    echo "WARNING: FC shed-server ($(SHED_FC_SERVER) on $(FC_REMOTE_HOST)) not reachable after 15 s; integration suite may skip FC tests."; \
 	  fi; \
 	  sleep 1; \
 	done
@@ -311,7 +326,7 @@ restore-remote-server:
 # test-integration-local: surfaces a restore failure separately
 # rather than silently swallowing it.
 test-integration-local-fc: install-remote-server
-	@SHED_FC_HOST=$(FC_REMOTE_HOST) $(MAKE) test-integration; SUITE=$$?; \
+	@SHED_FC_HOST=$(FC_REMOTE_HOST) SHED_FC_SERVER=$(SHED_FC_SERVER) $(MAKE) test-integration; SUITE=$$?; \
 	 $(MAKE) restore-remote-server; RESTORE=$$?; \
 	 if [ $$SUITE -ne 0 ] && [ $$RESTORE -ne 0 ]; then \
 	   echo "test-integration-local-fc: suite FAILED (exit $$SUITE) AND restore FAILED (exit $$RESTORE); inspect $(FC_REMOTE_HOST) state"; \

--- a/Makefile
+++ b/Makefile
@@ -182,8 +182,19 @@ restore-brew-server:
 # BOTH the suite and the restore exit codes — a restore failure is at
 # least as serious as a suite failure (it strands the host), so the
 # chain target reports non-zero if either step fails.
-test-integration-local: install-local-server
-	@SHED_VZ_SERVER=$(SHED_VZ_SERVER) $(MAKE) test-integration; SUITE=$$?; \
+# install-local-server is invoked from the recipe body (not as a make
+# prerequisite) so that a partial-failure install — backup created but
+# brew restart fails, codesign hiccup, etc. — still runs the restore
+# step. A make prerequisite would halt the recipe before it reaches
+# the restore block, leaving the host stranded.
+test-integration-local:
+	@$(MAKE) install-local-server; INSTALL=$$?; \
+	 if [ $$INSTALL -ne 0 ]; then \
+	   echo "test-integration-local: install FAILED (exit $$INSTALL); attempting restore for safety"; \
+	   $(MAKE) restore-brew-server; \
+	   exit $$INSTALL; \
+	 fi; \
+	 SHED_VZ_SERVER=$(SHED_VZ_SERVER) $(MAKE) test-integration; SUITE=$$?; \
 	 $(MAKE) restore-brew-server; RESTORE=$$?; \
 	 if [ $$SUITE -ne 0 ] && [ $$RESTORE -ne 0 ]; then \
 	   echo "test-integration-local: suite FAILED (exit $$SUITE) AND restore FAILED (exit $$RESTORE); inspect host state"; \
@@ -258,21 +269,29 @@ install-remote-server: build-fc-remote-server
 	@if [ -z "$(RELEASE_BUILD_TOOLS_REF)" ]; then \
 	  echo "ERROR: RELEASE_BUILD_TOOLS_REF is empty; can't infer from git tag."; \
 	  echo "       Either tag this repo (git tag --list 'v*' returned nothing)"; \
-	  echo "       or override: RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:vX.Y.Z"; exit 1; \
+	  echo "       or override: shed-build-tools image ref"; exit 1; \
 	fi
-	@ssh -o BatchMode=yes -o ConnectTimeout=5 $(FC_REMOTE_HOST) \
-	  "test ! -f $(FC_REMOTE_BACKUP) || ( [ '$(FORCE)' = '1' ] || \
-	   ( echo 'ERROR: backup already exists at $(FC_REMOTE_HOST):$(FC_REMOTE_BACKUP); run make restore-remote-server first, or pass FORCE=1' && exit 1 ) )"
-	@scp bin/shed-server-fc-remote $(FC_REMOTE_HOST):/tmp/shed-server-dev
-	@ssh -o BatchMode=yes $(FC_REMOTE_HOST) "set -e; \
-	  sudo cp $(FC_REMOTE_BIN_PATH) $(FC_REMOTE_BACKUP); \
-	  sudo systemctl stop shed-server; \
-	  sudo install -m 755 /tmp/shed-server-dev $(FC_REMOTE_BIN_PATH); \
-	  sudo mkdir -p $$(dirname $(FC_REMOTE_ENVOVERRIDE)); \
-	  printf '[Service]\nEnvironment=SHED_BUILD_TOOLS_REF=$(RELEASE_BUILD_TOOLS_REF)\n' | sudo tee $(FC_REMOTE_ENVOVERRIDE) > /dev/null; \
-	  sudo systemctl daemon-reload; \
-	  sudo systemctl start shed-server; \
-	  rm -f /tmp/shed-server-dev"
+	@# Use a PID-unique tmp path on the remote so two concurrent
+	@# install-remote-server runs on the same host don't clobber each
+	@# other's uploaded binary at /tmp/shed-server-dev. Belt-and-suspenders
+	@# — the dev workstation is single-user — but the cost is one $$
+	@# substitution.
+	@TMP=/tmp/shed-server-dev.$$$$; \
+	 scp bin/shed-server-fc-remote $(FC_REMOTE_HOST):$$TMP && \
+	 ssh -o BatchMode=yes $(FC_REMOTE_HOST) "set -e; \
+	   if [ -f $(FC_REMOTE_BACKUP) ] && [ '$(FORCE)' != '1' ]; then \
+	     echo 'ERROR: backup already exists at $(FC_REMOTE_HOST):$(FC_REMOTE_BACKUP); run make restore-remote-server first, or pass FORCE=1'; \
+	     rm -f $$TMP; \
+	     exit 1; \
+	   fi; \
+	   sudo cp $(FC_REMOTE_BIN_PATH) $(FC_REMOTE_BACKUP); \
+	   sudo systemctl stop shed-server; \
+	   sudo install -m 755 $$TMP $(FC_REMOTE_BIN_PATH); \
+	   sudo mkdir -p \$$(dirname $(FC_REMOTE_ENVOVERRIDE)); \
+	   printf '[Service]\nEnvironment=SHED_BUILD_TOOLS_REF=$(RELEASE_BUILD_TOOLS_REF)\n' | sudo tee $(FC_REMOTE_ENVOVERRIDE) > /dev/null; \
+	   sudo systemctl daemon-reload; \
+	   sudo systemctl start shed-server; \
+	   rm -f $$TMP"
 	@# systemctl start returns before the service has bound 8080. Poll
 	@# the local `shed -s $(FC_REMOTE_HOST) list` (matches the suite's
 	@# probe) so the chain target's suite invocation doesn't race the
@@ -325,8 +344,20 @@ restore-remote-server:
 # of suite outcome. Same exit-code propagation pattern as
 # test-integration-local: surfaces a restore failure separately
 # rather than silently swallowing it.
-test-integration-local-fc: install-remote-server
-	@SHED_FC_HOST=$(FC_REMOTE_HOST) SHED_FC_SERVER=$(SHED_FC_SERVER) $(MAKE) test-integration; SUITE=$$?; \
+# install-remote-server is invoked from the recipe body (not as a make
+# prerequisite) so that a partial-failure install — backup created but
+# systemctl restart fails, scp succeeds but daemon-reload errors, etc.
+# — still runs the restore step. A make prerequisite would halt the
+# recipe before it reaches the restore block, leaving the remote
+# stranded. Same shape as test-integration-local.
+test-integration-local-fc:
+	@$(MAKE) install-remote-server; INSTALL=$$?; \
+	 if [ $$INSTALL -ne 0 ]; then \
+	   echo "test-integration-local-fc: install FAILED (exit $$INSTALL); attempting restore on $(FC_REMOTE_HOST) for safety"; \
+	   $(MAKE) restore-remote-server; \
+	   exit $$INSTALL; \
+	 fi; \
+	 SHED_FC_HOST=$(FC_REMOTE_HOST) SHED_FC_SERVER=$(SHED_FC_SERVER) $(MAKE) test-integration; SUITE=$$?; \
 	 $(MAKE) restore-remote-server; RESTORE=$$?; \
 	 if [ $$SUITE -ne 0 ] && [ $$RESTORE -ne 0 ]; then \
 	   echo "test-integration-local-fc: suite FAILED (exit $$SUITE) AND restore FAILED (exit $$RESTORE); inspect $(FC_REMOTE_HOST) state"; \

--- a/Makefile
+++ b/Makefile
@@ -183,15 +183,34 @@ restore-brew-server:
 # least as serious as a suite failure (it strands the host), so the
 # chain target reports non-zero if either step fails.
 # install-local-server is invoked from the recipe body (not as a make
-# prerequisite) so that a partial-failure install — backup created but
-# brew restart fails, codesign hiccup, etc. — still runs the restore
-# step. A make prerequisite would halt the recipe before it reaches
-# the restore block, leaving the host stranded.
+# prerequisite) so a partial-failure install — backup created but
+# brew restart fails, codesign hiccup mid-stream — still runs the
+# restore step. A make prerequisite would halt the recipe before it
+# reaches the restore block, stranding the host.
+#
+# Crucially the auto-restore must ONLY fire when THIS invocation
+# created new state. Bare "is there a backup?" detection would also
+# restore when install bailed at the preflight 'backup already
+# exists' check, silently consuming a backup that belongs to an
+# EARLIER manual install — reverting someone's in-flight dev
+# workflow. Snapshot pre-state, compare post-state, restore only on
+# new mutation.
 test-integration-local:
-	@$(MAKE) install-local-server; INSTALL=$$?; \
+	@HAD_BACKUP=0; HAD_ENV=0; \
+	 [ -f "$(BACKUP_PATH)" ] && HAD_BACKUP=1; \
+	 [ -n "$$(launchctl getenv SHED_BUILD_TOOLS_REF)" ] && HAD_ENV=1; \
+	 $(MAKE) install-local-server; INSTALL=$$?; \
 	 if [ $$INSTALL -ne 0 ]; then \
-	   echo "test-integration-local: install FAILED (exit $$INSTALL); attempting restore for safety"; \
-	   $(MAKE) restore-brew-server; \
+	   HAS_BACKUP=0; HAS_ENV=0; \
+	   [ -f "$(BACKUP_PATH)" ] && HAS_BACKUP=1; \
+	   [ -n "$$(launchctl getenv SHED_BUILD_TOOLS_REF)" ] && HAS_ENV=1; \
+	   if { [ $$HAD_BACKUP -eq 0 ] && [ $$HAS_BACKUP -eq 1 ]; } || \
+	      { [ $$HAD_ENV -eq 0 ] && [ $$HAS_ENV -eq 1 ]; }; then \
+	     echo "test-integration-local: install FAILED (exit $$INSTALL); NEW mutation created during this run; running restore"; \
+	     $(MAKE) restore-brew-server; \
+	   else \
+	     echo "test-integration-local: install FAILED (exit $$INSTALL); no new mutation detected (any pre-existing backup/env belongs to a prior install); leaving brew install alone"; \
+	   fi; \
 	   exit $$INSTALL; \
 	 fi; \
 	 SHED_VZ_SERVER=$(SHED_VZ_SERVER) $(MAKE) test-integration; SUITE=$$?; \
@@ -279,9 +298,9 @@ install-remote-server: build-fc-remote-server
 	@TMP=/tmp/shed-server-dev.$$$$; \
 	 scp bin/shed-server-fc-remote $(FC_REMOTE_HOST):$$TMP && \
 	 ssh -o BatchMode=yes $(FC_REMOTE_HOST) "set -e; \
+	   trap 'rm -f $$TMP' EXIT; \
 	   if [ -f $(FC_REMOTE_BACKUP) ] && [ '$(FORCE)' != '1' ]; then \
 	     echo 'ERROR: backup already exists at $(FC_REMOTE_HOST):$(FC_REMOTE_BACKUP); run make restore-remote-server first, or pass FORCE=1'; \
-	     rm -f $$TMP; \
 	     exit 1; \
 	   fi; \
 	   sudo cp $(FC_REMOTE_BIN_PATH) $(FC_REMOTE_BACKUP); \
@@ -290,8 +309,7 @@ install-remote-server: build-fc-remote-server
 	   sudo mkdir -p \$$(dirname $(FC_REMOTE_ENVOVERRIDE)); \
 	   printf '[Service]\nEnvironment=SHED_BUILD_TOOLS_REF=$(RELEASE_BUILD_TOOLS_REF)\n' | sudo tee $(FC_REMOTE_ENVOVERRIDE) > /dev/null; \
 	   sudo systemctl daemon-reload; \
-	   sudo systemctl start shed-server; \
-	   rm -f $$TMP"
+	   sudo systemctl start shed-server"
 	@# systemctl start returns before the service has bound 8080. Poll
 	@# the local `shed -s $(FC_REMOTE_HOST) list` (matches the suite's
 	@# probe) so the chain target's suite invocation doesn't race the
@@ -344,17 +362,29 @@ restore-remote-server:
 # of suite outcome. Same exit-code propagation pattern as
 # test-integration-local: surfaces a restore failure separately
 # rather than silently swallowing it.
-# install-remote-server is invoked from the recipe body (not as a make
-# prerequisite) so that a partial-failure install — backup created but
-# systemctl restart fails, scp succeeds but daemon-reload errors, etc.
-# — still runs the restore step. A make prerequisite would halt the
-# recipe before it reaches the restore block, leaving the remote
-# stranded. Same shape as test-integration-local.
+# Same shape as test-integration-local: install in body (not as a
+# prerequisite) so partial-failure installs reach the restore block,
+# with pre/post snapshot so the auto-restore doesn't consume a
+# pre-existing backup that belongs to a prior manual install.
 test-integration-local-fc:
-	@$(MAKE) install-remote-server; INSTALL=$$?; \
+	@HAD_REMOTE_STATE=0; \
+	 if ssh -o BatchMode=yes -o ConnectTimeout=5 $(FC_REMOTE_HOST) \
+	      "test -f $(FC_REMOTE_BACKUP) || test -f $(FC_REMOTE_ENVOVERRIDE)" 2>/dev/null; then \
+	   HAD_REMOTE_STATE=1; \
+	 fi; \
+	 $(MAKE) install-remote-server; INSTALL=$$?; \
 	 if [ $$INSTALL -ne 0 ]; then \
-	   echo "test-integration-local-fc: install FAILED (exit $$INSTALL); attempting restore on $(FC_REMOTE_HOST) for safety"; \
-	   $(MAKE) restore-remote-server; \
+	   HAS_REMOTE_STATE=0; \
+	   if ssh -o BatchMode=yes -o ConnectTimeout=5 $(FC_REMOTE_HOST) \
+	        "test -f $(FC_REMOTE_BACKUP) || test -f $(FC_REMOTE_ENVOVERRIDE)" 2>/dev/null; then \
+	     HAS_REMOTE_STATE=1; \
+	   fi; \
+	   if [ $$HAD_REMOTE_STATE -eq 0 ] && [ $$HAS_REMOTE_STATE -eq 1 ]; then \
+	     echo "test-integration-local-fc: install FAILED (exit $$INSTALL); NEW remote mutation on $(FC_REMOTE_HOST); running restore"; \
+	     $(MAKE) restore-remote-server; \
+	   else \
+	     echo "test-integration-local-fc: install FAILED (exit $$INSTALL); no new mutation on $(FC_REMOTE_HOST) (any pre-existing state belongs to a prior install); leaving deb install alone"; \
+	   fi; \
 	   exit $$INSTALL; \
 	 fi; \
 	 SHED_FC_HOST=$(FC_REMOTE_HOST) SHED_FC_SERVER=$(SHED_FC_SERVER) $(MAKE) test-integration; SUITE=$$?; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-cli build-server build-agent build-firstboot build-tools test test-integration test-integration-local install-local-server restore-brew-server release clean dev-server dev-cli check check-kernel-pin coverage lint-all docs docs-serve firecracker-rootfs download-firecracker vz-rootfs vz-rootfs-base vz-rootfs-all
+.PHONY: build build-cli build-server build-agent build-firstboot build-tools build-fc-remote-server test test-integration test-integration-local test-integration-local-fc install-local-server restore-brew-server install-remote-server restore-remote-server release clean dev-server dev-cli check check-kernel-pin coverage lint-all docs docs-serve firecracker-rootfs download-firecracker vz-rootfs vz-rootfs-base vz-rootfs-all
 
 GOARCH ?= $(shell go env GOARCH)
 
@@ -114,6 +114,20 @@ install-local-server: build
 	@chmod -w "$(BREW_SHED_BIN)"
 	@launchctl setenv SHED_BUILD_TOOLS_REF "$(RELEASE_BUILD_TOOLS_REF)"
 	@brew services start shed
+	@# launchd start is async — the suite's session-scoped probe runs
+	@# the moment make returns and can race the server before it binds
+	@# 8080. Poll until \`shed list\` succeeds (the same probe the
+	@# integration suite uses) or 15 s elapses. Without this the suite
+	@# silently skips all VZ tests with "shed-server not reachable."
+	@for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do \
+	  if shed -s my-server list >/dev/null 2>&1; then \
+	    echo "VZ shed-server ready after $${i}s."; break; \
+	  fi; \
+	  if [ "$$i" = "15" ]; then \
+	    echo "WARNING: VZ shed-server not reachable after 15 s; integration suite may skip VZ tests."; \
+	  fi; \
+	  sleep 1; \
+	done
 	@echo ""
 	@echo "Dev shed-server installed in brew Cellar at $(BREW_SHED_BIN)."
 	@echo "Build-tools ref: $(RELEASE_BUILD_TOOLS_REF)"
@@ -172,6 +186,141 @@ test-integration-local: install-local-server
 	   exit $$SUITE; \
 	 elif [ $$RESTORE -ne 0 ]; then \
 	   echo "test-integration-local: suite passed BUT restore FAILED (exit $$RESTORE); inspect host state"; \
+	   exit $$RESTORE; \
+	 fi
+
+# Remote dev-binary swap + integration suite + restore for the FC
+# backend on `$SHED_FC_HOST` (default `mini3`) over SSH. The FC sibling
+# of test-integration-local: closes the same gap for FC-side PRs.
+# Together they make the workflow promise — every server-side PR (VZ
+# or FC) can validate against its own branch in one command — true.
+#
+# Assumes (and the install recipe sanity-checks):
+#  - Passwordless SSH from this host to $(FC_REMOTE_HOST).
+#  - Passwordless sudo on the remote for the SSH user (the integration
+#    suite's journalctl read already requires this, so this is the
+#    same bar).
+#  - shed-server on the remote installed at $(FC_REMOTE_BIN_PATH) and
+#    run by systemd as shed-server.service. Default path is
+#    /usr/local/bin/shed-server, matching the deb's install location
+#    (verified on mini3 v0.5.8: ExecStart=/usr/local/bin/shed-server).
+#    Override with FC_REMOTE_BIN_PATH=... if the deploy location moves.
+
+FC_REMOTE_HOST ?= $(or $(SHED_FC_HOST),mini3)
+FC_REMOTE_BIN_PATH ?= /usr/local/bin/shed-server
+FC_REMOTE_BACKUP := /tmp/shed-server-deb.bak
+FC_REMOTE_ENVOVERRIDE := /etc/systemd/system/shed-server.service.d/dev-override.conf
+
+# Cross-compile shed-server for the remote host's GOARCH. Detects arch
+# at recipe time via `ssh <host> uname -m`; refuses to silently default
+# (a mismatch here produces a "cannot execute binary" failure later
+# that's painful to debug). Today mini3 is x86_64 → amd64; future
+# arm64 Linux boxes work without code changes. Always builds to a
+# fixed output path so install-remote-server doesn't need to re-detect.
+build-fc-remote-server:
+	@ARCH=$$(ssh -o BatchMode=yes -o ConnectTimeout=5 $(FC_REMOTE_HOST) "uname -m" 2>/dev/null); \
+	 case "$$ARCH" in \
+	   x86_64)  GOARCH=amd64 ;; \
+	   aarch64) GOARCH=arm64 ;; \
+	   "")  echo "ERROR: could not detect arch on $(FC_REMOTE_HOST); is SSH reachable?"; exit 1 ;; \
+	   *)   echo "ERROR: unsupported remote arch on $(FC_REMOTE_HOST): $$ARCH"; exit 1 ;; \
+	 esac; \
+	 echo "Cross-compiling shed-server for linux/$$GOARCH (remote $(FC_REMOTE_HOST) is $$ARCH)..."; \
+	 GOOS=linux GOARCH=$$GOARCH go build $(LDFLAGS) -o bin/shed-server-fc-remote ./cmd/shed-server
+
+# Swap the just-built dev binary into the remote at $(FC_REMOTE_BIN_PATH),
+# back up the deb-installed binary on the REMOTE (so a developer
+# rebooting their workstation mid-test can still recover the host via
+# `make restore-remote-server`), drop a systemd Environment= override
+# for SHED_BUILD_TOOLS_REF, daemon-reload, restart shed-server.
+# Refuses to clobber an existing backup unless FORCE=1, matching the
+# local install-local-server safety pattern.
+#
+# WARNING: this swaps the binary on the SHARED dev/test host. Any
+# active sessions against $(FC_REMOTE_HOST) will see the service
+# restart. Don't run while another developer is mid-create.
+install-remote-server: build-fc-remote-server
+	@if [ -z "$(RELEASE_BUILD_TOOLS_REF)" ]; then \
+	  echo "ERROR: RELEASE_BUILD_TOOLS_REF is empty; can't infer from git tag."; \
+	  echo "       Either tag this repo (git tag --list 'v*' returned nothing)"; \
+	  echo "       or override: RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:vX.Y.Z"; exit 1; \
+	fi
+	@ssh -o BatchMode=yes -o ConnectTimeout=5 $(FC_REMOTE_HOST) \
+	  "test ! -f $(FC_REMOTE_BACKUP) || ( [ '$(FORCE)' = '1' ] || \
+	   ( echo 'ERROR: backup already exists at $(FC_REMOTE_HOST):$(FC_REMOTE_BACKUP); run make restore-remote-server first, or pass FORCE=1' && exit 1 ) )"
+	@scp bin/shed-server-fc-remote $(FC_REMOTE_HOST):/tmp/shed-server-dev
+	@ssh -o BatchMode=yes $(FC_REMOTE_HOST) "set -e; \
+	  sudo cp $(FC_REMOTE_BIN_PATH) $(FC_REMOTE_BACKUP); \
+	  sudo systemctl stop shed-server; \
+	  sudo install -m 755 /tmp/shed-server-dev $(FC_REMOTE_BIN_PATH); \
+	  sudo mkdir -p $$(dirname $(FC_REMOTE_ENVOVERRIDE)); \
+	  printf '[Service]\nEnvironment=SHED_BUILD_TOOLS_REF=$(RELEASE_BUILD_TOOLS_REF)\n' | sudo tee $(FC_REMOTE_ENVOVERRIDE) > /dev/null; \
+	  sudo systemctl daemon-reload; \
+	  sudo systemctl start shed-server; \
+	  rm -f /tmp/shed-server-dev"
+	@# systemctl start returns before the service has bound 8080. Poll
+	@# the local `shed -s $(FC_REMOTE_HOST) list` (matches the suite's
+	@# probe) so the chain target's suite invocation doesn't race the
+	@# startup and skip all FC tests.
+	@for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do \
+	  if shed -s $(FC_REMOTE_HOST) list >/dev/null 2>&1; then \
+	    echo "Remote FC shed-server on $(FC_REMOTE_HOST) ready after $${i}s."; break; \
+	  fi; \
+	  if [ "$$i" = "15" ]; then \
+	    echo "WARNING: $(FC_REMOTE_HOST) shed-server not reachable after 15 s; integration suite may skip FC tests."; \
+	  fi; \
+	  sleep 1; \
+	done
+	@echo ""
+	@echo "Dev shed-server installed on $(FC_REMOTE_HOST) at $(FC_REMOTE_BIN_PATH)."
+	@echo "Build-tools ref (via $(FC_REMOTE_ENVOVERRIDE)): $(RELEASE_BUILD_TOOLS_REF)"
+	@echo "Backup at $(FC_REMOTE_HOST):$(FC_REMOTE_BACKUP)."
+	@echo "Run 'make restore-remote-server' to revert (or it runs automatically"
+	@echo "at the end of 'make test-integration-local-fc')."
+
+# Reverse of install-remote-server. Idempotent: a no-op when no backup
+# exists. The systemd drop-in is removed in BOTH branches so a
+# stranded override doesn't survive a manual restore.
+restore-remote-server:
+	@# Always remove the env override + daemon-reload, even if the
+	@# binary backup is missing — same reasoning as restore-brew-server's
+	@# unconditional launchctl unsetenv: the override is the companion
+	@# to the binary swap, and restoring the binary without removing
+	@# the override leaves dev-binary behavior wired into shed-server.
+	@ssh -o BatchMode=yes -o ConnectTimeout=5 $(FC_REMOTE_HOST) "set -e; \
+	  if [ ! -f $(FC_REMOTE_BACKUP) ]; then \
+	    echo 'No backup at $(FC_REMOTE_HOST):$(FC_REMOTE_BACKUP); nothing to restore.'; \
+	    if [ -f $(FC_REMOTE_ENVOVERRIDE) ]; then \
+	      echo 'Removing stranded env override $(FC_REMOTE_ENVOVERRIDE)...'; \
+	      sudo rm -f $(FC_REMOTE_ENVOVERRIDE); \
+	      sudo systemctl daemon-reload; \
+	      sudo systemctl restart shed-server; \
+	    fi; \
+	  else \
+	    sudo systemctl stop shed-server; \
+	    sudo install -m 755 $(FC_REMOTE_BACKUP) $(FC_REMOTE_BIN_PATH); \
+	    sudo rm -f $(FC_REMOTE_ENVOVERRIDE) $(FC_REMOTE_BACKUP); \
+	    sudo systemctl daemon-reload; \
+	    sudo systemctl start shed-server; \
+	    echo 'Remote shed-server restored from backup; backup + env override removed.'; \
+	  fi"
+
+# Chain: install dev binary on the remote, run integration suite
+# against it (via SHED_FC_HOST), restore the remote binary REGARDLESS
+# of suite outcome. Same exit-code propagation pattern as
+# test-integration-local: surfaces a restore failure separately
+# rather than silently swallowing it.
+test-integration-local-fc: install-remote-server
+	@SHED_FC_HOST=$(FC_REMOTE_HOST) $(MAKE) test-integration; SUITE=$$?; \
+	 $(MAKE) restore-remote-server; RESTORE=$$?; \
+	 if [ $$SUITE -ne 0 ] && [ $$RESTORE -ne 0 ]; then \
+	   echo "test-integration-local-fc: suite FAILED (exit $$SUITE) AND restore FAILED (exit $$RESTORE); inspect $(FC_REMOTE_HOST) state"; \
+	   exit $$SUITE; \
+	 elif [ $$SUITE -ne 0 ]; then \
+	   echo "test-integration-local-fc: suite FAILED (exit $$SUITE); restore succeeded"; \
+	   exit $$SUITE; \
+	 elif [ $$RESTORE -ne 0 ]; then \
+	   echo "test-integration-local-fc: suite passed BUT restore FAILED (exit $$RESTORE); inspect $(FC_REMOTE_HOST) state"; \
 	   exit $$RESTORE; \
 	 fi
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -193,14 +193,70 @@ RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:v0.5.7 \
   make install-local-server
 ```
 
-The FC remote (mini3 over SSH) sibling — `make
-test-integration-local-fc` — will close the same gap on the
-Firecracker backend. **Planned for a follow-up PR** (not yet in the
-repo); tracked in `docs/discovery/integration-suite-server-coverage.md`
-§5 Option 1b. Until it lands, validate FC server-side changes via the
-manual swap on `$SHED_FC_HOST` (cross-compile +
-`scp` + systemd unit override + restore — see the discovery doc for
-the full sequence).
+## Validating server-side changes (FC remote)
+
+`make test-integration-local-fc` closes the same gap for the
+Firecracker backend over SSH to `$SHED_FC_HOST` (default `mini3`):
+
+```sh
+make test-integration-local-fc
+```
+
+That target:
+
+1. `build-fc-remote-server` — cross-compiles `shed-server` for the
+   remote host's GOARCH (detected at recipe time via `ssh <host>
+   uname -m`; today `mini3` is x86_64 → amd64, but an arm64 Linux
+   box works without code changes). Output lands at
+   `bin/shed-server-fc-remote`.
+2. `install-remote-server` — refuses to clobber an existing backup
+   without `FORCE=1`, then `scp`s the dev binary, backs up
+   `/usr/local/bin/shed-server` on the remote, swaps in the dev
+   binary via `install -m 755` (atomic copy + perms), writes a
+   systemd drop-in at `/etc/systemd/system/shed-server.service.d/
+   dev-override.conf` setting `Environment=SHED_BUILD_TOOLS_REF=...`,
+   `daemon-reload`s, and restarts `shed-server.service`. Polls the
+   remote for readiness before returning so the chained suite doesn't
+   race the systemd start.
+3. `test-integration` runs against `SHED_FC_HOST` (full suite — VZ
+   tests still run against your local brew install).
+4. `restore-remote-server` — restores the deb binary from the
+   remote backup, removes the systemd drop-in, `daemon-reload`s,
+   restarts the service, removes the backup. Idempotent: the
+   systemd drop-in is always removed (even when no backup exists),
+   matching `restore-brew-server`'s "env override is the companion
+   to the binary swap" semantics. Runs unconditionally after the
+   suite, regardless of pass/fail.
+
+Backup lives on the **remote host** (`/tmp/shed-server-deb.bak`), so
+a developer who reboots their workstation mid-test can still recover
+the remote with `make restore-remote-server`.
+
+Assumed infrastructure (same as the existing FC test path):
+
+- Passwordless SSH from this host to `$SHED_FC_HOST`.
+- Passwordless `sudo` for the SSH user (the integration suite's
+  journalctl read already requires this).
+- `shed-server` installed at `/usr/local/bin/shed-server` (the deb's
+  install location). Override with `FC_REMOTE_BIN_PATH=...` if the
+  deploy location changes.
+- systemd unit named `shed-server.service`.
+
+```sh
+# Pin a specific build-tools tag (default: latest git v* tag):
+RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:v0.5.7 \
+  make install-remote-server
+
+# Target a different remote:
+SHED_FC_HOST=other-host make test-integration-local-fc
+# or: FC_REMOTE_HOST=other-host make test-integration-local-fc
+```
+
+After `install-remote-server` + `restore-remote-server` ship,
+the workflow promise is concrete: every server-side PR — VZ or FC —
+has a one-command path to exercise its own branch on the appropriate
+host. See `docs/discovery/integration-suite-server-coverage.md` §12
+"Cross-host bootstrap framing" for the broader motivation.
 
 ## What this suite is *not*
 


### PR DESCRIPTION
## What

Four new Makefile targets that close the **FC remote half** of the integration-suite-server-coverage gap. After this PR ships, the workflow promise becomes concrete: **every server-side PR — VZ or FC — has a one-command path to validate against the developer's source tree.**

| Target | What it does |
|---|---|
| `build-fc-remote-server` | Cross-compiles `shed-server` for the remote host's GOARCH (detected at recipe time via `ssh <host> uname -m`). |
| `install-remote-server` | scp's dev binary → backs up remote `/usr/local/bin/shed-server` → swaps via `install -m 755` → writes systemd drop-in for `SHED_BUILD_TOOLS_REF` → `daemon-reload` + restart → polls for readiness. Refuses to clobber an existing backup without `FORCE=1`. |
| `restore-remote-server` | Restores from remote backup, removes drop-in, restarts service, removes backup. Idempotent. Drop-in is removed in BOTH branches so a stranded override doesn't survive a manual restore. |
| `test-integration-local-fc` | Chain: install → `SHED_FC_HOST=$(FC_REMOTE_HOST) make test-integration` → restore. Captures BOTH exit codes; surfaces restore failures separately from suite failures. |

The backup lives on the **remote host** (`/tmp/shed-server-deb.bak`), so a developer who reboots their workstation mid-test can still recover the remote with `make restore-remote-server`.

## Plan corrections surfaced live

Two of the plan's assumptions were wrong against the actual mini3 state. Both fixed in the recipe before push:

- **shed-server lives at `/usr/local/bin/shed-server`**, not `/usr/bin/shed-server`. `systemctl cat shed-server` shows `ExecStart=/usr/local/bin/shed-server serve --config /etc/shed/server.yaml`. `FC_REMOTE_BIN_PATH` defaults accordingly; override with `FC_REMOTE_BIN_PATH=...` if the deploy location moves.
- **mini3 is x86_64**, not arm64. The plan's `build-linux-arm64` would have produced a binary that fails to execute on the remote. The arch is now detected at recipe time so future arm64 Linux boxes work without code changes.

## Also fixes a real race in PR 2's install-local-server

`brew services start shed` is async, and the integration suite probes immediately when make returns. Checkpoint g surfaced this: the same target that passed cleanly in PR 2's validation skipped all 17 VZ tests in this PR's validation cycle ("VZ shed-server ('my-server') is not reachable"). Added a readiness wait pattern (poll `shed -s my-server list` for up to 15 s) to both `install-local-server` and `install-remote-server`. Re-ran checkpoint g after the fix: 42 pass / 1 skip, deterministic.

## Validation Results

All 7 checkpoints per plan §3.2 green:

| # | Scenario | Outcome |
|---|---|---|
| a | Cold-state install on `mini3` | Dev binary `v0.5.8-11-geae01f6-dirty` swapped in; systemd drop-in `dev-override.conf` active; backup at `mini3:/tmp/shed-server-deb.bak`. |
| b | Idempotent install guard | Second install errors with `'backup already exists ... run make restore-remote-server first, or pass FORCE=1'`. |
| c | Restore + idempotent re-run | First restore brings deb `v0.5.8` back, removes drop-in + backup. Second restore prints `'No backup ...; nothing to restore.'` and exits 0. |
| d | Chained happy path (`make test-integration-local-fc`) | First run: 41 pass + 1 transient FC test flake (see below) + 1 FC-template skip. Re-run after readiness-wait fix: 42 pass + 1 FC-template skip, deterministic. Restore clean both times. |
| e | Chained failure path (conftest.py injection: `raise RuntimeError(...)` at module top) | Pytest exited `Error 4`; chain target captured + re-emitted as `Error 2`; restore still ran; backup + drop-in gone; deb binary back. |
| f | Dogfood against PR #156's `RestoreStoppedMetadata` path on FC | Created `repro-fc2 --local-dir /tmp/repro-dir-fc2`, stopped, `ssh mini3 rm -rf /tmp/repro-dir-fc2`, attempted start → failed with `BACKEND_ERROR: failed to mount 9P in guest on start: mount-9p exec failed`. **`shed list` showed `status=stopped` IMMEDIATELY** — proves the new infrastructure exercises FC server-side changes and PR #156's fix is live on the FC dev binary. |
| g | Local VZ smoke (no regression in PR 2's targets) | After the install-local-server readiness-wait fix: 42 pass + 1 FC-template skip. |

`make check` clean.

## Transient flake surfaced (out of scope for this PR)

`test_ssh_exec_command_substitution[fc]` failed once in checkpoint d's first run (`'hostname'` returned empty string). The test passes in isolation AND in `make test-integration-local-fc` re-runs. Treated as test-contamination flake unrelated to PR 3's build tooling. Worth a follow-up issue if it surfaces again, but not gating this PR.

## What's NOT in this PR

- Server-side regression investigation for the above flake.
- Updates to `docs/discovery/integration-suite-server-coverage.md` — those happen in a follow-up session per plan §9.
- Mac-remote (`ssh into a remote Mac running vfkit`) support — see plan §5 "Out of scope."

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote Firecracker server testing and deployment workflow with automatic binary installation
  * macOS shed-server startup health checks prevent silent test failures

* **Documentation**
  * Integration test guide now includes remote server validation workflow instructions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/shed/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->