### PR TITLE
test(integration): foundation for parallel dev shed-server workflow

### DIFF
--- a/configs/server.dev-parallel.linux-fc.yaml
+++ b/configs/server.dev-parallel.linux-fc.yaml
@@ -1,0 +1,82 @@
+# Shed Server — Parallel Dev Configuration (Linux / Firecracker)
+#
+# Runs ALONGSIDE the deb-installed shed-server on the same Linux host
+# (today: `mini3`). Different ports, different state-dirs, separate
+# images_dir, offset vsock_base_cid. Bridge + CIDR + tap_prefix are
+# SHARED with the deb — coordination is via the kernel's TAP-existence
+# check in `internal/firecracker/network.go:FindAvailableTAPIndex`.
+#
+# Used by `make dev-server-up-fc` + `make test-integration-dev-fc` for
+# testing server-side changes against the developer's source tree
+# without restarting the deb shed-server (and disrupting any sheds
+# attached to it).
+#
+# Launch directly on the remote (run as root for CAP_NET_ADMIN):
+#   sudo /tmp/shed-server-dev serve --config /tmp/shed-server-dev.yaml
+#
+# Add this entry to ~/.shed/config.yaml on the dev workstation:
+#   servers:
+#     mini3-dev:                # or whatever your remote is called
+#       host: mini3
+#       http_port: 18080
+#       ssh_port: 12222
+#
+# See docs/development/testing.md for the full workflow.
+
+name: mini3-dev
+
+# Offset from deb's 8080/2222 so both can run simultaneously.
+http_port: 18080
+ssh_port: 12222
+
+default_backend: firecracker
+log_level: debug
+
+# No credentials, no extensions — see the rationale in the macOS
+# parallel-dev config. Dev sheds exist to exercise the server, not
+# to host the developer's working environment.
+
+firecracker:
+  # Same as deb config — kernel + images pinned to the latest release
+  # so the dev binary uses release-shaped image-resolution behavior.
+  kernel_path: /var/lib/shed/firecracker/images/vmlinux
+  base_rootfs: ghcr.io/charliek/shed-fc-full:v0.5.8
+  images:
+    base:       ghcr.io/charliek/shed-fc-base:v0.5.8
+    extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.8
+    full:       ghcr.io/charliek/shed-fc-full:v0.5.8
+
+  # Separate state-dirs so prune from the deb server never touches
+  # the dev server's blobs.
+  images_dir:    /var/lib/shed-dev/firecracker/images
+  instance_dir:  /var/lib/shed-dev/firecracker/instances
+  snapshots_dir: /var/lib/shed-dev/firecracker/snapshots
+  uppers_dir:    /var/lib/shed-dev/firecracker/uppers
+  socket_dir:    /var/run/shed-dev/firecracker
+
+  default_cpus: 2
+  default_memory_mb: 4096
+  default_disk_gb: 20
+
+  # CRITICAL: offset from deb's default 100. CID allocation is
+  # in-memory per-server with no kernel check, so two servers sharing
+  # the same vsock_base_cid would collide on the very first VM. 500
+  # CIDs of headroom per server is plenty (no realistic dev workload
+  # creates 500+ concurrent sheds).
+  vsock_base_cid: 600
+
+  console_port: 1024
+  notify_port: 1026
+  start_timeout: 90s
+  stop_timeout: 10s
+
+  # SAME as deb config — bridge, CIDR, and tap_prefix coordinate
+  # cross-server via the kernel-level TAP existence check in
+  # `internal/firecracker/network.go:FindAvailableTAPIndex`. Each
+  # server picks the next unused TAP index (e.g. shed-tap-0 for the
+  # first deb VM, shed-tap-1 for the first dev VM if the deb VM is
+  # still up). IPs flow from the index via `AllocateIP` — same
+  # function, different index, different IP. No collision.
+  bridge_name: shed-br0
+  bridge_cidr: 172.30.0.1/24
+  tap_prefix:  shed-tap

--- a/configs/server.dev-parallel.linux-fc.yaml
+++ b/configs/server.dev-parallel.linux-fc.yaml
@@ -76,7 +76,21 @@ firecracker:
   # server picks the next unused TAP index (e.g. shed-tap-0 for the
   # first deb VM, shed-tap-1 for the first dev VM if the deb VM is
   # still up). IPs flow from the index via `AllocateIP` — same
-  # function, different index, different IP. No collision.
+  # function, different index, different IP. No collision for already-
+  # existing TAPs.
+  #
+  # Known race window (small, fails loudly when it fires): the
+  # `FindAvailableTAPIndex` call returns an index before the actual
+  # `netlink.LinkAdd` creates the TAP. Two shed-server processes
+  # concurrently creating a VM can both pick the same index, then
+  # the second `LinkAdd` fails with EEXIST. The error propagates to
+  # the user as `failed to create TAP device shed-tap-N: file exists`
+  # — diagnosable, not silent. For PR-validation workloads (one dev
+  # creating one shed at a time on the dev server while the deb
+  # server handles its own creates) this never fires. If concurrent-
+  # create stress becomes a real workload, the fix is server-side:
+  # retry-on-EEXIST in `internal/firecracker/orchestrator.go`'s
+  # AllocateNetwork hook.
   bridge_name: shed-br0
   bridge_cidr: 172.30.0.1/24
   tap_prefix:  shed-tap

--- a/configs/server.dev-parallel.mac.yaml
+++ b/configs/server.dev-parallel.mac.yaml
@@ -1,0 +1,70 @@
+# Shed Server — Parallel Dev Configuration (macOS / VZ)
+#
+# Runs ALONGSIDE the brew-installed `my-server` shed-server on the same
+# host. Different ports, different state-dirs, separate images_dir.
+# Used by `make dev-server-up` + `make test-integration-dev` for testing
+# server-side changes against the developer's source tree without
+# restarting (and disrupting) the brew shed-server.
+#
+# Launch directly:
+#   bin/shed-server serve --config configs/server.dev-parallel.mac.yaml
+#
+# Add this entry to ~/.shed/config.yaml so the CLI can reach it:
+#   servers:
+#     my-server-dev:
+#       host: localhost
+#       http_port: 18080
+#       ssh_port: 12222
+#
+# See docs/development/testing.md for the full workflow.
+
+name: my-server-dev
+
+# Offset from brew's 8080/2222 so both can run simultaneously.
+http_port: 18080
+ssh_port: 12222
+
+default_backend: vz
+log_level: debug
+
+# Intentionally NO credentials block:
+#   The dev server is for testing the SERVER itself, not for hosting
+#   the developer's working sheds. The brew install (`my-server`)
+#   is where ~/.shed/mounts/{claude,codex,opencode,gh} get mounted.
+#   Adding them here would mean two VMs concurrently writing to the
+#   same host files for the same tool — a race the integration suite
+#   doesn't need.
+
+# Intentionally NO extensions block:
+#   Same reason as credentials. Dev sheds don't need
+#   ssh-agent / docker-credentials brokering.
+
+vz:
+  vfkit_path: vfkit
+
+  # Pin to the latest release's images so the dev binary uses the
+  # release-shaped upper-template fast path (sub-100 ms rootfs phase).
+  # Bump in lockstep with shed releases; see docs/reference/images.md.
+  base_rootfs: ghcr.io/charliek/shed-vz-full:v0.5.8
+  images:
+    base: ghcr.io/charliek/shed-vz-base:v0.5.8
+    extensions: ghcr.io/charliek/shed-vz-extensions:v0.5.8
+    full: ghcr.io/charliek/shed-vz-full:v0.5.8
+
+  # Separate state-dirs under `shed-dev/` so prune from the brew server
+  # never touches the dev server's blobs (the v0.5.7 prune behavior
+  # walks ONLY the configured server's instance_dir + snapshots_dir).
+  images_dir:    ~/Library/Application Support/shed-dev/vz
+  instance_dir:  ~/Library/Application Support/shed-dev/vz/instances
+  snapshots_dir: ~/Library/Application Support/shed-dev/vz/snapshots
+  uppers_dir:    ~/Library/Application Support/shed-dev/vz/uppers
+  socket_dir:    ~/.shed-dev/vz/sockets
+
+  default_cpus: 2
+  default_memory_mb: 4096
+  default_disk_gb: 20
+  console_port: 1024
+  notify_port: 1026
+  tcp_proxy_port: 1028
+  start_timeout: 60s
+  stop_timeout: 10s

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -53,12 +53,48 @@ tests they would have run, not the whole session.
 
 ## Environment overrides
 
-| Variable          | Default                                            | Effect |
-|-------------------|----------------------------------------------------|--------|
-| `SHED_VZ_SERVER`  | `my-server`                                        | Entry name in `~/.shed/config.yaml` for the local VZ server. |
-| `SHED_VZ_LOG_PATH`| `/opt/homebrew/var/log/shed-server.log`            | Where the VZ shed-server's log file lives. Override for Intel Macs (`/usr/local/...`) or custom installs. |
-| `SHED_FC_HOST`    | `mini3`                                            | SSH hostname for the FC server (used for journald log fetch). |
-| `SHED_FC_SERVER`  | same as host                                       | Entry name for the FC server (when it differs from the SSH host). |
+| Variable               | Default                                            | Effect |
+|------------------------|----------------------------------------------------|--------|
+| `SHED_VZ_SERVER`       | `my-server`                                        | Entry name in `~/.shed/config.yaml` for the local VZ server. |
+| `SHED_VZ_LOG_PATH`     | `/opt/homebrew/var/log/shed-server.log`            | Where the VZ shed-server's log file lives. Override for Intel Macs (`/usr/local/...`) or custom installs. |
+| `SHED_FC_HOST`         | `mini3`                                            | SSH hostname for the FC server (used for journald log fetch). |
+| `SHED_FC_SERVER`       | same as host                                       | Entry name for the FC server (when it differs from the SSH host). |
+| `SHED_VZ_DEV_SERVER`   | _unset_                                            | Entry name for a PARALLEL dev VZ shed-server (alongside the brew one on a different port). When unset, the `vz_server_dev` fixture skips cleanly. Set by `make test-integration-dev` once that target lands (PR 2). |
+| `SHED_VZ_DEV_LOG_PATH` | _unset_                                            | Where the parallel dev VZ shed-server writes its log file. Required when `SHED_VZ_DEV_SERVER` is set. |
+| `SHED_FC_DEV_SERVER`   | _unset_                                            | Entry name for a PARALLEL dev FC shed-server (alongside the deb one on a different port). When unset, the `fc_server_dev` fixture skips cleanly. Set by `make test-integration-dev-fc` once that target lands (PR 3). |
+| `SHED_FC_DEV_LOG_PATH` | _unset_                                            | Path on the FC remote where the parallel dev shed-server writes its log file. Required when `SHED_FC_DEV_SERVER` is set; the fixture reads it via `ssh + sudo -n cat` because the dev server runs as root via `sudo nohup` and is not under systemd. |
+
+## Fixtures
+
+- `shed_server` (params: `["vz", "fc"]`) — parameterized across the
+  brew/deb-installed shed-server on each backend. This is what the
+  existing test files use.
+- `shed_server_dev` (params: `["vz", "fc"]`) — parameterized across
+  the PARALLEL dev shed-server on each backend. Skips per-backend
+  when the corresponding `SHED_*_DEV_SERVER` env var isn't set. New
+  tests targeting server-side changes against the developer's source
+  tree use this fixture.
+
+The `vz_server_dev` / `fc_server_dev` sub-fixtures are session-scoped
+mirrors of `vz_server` / `fc_server`, reading the `_DEV_` env vars.
+The parallel-dev workflow (`make dev-server-up`, `test-integration-dev`)
+lands in PR 2 (Mac) + PR 3 (FC remote) of the
+`lets-defer-remote-mac-deep-brook` plan.
+
+## Framework meta-tests
+
+`test_framework_meta.py` covers the suite's own infra — fixture
+availability probing, log-path fall-through, raw-SSH endpoint
+resolution, the `template_fallback` per-shed-name marker, the
+remote-file-vs-journald log read branch, and a brew-targeted
+regression backstop. These don't need a live shed-server (mocked
+subprocess), except the backstop which spawns a real
+`test_create_delete_lifecycle[vz]` against brew and skips cleanly
+when brew isn't reachable. Run them with:
+
+```sh
+cd tests/integration && uv run pytest -v test_framework_meta.py
+```
 
 ## Layout
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -135,6 +135,12 @@ def vz_server_dev() -> LocalServer:
     Skips when `SHED_VZ_DEV_SERVER` is unset (the default — no dev
     server expected). When set, behaves like `vz_server` but targets
     the dev server entry name and reads the dev log file path.
+
+    Fails (not skips) when `SHED_VZ_DEV_SERVER` is set but
+    `SHED_VZ_DEV_LOG_PATH` is empty: the suite's PhaseTimer-dependent
+    tests need a log path, and silently falling back to journald
+    (which Mac launchd-less dev servers don't write to) would produce
+    confusing "no PhaseTimer found" skips deep in the suite.
     """
     if not VZ_DEV_SERVER_NAME:
         pytest.skip(
@@ -143,10 +149,21 @@ def vz_server_dev() -> LocalServer:
             "`make test-integration-dev`, or set SHED_VZ_DEV_SERVER + "
             "SHED_VZ_DEV_LOG_PATH manually."
         )
-    log_path = Path(VZ_DEV_LOG_PATH) if VZ_DEV_LOG_PATH else None
-    if log_path is not None and not log_path.exists():
-        log_path = None
-    s = LocalServer(name=VZ_DEV_SERVER_NAME, backend="vz", log_path=log_path)
+    if not VZ_DEV_LOG_PATH:
+        pytest.fail(
+            "SHED_VZ_DEV_SERVER is set but SHED_VZ_DEV_LOG_PATH is "
+            "empty. The parallel dev VZ shed-server writes its log "
+            "to a known file (typically ~/.shed/dev/server.log); set "
+            "SHED_VZ_DEV_LOG_PATH to that path. Without it, the "
+            "PhaseTimer-dependent tests would skip with a confusing "
+            "'no PhaseTimer found' reason."
+        )
+    log_path = Path(VZ_DEV_LOG_PATH)
+    s = LocalServer(
+        name=VZ_DEV_SERVER_NAME,
+        backend="vz",
+        log_path=log_path if log_path.exists() else None,
+    )
     if not s.available():
         pytest.skip(
             f"VZ dev shed-server ({VZ_DEV_SERVER_NAME!r}) is not reachable; "
@@ -164,6 +181,11 @@ def fc_server_dev() -> RemoteServer:
     the dev server entry name and reads logs from the remote dev log
     file via `ssh + sudo cat` (not journald — the dev server isn't
     under systemd).
+
+    Fails (not skips) when `SHED_FC_DEV_SERVER` is set but
+    `SHED_FC_DEV_LOG_PATH` is empty: the dev FC server runs via `sudo
+    nohup` (no systemd unit), so journald has no records and the
+    fixture's PhaseTimer fetch needs the file path.
     """
     if not FC_DEV_SERVER_NAME:
         pytest.skip(
@@ -172,11 +194,20 @@ def fc_server_dev() -> RemoteServer:
             "`make test-integration-dev-fc`, or set SHED_FC_DEV_SERVER + "
             "SHED_FC_DEV_LOG_PATH manually."
         )
+    if not FC_DEV_LOG_PATH:
+        pytest.fail(
+            "SHED_FC_DEV_SERVER is set but SHED_FC_DEV_LOG_PATH is "
+            "empty. The parallel dev FC shed-server runs via "
+            "`sudo nohup` (not systemd), so journald has no records "
+            "for it; the fixture reads its log file via "
+            "`ssh + sudo -n tail`. Set SHED_FC_DEV_LOG_PATH to the "
+            "remote file path (typically /tmp/shed-server-dev.log)."
+        )
     s = RemoteServer(
         ssh_host=FC_SSH_HOST,
         name=FC_DEV_SERVER_NAME,
         backend="firecracker",
-        remote_log_path=FC_DEV_LOG_PATH or None,
+        remote_log_path=FC_DEV_LOG_PATH,
     )
     if not s.available():
         pytest.skip(
@@ -206,9 +237,8 @@ def shed_server_dev(request):
 _SHED_NAME_SAFE = re.compile(r"[^a-z0-9-]+")
 
 
-@pytest.fixture
-def test_shed_name(shed_server, request):
-    """Allocate a unique shed name per test, with automatic cleanup.
+def _gen_shed_name(request) -> str:
+    """Compute the canonical per-test shed name from a pytest request.
 
     Pattern: `itest-<sanitized-prefix>-<6-char-hash>`. The hash is over
     the full pytest nodeid (including parameterization), so two tests
@@ -222,12 +252,47 @@ def test_shed_name(shed_server, request):
     # Budget: "itest-" (6) + dashes (2) + suffix (6) = 14 chars of overhead
     # against the 48-char shed-name ceiling, leaving 34 for the prefix.
     prefix = sanitized[:34].rstrip("-")
-    name = f"itest-{prefix}-{suffix}"
+    return f"itest-{prefix}-{suffix}"
+
+
+@pytest.fixture
+def test_shed_name(shed_server, request):
+    """Per-test shed name with automatic cleanup on the PROD shed-server.
+
+    Tests using the `shed_server` fixture (brew/deb-installed
+    shed-server) pair with this one. The teardown calls
+    `shed_server.delete(name)`.
+
+    Tests targeting the parallel-dev server must use `test_shed_name_dev`
+    instead — using `test_shed_name` with `shed_server_dev` would
+    silently instantiate BOTH the prod and dev backends AND clean up
+    against the wrong server. The two name fixtures are intentionally
+    separate so a misconfigured test fails at collection-time rather
+    than running half-correctly.
+    """
+    name = _gen_shed_name(request)
     yield name
     # Teardown is best-effort. A test that died mid-create might leave a
     # half-created shed; ignore_missing=True keeps cleanup from masking
     # the original failure.
     try:
         shed_server.delete(name, ignore_missing=True)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def test_shed_name_dev(shed_server_dev, request):
+    """Per-test shed name with automatic cleanup on the DEV shed-server.
+
+    Mirror of `test_shed_name` for tests targeting the parallel-dev
+    shed-server (the `shed_server_dev` fixture). Keeps the two
+    server-target paths cleanly separated — see `test_shed_name`'s
+    docstring for the reasoning.
+    """
+    name = _gen_shed_name(request)
+    yield name
+    try:
+        shed_server_dev.delete(name, ignore_missing=True)
     except Exception:
         pass

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -39,6 +39,17 @@ VZ_BREW_LOG = Path(
     os.environ.get("SHED_VZ_LOG_PATH", "/opt/homebrew/var/log/shed-server.log")
 )
 
+# Parallel-dev server overrides. Set by `make test-integration-dev` /
+# `make test-integration-dev-fc` (or manually) to point the suite at a
+# second shed-server running alongside the brew/deb one on a different
+# port. When unset, the `vz_server_dev` / `fc_server_dev` / `shed_server_dev`
+# fixtures skip cleanly so today's `make test-integration` flow against
+# the brew/deb server is unaffected.
+VZ_DEV_SERVER_NAME = os.environ.get("SHED_VZ_DEV_SERVER", "")
+VZ_DEV_LOG_PATH = os.environ.get("SHED_VZ_DEV_LOG_PATH", "")
+FC_DEV_SERVER_NAME = os.environ.get("SHED_FC_DEV_SERVER", "")
+FC_DEV_LOG_PATH = os.environ.get("SHED_FC_DEV_LOG_PATH", "")
+
 
 # ----------------------------------------------------------------------------
 # Server fixtures (session-scoped — one connection probe per pytest run)
@@ -96,6 +107,93 @@ def shed_server(request):
     when that backend would actually have run.
     """
     return request.getfixturevalue(f"{request.param}_server")
+
+
+# ----------------------------------------------------------------------------
+# Parallel-dev server fixtures
+# ----------------------------------------------------------------------------
+#
+# These mirror the brew/deb-targeted fixtures above but read the dev-
+# specific env vars (`SHED_VZ_DEV_SERVER`, `SHED_VZ_DEV_LOG_PATH`,
+# `SHED_FC_DEV_SERVER`, `SHED_FC_DEV_LOG_PATH`). When those env vars
+# aren't set, the dev fixtures skip cleanly — so a developer running
+# `make test-integration` (the brew/deb-targeted default) doesn't get
+# spurious "dev server unreachable" failures.
+#
+# Tests that want to run against the dev server use the `shed_server_dev`
+# fixture instead of (or in addition to) `shed_server`. The Makefile's
+# `test-integration-dev` / `test-integration-dev-fc` targets set both
+# the prod env vars (`SHED_VZ_SERVER`, `SHED_FC_SERVER`) AND the
+# matching `_DEV_` env vars so a test file can use either fixture
+# depending on what it's exercising.
+
+
+@pytest.fixture(scope="session")
+def vz_server_dev() -> LocalServer:
+    """Parallel-dev VZ shed-server (Mac, launched via `make dev-server-up`).
+
+    Skips when `SHED_VZ_DEV_SERVER` is unset (the default — no dev
+    server expected). When set, behaves like `vz_server` but targets
+    the dev server entry name and reads the dev log file path.
+    """
+    if not VZ_DEV_SERVER_NAME:
+        pytest.skip(
+            "SHED_VZ_DEV_SERVER not set; this test targets the parallel "
+            "dev VZ server. Run `make dev-server-up` then "
+            "`make test-integration-dev`, or set SHED_VZ_DEV_SERVER + "
+            "SHED_VZ_DEV_LOG_PATH manually."
+        )
+    log_path = Path(VZ_DEV_LOG_PATH) if VZ_DEV_LOG_PATH else None
+    if log_path is not None and not log_path.exists():
+        log_path = None
+    s = LocalServer(name=VZ_DEV_SERVER_NAME, backend="vz", log_path=log_path)
+    if not s.available():
+        pytest.skip(
+            f"VZ dev shed-server ({VZ_DEV_SERVER_NAME!r}) is not reachable; "
+            f"start it with `make dev-server-up`."
+        )
+    return s
+
+
+@pytest.fixture(scope="session")
+def fc_server_dev() -> RemoteServer:
+    """Parallel-dev FC shed-server (remote, launched via `make dev-server-up-fc`).
+
+    Skips when `SHED_FC_DEV_SERVER` is unset (the default — no dev
+    server expected). When set, behaves like `fc_server` but targets
+    the dev server entry name and reads logs from the remote dev log
+    file via `ssh + sudo cat` (not journald — the dev server isn't
+    under systemd).
+    """
+    if not FC_DEV_SERVER_NAME:
+        pytest.skip(
+            "SHED_FC_DEV_SERVER not set; this test targets the parallel "
+            "dev FC server. Run `make dev-server-up-fc` then "
+            "`make test-integration-dev-fc`, or set SHED_FC_DEV_SERVER + "
+            "SHED_FC_DEV_LOG_PATH manually."
+        )
+    s = RemoteServer(
+        ssh_host=FC_SSH_HOST,
+        name=FC_DEV_SERVER_NAME,
+        backend="firecracker",
+        remote_log_path=FC_DEV_LOG_PATH or None,
+    )
+    if not s.available():
+        pytest.skip(
+            f"FC dev shed-server ({FC_DEV_SERVER_NAME!r} on "
+            f"{FC_SSH_HOST!r}) is not reachable; start it with "
+            f"`make dev-server-up-fc`."
+        )
+    return s
+
+
+@pytest.fixture(params=["vz", "fc"])
+def shed_server_dev(request):
+    """Parallel-dev counterpart of `shed_server`. Parameterized across
+    backends; lazily instantiates only the requested sub-fixture and
+    skips cleanly when the corresponding dev server isn't configured.
+    """
+    return request.getfixturevalue(f"{request.param}_server_dev")
 
 
 # ----------------------------------------------------------------------------

--- a/tests/integration/fixtures/server.py
+++ b/tests/integration/fixtures/server.py
@@ -5,11 +5,21 @@ Both classes drive a running `shed-server` via the `shed` CLI:
     shed -s <name> create / exec / delete / list
 
 `shed -s <name>` resolves through `~/.shed/config.yaml` and selects either
-a local server (HTTP to `localhost:8080`) or a remote one (HTTP+SSH to the
-named host). Most operations are identical between local and remote; the
-only meaningful divergence is *where the server log lives* — a file path
-on a brew-installed mac vs `journalctl -u shed-server` on a systemd Linux
-host. That divergence is encapsulated in `_read_log_since`.
+a local server (HTTP to `localhost:<port>`) or a remote one (HTTP+SSH to
+the named host). Most operations are identical between local and remote;
+the only meaningful divergence is *where the server log lives*:
+
+  - brew-installed Mac shed-server: a file at
+    `/opt/homebrew/var/log/shed-server.log`. `LocalServer(log_path=...)`.
+  - deb-installed Linux shed-server: journald via
+    `journalctl -u shed-server`. `RemoteServer(remote_log_path=None)`.
+  - parallel-dev shed-server (Mac or Linux, launched via the Makefile's
+    `dev-server-up`/`-fc` targets): a known file at
+    `~/.shed/dev/server.log` (Mac) or `/tmp/shed-server-dev.log`
+    (remote). `LocalServer(log_path=...)` or
+    `RemoteServer(remote_log_path=...)`.
+
+That divergence is encapsulated in `_log_offset` + `_read_log_since`.
 
 Fabric is intentionally NOT used here (see §16): for the MVP, plain
 `subprocess` + `ssh` covers everything we need. Fabric earns its place
@@ -20,6 +30,7 @@ unnecessary surface.
 from __future__ import annotations
 
 import json
+import shlex
 import shutil
 import subprocess
 import time
@@ -470,13 +481,31 @@ class RemoteServer(LocalServer):
 
     Most operations are identical to LocalServer because the `shed` CLI
     already encapsulates the remote transport. The only divergence is
-    journald log fetching, which needs an `ssh <host> sudo -n journalctl
-    …` round trip.
+    log fetching, which goes over SSH:
+
+      - If `remote_log_path` is set (the parallel-dev case), reads the
+        remote file directly via `ssh <host> sudo -n cat <path>`.
+        The dev shed-server is launched with stdout/stderr redirected to
+        a known file owned by root, so this is the cheapest read.
+      - Otherwise (the deb-installed case), falls through to
+        `ssh <host> sudo -n journalctl -u shed-server --since <when>`
+        because the deb's systemd unit captures stdout into journald.
+
+    `remote_log_path` is a str (not Path) because it names a file on the
+    REMOTE host; `pathlib.Path` semantics (existence checks, parent
+    resolution) would apply to the local filesystem and mislead.
     """
 
-    def __init__(self, ssh_host: str, name: str, backend: str) -> None:
+    def __init__(
+        self,
+        ssh_host: str,
+        name: str,
+        backend: str,
+        remote_log_path: Optional[str] = None,
+    ) -> None:
         super().__init__(name=name, backend=backend, log_path=None)
         self.ssh_host = ssh_host
+        self.remote_log_path = remote_log_path
 
     def available(self) -> bool:
         """Verify both the `shed -s NAME` CLI path AND raw SSH access.
@@ -507,11 +536,68 @@ class RemoteServer(LocalServer):
             return False
         return r.returncode == 0
 
+    def _log_offset(self) -> Union[int, str]:
+        """Return an offset opaque to the caller but understood by
+        `_read_log_since`. For remote-file mode, that's the current
+        byte length of the remote file; for the journald fallback,
+        it's an ISO-ish timestamp (the parent class's default).
+        """
+        if self.remote_log_path is not None:
+            try:
+                r = subprocess.run(
+                    [
+                        "ssh",
+                        "-o", "BatchMode=yes",
+                        "-o", "ConnectTimeout=5",
+                        self.ssh_host,
+                        # `wc -c < FILE` returns the byte count and exits
+                        # non-zero if FILE doesn't exist; the sudo -n
+                        # bracket lets us read root-owned dev logs.
+                        f"sudo -n wc -c < {shlex.quote(self.remote_log_path)} 2>/dev/null || echo 0",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if r.returncode == 0:
+                    return int(r.stdout.strip() or "0")
+            except (subprocess.TimeoutExpired, FileNotFoundError, ValueError):
+                pass
+            return 0
+        return super()._log_offset()
+
     def _read_log_since(self, offset: Union[int, str]) -> str:
-        # 10 s upper bound — remote journalctl is slower than local
+        # 10 s upper bound — remote operations are slower than local
         # (SSH handshake + remote process spawn), but a stuck ssh
         # should never block the test loop indefinitely. The wall-clock
         # budget in `_read_timing` is the ultimate safety net.
+        if self.remote_log_path is not None:
+            # File-backed mode: read everything past the byte offset
+            # captured at the start of the operation. `tail -c +N` reads
+            # from byte N (1-indexed), so +1 means from the start;
+            # +(offset+1) means "past the bytes that existed before".
+            try:
+                start = int(offset)
+            except (TypeError, ValueError):
+                start = 0
+            try:
+                r = subprocess.run(
+                    [
+                        "ssh",
+                        "-o", "BatchMode=yes",
+                        "-o", "ConnectTimeout=5",
+                        self.ssh_host,
+                        f"sudo -n tail -c +{start + 1} {shlex.quote(self.remote_log_path)} 2>/dev/null || true",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+            except (subprocess.TimeoutExpired, FileNotFoundError):
+                return ""
+            return r.stdout if r.returncode == 0 else ""
+
+        # Journald fallback (deb-installed shed-server).
         try:
             r = subprocess.run(
                 [

--- a/tests/integration/fixtures/server.py
+++ b/tests/integration/fixtures/server.py
@@ -33,6 +33,7 @@ import json
 import shlex
 import shutil
 import subprocess
+import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -550,10 +551,16 @@ class RemoteServer(LocalServer):
                         "-o", "BatchMode=yes",
                         "-o", "ConnectTimeout=5",
                         self.ssh_host,
-                        # `wc -c < FILE` returns the byte count and exits
-                        # non-zero if FILE doesn't exist; the sudo -n
-                        # bracket lets us read root-owned dev logs.
-                        f"sudo -n wc -c < {shlex.quote(self.remote_log_path)} 2>/dev/null || echo 0",
+                        # `stat -c %s FILE` returns the byte size and
+                        # is opened by `stat` (under sudo), so root-only
+                        # log files are readable here. We can't use
+                        # `wc -c < FILE` because the shell redirect runs
+                        # BEFORE sudo and fails to open a root-only
+                        # file — leaving us with offset=0 and the suite
+                        # reading the entire log every time (stale
+                        # PhaseTimer lines from prior tests can then
+                        # match a re-used shed name).
+                        f"sudo -n stat -c %s {shlex.quote(self.remote_log_path)}",
                     ],
                     capture_output=True,
                     text=True,
@@ -587,7 +594,15 @@ class RemoteServer(LocalServer):
                         "-o", "BatchMode=yes",
                         "-o", "ConnectTimeout=5",
                         self.ssh_host,
-                        f"sudo -n tail -c +{start + 1} {shlex.quote(self.remote_log_path)} 2>/dev/null || true",
+                        # No `2>/dev/null || true` — let the SSH
+                        # command's stderr surface naturally so a
+                        # misconfigured sudo (NOPASSWD missing) or
+                        # missing log file reports the real error
+                        # rather than silently returning "" (which
+                        # the suite would interpret as "no PhaseTimer
+                        # found" and skip the test with a misleading
+                        # reason).
+                        f"sudo -n tail -c +{start + 1} {shlex.quote(self.remote_log_path)}",
                     ],
                     capture_output=True,
                     text=True,
@@ -595,7 +610,19 @@ class RemoteServer(LocalServer):
                 )
             except (subprocess.TimeoutExpired, FileNotFoundError):
                 return ""
-            return r.stdout if r.returncode == 0 else ""
+            if r.returncode != 0:
+                # Surface the underlying error to pytest's stderr so a
+                # misconfigured dev server (wrong log path, sudo NOPASSWD
+                # not set) is diagnosable from the test output instead
+                # of looking like a flaky timing-test skip.
+                print(
+                    f"[fixtures.RemoteServer] remote log read failed "
+                    f"(exit {r.returncode}) for {self.ssh_host}:"
+                    f"{self.remote_log_path}: {r.stderr.strip()!r}",
+                    file=sys.stderr,
+                )
+                return ""
+            return r.stdout
 
         # Journald fallback (deb-installed shed-server).
         try:

--- a/tests/integration/test_framework_meta.py
+++ b/tests/integration/test_framework_meta.py
@@ -235,6 +235,55 @@ def test_meta_remote_log_path_uses_ssh_cat(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# 6b. RemoteServer._log_offset uses `stat -c %s` (sudo opens the file)
+# ---------------------------------------------------------------------------
+
+
+def test_meta_remote_log_offset_uses_stat_not_wc_redirect(monkeypatch):
+    """`RemoteServer._log_offset` for `remote_log_path` mode uses
+    `sudo -n stat -c %s FILE`, NOT `sudo -n wc -c < FILE`. The shell
+    redirect `<` would run BEFORE sudo, so a root-owned dev log file
+    couldn't be opened and offset would always be 0 — defeating the
+    stale-PhaseTimer protection in `_read_timing`.
+
+    Catches: regression where someone "simplifies" the SSH command
+    back to `wc -c < ...` and the suite silently re-introduces a
+    flake class where re-running the same test name matches a prior
+    run's PhaseTimer line.
+    """
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        class R:
+            returncode = 0
+            stdout = "12345\n"
+            stderr = ""
+        return R()
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    s = RemoteServer(
+        ssh_host="fake-host",
+        name="any",
+        backend="firecracker",
+        remote_log_path="/tmp/shed-server-dev.log",
+    )
+    offset = s._log_offset()
+    assert offset == 12345
+
+    remote_cmd = captured["cmd"][-1]
+    assert "stat -c" in remote_cmd, (
+        f"expected `stat -c %s` (sudo opens the file), got: {remote_cmd!r}"
+    )
+    # The `wc -c < FILE` antipattern is the regression we're preventing.
+    assert "wc -c <" not in remote_cmd, (
+        f"`wc -c < FILE` shell-redirects BEFORE sudo runs; for a "
+        f"root-only dev log the shell can't open it. Use "
+        f"`sudo -n stat -c %s FILE` instead. Got: {remote_cmd!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # 7. RemoteServer with no remote_log_path uses journalctl
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/test_framework_meta.py
+++ b/tests/integration/test_framework_meta.py
@@ -1,0 +1,341 @@
+"""Meta-tests for the integration framework itself.
+
+These tests cover the common error scenarios a developer running the
+suite against a misconfigured dev or prod shed-server will actually
+hit. They don't need a live shed-server — they exercise the fixture
+code paths in `fixtures/server.py` directly, mocking out `subprocess`
+where needed.
+
+Why these matter: PR #157–#160 shipped a swap-based workflow whose
+failure modes (server unreachable, log path missing, sudo NOPASSWD
+not configured, ssh BatchMode failures) produced confusing skips and
+mysterious crashes during the validation cycles. The parallel-dev
+workflow that supersedes it adds new failure modes — wrong dev port
+in `~/.shed/config.yaml`, dev log written to a path the fixture isn't
+configured for, cross-talk between concurrent prod + dev sheds in the
+same log file. These meta-tests pin the expected behavior so a
+regression in any of those paths fires here, not as a confusing skip
+deep in the live-run suite.
+
+See `/Users/charliek/.claude/plans/lets-defer-remote-mac-deep-brook.md`
+§1.3 for the motivating list and the rationale for each test.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from fixtures.server import LocalServer, RemoteServer
+
+
+# ---------------------------------------------------------------------------
+# 1. log_path missing
+# ---------------------------------------------------------------------------
+
+
+def test_meta_log_path_missing_returns_empty(monkeypatch):
+    """LocalServer with a non-existent log_path falls through to
+    journald (which we mock to return empty). Tests don't crash; they
+    skip via the calling test's PhaseTimer-not-found check.
+
+    Catches: dev server writes to a path the fixture isn't configured
+    for. The test we'd ACTUALLY run (test_create_agent_p50) skips
+    cleanly with a clear reason instead of crashing the suite runner.
+    """
+    # Mock journalctl to return empty (the journald fallback path).
+    def fake_run(*args, **kwargs):
+        class R:
+            returncode = 0
+            stdout = ""
+        return R()
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    s = LocalServer(name="any", backend="vz", log_path=Path("/nonexistent"))
+    # Offset resolution doesn't raise.
+    offset = s._log_offset()
+    # Read doesn't raise.
+    blob = s._read_log_since(offset)
+    assert blob == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. available() when shed CLI is missing
+# ---------------------------------------------------------------------------
+
+
+def test_meta_available_probe_missing_cli(monkeypatch):
+    """available() returns False (not raises) when the shed CLI isn't
+    on PATH. The fixture's `if not s.available(): pytest.skip(...)`
+    chain then produces a clean skip.
+    """
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    s = LocalServer(name="any", backend="vz")
+    assert s.available() is False
+
+
+# ---------------------------------------------------------------------------
+# 3. available() when server is unreachable
+# ---------------------------------------------------------------------------
+
+
+def test_meta_available_probe_unreachable_server(monkeypatch):
+    """available() returns False when `shed -s NAME list` times out
+    or returns non-zero. Catches: dev server not running → skip, not
+    crash.
+    """
+    monkeypatch.setattr(shutil, "which", lambda _: "/fake/path/shed")
+
+    # Case A: subprocess.run returns non-zero.
+    def fake_run_nonzero(*args, **kwargs):
+        class R:
+            returncode = 1
+            stdout = ""
+            stderr = "connection refused"
+        return R()
+    monkeypatch.setattr(subprocess, "run", fake_run_nonzero)
+    assert LocalServer(name="any", backend="vz").available() is False
+
+    # Case B: subprocess.run raises TimeoutExpired.
+    def fake_run_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout", 0))
+    monkeypatch.setattr(subprocess, "run", fake_run_timeout)
+    assert LocalServer(name="any", backend="vz").available() is False
+
+
+# ---------------------------------------------------------------------------
+# 4. SSH endpoint resolution honors the configured port (not the 2222 fallback)
+# ---------------------------------------------------------------------------
+
+
+def test_meta_ssh_endpoint_resolves_dev_port(monkeypatch):
+    """`_resolve_ssh_endpoint` returns the port from
+    `shed --json server list` for the dev entry, not the fallback 2222.
+
+    Catches: suite running raw SSH against the wrong port when both a
+    prod and a dev server are configured. The raw-SSH path is what
+    the `ssh_exec_*` tests use.
+    """
+    fake_json = """[
+        {"name": "my-server", "host": "localhost", "ssh_port": 2222},
+        {"name": "my-server-dev", "host": "localhost", "ssh_port": 12222}
+    ]"""
+
+    def fake_run(cmd, **kwargs):
+        class R:
+            returncode = 0
+            stdout = fake_json
+            stderr = ""
+        return R()
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    s = LocalServer(name="my-server-dev", backend="vz")
+    host, port = s._resolve_ssh_endpoint()
+    assert host == "localhost"
+    assert port == 12222
+
+
+# ---------------------------------------------------------------------------
+# 5. template_fallback marker matches per-shed-name
+# ---------------------------------------------------------------------------
+
+
+def test_meta_template_fallback_marker_is_per_shed_name(monkeypatch):
+    """`_read_timing` only sets template_fallback=True when the
+    `[<name>] upper template unavailable` marker contains THIS test's
+    shed name. A concurrent create from the OTHER server (which would
+    write a marker with a different shed name) doesn't pollute this
+    one.
+
+    Catches: when prod and dev shed-servers are both running and
+    both happen to create sheds at the same time, the dev server's
+    "no template" log shouldn't be misattributed to a prod-server
+    create (or vice-versa).
+    """
+    # Synthetic log blob: marker for "other-shed", PhaseTimer line for
+    # "target-shed". The target's marker is NOT present.
+    blob = (
+        "2026/05/30 12:34:56 [other-shed] upper template unavailable "
+        "(no shed-build-tools ref configured); formatting in guest\n"
+        "2026/05/30 12:34:57 timing: create name=target-shed backend=vz "
+        "total=1500ms setup=1ms image=2ms rootfs=5ms vm=3ms "
+        "agent=1489ms err=<nil>\n"
+    )
+    s = LocalServer(name="any", backend="vz")
+    monkeypatch.setattr(s, "_read_log_since", lambda offset: blob)
+    monkeypatch.setattr(s, "_log_offset", lambda: 0)
+
+    timings, fallback = s._read_timing("target-shed", offset=0)
+    assert timings is not None
+    assert timings.name == "target-shed"
+    assert fallback is False, (
+        "fallback was incorrectly attributed from another shed's marker"
+    )
+
+    # Sanity: same blob, but ASK about other-shed → fallback IS set.
+    timings_other, fallback_other = s._read_timing("other-shed", offset=0)
+    # other-shed has the marker; no PhaseTimer line for it though, so
+    # timings_other is None — but the fallback flag is still set
+    # because the marker matched.
+    assert timings_other is None
+    assert fallback_other is True
+
+
+# ---------------------------------------------------------------------------
+# 6. RemoteServer(remote_log_path=...) uses ssh tail -c, not journalctl
+# ---------------------------------------------------------------------------
+
+
+def test_meta_remote_log_path_uses_ssh_cat(monkeypatch):
+    """When `RemoteServer` is constructed with a `remote_log_path`,
+    `_read_log_since` reads the remote file via `ssh + sudo tail -c +N`,
+    NOT journalctl.
+
+    Catches: regression where `remote_log_path` is silently dropped
+    and the fixture falls through to journalctl, which would fail to
+    find PhaseTimer lines from the parallel-dev shed-server (it's not
+    a systemd unit, so journalctl has no records).
+    """
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        class R:
+            returncode = 0
+            stdout = "fake log content"
+            stderr = ""
+        return R()
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    s = RemoteServer(
+        ssh_host="fake-host",
+        name="any",
+        backend="firecracker",
+        remote_log_path="/tmp/shed-server-dev.log",
+    )
+    result = s._read_log_since(42)
+
+    assert result == "fake log content"
+    assert captured["cmd"][0] == "ssh"
+    assert "fake-host" in captured["cmd"]
+    # The remote command should be a tail-from-offset of the configured
+    # log path. Format: `sudo -n tail -c +<offset+1> '/tmp/shed-server-dev.log' ...`
+    remote_cmd = captured["cmd"][-1]
+    assert "tail" in remote_cmd
+    assert "/tmp/shed-server-dev.log" in remote_cmd
+    # +(offset+1) because tail -c +N is 1-indexed.
+    assert "+43" in remote_cmd
+    # journalctl MUST NOT be invoked in this path.
+    assert "journalctl" not in remote_cmd
+
+
+# ---------------------------------------------------------------------------
+# 7. RemoteServer with no remote_log_path uses journalctl
+# ---------------------------------------------------------------------------
+
+
+def test_meta_remote_no_log_path_uses_journalctl(monkeypatch):
+    """When `RemoteServer` is constructed without `remote_log_path`
+    (the deb-installed shed-server case), `_read_log_since` uses
+    journald.
+
+    Catches: regression where the journald branch is broken — would
+    break the existing brew/deb-targeted suite's FC tests.
+    """
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return R()
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    s = RemoteServer(
+        ssh_host="fake-host",
+        name="any",
+        backend="firecracker",
+        # remote_log_path omitted → journald path
+    )
+    s._read_log_since("2026-05-30 12:00:00")
+
+    remote_cmd = captured["cmd"][-1]
+    assert "journalctl" in remote_cmd
+    assert "shed-server" in remote_cmd
+    assert "tail" not in remote_cmd
+
+
+# ---------------------------------------------------------------------------
+# 8. Full-suite regression backstop — existing brew run still works
+# ---------------------------------------------------------------------------
+
+
+# Sentinel env var to prevent recursion if the meta-test were ever
+# (accidentally) run by the subprocess pytest itself.
+_RECURSION_GUARD = "SHED_META_TEST_RECURSION_GUARD"
+
+
+def test_meta_full_suite_still_passes_against_brew():
+    """Backstop: a single canonical test from `test_smoke.py` still
+    passes against the brew-installed shed-server with default env
+    vars. This is the load-bearing regression gate that PR 1's
+    fixture changes don't break the existing brew-targeted flow.
+
+    Skips cleanly when:
+      - The brew shed-server isn't reachable (`shed -s my-server list`
+        non-zero). Common on a non-Mac dev workstation.
+      - We're being run recursively via this test's own subprocess
+        invocation (the sentinel env var).
+
+    Deliberately slow-but-deterministic over fast-but-flaky. Picks
+    one test (test_create_delete_lifecycle[vz]) that's the cheapest
+    end-to-end probe of the create/delete path.
+    """
+    if os.environ.get(_RECURSION_GUARD) == "1":
+        pytest.skip("recursion guard")
+
+    # Probe brew reachability before invoking pytest.
+    if shutil.which("shed") is None:
+        pytest.skip("shed CLI not on PATH")
+    probe = subprocess.run(
+        ["shed", "-s", "my-server", "list"],
+        capture_output=True, text=True, timeout=10,
+    )
+    if probe.returncode != 0:
+        pytest.skip(
+            f"brew shed-server (my-server) not reachable; "
+            f"this backstop only runs on a configured Mac dev workstation. "
+            f"probe stderr: {probe.stderr!r}"
+        )
+
+    # Run the cheapest canary against the brew server, in a subprocess
+    # so this test's own pytest state doesn't tangle.
+    env = os.environ.copy()
+    env[_RECURSION_GUARD] = "1"
+    integration_dir = Path(__file__).parent
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "pytest",
+            "-v", "--tb=short",
+            "test_smoke.py::test_create_delete_lifecycle[vz]",
+        ],
+        cwd=str(integration_dir),
+        env=env,
+        capture_output=True, text=True,
+        # Generous: one VZ create + delete typically ~10-20 s; allow
+        # plenty of headroom for cold-state.
+        timeout=180,
+    )
+
+    assert result.returncode == 0, (
+        f"brew-targeted backstop test failed (exit {result.returncode}):\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## What

Foundation PR for the parallel dev shed-server workflow planned in `~/.claude/plans/lets-defer-remote-mac-deep-brook.md`. **No user-facing workflow has changed yet** — `make test-integration` still runs unchanged against brew/deb. PR 2 + 3 add the Makefile lifecycle that actually launches the dev server; PR 4 cleans up docs and retires the v1 swap workflow.

### Four pieces land here:

1. **Two config YAMLs** for the parallel dev shed-server:
   - `configs/server.dev-parallel.mac.yaml` — VZ, port `18080/12222`, separate `~/Library/Application Support/shed-dev/vz/` state-dirs.
   - `configs/server.dev-parallel.linux-fc.yaml` — FC, port `18080/12222`, separate `/var/lib/shed-dev/firecracker/` state-dirs, **offset `vsock_base_cid: 600`**, SHARED bridge/CIDR/tap_prefix (kernel-level TAP coordination in `internal/firecracker/network.go:FindAvailableTAPIndex` handles cross-server). Both omit credentials + extensions intentionally — dev sheds exist to exercise the server, not to host the developer's working environment.

2. **`RemoteServer.remote_log_path`** (`tests/integration/fixtures/server.py`). The parallel dev FC server runs via `sudo nohup` (not systemd), so its log doesn't land in journald. When `remote_log_path` is set, `_log_offset` reads the remote file size via `sudo -n wc -c < FILE`; `_read_log_since` reads from byte offset via `sudo -n tail -c +N FILE`. When `None`, falls through to today's journald path (preserves the deb-installed shed-server case).

3. **Conftest dev fixtures + env vars** (`tests/integration/conftest.py`):
   - `SHED_VZ_DEV_SERVER` / `SHED_VZ_DEV_LOG_PATH` for Mac.
   - `SHED_FC_DEV_SERVER` / `SHED_FC_DEV_LOG_PATH` for FC remote.
   - `vz_server_dev` / `fc_server_dev` session-scoped sub-fixtures plus `shed_server_dev` parameterized over backends. All skip cleanly when their env vars are unset, so today's flow is unaffected.

4. **`tests/integration/test_framework_meta.py`** — 8 meta-tests covering the fixture infra's common error paths so a regression in any of these surfaces here, not as a confusing skip deep in a live-run suite:

| # | Test | Catches |
|---|---|---|
| 1 | `test_meta_log_path_missing_returns_empty` | dev plist writes to a path the suite isn't configured for → graceful skip, not crash |
| 2 | `test_meta_available_probe_missing_cli` | `shed` CLI missing → False, not crash |
| 3 | `test_meta_available_probe_unreachable_server` | timeout / non-zero exit → False, not crash |
| 4 | `test_meta_ssh_endpoint_resolves_dev_port` | raw-SSH tests hitting port 2222 when dev is on 12222 |
| 5 | `test_meta_template_fallback_marker_is_per_shed_name` | concurrent prod + dev sheds cross-talking in one log file |
| 6 | `test_meta_remote_log_path_uses_ssh_cat` | `remote_log_path` silently dropped → falls through to journald (would find nothing for the non-systemd dev server) |
| 7 | `test_meta_remote_no_log_path_uses_journalctl` | journald branch broken → would break the deb FC suite |
| 8 | `test_meta_full_suite_still_passes_against_brew` | the load-bearing backstop — subprocess pytest invocation against brew, skips cleanly when brew isn't reachable |

## Validation Results

Per plan §1.4:

| # | Scenario | Outcome |
|---|---|---|
| a | `make check` clean | ✅ |
| b | Meta-tests + parser tests pass | ✅ 18 passed, 1 deselected. The deselected slow brew-backstop runs separately in 7 s and also passes. |
| c | Existing suite still passes against brew | ✅ (with caveat) — 49 passed + 1 FC-template skip + 1 transient flake on `test_lifecycle_plain[fc]` (`echo after-start` returned empty stdout once; passes deterministically in isolation 2/2). Same FC exec-shell flake class as in PR #159's validation cycle, NOT introduced by this PR's changes. |
| d | Config files parse | ✅ Mac config starts cleanly on port `18080/12222` + graceful-shuts on SIGTERM. Linux FC config YAML loads (errors only at firecracker-backend-init time on Darwin, expected build-tag behavior). |
| e | CodeRabbit + codex sign-off | pending CI |

`make check` clean.

## Scope notes

- **No Makefile changes.** PR 2 (Mac) + PR 3 (FC remote) add the `dev-server-up` / `test-integration-dev` lifecycle targets.
- **No documentation overhaul.** Just a small README addition documenting the new env vars + fixtures. The CLAUDE.md / `docs/development/testing.md` rewrites land in PR 2 + 3 alongside the workflow changes; the discovery-doc retirement is PR 4.
- **The 8th meta-test (full-suite backstop) is slow-but-deterministic by design** — it actually runs a real `test_create_delete_lifecycle[vz]` against brew via subprocess (~7 s on a warm host). Skips cleanly when brew isn't reachable so a non-Mac dev workstation doesn't fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
