### PR TITLE
build: Mac local parallel dev server + delete Mac swap workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,8 @@ The suite is **parameterized over `["vz", "fc"]`** and skips cleanly when a back
 #   2. make dev-server-up           # launches dev shed-server on ports 18080/12222
 #
 # Per development cycle:
-make dev-server-up                  # idempotent; no-op if already running
-make test-integration-dev           # run suite against dev server
+make dev-server-up                  # refuses if already running (use dev-server-restart)
+make test-integration-dev           # run suite against dev server (auto-ups if needed)
 # ... edit source ...
 make build && make dev-server-restart   # pick up the rebuild
 make test-integration-dev           # re-run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,50 +38,70 @@ The suite is **parameterized over `["vz", "fc"]`** and skips cleanly when a back
 
 **FC live tests require the remote `shed-server` to emit `PhaseTimer` log lines** (added in v0.5.4 via PR #118). Two tests (`test_phase_timer_emitted[fc]`, `test_create_agent_p50[fc]`) skip cleanly with a clear message if the remote is older — the other tests work against any shed-server version. Once the remote upgrades to v0.5.4+, the suite picks up the FC tests automatically with no config change.
 
-#### Server-side changes — required e2e validation
+#### Server-side changes — parallel dev server
 
-`make test-integration` runs against whatever `shed-server` binary is currently **installed** on the host, not the source tree you're editing. A server-side-only change (orchestrator, lifecycle internals, backend handlers with no CLI-visible signature change) can pass `make test-integration` without ever executing the new code path — the brew/deb binary is still the OLD one. This gap masked real coverage on PRs #151-156; see `docs/discovery/integration-suite-server-coverage.md` for the full motivation.
+`make test-integration` runs against whatever `shed-server` binary is currently **installed** on the host (brew on Mac, deb on Linux), not the source tree you're editing. A server-side-only change (orchestrator, lifecycle internals, backend handlers with no CLI-visible signature change) can pass `make test-integration` without ever executing the new code path — the installed binary is still the OLD one.
 
-**Any server-side change MUST be validated against the developer's own source tree before opening a PR.** Two one-command targets automate the build + binary-swap + suite + restore cycle:
+**Any server-side change must be validated against the developer's own source tree before opening a PR.** The mechanism is a **parallel dev shed-server** that runs alongside the brew/deb one on a different port — the production server keeps running undisturbed, the dev server is what the suite targets.
 
 ```bash
-# VZ on local Mac (brew shed-server). macOS only.
-make test-integration-local
-
-# FC on remote Linux (default $SHED_FC_HOST=mini3) over SSH. Linux deb shed-server.
-make test-integration-local-fc
+# One-time setup per developer (Mac):
+#   1. Add a ~/.shed/config.yaml entry for the dev server (snippet below).
+#   2. make dev-server-up           # launches dev shed-server on ports 18080/12222
+#
+# Per development cycle:
+make dev-server-up                  # idempotent; no-op if already running
+make test-integration-dev           # run suite against dev server
+# ... edit source ...
+make build && make dev-server-restart   # pick up the rebuild
+make test-integration-dev           # re-run
+make dev-server-down                # when done
 ```
 
-Both targets build the dev binary, swap it in (codesigned on Mac; systemd drop-in on Linux), set `SHED_BUILD_TOOLS_REF` to the latest release tag so the dev binary uses release-shaped behavior, run the full suite, and restore the host's installed binary **regardless of suite outcome**. The chained targets capture both the suite and the restore exit codes so a restore failure is surfaced separately from a suite failure. Backups live at `/tmp/shed-server-v<VERSION>.bak` (Mac) and `/tmp/shed-server-deb.bak` (remote); the install targets refuse to clobber an existing backup without `FORCE=1`.
+The dev server's lifecycle is intentionally `nohup` + PID file under `~/.shed/dev/` — no launchd plist, no auto-restart on crash (crashes should be visible), no survives-reboot. State-dirs are isolated under `~/Library/Application Support/shed-dev/vz/` so `shed image prune` from the brew server never touches dev blobs. The dev server's `SHED_BUILD_TOOLS_REF` is set inline to the latest release tag so the dev binary uses release-shaped upper-template behavior (sub-100 ms rootfs phase).
 
-**Open a server-side PR with `make test-integration-local: N/N pass against dev-build at commit <sha>`** (or its `-fc` sibling), and that statement is true and meaningful — not a brew-binary alibi.
+**`~/.shed/config.yaml` entry** (copy-paste alongside the existing `my-server` entry):
+
+```yaml
+servers:
+  my-server-dev:
+    host: localhost
+    http_port: 18080
+    ssh_port: 12222
+```
+
+Or run `shed server add localhost --port 18080 --name my-server-dev` after the first `make dev-server-up` — it registers the entry by probing the running server's `/info` endpoint.
+
+The FC remote sibling (`make dev-server-up-fc` / `make test-integration-dev-fc` targeting `$SHED_FC_HOST`) lands in a follow-up PR; today validate FC changes via the existing `make test-integration-local-fc` swap workflow.
+
+**Open a server-side PR with `make test-integration-dev: N/N pass against dev-build at commit <sha>`**, and that statement is true and meaningful — not a brew-binary alibi.
 
 #### Performance impact — vet against the released version
 
-For changes that touch the boot path, agent dial, healthPoll, upper-allocation, mount, image-resolution, or any other hot path: **measure the impact on each platform the change affects, against the most recent release binary, before merging.** The split timing gate (`test_create_agent_p50` + `test_create_rootfs_template_present`) is the floor — it'll fire on regressions around 500 ms or more (see `tests/integration/fixtures/server.py:DEFAULT_AGENT_P50_MS` for the per-backend regression budget) — but a sub-threshold regression (or worse, a "no regression" that masks an actual gain that didn't materialise) won't trip it.
+For changes that touch the boot path, agent dial, healthPoll, upper-allocation, mount, image-resolution, or any other hot path: **measure the impact on each platform the change affects, against the most recent release binary, before merging.** The split timing gate (`test_create_agent_p50` + `test_create_rootfs_template_present`) is the floor — it fires on regressions around 500 ms or more (see `tests/integration/fixtures/server.py:DEFAULT_AGENT_P50_MS` for the per-backend regression budget) — but a sub-threshold regression (or worse, a "no regression" that masks an actual gain that didn't materialise) won't trip it.
 
-The workflow:
+The workflow uses the parallel-dev pair on both sides of the comparison — no service interruption needed:
 
-1. Run the suite against the **release** binary (the bare `make test-integration` — it picks up the brew/deb install). Record the agent_p50 + total wall-clock from the PhaseTimer line for each backend you're changing.
-2. Swap in the dev binary (`make install-local-server` / `make install-remote-server`) and re-run. Same measurements.
-3. Compare. The dev binary on `SHED_BUILD_TOOLS_REF=<latest-tag>` should be the apples-to-apples comparison.
-4. Repeat on every backend the change affects. **A change shipping for both VZ and FC needs both backends measured** — Apple Silicon vfkit and Linux KVM Firecracker have different floors and the same code can be faster on one and slower on the other.
-5. Record the measurements in the PR body. Hypothesised gains that don't show up are worth investigating before merge.
+1. **Baseline against release.** `make test-integration` (it targets the brew/deb install). Record the agent_p50 and rootfs_ms from the PhaseTimer line for each backend you're changing.
+2. **Compare against your branch.** `make build && make dev-server-restart && make test-integration-dev` (it targets the parallel dev server running your source). Same measurements.
+3. **Repeat on every affected backend.** A change shipping for both VZ and FC needs both backends measured — Apple Silicon vfkit and Linux KVM Firecracker have different floors and the same code can be faster on one and slower on the other.
+4. **Record the measurements in the PR body.** Hypothesised gains that don't show up are worth investigating before merge.
 
-This is what kept the v0.5.4 build-tools-ref regression hidden (caught by a user noticing slow creates after `brew upgrade`, not by the suite). The dynamic timing gate complements the unit tests; the per-platform measurement is the only safety net for changes whose value-add IS the timing characteristic.
+This catches the v0.5.4-class regression where the binary built correctly but a config knob (build-tools-ref, healthPoll constant, etc.) silently disabled the fast path. The dynamic timing gate complements the unit tests; the per-platform measurement is the only safety net for changes whose value-add IS the timing characteristic.
 
 #### Environment overrides (full list in `tests/integration/README.md`)
 
 | Variable | Default | Effect |
 |---|---|---|
-| `SHED_VZ_SERVER` | `my-server` | `~/.shed/config.yaml` entry for the local VZ server. Also honored by `make install-local-server` / `make test-integration-local`. |
-| `SHED_VZ_LOG_PATH` | `/opt/homebrew/var/log/shed-server.log` | brew log path (override for Intel-Mac homebrew prefix or custom installs) |
-| `SHED_FC_HOST` | `mini3` | SSH host for FC live tests + `make install-remote-server` / `make test-integration-local-fc`. |
-| `SHED_FC_SERVER` | same as `$SHED_FC_HOST` | `~/.shed/config.yaml` entry name when it differs from the SSH host |
-| `FC_REMOTE_BIN_PATH` | `/usr/local/bin/shed-server` | shed-server install path on the FC remote (override if the deb's install location moves) |
-| `RELEASE_BUILD_TOOLS_REF` | latest `git tag` matching `v*` | shed-build-tools image ref injected into the dev binary so it uses release-shaped behavior. Pin to an older release if your source has drifted: `RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:v0.5.7` |
+| `SHED_VZ_SERVER` | `my-server` | `~/.shed/config.yaml` entry for the brew/deb VZ server. |
+| `SHED_VZ_DEV_SERVER` | `my-server-dev` | `~/.shed/config.yaml` entry for the parallel dev VZ server. Honored by `make dev-server-up` / `dev-server-status` / `test-integration-dev`. |
+| `SHED_VZ_LOG_PATH` | `/opt/homebrew/var/log/shed-server.log` | brew log path (override for Intel-Mac homebrew prefix or custom installs). Set by `test-integration-dev` to the dev log path automatically. |
+| `SHED_FC_HOST` | `mini3` | SSH host for FC live tests + the existing `test-integration-local-fc` workflow. |
+| `SHED_FC_SERVER` | same as `$SHED_FC_HOST` | `~/.shed/config.yaml` entry name when it differs from the SSH host. |
+| `FC_REMOTE_BIN_PATH` | `/usr/local/bin/shed-server` | shed-server install path on the FC remote. |
+| `RELEASE_BUILD_TOOLS_REF` | latest `git tag` matching `v*` | shed-build-tools image ref injected into the dev binary so it uses release-shaped upper-template behavior. Pin to an older release if your source has drifted: `RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:v0.5.7`. |
 
-See `docs/development/testing.md` (Development → Testing on the docs site) for the full operator guide — adding a test, the per-backend timing ceilings, the fixture conventions, the FC remote upgrade procedure for first-time setup, etc.
+See `docs/development/testing.md` for the full operator guide — adding a test, the per-backend timing ceilings, the fixture conventions, the dev-server lifecycle.
 
 ## Project Structure
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-cli build-server build-agent build-firstboot build-tools build-fc-remote-server test test-integration test-integration-local test-integration-local-fc install-local-server restore-brew-server install-remote-server restore-remote-server release clean dev-server dev-cli check check-kernel-pin coverage lint-all docs docs-serve firecracker-rootfs download-firecracker vz-rootfs vz-rootfs-base vz-rootfs-all
+.PHONY: build build-cli build-server build-agent build-firstboot build-tools build-fc-remote-server test test-integration test-integration-dev test-integration-local-fc install-remote-server restore-remote-server dev-server-up dev-server-down dev-server-status dev-server-logs dev-server-restart release clean dev-server dev-cli check check-kernel-pin coverage lint-all docs docs-serve firecracker-rootfs download-firecracker vz-rootfs vz-rootfs-base vz-rootfs-all
 
 GOARCH ?= $(shell go env GOARCH)
 
@@ -45,186 +45,193 @@ test-integration:
 	}
 	cd tests/integration && uv sync && uv run pytest -v
 
-# Local dev-binary swap + integration suite + restore (Mac VZ only).
+# Parallel dev shed-server lifecycle (Mac VZ).
 #
-# Closes the integration-suite-server-coverage gap documented in
-# docs/discovery/integration-suite-server-coverage.md: by default
-# `make test-integration` runs against whichever shed-server binary is
-# currently installed (typically the brew release), so server-side PRs
-# can pass the suite without exercising their own code. These targets
-# swap in the just-built dev binary, run the suite against it, and
-# restore the brew binary regardless of suite outcome.
+# Runs the just-built bin/shed-server ALONGSIDE the brew-installed
+# shed-server on a different port (18080/12222). The brew server keeps
+# running undisturbed; the dev server is for testing server-side
+# changes against the developer's source tree.
 #
-# Discovery surfaced during PR-B1 (#153) and formalised in
-# ~/.claude/plans/patient-bridging-heron.md §2. The corresponding FC
-# remote (mini3 via SSH) workflow lives in PR 3's
-# `test-integration-local-fc` target.
+# Workflow:
+#   1. make dev-server-up                # once (or after rebuild via -restart)
+#   2. make test-integration-dev         # runs the suite against the dev server
+#   3. ... iterate on source ...
+#   4. make build && make dev-server-restart  # pick up the new binary
+#   5. make dev-server-down              # when done
+#
+# Setup (one-time per developer):
+#   - Add a ~/.shed/config.yaml entry for $(SHED_VZ_DEV_SERVER); see
+#     CLAUDE.md or tests/integration/README.md for the snippet.
+#
+# Why no launchd plist:
+#   The dev server is intentionally ephemeral — no auto-restart on
+#   crash (crashes should be visible), no survives-reboot (re-up after
+#   reboot). `nohup` + PID file gives clean start/stop/restart
+#   semantics without an Apple-specific lifecycle layer.
 
-# Shed CLI entry name for the local VZ server (the entry in
-# `~/.shed/config.yaml`). Mirrors the integration suite's
-# `SHED_VZ_SERVER` env var (see tests/integration/conftest.py); the
-# install-local-server readiness probe uses this so a developer with
-# a non-default VZ entry name still gets a useful ready signal.
+# Shed CLI entry name for the brew VZ server (the entry in
+# `~/.shed/config.yaml`). Mirrors `SHED_VZ_SERVER` in the test suite.
 SHED_VZ_SERVER ?= my-server
 
-# Brew install paths. Resolved dynamically because the Cellar version
-# changes per release; we don't want to hardcode a stale path.
-# All three variables collapse to empty when brew shed isn't installed;
-# the install-local-server recipe checks that before doing anything
-# destructive.
-BREW_SHED_PREFIX := $(shell brew --prefix shed 2>/dev/null)
-BREW_VERSION := $(shell test -n "$(BREW_SHED_PREFIX)" && basename "$$(readlink "$(BREW_SHED_PREFIX)" 2>/dev/null)" 2>/dev/null)
-BREW_SHED_BIN := $(BREW_SHED_PREFIX)/bin/shed-server
-BACKUP_PATH := /tmp/shed-server-v$(BREW_VERSION).bak
+# Shed CLI entry name for the parallel dev VZ server. Mirrors
+# `SHED_VZ_DEV_SERVER` in the test suite's conftest.
+SHED_VZ_DEV_SERVER ?= my-server-dev
+
+DEV_LOG_PATH := $(HOME)/.shed/dev/server.log
+DEV_PID_PATH := $(HOME)/.shed/dev/server.pid
+DEV_CONFIG   := $(CURDIR)/configs/server.dev-parallel.mac.yaml
 
 # shed-build-tools image ref to inject when the dev binary runs.
 # Dev binaries embed Version="vX.Y.Z-N-gHASH-dirty", which
-# BuildToolsRefForTag returns "" for by design (dev-build isolation —
-# see docs/discovery/integration-suite-server-coverage.md §7). Without
-# the env var the dev binary falls back to in-guest mkfs.ext4 on first
-# boot (~4 s on VZ), which the split timing gate (PR #157) skips
-# cleanly but it's still not the path we want when validating server
+# BuildToolsRefForTag returns "" for by design (dev-build isolation).
+# Without the env var the dev binary falls back to in-guest mkfs.ext4
+# on first boot (~4 s on VZ), which the split timing gate (PR #157)
+# skips cleanly but isn't the path we want when validating server
 # changes against release-shaped behavior. Override with
 # `RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:vX.Y.Z`
 # to pin to a non-latest release.
 RELEASE_BUILD_TOOLS_REF ?= $(shell git tag --list 'v*' --sort=-version:refname | head -1 | sed 's|^|ghcr.io/charliek/shed-build-tools:|')
 
-# Swap the just-built bin/shed-server into the brew Cellar, codesign
-# ad-hoc (launchd SIGKILLs unsigned binaries), set SHED_BUILD_TOOLS_REF
-# in the user's launchd domain, and restart the brew service.
-# Refuses to clobber an existing backup unless FORCE=1, so a developer
-# who runs this twice doesn't lose the original brew binary.
-install-local-server: build
+dev-server-up: build
 	@case "$$(uname -s)" in \
 	  Darwin) ;; \
-	  *) echo "ERROR: install-local-server targets the brew-installed shed-server on macOS;"; \
-	     echo "       run this on a Mac. For the FC remote ($(FC_REMOTE_HOST)) workflow see"; \
-	     echo "       'make install-remote-server'."; exit 1 ;; \
+	  *) echo "ERROR: dev-server-up targets the local Mac VZ shed-server."; \
+	     echo "       For the FC remote workflow see 'make dev-server-up-fc'."; exit 1 ;; \
 	esac
-	@if [ -z "$(BREW_VERSION)" ]; then \
-	  echo "ERROR: brew shed is not installed (or 'brew --prefix shed' failed)."; \
-	  echo "       Install with 'brew install charliek/shed/shed' and retry."; exit 1; \
+	@mkdir -p "$(HOME)/.shed/dev"
+	@# Refuse if already running — `dev-server-restart` is the way to
+	@# pick up a rebuilt binary. Plain `dev-server-up` should never
+	@# silently kill an existing server.
+	@if [ -f "$(DEV_PID_PATH)" ] && kill -0 "$$(cat $(DEV_PID_PATH))" 2>/dev/null; then \
+	  echo "ERROR: dev server already running (pid $$(cat $(DEV_PID_PATH)))."; \
+	  echo "       Use 'make dev-server-restart' to pick up a rebuild,"; \
+	  echo "       or 'make dev-server-down' to stop it first."; \
+	  exit 1; \
 	fi
-	@if [ -f "$(BACKUP_PATH)" ] && [ "$(FORCE)" != "1" ]; then \
-	  echo "ERROR: backup already exists at $(BACKUP_PATH)."; \
-	  echo "       Run 'make restore-brew-server' first, or pass FORCE=1 to overwrite"; \
-	  echo "       (FORCE=1 is destructive — the existing backup is lost)."; exit 1; \
-	fi
-	@cp -f "$(BREW_SHED_BIN)" "$(BACKUP_PATH)"
-	@brew services stop shed
-	@chmod +w "$(BREW_SHED_BIN)"
-	@cp -f bin/shed-server "$(BREW_SHED_BIN)"
-	@# --force lets us re-sign cleanly on subsequent runs without
-	@# tripping codesign's "is already signed" error. macOS launchd
-	@# SIGKILLs unsigned binaries so this step is non-optional.
-	@codesign --force -s - "$(BREW_SHED_BIN)"
-	@chmod -w "$(BREW_SHED_BIN)"
-	@launchctl setenv SHED_BUILD_TOOLS_REF "$(RELEASE_BUILD_TOOLS_REF)"
-	@brew services start shed
-	@# launchd start is async — the suite's session-scoped probe runs
-	@# the moment make returns and can race the server before it binds
-	@# 8080. Poll until \`shed list\` succeeds (the same probe the
-	@# integration suite uses) or 15 s elapses. Without this the suite
-	@# silently skips all VZ tests with "shed-server not reachable."
+	@# Inline env so we don't pollute the caller's launchctl domain
+	@# (and so the brew server's launchctl env is left alone). Note
+	@# the env var name: shed-server reads SHED_BUILD_TOOLS_REF; the
+	@# Makefile-level variable that holds its value is named
+	@# RELEASE_BUILD_TOOLS_REF (because it points at the *release*
+	@# tooling image).
+	@SHED_BUILD_TOOLS_REF="$(RELEASE_BUILD_TOOLS_REF)" \
+	  nohup bin/shed-server serve --config "$(DEV_CONFIG)" \
+	    > "$(DEV_LOG_PATH)" 2>&1 & \
+	  echo $$! > "$(DEV_PID_PATH)"
+	@# Readiness probe — same shape used everywhere in this Makefile.
 	@for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do \
-	  if shed -s $(SHED_VZ_SERVER) list >/dev/null 2>&1; then \
-	    echo "VZ shed-server ($(SHED_VZ_SERVER)) ready after $${i}s."; break; \
+	  if shed -s $(SHED_VZ_DEV_SERVER) list >/dev/null 2>&1; then \
+	    echo "Dev VZ shed-server ($(SHED_VZ_DEV_SERVER)) ready after $${i}s."; \
+	    break; \
 	  fi; \
 	  if [ "$$i" = "15" ]; then \
-	    echo "WARNING: VZ shed-server ($(SHED_VZ_SERVER)) not reachable after 15 s; integration suite may skip VZ tests."; \
+	    echo "WARNING: Dev VZ shed-server ($(SHED_VZ_DEV_SERVER)) not reachable after 15 s."; \
+	    echo "  - Tail the log:  make dev-server-logs   (or 'tail $(DEV_LOG_PATH)')"; \
+	    echo "  - CLI entry:     verify ~/.shed/config.yaml has '$(SHED_VZ_DEV_SERVER)' on port 18080"; \
+	    echo "  - Brew server:   should be unaffected; 'shed -s $(SHED_VZ_SERVER) list' still works"; \
 	  fi; \
 	  sleep 1; \
 	done
 	@echo ""
-	@echo "Dev shed-server installed in brew Cellar at $(BREW_SHED_BIN)."
-	@echo "Build-tools ref: $(RELEASE_BUILD_TOOLS_REF)"
-	@echo "Backup at $(BACKUP_PATH)."
-	@echo "Run 'make restore-brew-server' to revert (or it runs automatically"
-	@echo "at the end of 'make test-integration-local')."
+	@echo "Dev shed-server up: pid $$(cat $(DEV_PID_PATH))"
+	@echo "  Config:  $(DEV_CONFIG)"
+	@echo "  Log:     $(DEV_LOG_PATH)"
+	@echo "  CLI:     shed -s $(SHED_VZ_DEV_SERVER) list"
+	@echo "Run 'make test-integration-dev' to run the suite against it."
 
-# Reverse of install-local-server: restore the brew binary from the
-# backup, clear the launchctl env var, restart the brew service, and
-# remove the backup file. Idempotent — re-running after a successful
-# restore is a no-op with a clear message.
-restore-brew-server:
+dev-server-down:
 	@case "$$(uname -s)" in \
 	  Darwin) ;; \
-	  *) echo "ERROR: restore-brew-server is macOS-only; see install-local-server."; exit 1 ;; \
+	  *) echo "ERROR: dev-server-down is macOS-only (Mac VZ)."; exit 1 ;; \
 	esac
-	@# Always clear the launchctl env var, even in the no-backup branch:
-	@# install-local-server sets the env var ALONGSIDE creating the
-	@# backup, so a stranded env (manual setenv, partial-failure run, or
-	@# a backup that someone rm'd by hand) is the case where "restore"
-	@# is most likely to be invoked. Skipping the unset there would
-	@# leave the dev binary's behavior wired into the brew binary's
-	@# next start.
-	@launchctl unsetenv SHED_BUILD_TOOLS_REF
-	@# Single shell block so the no-op branch can short-circuit cleanly
-	@# (a separate `@if ... exit 0` line only exits its sub-shell, not
-	@# the recipe — make would continue running the restore steps even
-	@# though there's no backup to restore from).
-	@if [ ! -f "$(BACKUP_PATH)" ]; then \
-	  echo "No backup at $(BACKUP_PATH); nothing to restore (env var cleared anyway). (Idempotent: this is OK.)"; \
+	@# Single shell block so the no-PID-file branch can short-circuit
+	@# cleanly (a separate `@if ... exit 0` line only exits its
+	@# sub-shell, not the recipe — make would continue to the next
+	@# `@cat $(DEV_PID_PATH)` line and emit a confusing "No such file
+	@# or directory").
+	@if [ ! -f "$(DEV_PID_PATH)" ]; then \
+	  echo "Dev server not running (no PID file at $(DEV_PID_PATH))."; \
+	  echo "  (Idempotent: this is OK.)"; \
 	else \
-	  set -e; \
-	  brew services stop shed; \
-	  chmod +w "$(BREW_SHED_BIN)"; \
-	  cp -f "$(BACKUP_PATH)" "$(BREW_SHED_BIN)"; \
-	  codesign --force -s - "$(BREW_SHED_BIN)"; \
-	  chmod -w "$(BREW_SHED_BIN)"; \
-	  brew services start shed; \
-	  rm -f "$(BACKUP_PATH)"; \
-	  echo "Brew shed-server restored from backup; backup removed."; \
+	  PID=$$(cat "$(DEV_PID_PATH)"); \
+	  if kill -0 $$PID 2>/dev/null; then \
+	    kill -TERM $$PID 2>/dev/null; \
+	    for i in 1 2 3 4 5; do \
+	      if ! kill -0 $$PID 2>/dev/null; then break; fi; \
+	      sleep 1; \
+	    done; \
+	    if kill -0 $$PID 2>/dev/null; then \
+	      echo "Dev server didn't stop gracefully after 5s; SIGKILL"; \
+	      kill -KILL $$PID 2>/dev/null; \
+	    fi; \
+	    echo "Dev server (pid $$PID) stopped."; \
+	  else \
+	    echo "Dev server PID $$PID is stale (process already gone); cleaning up PID file."; \
+	  fi; \
+	  rm -f "$(DEV_PID_PATH)"; \
 	fi
 
-# Chain: install dev binary locally, run the integration suite against
-# it, restore the brew binary REGARDLESS of suite outcome. Captures
-# BOTH the suite and the restore exit codes — a restore failure is at
-# least as serious as a suite failure (it strands the host), so the
-# chain target reports non-zero if either step fails.
-# install-local-server is invoked from the recipe body (not as a make
-# prerequisite) so a partial-failure install — backup created but
-# brew restart fails, codesign hiccup mid-stream — still runs the
-# restore step. A make prerequisite would halt the recipe before it
-# reaches the restore block, stranding the host.
+dev-server-status:
+	@case "$$(uname -s)" in \
+	  Darwin) ;; \
+	  *) echo "ERROR: dev-server-status is macOS-only (Mac VZ)."; exit 1 ;; \
+	esac
+	@if [ -f "$(DEV_PID_PATH)" ] && kill -0 "$$(cat $(DEV_PID_PATH))" 2>/dev/null; then \
+	  PID=$$(cat "$(DEV_PID_PATH)"); \
+	  echo "Dev server: running (pid $$PID)"; \
+	  if shed -s $(SHED_VZ_DEV_SERVER) list >/dev/null 2>&1; then \
+	    echo "Reachable:  YES (shed -s $(SHED_VZ_DEV_SERVER) list succeeds)"; \
+	  else \
+	    echo "Reachable:  NO (shed -s $(SHED_VZ_DEV_SERVER) list failed)"; \
+	    echo "            (process is running but the CLI can't reach it —"; \
+	    echo "             check ~/.shed/config.yaml has '$(SHED_VZ_DEV_SERVER)')"; \
+	  fi; \
+	  echo "Log:        $(DEV_LOG_PATH)"; \
+	  echo "Config:     $(DEV_CONFIG)"; \
+	else \
+	  echo "Dev server: NOT running"; \
+	  if [ -f "$(DEV_PID_PATH)" ]; then \
+	    echo "  (Stale PID file at $(DEV_PID_PATH); 'make dev-server-down' will clean up.)"; \
+	  fi; \
+	fi
+
+dev-server-logs:
+	@if [ ! -f "$(DEV_LOG_PATH)" ]; then \
+	  echo "No log at $(DEV_LOG_PATH). Run 'make dev-server-up' first."; \
+	  exit 1; \
+	fi
+	@tail -F "$(DEV_LOG_PATH)"
+
+dev-server-restart: dev-server-down dev-server-up
+
+# Run the integration suite against the parallel dev shed-server.
+# Auto-starts the dev server if it isn't already running. Doesn't
+# auto-stop after — the dev server is intentionally long-lived for
+# iterative work. Use 'make dev-server-down' to stop.
 #
-# Crucially the auto-restore must ONLY fire when THIS invocation
-# created new state. Bare "is there a backup?" detection would also
-# restore when install bailed at the preflight 'backup already
-# exists' check, silently consuming a backup that belongs to an
-# EARLIER manual install — reverting someone's in-flight dev
-# workflow. Snapshot pre-state, compare post-state, restore only on
-# new mutation.
-test-integration-local:
-	@HAD_BACKUP=0; HAD_ENV=0; \
-	 [ -f "$(BACKUP_PATH)" ] && HAD_BACKUP=1; \
-	 [ -n "$$(launchctl getenv SHED_BUILD_TOOLS_REF)" ] && HAD_ENV=1; \
-	 $(MAKE) install-local-server; INSTALL=$$?; \
-	 if [ $$INSTALL -ne 0 ]; then \
-	   HAS_BACKUP=0; HAS_ENV=0; \
-	   [ -f "$(BACKUP_PATH)" ] && HAS_BACKUP=1; \
-	   [ -n "$$(launchctl getenv SHED_BUILD_TOOLS_REF)" ] && HAS_ENV=1; \
-	   if { [ $$HAD_BACKUP -eq 0 ] && [ $$HAS_BACKUP -eq 1 ]; } || \
-	      { [ $$HAD_ENV -eq 0 ] && [ $$HAS_ENV -eq 1 ]; }; then \
-	     echo "test-integration-local: install FAILED (exit $$INSTALL); NEW mutation created during this run; running restore"; \
-	     $(MAKE) restore-brew-server; \
-	   else \
-	     echo "test-integration-local: install FAILED (exit $$INSTALL); no new mutation detected (any pre-existing backup/env belongs to a prior install); leaving brew install alone"; \
-	   fi; \
-	   exit $$INSTALL; \
-	 fi; \
-	 SHED_VZ_SERVER=$(SHED_VZ_SERVER) $(MAKE) test-integration; SUITE=$$?; \
-	 $(MAKE) restore-brew-server; RESTORE=$$?; \
-	 if [ $$SUITE -ne 0 ] && [ $$RESTORE -ne 0 ]; then \
-	   echo "test-integration-local: suite FAILED (exit $$SUITE) AND restore FAILED (exit $$RESTORE); inspect host state"; \
-	   exit $$SUITE; \
-	 elif [ $$SUITE -ne 0 ]; then \
-	   echo "test-integration-local: suite FAILED (exit $$SUITE); restore succeeded"; \
-	   exit $$SUITE; \
-	 elif [ $$RESTORE -ne 0 ]; then \
-	   echo "test-integration-local: suite passed BUT restore FAILED (exit $$RESTORE); inspect host state"; \
-	   exit $$RESTORE; \
-	 fi
+# The suite is env-var-retargeted: SHED_VZ_SERVER points at the dev
+# entry, SHED_VZ_LOG_PATH points at the dev log file. The existing
+# `shed_server` fixture (parameterized over [vz, fc]) honors these
+# without any test-side changes — VZ tests run against the dev server;
+# FC tests still target $(FC_REMOTE_HOST) (the deb prod on mini3) as
+# in `make test-integration`. PR 3 adds the FC parallel-dev sibling
+# `test-integration-dev-fc` for testing FC changes.
+#
+# If you rebuilt the source but the dev server is still running the
+# old binary, run 'make dev-server-restart' before this target.
+test-integration-dev: build
+	@case "$$(uname -s)" in \
+	  Darwin) ;; \
+	  *) echo "ERROR: test-integration-dev targets the local Mac VZ dev server."; \
+	     echo "       For the FC remote workflow see 'make test-integration-dev-fc'."; exit 1 ;; \
+	esac
+	@if [ ! -f "$(DEV_PID_PATH)" ] || ! kill -0 "$$(cat $(DEV_PID_PATH))" 2>/dev/null; then \
+	  echo "Dev server not running; starting via dev-server-up..."; \
+	  $(MAKE) dev-server-up; \
+	fi
+	SHED_VZ_SERVER=$(SHED_VZ_DEV_SERVER) \
+	  SHED_VZ_LOG_PATH=$(DEV_LOG_PATH) \
+	  $(MAKE) test-integration
 
 # Remote dev-binary swap + integration suite + restore for the FC
 # backend on `$SHED_FC_HOST` (default `mini3`) over SSH. The FC sibling

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,17 @@ dev-server-down:
 	  echo "  (Idempotent: this is OK.)"; \
 	else \
 	  PID=$$(cat "$(DEV_PID_PATH)"); \
-	  if kill -0 $$PID 2>/dev/null; then \
+	  if ! kill -0 $$PID 2>/dev/null; then \
+	    echo "Dev server PID $$PID is stale (process already gone); cleaning up PID file."; \
+	    rm -f "$(DEV_PID_PATH)"; \
+	  elif ! ps -p $$PID -o comm= 2>/dev/null | grep -q "shed-server"; then \
+	    echo "Dev server PID $$PID points at an unrelated process"; \
+	    echo "  (current comm: $$(ps -p $$PID -o comm= 2>/dev/null))."; \
+	    echo "  Refusing to send signals; cleaning up the stale PID file only."; \
+	    echo "  If you have a stranded shed-server somewhere, find it with"; \
+	    echo "  'pgrep -fl shed-server' and stop it by hand."; \
+	    rm -f "$(DEV_PID_PATH)"; \
+	  else \
 	    kill -TERM $$PID 2>/dev/null; \
 	    for i in 1 2 3 4 5; do \
 	      if ! kill -0 $$PID 2>/dev/null; then break; fi; \
@@ -165,10 +175,8 @@ dev-server-down:
 	      kill -KILL $$PID 2>/dev/null; \
 	    fi; \
 	    echo "Dev server (pid $$PID) stopped."; \
-	  else \
-	    echo "Dev server PID $$PID is stale (process already gone); cleaning up PID file."; \
+	    rm -f "$(DEV_PID_PATH)"; \
 	  fi; \
-	  rm -f "$(DEV_PID_PATH)"; \
 	fi
 
 dev-server-status:
@@ -229,8 +237,17 @@ test-integration-dev: build
 	  echo "Dev server not running; starting via dev-server-up..."; \
 	  $(MAKE) dev-server-up; \
 	fi
+	@# Set BOTH the prod env-var pair (so the existing `shed_server`
+	@# fixture in test_smoke / test_lifecycle / test_exec_shell retargets
+	@# at the dev server) AND the dev env-var pair (so the
+	@# `shed_server_dev` fixture activates for any test that explicitly
+	@# uses it). Today's tests all use `shed_server`; future
+	@# dev-specific meta-tests can use `shed_server_dev` without needing
+	@# a different Make target.
 	SHED_VZ_SERVER=$(SHED_VZ_DEV_SERVER) \
 	  SHED_VZ_LOG_PATH=$(DEV_LOG_PATH) \
+	  SHED_VZ_DEV_SERVER=$(SHED_VZ_DEV_SERVER) \
+	  SHED_VZ_DEV_LOG_PATH=$(DEV_LOG_PATH) \
 	  $(MAKE) test-integration
 
 # Remote dev-binary swap + integration suite + restore for the FC

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -7,13 +7,14 @@ This document covers Shed's testing strategy, how to run each tier of tests, and
 | Tier | Scope | Tool | Requirements | CI |
 |------|-------|------|--------------|-----|
 | Unit | Pure logic, file-shape, ordering invariants | `go test` | Go toolchain | Yes |
-| Integration suite (installed binary) | Live create-cycle via `shed` CLI (both backends) | `pytest` + subprocess (uv-managed) | Reachable shed-server (local or remote); for FC: SSH to the host | No (locally + bare-metal release-validation) |
-| Integration suite (dev binary) | Same, but runs the suite against the just-built source | `make test-integration-local` / `make test-integration-local-fc` | All of the above + brew shed on Mac (VZ), or SSH + sudo NOPASSWD on the remote (FC) | No |
+| Integration suite (installed binary) | Live create-cycle via `shed` CLI against the brew/deb-installed shed-server | `pytest` + subprocess (uv-managed) | Reachable shed-server (local or remote); for FC: SSH to the host | No (locally + bare-metal release-validation) |
+| Integration suite (dev binary, VZ) | Same, but targets a parallel dev shed-server running from the just-built source on the local Mac | `make dev-server-up` + `make test-integration-dev` | All of the above + a `~/.shed/config.yaml` entry for the dev server | No |
+| Integration suite (dev binary, FC) | Same, but targets a swap-installed dev shed-server on the FC remote | `make test-integration-local-fc` | SSH + sudo NOPASSWD on the remote | No |
 | E2E (Firecracker, legacy) | Full VM lifecycle via API directly | `go test -tags=e2e` | KVM, root, Firecracker assets | No |
 
 The **integration suite** (PR #132) is the recommended path for live create-cycle verification on both backends. The Go-tagged FC e2e tests predate it and remain available for low-level API exercise.
 
-**Server-side changes require the dev-binary variant** (`make test-integration-local` / `-local-fc`). The plain `make test-integration` runs whatever binary is currently *installed* on the host, not your source — so a server-side-only change can pass the installed-binary tier without ever exercising the new code path. See [Validating server-side changes](#validating-server-side-changes-required-for-server-side-prs) below for the workflow.
+**Server-side changes require the dev-binary variant.** The plain `make test-integration` runs whatever binary is currently *installed* on the host, not your source — so a server-side-only change can pass the installed-binary tier without ever exercising the new code path. See [Validating server-side changes — parallel dev server](#validating-server-side-changes-parallel-dev-server) below for the workflow.
 
 ## Running Tests
 
@@ -111,59 +112,78 @@ The suite picks up FC tests automatically once the remote server emits PhaseTime
 
 | Variable | Default | Effect |
 |---|---|---|
-| `SHED_VZ_SERVER` | `my-server` | `~/.shed/config.yaml` entry for the local VZ server. Also honored by `make install-local-server` / `make test-integration-local`. |
-| `SHED_VZ_LOG_PATH` | `/opt/homebrew/var/log/shed-server.log` | Where the local VZ server writes its log file. Override for Intel-Mac Homebrew (`/usr/local/...`) or custom installs. |
+| `SHED_VZ_SERVER` | `my-server` | `~/.shed/config.yaml` entry for the brew-installed VZ server. The `dev-server-*` and `test-integration-dev` Makefile targets use `SHED_VZ_DEV_SERVER` instead. |
+| `SHED_VZ_LOG_PATH` | `/opt/homebrew/var/log/shed-server.log` | Where the local VZ server writes its log file. Override for Intel-Mac Homebrew (`/usr/local/...`) or custom installs. Set automatically by `make test-integration-dev` to the dev server's log file. |
+| `SHED_VZ_DEV_SERVER` | `my-server-dev` | `~/.shed/config.yaml` entry for the parallel dev VZ server. Honored by the `dev-server-*` Makefile targets. |
 | `SHED_FC_HOST` | `mini3` | SSH hostname for the FC server. Also honored by `make install-remote-server` / `make test-integration-local-fc`. |
 | `SHED_FC_SERVER` | same as `$SHED_FC_HOST` | `~/.shed/config.yaml` entry name when it differs from the SSH host. |
 | `FC_REMOTE_BIN_PATH` | `/usr/local/bin/shed-server` | Path to the shed-server binary on the FC remote. Override if the deb's install location moves or you've installed elsewhere. |
 | `RELEASE_BUILD_TOOLS_REF` | latest `git tag` matching `v*` | shed-build-tools image ref injected into the dev binary so it uses release-shaped upper-template behavior. Pin to an older release if your source has drifted: `RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:v0.5.7`. |
 
-#### Validating server-side changes (required for server-side PRs)
+#### Validating server-side changes — parallel dev server
 
-`make test-integration` runs against whichever `shed-server` binary is currently *installed* on the host (brew on Mac, deb on Linux), not the source tree you're editing. A server-side-only change (orchestrator, lifecycle internals, backend handlers with no CLI-visible surface) can pass that suite without ever exercising its own code, because the installed binary is the OLD one. This pattern silently masked coverage on PRs #151-156 — see [`docs/discovery/integration-suite-server-coverage.md`](../discovery/integration-suite-server-coverage.md) for the full motivation.
+`make test-integration` runs against whichever `shed-server` binary is currently *installed* on the host (brew on Mac, deb on Linux), not the source tree you're editing. A server-side-only change (orchestrator, lifecycle internals, backend handlers with no CLI-visible surface) can pass that suite without ever exercising its own code, because the installed binary is the OLD one.
 
-Two one-command targets close the gap:
+The mechanism for closing this gap is a **parallel dev shed-server** that runs alongside the brew/deb one on a different port. The production server keeps running undisturbed; the dev server is what the suite targets when you run the dev-targeted Makefile chain.
 
 **VZ (local Mac):**
 
 ```sh
-make test-integration-local
+# One-time setup per developer:
+#   Add a ~/.shed/config.yaml entry for the dev server (snippet at the
+#   end of this section), OR run `shed server add localhost --port 18080
+#   --name my-server-dev` after the first `make dev-server-up`.
+
+# Per dev cycle:
+make dev-server-up              # launches dev shed-server on 18080/12222
+make test-integration-dev       # runs suite against dev server (auto-ups if needed)
+# ... edit source ...
+make build && make dev-server-restart
+make test-integration-dev
+make dev-server-down            # when done
 ```
 
-That target builds the dev `bin/shed-server`, backs up the brew binary at `/tmp/shed-server-v<VERSION>.bak`, swaps the dev binary into the Cellar (codesigned ad-hoc so launchd will exec it), sets `SHED_BUILD_TOOLS_REF` via `launchctl`, restarts the brew service, runs the suite, then restores the brew binary. The restore runs unconditionally — a suite failure can't strand the host on the dev binary.
+The dev server:
 
-**FC (remote Linux over SSH; default `$SHED_FC_HOST=mini3`):**
+- Runs from `bin/shed-server` (the just-built dev binary) via `nohup` — no launchd plist, no auto-restart, no survives-reboot. Crashes are visible (not silently recovered); re-up after a reboot is one command.
+- Listens on ports `18080` (HTTP) + `12222` (SSH), separate from the brew server's `8080` + `2222`. Both servers run simultaneously without conflict.
+- Uses isolated state-dirs under `~/Library/Application Support/shed-dev/vz/` — separate `images_dir`, `instance_dir`, `snapshots_dir`, `uppers_dir`, `socket_dir`. `shed image prune` from the brew server never touches dev blobs, and vice versa.
+- Has `SHED_BUILD_TOOLS_REF` set inline to the latest release tag, so the dev binary uses the release-shaped upper-template fast path (sub-100 ms rootfs phase) — the suite's `test_create_rootfs_template_present` test passes against the dev server when the env var is wired correctly.
+
+**FC (remote Linux over SSH; default `$SHED_FC_HOST=mini3`) — current state:**
 
 ```sh
 make test-integration-local-fc
 ```
 
-Cross-compiles `shed-server` for the remote's GOARCH (detected at recipe time via `ssh <host> uname -m` — `x86_64` → `amd64`, `aarch64` → `arm64`), `scp`s the dev binary, backs up the deb binary on the remote at `/tmp/shed-server-deb.bak`, swaps via `install -m 755`, writes a systemd drop-in at `/etc/systemd/system/shed-server.service.d/dev-override.conf` setting `Environment=SHED_BUILD_TOOLS_REF=<release-tag>`, `daemon-reload`s, restarts the service, runs the suite, then restores. The backup lives on the **remote** so a workstation reboot mid-test doesn't strand the remote in dev-binary state.
+(The parallel-dev sibling `make test-integration-dev-fc` lands in a follow-up PR. Today, FC server-side validation uses the swap-based workflow that cross-compiles for the remote, scps, drops a systemd Environment= override, runs the suite, and restores. See the next subsection.)
 
-Both chained targets:
+A server-side PR should open with **"`make test-integration-dev`: N/N pass against dev-build at commit `<sha>`"** (or `test-integration-local-fc` for FC changes until the FC parallel-dev sibling ships). That sentence is then true and meaningful — not a brew/deb-binary alibi.
 
-- Capture BOTH the suite exit code and the restore exit code, and report each separately if either fails. A restore failure is at least as serious as a suite failure (a stranded host vs. a normal red test).
-- Snapshot pre/post state around the install step. If install fails AND your invocation didn't create new state (e.g., the preflight rejected because a prior manual install left a backup), the chain does NOT auto-restore — it leaves your existing dev install alone. If install fails AND it had started mutating state, auto-restore runs to clean up.
-- Refuse to clobber an existing backup without `FORCE=1`, so `make install-X-server` followed accidentally by a second `make install-X-server` doesn't lose the original.
+**`~/.shed/config.yaml` entry** to add for the parallel-dev VZ server:
 
-A server-side PR should open with **"`make test-integration-local`: N/N pass against dev-build at commit `<sha>`"** (or its `-fc` sibling) in the body. That sentence is then true and meaningful — not a brew/deb-binary alibi.
-
-Standalone `make install-local-server` / `make install-remote-server` and `make restore-brew-server` / `make restore-remote-server` exist as targets too, for manual repro flows (e.g. running `shed create` against the dev binary by hand between the swap and the restore).
+```yaml
+servers:
+  my-server-dev:
+    host: localhost
+    http_port: 18080
+    ssh_port: 12222
+```
 
 #### Performance validation against the released version
 
 For changes that touch the boot path, agent dial, healthPoll, upper-allocation, mount, image-resolution, or any other hot path: **measure the impact on each platform the change affects, against the most recent release binary, before merging.**
 
-The split timing gate (`test_create_agent_p50` + `test_create_rootfs_template_present`) is the floor — it fires on regressions around 500 ms or more (see `tests/integration/fixtures/server.py:DEFAULT_AGENT_P50_MS` for the per-backend ceiling; VZ has ~500 ms regression budget over its ~1550 ms median, FC has ~500 ms over its ~2400 ms median) — but a sub-threshold regression (or worse, a "no regression" that masks an actual gain that didn't materialise) won't trip it. The dynamic timing gate complements the unit tests; this manual per-platform measurement is the only safety net for changes whose value-add IS the timing characteristic.
+The split timing gate (`test_create_agent_p50` + `test_create_rootfs_template_present`) is the floor — it fires on regressions around 500 ms or more (see `tests/integration/fixtures/server.py:DEFAULT_AGENT_P50_MS` for the per-backend ceiling; VZ has ~500 ms regression budget over its ~1550 ms median, FC has ~500 ms over its ~2400 ms median) — but a sub-threshold regression (or worse, a "no regression" that masks an actual gain that didn't materialise) won't trip it.
 
-The workflow:
+The workflow uses the parallel-dev pair on both sides of the comparison — no service interruption needed:
 
-1. **Baseline against release.** Run `make test-integration` (it picks up the brew/deb install). Record the agent_p50 and rootfs_ms (and total wall-clock) from the PhaseTimer line for each backend you're changing.
-2. **Compare against your branch.** Run `make test-integration-local` and/or `make test-integration-local-fc` (it swaps in your dev binary with `SHED_BUILD_TOOLS_REF=<latest-tag>` so the comparison is apples-to-apples). Same measurements.
+1. **Baseline against release.** `make test-integration` (it targets the brew/deb install). Record the agent_p50 and rootfs_ms (and total wall-clock) from the PhaseTimer line for each backend you're changing.
+2. **Compare against your branch.** `make build && make dev-server-restart && make test-integration-dev` (it targets the parallel dev server running your source). Same measurements.
 3. **Repeat on every affected backend.** A change shipping for both VZ and FC needs both backends measured — Apple Silicon vfkit and Linux KVM Firecracker have different floors, and the same code can be faster on one and slower on the other.
 4. **Record the measurements in the PR body.** Hypothesised gains that don't show up are worth investigating before merge.
 
-The v0.5.4 build-tools-ref regression (caught by a user noticing slow creates after `brew upgrade`, not by the suite) is the canonical example of "the binary built correctly but a config knob silently disabled the fast path." Measuring on the actual swapped-in dev binary is what catches that class of bug before users do.
+The v0.5.4 build-tools-ref regression (caught by a user noticing slow creates after `brew upgrade`, not by the suite) is the canonical example of "the binary built correctly but a config knob silently disabled the fast path." Measuring on the actual dev binary is what catches that class of bug before users do.
 
 #### Adding a test
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -181,53 +181,84 @@ def test_only_on_fc(fc_server, ...):
 (Markers are declared in `pyproject.toml` under
 `[tool.pytest.ini_options].markers` — keep them in sync.)
 
-## Validating server-side changes (VZ local)
+## Validating server-side changes — parallel dev server (Mac VZ)
 
 By default `make test-integration` runs against whichever `shed-server`
-binary is currently *installed* on the host (typically the brew
-release). A server-side-only PR — orchestrator change, lifecycle
+binary is currently *installed* on the host (brew on Mac, deb on
+Linux). A server-side-only PR — orchestrator change, lifecycle
 internals, backend handler refactor — can pass that suite without ever
 exercising its own code, because the installed binary is the OLD one.
 
-`make test-integration-local` closes that gap on the local Mac (VZ):
+The mechanism for closing this gap on Mac is a **parallel dev
+shed-server** that runs alongside the brew one on a different port
+(`18080/12222`). The brew server keeps running undisturbed; the dev
+server is what the suite targets.
 
 ```sh
-make test-integration-local
+# One-time setup: add a ~/.shed/config.yaml entry for the dev server.
+# Either copy this snippet:
+cat >> ~/.shed/config.yaml <<'EOF'
+servers:
+  my-server-dev:
+    host: localhost
+    http_port: 18080
+    ssh_port: 12222
+EOF
+# Or run after the first `make dev-server-up`:
+shed server add localhost --port 18080 --name my-server-dev
+
+# Per dev cycle:
+make dev-server-up              # launches dev server (nohup, PID file)
+make test-integration-dev       # runs suite against dev server (auto-ups if needed)
+
+# ... edit source ...
+make build && make dev-server-restart
+make test-integration-dev
+
+make dev-server-down            # when done
 ```
 
-That target:
+The dev server's lifecycle is intentionally simple — `nohup` writing
+to `~/.shed/dev/server.log` with PID tracked at
+`~/.shed/dev/server.pid`. No launchd plist, no auto-restart on crash
+(crashes should be visible), no survives-reboot (re-up after reboot is
+one command). State-dirs are isolated under
+`~/Library/Application Support/shed-dev/vz/` so `shed image prune`
+from the brew server never touches dev blobs.
 
-1. `install-local-server` — builds `bin/shed-server`, backs up the
-   brew binary to `/tmp/shed-server-vN.M.K.bak`, swaps the dev
-   binary into the brew Cellar, ad-hoc-codesigns it (launchd
-   SIGKILLs unsigned binaries), sets `SHED_BUILD_TOOLS_REF` to the
-   latest release tag (so the dev binary uses the release-shaped
-   pre-formatted-template fast path instead of the in-guest mkfs
-   fallback — see the split-gate explanation above), and restarts
-   the brew service.
-2. `test-integration` — runs the full suite against the dev binary.
-3. `restore-brew-server` — restores the brew binary from the backup,
-   clears the env var, restarts the brew service, removes the
-   backup. Runs unconditionally (even if the suite fails).
-
-Run `make install-local-server` and `make restore-brew-server`
-standalone if you want to drive the suite manually between the swap
-and restore (e.g. for an ad-hoc `shed create` repro against the dev
-binary). Both are macOS-only and idempotent:
-
-- `install-local-server` refuses to overwrite an existing backup
-  without `FORCE=1` (so a developer who runs it twice doesn't lose
-  the original).
-- `restore-brew-server` is a no-op when no backup exists.
-
-`RELEASE_BUILD_TOOLS_REF` defaults to the latest `git tag` matching
-`v*`. Override to pin to an older release if your source has drifted
-from `main`:
+The dev server's `SHED_BUILD_TOOLS_REF` is set inline to the latest
+release tag so the dev binary uses release-shaped upper-template
+behavior (sub-100 ms rootfs phase). `RELEASE_BUILD_TOOLS_REF`
+defaults to the latest `git tag` matching `v*`; override to pin to
+an older release if your source has drifted from `main`:
 
 ```sh
 RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:v0.5.7 \
-  make install-local-server
+  make dev-server-restart
 ```
+
+Lifecycle helpers:
+
+- `make dev-server-up` — refuses to start if a dev server is already
+  running (use `dev-server-restart`).
+- `make dev-server-down` — graceful TERM with 5 s wait, then KILL.
+  Idempotent (no-op with clear message if not running).
+- `make dev-server-status` — running / reachable / log / config.
+- `make dev-server-logs` — `tail -F ~/.shed/dev/server.log`.
+- `make dev-server-restart` — down + up. Use this after `make build`
+  to pick up a rebuilt binary.
+
+Why this isn't a `launchd` plist: the dev server is intentionally
+ephemeral. A crash should surface to the developer, not be silently
+recovered. A reboot should require an explicit `make dev-server-up`,
+not auto-start a possibly-stale binary. The PID-file lifecycle gives
+us start / stop / restart semantics with zero Apple-specific machinery.
+
+**Coexistence:** brew shed-server on port 8080/2222 + dev shed-server
+on port 18080/12222. Both run simultaneously. The SSH host key
+(`~/.shed/host_key`) is shared between them; the CLI's
+`~/.shed/known_hosts` keys by `host:port` so each entry's
+fingerprint is recorded independently.
 
 ## Validating server-side changes (FC remote)
 
@@ -259,10 +290,9 @@ That target:
 4. `restore-remote-server` — restores the deb binary from the
    remote backup, removes the systemd drop-in, `daemon-reload`s,
    restarts the service, removes the backup. Idempotent: the
-   systemd drop-in is always removed (even when no backup exists),
-   matching `restore-brew-server`'s "env override is the companion
-   to the binary swap" semantics. Runs unconditionally after the
-   suite, regardless of pass/fail.
+   systemd drop-in is always removed (even when no backup exists)
+   so a stranded override doesn't survive a manual restore. Runs
+   unconditionally after the suite, regardless of pass/fail.
 
 Backup lives on the **remote host** (`/tmp/shed-server-deb.bak`), so
 a developer who reboots their workstation mid-test can still recover


### PR DESCRIPTION
## What

PR 2 of the [parallel dev shed-server plan](../../charliek/.claude/plans/lets-defer-remote-mac-deep-brook.md). Replaces the v1 Mac swap workflow with a parallel dev shed-server running ALONGSIDE the brew shed-server on different ports.

### New Makefile targets

| Target | What it does |
|---|---|
| `dev-server-up` | Builds + launches `bin/shed-server` via `nohup` with `SHED_BUILD_TOOLS_REF` inline. Refuses to start if already running. Polls `shed -s my-server-dev list` for readiness (15 s). |
| `dev-server-down` | Graceful TERM (5 s budget) then KILL. Idempotent — no-op with clear message if not running. |
| `dev-server-status` | running / reachable / log / config summary. |
| `dev-server-logs` | `tail -F ~/.shed/dev/server.log`. |
| `dev-server-restart` | down + up. |
| `test-integration-dev` | Auto-ups the dev server if needed; env-var-retargets `SHED_VZ_SERVER` + `SHED_VZ_LOG_PATH` at the dev server; runs existing `test-integration`. VZ tests run against dev, FC still targets `mini3` (PR 3 adds the FC parallel sibling). |

### DELETED — v1 Mac swap workflow

- `install-local-server` (and `BREW_SHED_PREFIX` / `BREW_VERSION` / `BREW_SHED_BIN` / `BACKUP_PATH` Makefile vars).
- `restore-brew-server`.
- `test-integration-local`.

Per user direction in the plan: no backwards compatibility, no two-ways-to-do-it.

### Docs

CLAUDE.md, `docs/development/testing.md`, `tests/integration/README.md` all updated to reflect parallel-dev as the only Mac VZ server-side-validation path. The `~/.shed/config.yaml` setup snippet is documented as copy-paste plus the `shed server add` path.

### Coexistence model

Both shed-server processes run simultaneously — brew on `8080/2222`, dev on `18080/12222`. Isolated state-dirs under `~/Library/Application Support/shed-dev/vz/`. CLI's `~/.shed/known_hosts` keys by `host:port` so each entry's fingerprint is recorded independently; shared `~/.shed/host_key` between the two servers is fine (both present the same fingerprint to the same port-derived known_hosts entry).

### Why no launchd plist

The dev server is intentionally ephemeral. Crashes should surface to the developer, not be silently recovered. Reboots should require an explicit `make dev-server-up` rather than auto-start a possibly-stale binary. PID file gives clean start/stop/restart semantics with zero Apple-specific machinery.

## Validation Results

Per plan §2.3, all 9 checkpoints green:

| # | Scenario | Outcome |
|---|---|---|
| a | `make check` clean | ✅ |
| b | Meta + parser tests | ✅ 20 passed in 22 s |
| c | Cold start: `make dev-server-up` | ✅ ready after 2 s, `shed -s my-server-dev list` succeeds |
| d | Coexistence: both servers running | ✅ `lsof -i:8080,18080` shows both ports bound; both `shed -s` calls work |
| e | `make test-integration-dev` | ✅ 50 passed + 1 FC-template skip (expected) + 1 transient FC exec-shell flake (same pre-existing intermittent issue as PR #157/#159; passes in isolation 2/2; not introduced here) |
| f | Brew suite still works (`make test-integration`) | ✅ 51 passed + 1 expected skip, no flake this run |
| g | `make dev-server-down` clean + idempotent | ✅ after fixing a sub-shell bug where `@if ... exit 0` let make continue (same pattern as the prior plan's `restore-brew-server` fix) |
| h | Dogfood PR #156 RestoreStoppedMetadata canary on dev server | ✅ created `repro-pr2-dev --local-dir`, stopped, `rm -rf` local-dir, attempted start → failed with `agent health check failed: context deadline exceeded`, `shed list` showed `status=stopped` IMMEDIATELY — proves dev binary exercises server-side code |
| i | CodeRabbit + codex sign-off | pending CI |

## One bug fixed during validation

`SHED_BUILD_TOOLS_REF` is the env var shed-server reads; `RELEASE_BUILD_TOOLS_REF` is the Makefile-level variable name (because it points at the *release* tooling image). I initially exported the wrong name on the `nohup` line, which caused the dev server to fall back to in-guest mkfs and the suite to skip the template-related tests with dev-mode messages. Fixed by `SHED_BUILD_TOOLS_REF=$(RELEASE_BUILD_TOOLS_REF) nohup ...`. Confirmed the fix by re-running `make test-integration-dev` — the dev-mode skips disappeared and `test_create_agent_p50` + `test_create_rootfs_template_present` now pass against the dev binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
