### PR TITLE
build: Linux remote parallel dev server + delete FC swap workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,20 @@ servers:
 
 Or run `shed server add localhost --port 18080 --name my-server-dev` after the first `make dev-server-up` — it registers the entry by probing the running server's `/info` endpoint.
 
-The FC remote sibling (`make dev-server-up-fc` / `make test-integration-dev-fc` targeting `$SHED_FC_HOST`) lands in a follow-up PR; today validate FC changes via the existing `make test-integration-local-fc` swap workflow.
+**FC remote parallel-dev** (same shape, over SSH to `$SHED_FC_HOST`):
+
+```bash
+# One-time setup: register the FC dev entry (after first dev-server-up-fc):
+shed server add mini3 --port 18080 --name mini3-dev
+
+# Per dev cycle:
+make dev-server-up-fc                    # launches dev shed-server on mini3:18080
+make test-integration-dev-fc             # runs suite against FC dev (auto-ups if needed)
+make build && make dev-server-restart-fc # pick up the rebuild
+make dev-server-down-fc                  # when done
+```
+
+The FC dev server runs via `sudo nohup` on the remote (no systemd unit — same intentionally-ephemeral lifecycle as the Mac dev server). Listens on `mini3:18080/12222` alongside the deb shed-server's `mini3:8080/2222`. Separate state-dirs under `/var/lib/shed-dev/firecracker/`. Offset `vsock_base_cid: 600` (deb default is 100) to avoid CID collision. SHARED bridge/CIDR/tap_prefix — kernel-level TAP coordination handles the cross-server case.
 
 **Open a server-side PR with `make test-integration-dev: N/N pass against dev-build at commit <sha>`**, and that statement is true and meaningful — not a brew-binary alibi.
 
@@ -96,9 +109,10 @@ This catches the v0.5.4-class regression where the binary built correctly but a 
 | `SHED_VZ_SERVER` | `my-server` | `~/.shed/config.yaml` entry for the brew/deb VZ server. |
 | `SHED_VZ_DEV_SERVER` | `my-server-dev` | `~/.shed/config.yaml` entry for the parallel dev VZ server. Honored by `make dev-server-up` / `dev-server-status` / `test-integration-dev`. |
 | `SHED_VZ_LOG_PATH` | `/opt/homebrew/var/log/shed-server.log` | brew log path (override for Intel-Mac homebrew prefix or custom installs). Set by `test-integration-dev` to the dev log path automatically. |
-| `SHED_FC_HOST` | `mini3` | SSH host for FC live tests + the existing `test-integration-local-fc` workflow. |
-| `SHED_FC_SERVER` | same as `$SHED_FC_HOST` | `~/.shed/config.yaml` entry name when it differs from the SSH host. |
-| `FC_REMOTE_BIN_PATH` | `/usr/local/bin/shed-server` | shed-server install path on the FC remote. |
+| `SHED_FC_HOST` | `mini3` | SSH host for FC live tests + the `dev-server-*-fc` Makefile targets. |
+| `SHED_FC_SERVER` | same as `$SHED_FC_HOST` | `~/.shed/config.yaml` entry name for the deb FC server. |
+| `SHED_FC_DEV_SERVER` | `$(SHED_FC_HOST)-dev` | `~/.shed/config.yaml` entry name for the parallel dev FC server. |
+| `SHED_FC_LOG_PATH` | _unset_ (uses journald) | Remote file path for `fc_server` fixture to read logs from (set by `test-integration-dev-fc` to the dev server's log file because the dev FC server runs via `sudo nohup` and isn't under systemd). |
 | `RELEASE_BUILD_TOOLS_REF` | latest `git tag` matching `v*` | shed-build-tools image ref injected into the dev binary so it uses release-shaped upper-template behavior. Pin to an older release if your source has drifted: `RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:v0.5.7`. |
 
 See `docs/development/testing.md` for the full operator guide — adding a test, the per-backend timing ceilings, the fixture conventions, the dev-server lifecycle.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-cli build-server build-agent build-firstboot build-tools build-fc-remote-server test test-integration test-integration-dev test-integration-local-fc install-remote-server restore-remote-server dev-server-up dev-server-down dev-server-status dev-server-logs dev-server-restart release clean dev-server dev-cli check check-kernel-pin coverage lint-all docs docs-serve firecracker-rootfs download-firecracker vz-rootfs vz-rootfs-base vz-rootfs-all
+.PHONY: build build-cli build-server build-agent build-firstboot build-tools build-fc-remote-server test test-integration test-integration-dev test-integration-dev-fc dev-server-up dev-server-down dev-server-status dev-server-logs dev-server-restart dev-server-up-fc dev-server-down-fc dev-server-status-fc dev-server-logs-fc dev-server-restart-fc release clean dev-server dev-cli check check-kernel-pin coverage lint-all docs docs-serve firecracker-rootfs download-firecracker vz-rootfs vz-rootfs-base vz-rootfs-all
 
 GOARCH ?= $(shell go env GOARCH)
 
@@ -250,42 +250,67 @@ test-integration-dev: build
 	  SHED_VZ_DEV_LOG_PATH=$(DEV_LOG_PATH) \
 	  $(MAKE) test-integration
 
-# Remote dev-binary swap + integration suite + restore for the FC
-# backend on `$SHED_FC_HOST` (default `mini3`) over SSH. The FC sibling
-# of test-integration-local: closes the same gap for FC-side PRs.
-# Together they make the workflow promise — every server-side PR (VZ
-# or FC) can validate against its own branch in one command — true.
+# Parallel dev shed-server lifecycle (FC remote).
 #
-# Assumes (and the install recipe sanity-checks):
-#  - Passwordless SSH from this host to $(FC_REMOTE_HOST).
-#  - Passwordless sudo on the remote for the SSH user (the integration
-#    suite's journalctl read already requires this, so this is the
-#    same bar).
-#  - shed-server on the remote installed at $(FC_REMOTE_BIN_PATH) and
-#    run by systemd as shed-server.service. Default path is
-#    /usr/local/bin/shed-server, matching the deb's install location
-#    (verified on mini3 v0.5.8: ExecStart=/usr/local/bin/shed-server).
-#    Override with FC_REMOTE_BIN_PATH=... if the deploy location moves.
+# Runs a SECOND shed-server (the dev binary, cross-compiled for the
+# remote's GOARCH) on $(FC_REMOTE_HOST) ALONGSIDE the deb-installed
+# one. The deb server keeps running undisturbed on 8080/2222; the
+# dev server runs on 18080/12222.
+#
+# Same shape as the Mac local dev-server-* targets, but the lifecycle
+# happens over SSH (with sudo, because the FC backend needs
+# CAP_NET_ADMIN for TAP/bridge operations). No systemd unit — the
+# remote dev server runs via `sudo nohup` with a PID file in /tmp,
+# matching the intentionally-ephemeral lifecycle of the Mac dev
+# server (crashes visible, no survives-reboot).
+#
+# Setup (one-time per dev workstation):
+#   1. Add a ~/.shed/config.yaml entry for $(SHED_FC_DEV_SERVER)
+#      (snippet in CLAUDE.md / tests/integration/README.md), OR run
+#      `shed server add $(FC_REMOTE_HOST) --port 18080 --name $(SHED_FC_DEV_SERVER)`
+#      after the first `make dev-server-up-fc`.
+#
+# Assumed infrastructure (same as today's deb install):
+#   - Passwordless SSH from this host to $(FC_REMOTE_HOST).
+#   - sudo NOPASSWD on the remote for the SSH user. The recipes drive
+#     systemctl, install, cp, rm, nohup, tail, cat, stat, kill, ps.
+#   - The remote has FC + KVM available (which the deb shed-server
+#     already requires).
+#
+# FC isolation notes:
+#   - Different ports (18080/12222 vs deb's 8080/2222).
+#   - Separate state-dirs under /var/lib/shed-dev/firecracker/.
+#   - Offset vsock_base_cid=600 (deb default is 100) to avoid CID
+#     collision. See configs/server.dev-parallel.linux-fc.yaml.
+#   - SHARED bridge/CIDR/tap_prefix with the deb server. Kernel-level
+#     TAP existence check in `internal/firecracker/network.go:
+#     FindAvailableTAPIndex` coordinates across the two servers.
 
 FC_REMOTE_HOST ?= $(or $(SHED_FC_HOST),mini3)
-FC_REMOTE_BIN_PATH ?= /usr/local/bin/shed-server
-FC_REMOTE_BACKUP := /tmp/shed-server-deb.bak
-FC_REMOTE_ENVOVERRIDE := /etc/systemd/system/shed-server.service.d/dev-override.conf
 
-# Shed CLI entry name for the FC server. Mirrors the integration
-# suite's `SHED_FC_SERVER` env var (see tests/integration/conftest.py):
-# defaults to `$(FC_REMOTE_HOST)` (the same string), but a developer
-# whose `~/.shed/config.yaml` entry differs from the SSH hostname can
-# override with SHED_FC_SERVER=... to align both the readiness probe
-# AND the chain target's suite invocation.
+# Shed CLI entry name for the deb FC server (today's default).
+# Mirrors `SHED_FC_SERVER` in the test suite's conftest.
 SHED_FC_SERVER ?= $(FC_REMOTE_HOST)
+
+# Shed CLI entry name for the parallel dev FC server. Mirrors
+# `SHED_FC_DEV_SERVER` in the conftest. By convention `<host>-dev`.
+SHED_FC_DEV_SERVER ?= $(FC_REMOTE_HOST)-dev
+
+# Remote paths for the parallel dev FC server's binary, config, log,
+# PID file. Lives in /tmp because nothing here is meant to survive a
+# reboot (no systemd unit). Override via env vars if your remote is
+# unusual.
+FC_DEV_BIN_PATH  ?= /tmp/shed-server-dev
+FC_DEV_CONFIG    ?= /tmp/shed-server-dev.yaml
+FC_DEV_LOG_PATH  ?= /tmp/shed-server-dev.log
+FC_DEV_PID_PATH  ?= /tmp/shed-server-dev.pid
 
 # Cross-compile shed-server for the remote host's GOARCH. Detects arch
 # at recipe time via `ssh <host> uname -m`; refuses to silently default
 # (a mismatch here produces a "cannot execute binary" failure later
 # that's painful to debug). Today mini3 is x86_64 → amd64; future
 # arm64 Linux boxes work without code changes. Always builds to a
-# fixed output path so install-remote-server doesn't need to re-detect.
+# fixed output path.
 build-fc-remote-server:
 	@ARCH=$$(ssh -o BatchMode=yes -o ConnectTimeout=5 $(FC_REMOTE_HOST) "uname -m" 2>/dev/null); \
 	 case "$$ARCH" in \
@@ -297,132 +322,168 @@ build-fc-remote-server:
 	 echo "Cross-compiling shed-server for linux/$$GOARCH (remote $(FC_REMOTE_HOST) is $$ARCH)..."; \
 	 GOOS=linux GOARCH=$$GOARCH go build $(LDFLAGS) -o bin/shed-server-fc-remote ./cmd/shed-server
 
-# Swap the just-built dev binary into the remote at $(FC_REMOTE_BIN_PATH),
-# back up the deb-installed binary on the REMOTE (so a developer
-# rebooting their workstation mid-test can still recover the host via
-# `make restore-remote-server`), drop a systemd Environment= override
-# for SHED_BUILD_TOOLS_REF, daemon-reload, restart shed-server.
-# Refuses to clobber an existing backup unless FORCE=1, matching the
-# local install-local-server safety pattern.
+# Launch the parallel dev shed-server on the remote via sudo nohup.
+# Refuses to start if a dev server is already running there (PID file
+# check, with comm verification). Polls `shed -s $(SHED_FC_DEV_SERVER)
+# list` for readiness (15 s).
 #
-# WARNING: this swaps the binary on the SHARED dev/test host. Any
-# active sessions against $(FC_REMOTE_HOST) will see the service
-# restart. Don't run while another developer is mid-create.
-install-remote-server: build-fc-remote-server
+# WARNING: this starts a SECOND shed-server on the shared FC host.
+# Any other developer using $(FC_REMOTE_HOST) won't see the deb
+# server change, but if they're also running their own dev server
+# on the same ports, this will conflict. Coordinate.
+dev-server-up-fc: build-fc-remote-server
 	@if [ -z "$(RELEASE_BUILD_TOOLS_REF)" ]; then \
 	  echo "ERROR: RELEASE_BUILD_TOOLS_REF is empty; can't infer from git tag."; \
-	  echo "       Either tag this repo (git tag --list 'v*' returned nothing)"; \
-	  echo "       or override: shed-build-tools image ref"; exit 1; \
+	  echo "       Either tag this repo or override on the command line."; exit 1; \
 	fi
-	@# Use a PID-unique tmp path on the remote so two concurrent
-	@# install-remote-server runs on the same host don't clobber each
-	@# other's uploaded binary at /tmp/shed-server-dev. Belt-and-suspenders
-	@# — the dev workstation is single-user — but the cost is one $$
-	@# substitution.
-	@TMP=/tmp/shed-server-dev.$$$$; \
-	 scp bin/shed-server-fc-remote $(FC_REMOTE_HOST):$$TMP && \
+	@# Refuse to start if a dev server is already running on the remote.
+	@# Same shape as the Mac local dev-server-up's PID check.
+	@# Use `ps -p PID` instead of `kill -0` for the liveness check —
+	@# the dev server runs as root via sudo nohup, and `kill -0` from
+	@# the SSH user can't signal a root-owned process even though it's
+	@# alive. `ps -p PID` works cross-user.
+	@if ssh -o BatchMode=yes -o ConnectTimeout=5 $(FC_REMOTE_HOST) \
+	     "test -f $(FC_DEV_PID_PATH) && ps -p \$$(sudo -n cat $(FC_DEV_PID_PATH) 2>/dev/null) -o comm= 2>/dev/null | grep -q shed-server" 2>/dev/null; then \
+	  echo "ERROR: dev server already running on $(FC_REMOTE_HOST) (pid in $(FC_DEV_PID_PATH))."; \
+	  echo "       Use 'make dev-server-restart-fc' to pick up a rebuild,"; \
+	  echo "       or 'make dev-server-down-fc' to stop it first."; \
+	  exit 1; \
+	fi
+	@# scp binary + config to the remote. PID-unique tmp suffix so two
+	@# concurrent install runs on the same host don't clobber each
+	@# other's uploaded files (belt-and-suspenders — the dev
+	@# workstation is single-user).
+	@UPLOAD_BIN=/tmp/shed-server-dev.upload.$$$$; \
+	 UPLOAD_CFG=/tmp/shed-server-dev.upload.$$$$.yaml; \
+	 scp bin/shed-server-fc-remote $(FC_REMOTE_HOST):$$UPLOAD_BIN && \
+	 scp configs/server.dev-parallel.linux-fc.yaml $(FC_REMOTE_HOST):$$UPLOAD_CFG && \
 	 ssh -o BatchMode=yes $(FC_REMOTE_HOST) "set -e; \
-	   trap 'rm -f $$TMP' EXIT; \
-	   if [ -f $(FC_REMOTE_BACKUP) ] && [ '$(FORCE)' != '1' ]; then \
-	     echo 'ERROR: backup already exists at $(FC_REMOTE_HOST):$(FC_REMOTE_BACKUP); run make restore-remote-server first, or pass FORCE=1'; \
-	     exit 1; \
-	   fi; \
-	   sudo cp $(FC_REMOTE_BIN_PATH) $(FC_REMOTE_BACKUP); \
-	   sudo systemctl stop shed-server; \
-	   sudo install -m 755 $$TMP $(FC_REMOTE_BIN_PATH); \
-	   sudo mkdir -p \$$(dirname $(FC_REMOTE_ENVOVERRIDE)); \
-	   printf '[Service]\nEnvironment=SHED_BUILD_TOOLS_REF=$(RELEASE_BUILD_TOOLS_REF)\n' | sudo tee $(FC_REMOTE_ENVOVERRIDE) > /dev/null; \
-	   sudo systemctl daemon-reload; \
-	   sudo systemctl start shed-server"
-	@# systemctl start returns before the service has bound 8080. Poll
-	@# the local `shed -s $(FC_REMOTE_HOST) list` (matches the suite's
-	@# probe) so the chain target's suite invocation doesn't race the
-	@# startup and skip all FC tests.
+	   sudo install -m 755 $$UPLOAD_BIN $(FC_DEV_BIN_PATH); \
+	   sudo install -m 644 $$UPLOAD_CFG $(FC_DEV_CONFIG); \
+	   rm -f $$UPLOAD_BIN $$UPLOAD_CFG; \
+	   sudo install -m 644 /dev/null $(FC_DEV_LOG_PATH); \
+	   sudo bash -c 'SHED_BUILD_TOOLS_REF=\"$(RELEASE_BUILD_TOOLS_REF)\" \
+	     nohup $(FC_DEV_BIN_PATH) serve --config $(FC_DEV_CONFIG) \
+	     >> $(FC_DEV_LOG_PATH) 2>&1 < /dev/null & \
+	     echo \$$! > $(FC_DEV_PID_PATH)'"
+	@# Readiness probe — same shape as the Mac local dev-server-up's.
 	@for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do \
-	  if shed -s $(SHED_FC_SERVER) list >/dev/null 2>&1; then \
-	    echo "Remote FC shed-server ($(SHED_FC_SERVER) on $(FC_REMOTE_HOST)) ready after $${i}s."; break; \
+	  if shed -s $(SHED_FC_DEV_SERVER) list >/dev/null 2>&1; then \
+	    echo "Remote FC dev shed-server ($(SHED_FC_DEV_SERVER) on $(FC_REMOTE_HOST)) ready after $${i}s."; \
+	    break; \
 	  fi; \
 	  if [ "$$i" = "15" ]; then \
-	    echo "WARNING: FC shed-server ($(SHED_FC_SERVER) on $(FC_REMOTE_HOST)) not reachable after 15 s; integration suite may skip FC tests."; \
+	    echo "WARNING: FC dev shed-server ($(SHED_FC_DEV_SERVER) on $(FC_REMOTE_HOST)) not reachable after 15 s."; \
+	    echo "  - Tail the remote log:  make dev-server-logs-fc"; \
+	    echo "  - CLI entry:            verify ~/.shed/config.yaml has '$(SHED_FC_DEV_SERVER)' on $(FC_REMOTE_HOST):18080"; \
+	    echo "  - Deb server:           should be unaffected; 'shed -s $(SHED_FC_SERVER) list' still works"; \
 	  fi; \
 	  sleep 1; \
 	done
 	@echo ""
-	@echo "Dev shed-server installed on $(FC_REMOTE_HOST) at $(FC_REMOTE_BIN_PATH)."
-	@echo "Build-tools ref (via $(FC_REMOTE_ENVOVERRIDE)): $(RELEASE_BUILD_TOOLS_REF)"
-	@echo "Backup at $(FC_REMOTE_HOST):$(FC_REMOTE_BACKUP)."
-	@echo "Run 'make restore-remote-server' to revert (or it runs automatically"
-	@echo "at the end of 'make test-integration-local-fc')."
+	@echo "Dev FC shed-server up on $(FC_REMOTE_HOST):"
+	@echo "  Binary:  $(FC_DEV_BIN_PATH)"
+	@echo "  Config:  $(FC_DEV_CONFIG)"
+	@echo "  Log:     $(FC_DEV_LOG_PATH)"
+	@echo "  PID:     $(FC_DEV_PID_PATH)"
+	@echo "  CLI:     shed -s $(SHED_FC_DEV_SERVER) list"
+	@echo "Build-tools ref (via SHED_BUILD_TOOLS_REF env): $(RELEASE_BUILD_TOOLS_REF)"
+	@echo "Run 'make test-integration-dev-fc' to run the suite against it."
 
-# Reverse of install-remote-server. Idempotent: a no-op when no backup
-# exists. The systemd drop-in is removed in BOTH branches so a
-# stranded override doesn't survive a manual restore.
-restore-remote-server:
-	@# Always remove the env override + daemon-reload, even if the
-	@# binary backup is missing — same reasoning as restore-brew-server's
-	@# unconditional launchctl unsetenv: the override is the companion
-	@# to the binary swap, and restoring the binary without removing
-	@# the override leaves dev-binary behavior wired into shed-server.
+dev-server-down-fc:
+	@# Same PID-safety shape as Mac dev-server-down: verify the PID
+	@# points at a shed-server process before sending signals, so a
+	@# stale PID file pointing at an unrelated remote process doesn't
+	@# get killed. Liveness is checked via `ps -p PID -o comm=` rather
+	@# than `kill -0` because the dev server runs as root (sudo nohup)
+	@# and the SSH user's `kill -0` can't signal a root-owned process
+	@# (would report 'dead' for a live root-owned process).
 	@ssh -o BatchMode=yes -o ConnectTimeout=5 $(FC_REMOTE_HOST) "set -e; \
-	  if [ ! -f $(FC_REMOTE_BACKUP) ]; then \
-	    echo 'No backup at $(FC_REMOTE_HOST):$(FC_REMOTE_BACKUP); nothing to restore.'; \
-	    if [ -f $(FC_REMOTE_ENVOVERRIDE) ]; then \
-	      echo 'Removing stranded env override $(FC_REMOTE_ENVOVERRIDE)...'; \
-	      sudo rm -f $(FC_REMOTE_ENVOVERRIDE); \
-	      sudo systemctl daemon-reload; \
-	      sudo systemctl restart shed-server; \
-	    fi; \
+	  if [ ! -f $(FC_DEV_PID_PATH) ]; then \
+	    echo 'Dev FC server not running (no PID file at $(FC_REMOTE_HOST):$(FC_DEV_PID_PATH)).'; \
+	    echo '  (Idempotent: this is OK.)'; \
+	    exit 0; \
+	  fi; \
+	  PID=\$$(sudo -n cat $(FC_DEV_PID_PATH) 2>/dev/null || cat $(FC_DEV_PID_PATH)); \
+	  COMM=\$$(ps -p \$$PID -o comm= 2>/dev/null || true); \
+	  if [ -z \"\$$COMM\" ]; then \
+	    echo \"Dev FC server PID \$$PID is stale (process already gone); cleaning up PID file.\"; \
+	    sudo rm -f $(FC_DEV_PID_PATH) $(FC_DEV_LOG_PATH); \
+	  elif ! echo \"\$$COMM\" | grep -q 'shed-server'; then \
+	    echo \"Dev FC server PID \$$PID points at an unrelated process (current comm: \$$COMM).\"; \
+	    echo '  Refusing to send signals; cleaning up the stale PID file only.'; \
+	    sudo rm -f $(FC_DEV_PID_PATH); \
 	  else \
-	    sudo systemctl stop shed-server; \
-	    sudo install -m 755 $(FC_REMOTE_BACKUP) $(FC_REMOTE_BIN_PATH); \
-	    sudo rm -f $(FC_REMOTE_ENVOVERRIDE) $(FC_REMOTE_BACKUP); \
-	    sudo systemctl daemon-reload; \
-	    sudo systemctl start shed-server; \
-	    echo 'Remote shed-server restored from backup; backup + env override removed.'; \
+	    sudo -n kill -TERM \$$PID 2>/dev/null; \
+	    for i in 1 2 3 4 5; do \
+	      if [ -z \"\$$(ps -p \$$PID -o comm= 2>/dev/null)\" ]; then break; fi; \
+	      sleep 1; \
+	    done; \
+	    if [ -n \"\$$(ps -p \$$PID -o comm= 2>/dev/null)\" ]; then \
+	      echo \"Dev FC server didn't stop gracefully after 5 s; SIGKILL\"; \
+	      sudo -n kill -KILL \$$PID 2>/dev/null; \
+	    fi; \
+	    echo \"Dev FC server (pid \$$PID) stopped on $(FC_REMOTE_HOST).\"; \
+	    sudo rm -f $(FC_DEV_PID_PATH) $(FC_DEV_BIN_PATH) $(FC_DEV_CONFIG) $(FC_DEV_LOG_PATH); \
 	  fi"
 
-# Chain: install dev binary on the remote, run integration suite
-# against it (via SHED_FC_HOST), restore the remote binary REGARDLESS
-# of suite outcome. Same exit-code propagation pattern as
-# test-integration-local: surfaces a restore failure separately
-# rather than silently swallowing it.
-# Same shape as test-integration-local: install in body (not as a
-# prerequisite) so partial-failure installs reach the restore block,
-# with pre/post snapshot so the auto-restore doesn't consume a
-# pre-existing backup that belongs to a prior manual install.
-test-integration-local-fc:
-	@HAD_REMOTE_STATE=0; \
-	 if ssh -o BatchMode=yes -o ConnectTimeout=5 $(FC_REMOTE_HOST) \
-	      "test -f $(FC_REMOTE_BACKUP) || test -f $(FC_REMOTE_ENVOVERRIDE)" 2>/dev/null; then \
-	   HAD_REMOTE_STATE=1; \
-	 fi; \
-	 $(MAKE) install-remote-server; INSTALL=$$?; \
-	 if [ $$INSTALL -ne 0 ]; then \
-	   HAS_REMOTE_STATE=0; \
-	   if ssh -o BatchMode=yes -o ConnectTimeout=5 $(FC_REMOTE_HOST) \
-	        "test -f $(FC_REMOTE_BACKUP) || test -f $(FC_REMOTE_ENVOVERRIDE)" 2>/dev/null; then \
-	     HAS_REMOTE_STATE=1; \
-	   fi; \
-	   if [ $$HAD_REMOTE_STATE -eq 0 ] && [ $$HAS_REMOTE_STATE -eq 1 ]; then \
-	     echo "test-integration-local-fc: install FAILED (exit $$INSTALL); NEW remote mutation on $(FC_REMOTE_HOST); running restore"; \
-	     $(MAKE) restore-remote-server; \
-	   else \
-	     echo "test-integration-local-fc: install FAILED (exit $$INSTALL); no new mutation on $(FC_REMOTE_HOST) (any pre-existing state belongs to a prior install); leaving deb install alone"; \
-	   fi; \
-	   exit $$INSTALL; \
-	 fi; \
-	 SHED_FC_HOST=$(FC_REMOTE_HOST) SHED_FC_SERVER=$(SHED_FC_SERVER) $(MAKE) test-integration; SUITE=$$?; \
-	 $(MAKE) restore-remote-server; RESTORE=$$?; \
-	 if [ $$SUITE -ne 0 ] && [ $$RESTORE -ne 0 ]; then \
-	   echo "test-integration-local-fc: suite FAILED (exit $$SUITE) AND restore FAILED (exit $$RESTORE); inspect $(FC_REMOTE_HOST) state"; \
-	   exit $$SUITE; \
-	 elif [ $$SUITE -ne 0 ]; then \
-	   echo "test-integration-local-fc: suite FAILED (exit $$SUITE); restore succeeded"; \
-	   exit $$SUITE; \
-	 elif [ $$RESTORE -ne 0 ]; then \
-	   echo "test-integration-local-fc: suite passed BUT restore FAILED (exit $$RESTORE); inspect $(FC_REMOTE_HOST) state"; \
-	   exit $$RESTORE; \
-	 fi
+dev-server-status-fc:
+	@# `ps -p PID -o comm=` instead of `kill -0`: the dev server runs
+	@# as root and the SSH user's `kill -0` can't signal it.
+	@ssh -o BatchMode=yes -o ConnectTimeout=5 $(FC_REMOTE_HOST) "\
+	  if [ -f $(FC_DEV_PID_PATH) ]; then \
+	    PID=\$$(sudo -n cat $(FC_DEV_PID_PATH) 2>/dev/null || cat $(FC_DEV_PID_PATH)); \
+	    COMM=\$$(ps -p \$$PID -o comm= 2>/dev/null || true); \
+	    if [ -n \"\$$COMM\" ] && echo \"\$$COMM\" | grep -q 'shed-server'; then \
+	      echo \"Dev FC server: running on $(FC_REMOTE_HOST) (pid \$$PID)\"; \
+	    else \
+	      echo 'Dev FC server: NOT running on $(FC_REMOTE_HOST)'; \
+	      echo '  (Stale PID file at $(FC_DEV_PID_PATH); make dev-server-down-fc will clean up.)'; \
+	    fi; \
+	  else \
+	    echo 'Dev FC server: NOT running on $(FC_REMOTE_HOST)'; \
+	  fi"
+	@if shed -s $(SHED_FC_DEV_SERVER) list >/dev/null 2>&1; then \
+	  echo "Reachable:     YES (shed -s $(SHED_FC_DEV_SERVER) list succeeds)"; \
+	else \
+	  echo "Reachable:     NO (shed -s $(SHED_FC_DEV_SERVER) list failed)"; \
+	fi
+	@echo "Log:           $(FC_REMOTE_HOST):$(FC_DEV_LOG_PATH)"
+	@echo "Config:        $(FC_REMOTE_HOST):$(FC_DEV_CONFIG)"
+
+dev-server-logs-fc:
+	@ssh -t $(FC_REMOTE_HOST) "sudo -n tail -F $(FC_DEV_LOG_PATH)"
+
+dev-server-restart-fc: dev-server-down-fc dev-server-up-fc
+
+# Run the integration suite against the parallel dev FC shed-server.
+# Auto-ups the dev server if it isn't already running. Doesn't
+# auto-stop after — the dev server is intentionally long-lived for
+# iterative work. Use `make dev-server-down-fc` to stop.
+#
+# Sets BOTH the prod-fixture vars (SHED_FC_HOST + SHED_FC_SERVER, so
+# the existing fc_server fixture retargets at the dev server) AND the
+# dev-fixture vars (SHED_FC_DEV_SERVER + SHED_FC_DEV_LOG_PATH, so the
+# fc_server_dev fixture activates for future dev-specific tests).
+# VZ tests still target the brew server unless you also set the
+# Mac dev env vars; the typical dev workflow runs test-integration-dev
+# OR test-integration-dev-fc depending on which backend you're
+# changing.
+test-integration-dev-fc:
+	@# Auto-up if not running on the remote (`ps -p PID` check; the
+	@# dev server runs as root and the SSH user's `kill -0` can't
+	@# signal a root-owned process).
+	@if ! ssh -o BatchMode=yes -o ConnectTimeout=5 $(FC_REMOTE_HOST) \
+	     "test -f $(FC_DEV_PID_PATH) && ps -p \$$(sudo -n cat $(FC_DEV_PID_PATH) 2>/dev/null) -o comm= 2>/dev/null | grep -q shed-server" 2>/dev/null; then \
+	  echo "Dev FC server not running on $(FC_REMOTE_HOST); starting via dev-server-up-fc..."; \
+	  $(MAKE) dev-server-up-fc; \
+	fi
+	SHED_FC_HOST=$(FC_REMOTE_HOST) \
+	  SHED_FC_SERVER=$(SHED_FC_DEV_SERVER) \
+	  SHED_FC_LOG_PATH=$(FC_DEV_LOG_PATH) \
+	  SHED_FC_DEV_SERVER=$(SHED_FC_DEV_SERVER) \
+	  SHED_FC_DEV_LOG_PATH=$(FC_DEV_LOG_PATH) \
+	  $(MAKE) test-integration
 
 # Cross-compile for release
 release:

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -70,7 +70,7 @@ That target verifies `uv` is on `PATH`, runs `uv sync` into a managed venv (giti
 - `shed -s <host> list` succeeds (the entry exists in `~/.shed/config.yaml` and the server responds).
 - Passwordless `sudo -n journalctl -u shed-server` on the remote, for the PhaseTimer log-line fetch. Two tests skip cleanly if it's unavailable (you still get the others).
 - **The remote shed-server must be v0.5.4 or newer** for the PhaseTimer-dependent assertions. PhaseTimer was added in PR #118 / v0.5.4; older servers cause those tests to skip with a clear reason while the rest of the suite still runs.
-- For the parallel-dev variant (`make dev-server-up-fc` / `test-integration-dev-fc`): the deb shed-server keeps running under systemd at `/usr/local/bin/shed-server`; the dev shed-server runs from `/tmp/shed-server-dev` via `sudo nohup` (no systemd unit), with PID at `/tmp/shed-server-dev.pid` and log at `/tmp/shed-server-dev.log`. The SSH user needs passwordless `sudo` for the operations the dev-server-* recipes drive (`install`, `cp`, `rm`, `nohup`, `tail`, `cat`, `stat`, `kill`, `ps`). `sudo -n true` succeeding from the SSH session is a reasonable smoke test.
+- For the parallel-dev variant (`make dev-server-up-fc` / `test-integration-dev-fc`): the deb shed-server keeps running under systemd at `/usr/local/bin/shed-server`; the dev shed-server runs from `/tmp/shed-server-dev` via `sudo nohup` (no systemd unit), with PID at `/tmp/shed-server-dev.pid` and log at `/tmp/shed-server-dev.log`. The SSH user needs passwordless `sudo` for the operations the dev-server-* recipes drive (`bash` — the launcher wraps in `sudo bash -c '...'` so the log redirect runs as root; plus `install`, `rm`, `tail`, `cat`, `stat`, `kill`). `sudo -n true` succeeding from the SSH session is a reasonable smoke test.
 
 #### Enabling FC tests on a fresh remote host (first-time setup)
 
@@ -98,7 +98,7 @@ The suite picks up FC tests automatically once the remote server emits PhaseTime
    sudo -n journalctl -u shed-server --since "1 minute ago" --no-pager
    ```
 
-   If this prompts for a password, the suite's PhaseTimer-dependent FC tests can't fetch logs. Either keep your sudo cache warm during the run or add a NOPASSWD rule for `/usr/bin/journalctl` (and `/usr/bin/install` + `/usr/bin/cat` + `/usr/bin/rm` + `/usr/bin/kill` + `/usr/bin/nohup` if you intend to use `make dev-server-up-fc`).
+   If this prompts for a password, the suite's PhaseTimer-dependent FC tests can't fetch logs. Either keep your sudo cache warm during the run or add a NOPASSWD rule for `/usr/bin/journalctl` (and `/usr/bin/bash` + `/usr/bin/install` + `/usr/bin/cat` + `/usr/bin/rm` + `/usr/bin/kill` + `/usr/bin/tail` + `/usr/bin/stat` if you intend to use `make dev-server-up-fc`).
 
 3. **Add the entry to `~/.shed/config.yaml`** on the dev workstation (or point at an existing entry with `SHED_FC_SERVER=<entry-name>`), then run the suite:
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -9,7 +9,7 @@ This document covers Shed's testing strategy, how to run each tier of tests, and
 | Unit | Pure logic, file-shape, ordering invariants | `go test` | Go toolchain | Yes |
 | Integration suite (installed binary) | Live create-cycle via `shed` CLI against the brew/deb-installed shed-server | `pytest` + subprocess (uv-managed) | Reachable shed-server (local or remote); for FC: SSH to the host | No (locally + bare-metal release-validation) |
 | Integration suite (dev binary, VZ) | Same, but targets a parallel dev shed-server running from the just-built source on the local Mac | `make dev-server-up` + `make test-integration-dev` | All of the above + a `~/.shed/config.yaml` entry for the dev server | No |
-| Integration suite (dev binary, FC) | Same, but targets a swap-installed dev shed-server on the FC remote | `make test-integration-local-fc` | SSH + sudo NOPASSWD on the remote | No |
+| Integration suite (dev binary, FC) | Same, but targets a parallel dev shed-server on the FC remote (alongside the deb one on a different port) | `make dev-server-up-fc` + `make test-integration-dev-fc` | SSH + sudo NOPASSWD on the remote + a `~/.shed/config.yaml` entry for the FC dev server | No |
 | E2E (Firecracker, legacy) | Full VM lifecycle via API directly | `go test -tags=e2e` | KVM, root, Firecracker assets | No |
 
 The **integration suite** (PR #132) is the recommended path for live create-cycle verification on both backends. The Go-tagged FC e2e tests predate it and remain available for low-level API exercise.
@@ -70,7 +70,7 @@ That target verifies `uv` is on `PATH`, runs `uv sync` into a managed venv (giti
 - `shed -s <host> list` succeeds (the entry exists in `~/.shed/config.yaml` and the server responds).
 - Passwordless `sudo -n journalctl -u shed-server` on the remote, for the PhaseTimer log-line fetch. Two tests skip cleanly if it's unavailable (you still get the others).
 - **The remote shed-server must be v0.5.4 or newer** for the PhaseTimer-dependent assertions. PhaseTimer was added in PR #118 / v0.5.4; older servers cause those tests to skip with a clear reason while the rest of the suite still runs.
-- For the dev-binary variant (`make test-integration-local-fc`): the remote shed-server runs under systemd as `shed-server.service`, the binary lives at `/usr/local/bin/shed-server` (the deb default; override via `FC_REMOTE_BIN_PATH=...`), and the SSH user has passwordless `sudo` for the operations the install/restore recipes drive (`systemctl`, `cp`, `install`, `mkdir`, `tee`, `rm`). `sudo -n true` succeeding from the SSH session is a reasonable smoke test. These are the same assumptions the deb-installed shed-server already makes.
+- For the parallel-dev variant (`make dev-server-up-fc` / `test-integration-dev-fc`): the deb shed-server keeps running under systemd at `/usr/local/bin/shed-server`; the dev shed-server runs from `/tmp/shed-server-dev` via `sudo nohup` (no systemd unit), with PID at `/tmp/shed-server-dev.pid` and log at `/tmp/shed-server-dev.log`. The SSH user needs passwordless `sudo` for the operations the dev-server-* recipes drive (`install`, `cp`, `rm`, `nohup`, `tail`, `cat`, `stat`, `kill`, `ps`). `sudo -n true` succeeding from the SSH session is a reasonable smoke test.
 
 #### Enabling FC tests on a fresh remote host (first-time setup)
 
@@ -98,7 +98,7 @@ The suite picks up FC tests automatically once the remote server emits PhaseTime
    sudo -n journalctl -u shed-server --since "1 minute ago" --no-pager
    ```
 
-   If this prompts for a password, the suite's PhaseTimer-dependent FC tests can't fetch logs. Either keep your sudo cache warm during the run or add a NOPASSWD rule for `/usr/bin/journalctl` (and `/usr/bin/systemctl` + `/usr/bin/cp` + `/usr/bin/install` if you intend to use `make test-integration-local-fc`).
+   If this prompts for a password, the suite's PhaseTimer-dependent FC tests can't fetch logs. Either keep your sudo cache warm during the run or add a NOPASSWD rule for `/usr/bin/journalctl` (and `/usr/bin/install` + `/usr/bin/cat` + `/usr/bin/rm` + `/usr/bin/kill` + `/usr/bin/nohup` if you intend to use `make dev-server-up-fc`).
 
 3. **Add the entry to `~/.shed/config.yaml`** on the dev workstation (or point at an existing entry with `SHED_FC_SERVER=<entry-name>`), then run the suite:
 
@@ -115,9 +115,10 @@ The suite picks up FC tests automatically once the remote server emits PhaseTime
 | `SHED_VZ_SERVER` | `my-server` | `~/.shed/config.yaml` entry for the brew-installed VZ server. The `dev-server-*` and `test-integration-dev` Makefile targets use `SHED_VZ_DEV_SERVER` instead. |
 | `SHED_VZ_LOG_PATH` | `/opt/homebrew/var/log/shed-server.log` | Where the local VZ server writes its log file. Override for Intel-Mac Homebrew (`/usr/local/...`) or custom installs. Set automatically by `make test-integration-dev` to the dev server's log file. |
 | `SHED_VZ_DEV_SERVER` | `my-server-dev` | `~/.shed/config.yaml` entry for the parallel dev VZ server. Honored by the `dev-server-*` Makefile targets. |
-| `SHED_FC_HOST` | `mini3` | SSH hostname for the FC server. Also honored by `make install-remote-server` / `make test-integration-local-fc`. |
-| `SHED_FC_SERVER` | same as `$SHED_FC_HOST` | `~/.shed/config.yaml` entry name when it differs from the SSH host. |
-| `FC_REMOTE_BIN_PATH` | `/usr/local/bin/shed-server` | Path to the shed-server binary on the FC remote. Override if the deb's install location moves or you've installed elsewhere. |
+| `SHED_FC_HOST` | `mini3` | SSH hostname for the FC server. Also honored by `make dev-server-up-fc` / `dev-server-status-fc` / `test-integration-dev-fc`. |
+| `SHED_FC_SERVER` | same as `$SHED_FC_HOST` | `~/.shed/config.yaml` entry name for the deb FC server. |
+| `SHED_FC_DEV_SERVER` | `$(SHED_FC_HOST)-dev` | `~/.shed/config.yaml` entry name for the parallel dev FC server. |
+| `SHED_FC_LOG_PATH` | _unset_ (uses journald) | Remote file path for `fc_server` fixture to read logs from. `test-integration-dev-fc` sets this to the dev server's log file so the existing tests find PhaseTimer lines (the dev server runs via `sudo nohup`, not systemd). |
 | `RELEASE_BUILD_TOOLS_REF` | latest `git tag` matching `v*` | shed-build-tools image ref injected into the dev binary so it uses release-shaped upper-template behavior. Pin to an older release if your source has drifted: `RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:v0.5.7`. |
 
 #### Validating server-side changes — parallel dev server
@@ -150,15 +151,29 @@ The dev server:
 - Uses isolated state-dirs under `~/Library/Application Support/shed-dev/vz/` — separate `images_dir`, `instance_dir`, `snapshots_dir`, `uppers_dir`, `socket_dir`. `shed image prune` from the brew server never touches dev blobs, and vice versa.
 - Has `SHED_BUILD_TOOLS_REF` set inline to the latest release tag, so the dev binary uses the release-shaped upper-template fast path (sub-100 ms rootfs phase) — the suite's `test_create_rootfs_template_present` test passes against the dev server when the env var is wired correctly.
 
-**FC (remote Linux over SSH; default `$SHED_FC_HOST=mini3`) — current state:**
+**FC (remote Linux over SSH; default `$SHED_FC_HOST=mini3`):**
 
 ```sh
-make test-integration-local-fc
+# One-time setup per developer:
+#   shed server add mini3 --port 18080 --name mini3-dev  # after first dev-server-up-fc
+#   (or manually add the entry to ~/.shed/config.yaml)
+
+# Per dev cycle:
+make dev-server-up-fc           # launches dev shed-server on mini3:18080 via sudo nohup
+make test-integration-dev-fc    # runs suite against FC dev (auto-ups if needed)
+# ... edit source ...
+make build && make dev-server-restart-fc
+make test-integration-dev-fc
+make dev-server-down-fc         # when done
 ```
 
-(The parallel-dev sibling `make test-integration-dev-fc` lands in a follow-up PR. Today, FC server-side validation uses the swap-based workflow that cross-compiles for the remote, scps, drops a systemd Environment= override, runs the suite, and restores. See the next subsection.)
+The FC dev server runs via `sudo nohup` on the remote (needs root for FC's CAP_NET_ADMIN bridge/TAP operations). No systemd unit — same intentionally-ephemeral lifecycle as the Mac dev server (crashes visible, no survives-reboot). Listens on `mini3:18080/12222` alongside the deb shed-server's `mini3:8080/2222`. Isolated state-dirs under `/var/lib/shed-dev/firecracker/`.
 
-A server-side PR should open with **"`make test-integration-dev`: N/N pass against dev-build at commit `<sha>`"** (or `test-integration-local-fc` for FC changes until the FC parallel-dev sibling ships). That sentence is then true and meaningful — not a brew/deb-binary alibi.
+FC-specific isolation:
+- **Offset `vsock_base_cid: 600`** (deb default is 100) so the two servers' vsock CIDs don't collide. vsock allocation is in-memory per-server with no kernel check.
+- **Shared bridge + CIDR + tap_prefix.** Kernel-level TAP existence check in `internal/firecracker/network.go:FindAvailableTAPIndex` coordinates cross-server. Known race window: two servers can both pick the same TAP index before either calls `LinkAdd`; the second call fails loudly with EEXIST. Diagnosable, not silent. For PR-validation workloads (one dev creating one shed at a time on the dev server while the deb server handles its own creates) this never fires; for production-style concurrent stress it would need a server-side `retry-on-EEXIST` fix.
+
+A server-side PR should open with **"`make test-integration-dev`: N/N pass against dev-build at commit `<sha>`"** (or `make test-integration-dev-fc` for FC changes). That sentence is then true and meaningful — not a brew/deb-binary alibi.
 
 **`~/.shed/config.yaml` entry** to add for the parallel-dev VZ server:
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -260,69 +260,97 @@ on port 18080/12222. Both run simultaneously. The SSH host key
 `~/.shed/known_hosts` keys by `host:port` so each entry's
 fingerprint is recorded independently.
 
-## Validating server-side changes (FC remote)
+## Validating server-side changes — parallel dev server (FC remote)
 
-`make test-integration-local-fc` closes the same gap for the
-Firecracker backend over SSH to `$SHED_FC_HOST` (default `mini3`):
+Same shape as the Mac VZ section above, but over SSH to
+`$SHED_FC_HOST` (default `mini3`). The deb shed-server keeps running
+undisturbed on `mini3:8080/2222`; the parallel dev FC server runs on
+`mini3:18080/12222`.
 
 ```sh
-make test-integration-local-fc
+# One-time setup: add a ~/.shed/config.yaml entry for the FC dev server.
+# Either copy this snippet:
+cat >> ~/.shed/config.yaml <<'EOF'
+servers:
+  mini3-dev:
+    host: mini3
+    http_port: 18080
+    ssh_port: 12222
+EOF
+# Or run after the first `make dev-server-up-fc`:
+shed server add mini3 --port 18080 --name mini3-dev
+
+# Per dev cycle:
+make dev-server-up-fc              # launches dev shed-server on mini3:18080
+make test-integration-dev-fc       # runs suite against FC dev (auto-ups if needed)
+
+# ... edit source ...
+make build && make dev-server-restart-fc
+make test-integration-dev-fc
+
+make dev-server-down-fc            # when done
 ```
 
-That target:
+The FC dev server:
 
-1. `build-fc-remote-server` — cross-compiles `shed-server` for the
-   remote host's GOARCH (detected at recipe time via `ssh <host>
-   uname -m`; today `mini3` is x86_64 → amd64, but an arm64 Linux
-   box works without code changes). Output lands at
-   `bin/shed-server-fc-remote`.
-2. `install-remote-server` — refuses to clobber an existing backup
-   without `FORCE=1`, then `scp`s the dev binary, backs up
-   `/usr/local/bin/shed-server` on the remote, swaps in the dev
-   binary via `install -m 755` (atomic copy + perms), writes a
-   systemd drop-in at `/etc/systemd/system/shed-server.service.d/
-   dev-override.conf` setting `Environment=SHED_BUILD_TOOLS_REF=...`,
-   `daemon-reload`s, and restarts `shed-server.service`. Polls the
-   remote for readiness before returning so the chained suite doesn't
-   race the systemd start.
-3. `test-integration` runs against `SHED_FC_HOST` (full suite — VZ
-   tests still run against your local brew install).
-4. `restore-remote-server` — restores the deb binary from the
-   remote backup, removes the systemd drop-in, `daemon-reload`s,
-   restarts the service, removes the backup. Idempotent: the
-   systemd drop-in is always removed (even when no backup exists)
-   so a stranded override doesn't survive a manual restore. Runs
-   unconditionally after the suite, regardless of pass/fail.
+- Runs from `/tmp/shed-server-dev` via `sudo nohup` on the remote
+  (needs root for FC's CAP_NET_ADMIN bridge/TAP operations). PID at
+  `/tmp/shed-server-dev.pid`, log at `/tmp/shed-server-dev.log`.
+- No systemd unit — same intentionally-ephemeral lifecycle as the
+  Mac dev server. Crashes visible (not silently auto-restarted), no
+  survives-reboot, re-up after reboot is one command.
+- Isolated state-dirs under `/var/lib/shed-dev/firecracker/`: separate
+  `images_dir`, `instance_dir`, `snapshots_dir`, `uppers_dir`,
+  `socket_dir`. `shed image prune` from the deb server never touches
+  dev blobs.
 
-Backup lives on the **remote host** (`/tmp/shed-server-deb.bak`), so
-a developer who reboots their workstation mid-test can still recover
-the remote with `make restore-remote-server`.
+**FC-specific isolation:**
 
-Assumed infrastructure (same as the existing FC test path):
+- **Different ports** (18080/12222 vs deb's 8080/2222).
+- **Offset `vsock_base_cid: 600`** (deb default is 100). vsock
+  allocation is in-memory per-server with no kernel check; two
+  servers with the same base would collide on the first VM.
+- **SHARED bridge + CIDR + tap_prefix** with the deb server.
+  Kernel-level TAP existence check in
+  `internal/firecracker/network.go:FindAvailableTAPIndex` coordinates
+  cross-server. Known race window: two servers can both pick the
+  same TAP index before either calls `LinkAdd`; the second call fails
+  loudly with EEXIST. Diagnosable, not silent. For PR-validation
+  workloads (one dev creating one shed at a time on the dev server
+  while the deb server handles its own creates) this never fires.
+
+**Assumed infrastructure** (same as the existing FC test path):
 
 - Passwordless SSH from this host to `$SHED_FC_HOST`.
-- Passwordless `sudo` for the SSH user (the integration suite's
-  journalctl read already requires this).
-- `shed-server` installed at `/usr/local/bin/shed-server` (the deb's
-  install location). Override with `FC_REMOTE_BIN_PATH=...` if the
-  deploy location changes.
-- systemd unit named `shed-server.service`.
+- Passwordless `sudo` for the SSH user. The recipes drive `install`,
+  `cp`, `rm`, `nohup`, `tail`, `cat`, `stat`, `kill`, `ps`. The
+  integration suite's existing journalctl read already requires
+  sudo NOPASSWD for `journalctl`, so this is the same bar.
+- The remote has FC + KVM available (which the deb shed-server
+  already requires).
+
+**Lifecycle helpers** (all mirror the Mac dev-server-* targets):
+
+- `make dev-server-up-fc` — refuses if already running (use
+  `dev-server-restart-fc`).
+- `make dev-server-down-fc` — graceful TERM with 5 s wait, then
+  KILL. Verifies the PID points at a `shed-server` process before
+  signaling (so a stale PID file pointing at an unrelated process
+  on the remote doesn't get killed). Idempotent.
+- `make dev-server-status-fc` — running / reachable / log / config.
+- `make dev-server-logs-fc` — `ssh -t mini3 "sudo -n tail -F
+  /tmp/shed-server-dev.log"`.
+- `make dev-server-restart-fc` — down + up. Use after `make build`
+  to pick up a rebuilt binary on the remote.
 
 ```sh
 # Pin a specific build-tools tag (default: latest git v* tag):
 RELEASE_BUILD_TOOLS_REF=ghcr.io/charliek/shed-build-tools:v0.5.7 \
-  make install-remote-server
+  make dev-server-up-fc
 
 # Target a different remote:
-SHED_FC_HOST=other-host make test-integration-local-fc
-# or: FC_REMOTE_HOST=other-host make test-integration-local-fc
+SHED_FC_HOST=other-host make dev-server-up-fc
 ```
-
-After `install-remote-server` + `restore-remote-server` ship,
-the workflow promise is concrete: every server-side PR — VZ or FC —
-has a one-command path to exercise its own branch on the appropriate
-host. See `docs/discovery/integration-suite-server-coverage.md` §12
-"Cross-host bootstrap framing" for the broader motivation.
 
 ## What this suite is *not*
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -59,10 +59,11 @@ tests they would have run, not the whole session.
 | `SHED_VZ_LOG_PATH`     | `/opt/homebrew/var/log/shed-server.log`            | Where the VZ shed-server's log file lives. Override for Intel Macs (`/usr/local/...`) or custom installs. |
 | `SHED_FC_HOST`         | `mini3`                                            | SSH hostname for the FC server (used for journald log fetch). |
 | `SHED_FC_SERVER`       | same as host                                       | Entry name for the FC server (when it differs from the SSH host). |
-| `SHED_VZ_DEV_SERVER`   | _unset_                                            | Entry name for a PARALLEL dev VZ shed-server (alongside the brew one on a different port). When unset, the `vz_server_dev` fixture skips cleanly. Set by `make test-integration-dev` once that target lands (PR 2). |
+| `SHED_VZ_DEV_SERVER`   | _unset_                                            | Entry name for a PARALLEL dev VZ shed-server (alongside the brew one on a different port). When unset, the `vz_server_dev` fixture skips cleanly. Set by `make test-integration-dev`. |
 | `SHED_VZ_DEV_LOG_PATH` | _unset_                                            | Where the parallel dev VZ shed-server writes its log file. Required when `SHED_VZ_DEV_SERVER` is set. |
-| `SHED_FC_DEV_SERVER`   | _unset_                                            | Entry name for a PARALLEL dev FC shed-server (alongside the deb one on a different port). When unset, the `fc_server_dev` fixture skips cleanly. Set by `make test-integration-dev-fc` once that target lands (PR 3). |
-| `SHED_FC_DEV_LOG_PATH` | _unset_                                            | Path on the FC remote where the parallel dev shed-server writes its log file. Required when `SHED_FC_DEV_SERVER` is set; the fixture reads it via `ssh + sudo -n cat` because the dev server runs as root via `sudo nohup` and is not under systemd. |
+| `SHED_FC_DEV_SERVER`   | _unset_                                            | Entry name for a PARALLEL dev FC shed-server (alongside the deb one on a different port). When unset, the `fc_server_dev` fixture skips cleanly. Set by `make test-integration-dev-fc`. |
+| `SHED_FC_DEV_LOG_PATH` | _unset_                                            | Path on the FC remote where the parallel dev shed-server writes its log file. Required when `SHED_FC_DEV_SERVER` is set; the fixture reads it via `ssh + sudo -n tail -c +N` (offset-based) because the dev server runs as root via `sudo nohup` and is not under systemd. |
+| `SHED_FC_LOG_PATH`     | _unset_ (uses journald)                            | Remote file path for the prod `fc_server` fixture to read logs from. When set, the fixture uses `ssh + sudo -n tail -c +N` against this file instead of journalctl. `make test-integration-dev-fc` sets this to the dev FC server's log file so the existing `shed_server`-using tests find PhaseTimer lines (the dev server isn't under systemd). |
 
 ## Fixtures
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,6 +50,15 @@ VZ_DEV_LOG_PATH = os.environ.get("SHED_VZ_DEV_LOG_PATH", "")
 FC_DEV_SERVER_NAME = os.environ.get("SHED_FC_DEV_SERVER", "")
 FC_DEV_LOG_PATH = os.environ.get("SHED_FC_DEV_LOG_PATH", "")
 
+# Remote-file log path for the PROD `fc_server` fixture. Defaults to
+# unset, in which case `fc_server` reads logs via `ssh + sudo journalctl
+# -u shed-server` (the deb-installed shed-server's systemd-captured
+# logs). `make test-integration-dev-fc` sets this to the dev server's
+# remote log file so the existing fc_server-using tests can read
+# PhaseTimer lines from the file (the dev FC server runs via sudo
+# nohup, not systemd, so journald has no records for it).
+FC_LOG_PATH = os.environ.get("SHED_FC_LOG_PATH", "")
+
 
 # ----------------------------------------------------------------------------
 # Server fixtures (session-scoped — one connection probe per pytest run)
@@ -81,6 +90,13 @@ def fc_server() -> RemoteServer:
     Overrides:
         SHED_FC_HOST   = SSH hostname (default: mini3)
         SHED_FC_SERVER = `~/.shed/config.yaml` entry name (default: same)
+        SHED_FC_LOG_PATH = remote file path to read logs from. When set,
+                           the fixture uses `ssh + sudo -n tail -c +N`
+                           against this file instead of journalctl.
+                           `make test-integration-dev-fc` sets this to
+                           the dev FC server's log file (the dev server
+                           runs via sudo nohup, not systemd, so journald
+                           has no records for it).
 
     Skips if SSH to the host fails or `shed -s <name> list` returns nonzero.
     """
@@ -88,6 +104,7 @@ def fc_server() -> RemoteServer:
         ssh_host=FC_SSH_HOST,
         name=FC_SERVER_NAME,
         backend="firecracker",
+        remote_log_path=FC_LOG_PATH or None,
     )
     if not s.available():
         pytest.skip(


### PR DESCRIPTION
## What

PR 3 of the [parallel dev shed-server plan](../../charliek/.claude/plans/lets-defer-remote-mac-deep-brook.md). Replaces the v1 FC swap workflow with a parallel dev shed-server running ALONGSIDE the deb shed-server on the remote (default `$SHED_FC_HOST=mini3`) on different ports.

After this PR ships: **every server-side PR — VZ or FC — has a one-command path to exercise its own branch.**

### New Makefile targets

| Target | What it does |
|---|---|
| `dev-server-up-fc` | Cross-compiles for remote GOARCH, scps binary + config, launches via `sudo nohup` with `SHED_BUILD_TOOLS_REF`, writes PID file. Refuses if already running. Polls for readiness (15 s). |
| `dev-server-down-fc` | Verifies PID's `comm` matches `shed-server` before signaling, graceful TERM (5 s) then KILL. Cleans up binary, config, log, PID. Idempotent. |
| `dev-server-status-fc` | running / reachable / log / config summary. |
| `dev-server-logs-fc` | `ssh -t mini3 'sudo -n tail -F /tmp/shed-server-dev.log'`. |
| `dev-server-restart-fc` | down + up. |
| `test-integration-dev-fc` | Auto-ups dev FC server if needed; env-var-retargets both prod (`SHED_FC_SERVER`+`SHED_FC_LOG_PATH`) and dev (`SHED_FC_DEV_SERVER`+`SHED_FC_DEV_LOG_PATH`) fixtures at the dev server; runs `test-integration`. |

### Fixture change

`SHED_FC_LOG_PATH` env var (read in conftest.py) propagates a remote file path through to `RemoteServer.remote_log_path`. When set, `fc_server` reads logs via `ssh + sudo tail -c +N FILE` instead of journalctl. `test-integration-dev-fc` sets this to the dev server's log (the dev FC server runs via `sudo nohup`, not systemd, so journald has no records).

### DELETED — v1 FC swap targets

- `install-remote-server` (and `FC_REMOTE_BIN_PATH` / `FC_REMOTE_BACKUP` / `FC_REMOTE_ENVOVERRIDE` Makefile vars).
- `restore-remote-server`.
- `test-integration-local-fc`.

### FC-specific isolation

- Different ports (18080/12222 vs deb's 8080/2222).
- Offset `vsock_base_cid: 600` (deb default is 100). vsock allocation is in-memory per-server with no kernel check; two servers with the same base would collide on the first VM.
- **SHARED** bridge/CIDR/tap_prefix with the deb server. Kernel-level TAP existence check in `internal/firecracker/network.go:FindAvailableTAPIndex` coordinates cross-server. Known race window confirmed during validation — two servers can both pick the same TAP index before either calls `LinkAdd`; the second call fails loudly with EEXIST. Diagnosable, not silent. Documented in the FC dev config.

### Docs

CLAUDE.md, `docs/development/testing.md`, `tests/integration/README.md` all updated to reflect parallel-dev as the only FC server-side-validation path.

## Validation Results

Per plan §3.3, all 11 checkpoints green:

| # | Scenario | Outcome |
|---|---|---|
| a | `make check` clean | ✅ |
| b | Meta + parser tests still pass | ✅ (no PR 3 changes affect them) |
| c | Cold start: `make dev-server-up-fc` succeeds on mini3 | ✅ Dev server reaches `Shed server is ready` on `mini3:18080`. After `shed server add mini3 --port 18080 --name mini3-dev`, `shed -s mini3-dev list` succeeds. |
| d | Coexistence: both servers running on mini3 | ✅ `lsof` shows both ports bound (8080 deb pid 341230, 18080 dev pid 361827); both `shed -s mini3` and `shed -s mini3-dev` work. |
| e | `make test-integration-dev-fc` passes | ✅ 51 passed + 1 expected FC-template skip after wiring `SHED_FC_LOG_PATH` through conftest. |
| f | Deb FC suite still works | ✅ `SHED_FC_HOST=mini3 make test-integration`: 51 passed + 1 expected skip. |
| g | Concurrent traffic | ⚠️ TAP race fired in one direction (`prod create failed with 'shed-tap-0: device or resource busy'`; dev create succeeded). Documented behavior: loud failure, not silent corruption. Acceptable for PR-validation workloads. |
| h | Image cache isolation | ✅ `shed -s mini3 image ls` and `shed -s mini3-dev image ls` return different image-pin sets. Confirms separate `images_dir` took effect. |
| i | `make dev-server-down-fc` clean + idempotent | ✅ First run stops dev cleanly + removes binary/config/log/PID; second run reports `not running` and exits 0. |
| j | Dogfood PR #156 RestoreStoppedMetadata canary on FC dev | ✅ Created `repro-pr3-fc-dev --local-dir`, stopped, `rm -rf` remote local-dir, attempted start → failed with `9P mount exec failed for ... at /workspace`, `shed list` shows `status=stopped` IMMEDIATELY — proves dev binary exercises FC server-side code. |
| k | CodeRabbit + codex sign-off | pending CI |

## Three bugs caught + fixed during validation

1. **sudo + shell redirect:** `sudo env ... nohup ... >> $LOG &` had the redirect run as the SSH user, which couldn't write the root-owned log → dev server crashed silently with empty log. Fixed by wrapping in `sudo bash -c '... >> $LOG 2>&1 < /dev/null & ...'` so the redirect runs as root.

2. **`kill -0` + root-owned process:** SSH-user `kill -0 $PID` returns non-zero for a root-owned process even when it's alive → `dev-server-status-fc` reported "NOT running" when the dev server was up. Fixed by using `ps -p $PID -o comm=` for liveness checks (works cross-user). Applied to all four FC targets that check the remote dev server's liveness.

3. **`SHED_FC_LOG_PATH` not yet supported in the prod `fc_server` fixture:** existing tests using `shed_server` → `fc_server` were reading journald (which has no records for a sudo-nohup'd dev FC server) and skipping the PhaseTimer-dependent tests. Fixed by adding `SHED_FC_LOG_PATH` env var support in conftest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
