### PR TITLE
docs: pre-release validation for build-tools + base image changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,8 @@ The FC dev server runs via `sudo nohup` on the remote (no systemd unit — same 
 
 **Open a server-side PR with `make test-integration-dev: N/N pass against dev-build at commit <sha>`**, and that statement is true and meaningful — not a brew-binary alibi.
 
+**For PRs that change `shed-build-tools` (`build-tools/`) or base images (`vz/Dockerfile`, `firecracker/Dockerfile`, shed-extensions bumps):** the dev-server workflow extends to those too — see `docs/development/testing.md` § "Validating pre-release: build-tools image changes" and § "Validating pre-release: base image changes" for the `RELEASE_BUILD_TOOLS_REF=shed-build-tools:dev` and `OUTPUT_DIR=...shed-dev/vz ./scripts/build-vz-rootfs.sh ...` overrides that wire local builds into the dev server's blob store.
+
 #### Performance impact — vet against the released version
 
 For changes that touch the boot path, agent dial, healthPoll, upper-allocation, mount, image-resolution, or any other hot path: **measure the impact on each platform the change affects, against the most recent release binary, before merging.** The split timing gate (`test_create_agent_p50` + `test_create_rootfs_template_present`) is the floor — it fires on regressions around 500 ms or more (see `tests/integration/fixtures/server.py:DEFAULT_AGENT_P50_MS` for the per-backend regression budget) — but a sub-threshold regression (or worse, a "no regression" that masks an actual gain that didn't materialise) won't trip it.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -194,6 +194,8 @@ on first VM create. By default that's the latest release tag
 change to the `build-tools/` tree before cutting a release:
 
 ```sh
+# Setup
+# -----
 # 1. Build the local shed-build-tools image. Tags it as
 #    shed-build-tools:dev in the local Docker daemon.
 make build-tools
@@ -207,6 +209,17 @@ RELEASE_BUILD_TOOLS_REF=shed-build-tools:dev make dev-server-restart-fc
 # 3. Run the suite (or a focused subset). The dev shed-server will
 #    invoke shed-build-tools:dev for upper-template formatting.
 make test-integration-dev   # or test-integration-dev-fc
+
+# Teardown
+# --------
+# 4. Restart WITHOUT the override so the dev server goes back to the
+#    latest-release tag for its next start (the env var is per-process,
+#    not persisted; this is just to leave a clean dev state).
+make dev-server-restart      # or dev-server-restart-fc
+
+# 5. Optionally remove the local shed-build-tools:dev image to
+#    reclaim ~145 MB:
+docker image rm shed-build-tools:dev
 ```
 
 How to confirm the override took effect: after a `shed create` the
@@ -217,19 +230,20 @@ shed. If you see `rootfs=` in the multi-second range, or the
 "unavailable" log line, the override didn't take and the dev binary
 fell back to in-guest mkfs.
 
-For an FC remote validation you may want to push `shed-build-tools:dev`
-to a registry the remote can pull from (or `docker save` + `docker load`
-across the SSH boundary). The local-only path works on Mac because
-the same Docker daemon serves both `make build-tools` and the
-shed-server's image-resolution call.
+For an FC remote validation you'll need `shed-build-tools:dev`
+loaded into the REMOTE's Docker daemon (the build-tools image is
+invoked by shed-server on the remote host, not by the dev
+workstation). Either push `shed-build-tools:dev` to a registry the
+remote can pull from, or `docker save` on the dev workstation +
+`docker load` on the remote across the SSH boundary.
 
-#### Validating pre-release: base image changes (vz/firecracker Dockerfiles, shed-extensions)
+#### Validating pre-release: base image changes (vz/firecracker Dockerfiles)
 
 Base images (`shed-vz-base`, `shed-vz-extensions`, `shed-vz-full`,
 and the FC counterparts) are built by
 `scripts/build-vz-rootfs.sh` / `scripts/build-firecracker-rootfs.sh`,
 which write OCI blobs + a tag pointer into an `OUTPUT_DIR`. The
-default `OUTPUT_DIR` is the BREW server's `images_dir`
+default `OUTPUT_DIR` is the BREW/deb server's `images_dir`
 (`~/Library/Application Support/shed/vz` for Mac VZ;
 `/var/lib/shed/firecracker/images` for Linux FC) — which means a
 naive local build lands in the brew/deb server's blob store, NOT the
@@ -241,17 +255,26 @@ To make the local-built image visible to the dev server, override
 **Mac VZ:**
 
 ```sh
+# Setup
+# -----
 # 1. Build the variant you changed. OUTPUT_DIR is the key override —
 #    it lands the blobs in the dev server's images_dir so `shed -s
 #    my-server-dev create --image base` picks them up.
 OUTPUT_DIR="$HOME/Library/Application Support/shed-dev/vz" \
   ./scripts/build-vz-rootfs.sh --variant base
 
-# If your change is in shed-extensions or build-tools too:
+# If your change is in build-tools too, pass --build-tools-version
+# dev so the local shed-build-tools:dev mints the rootfs erofs:
 OUTPUT_DIR="$HOME/Library/Application Support/shed-dev/vz" \
-  ./scripts/build-vz-rootfs.sh --variant extensions \
-    --shed-ext-version dev \
-    --build-tools-version dev
+  ./scripts/build-vz-rootfs.sh --variant base --build-tools-version dev
+
+# Note on shed-extensions changes: the build-vz-rootfs.sh script
+# does NOT pass --shed-ext-version through to the docker build
+# (its `--shed-ext-version` flag is informational only, per
+# scripts/build-vz-rootfs.sh:201-211). To validate a shed-extensions
+# bump, edit `ARG SHED_EXT_VERSION` in `vz/Dockerfile` directly
+# before running the script, or invoke `docker buildx build
+# --build-arg SHED_EXT_VERSION=<tag> ...` manually.
 
 # 2. Restart the dev server (it picks up the new blobs automatically
 #    — the OCI store is content-addressed so a `shed image ls` will
@@ -261,30 +284,61 @@ make dev-server-restart
 # 3. Run the suite, or just a focused test that uses the variant.
 make test-integration-dev
 # or for a focused single test:
-SHED_VZ_SERVER=my-server-dev SHED_VZ_LOG_PATH=~/.shed/dev/server.log \
-  cd tests/integration && uv run pytest -v test_smoke.py::test_create_delete_lifecycle
+cd tests/integration && \
+  SHED_VZ_SERVER=my-server-dev \
+  SHED_VZ_LOG_PATH="$HOME/.shed/dev/server.log" \
+  uv run pytest -v test_smoke.py::test_create_delete_lifecycle
+
+# Teardown
+# --------
+# 4. Stop the dev server.
+make dev-server-down
+
+# 5. Optionally remove the locally-built blobs to reclaim disk (~250 MB
+#    to ~750 MB per variant). The shed-dev/vz tree is the dev server's
+#    images_dir; deleting it is safe because the brew server uses a
+#    DIFFERENT directory (~/Library/Application Support/shed/vz).
+rm -rf "$HOME/Library/Application Support/shed-dev/vz/blobs"
+rm -rf "$HOME/Library/Application Support/shed-dev/vz/tags"
+# Or: `shed -s my-server-dev image rm <variant>` for one variant
+# at a time + `shed -s my-server-dev image prune` to GC orphaned
+# blobs (the dev server's prune is isolated from the brew server's).
 ```
 
 **FC remote:**
 
-The build script needs to run on Linux (or cross-compile via Docker
-on Mac), and the resulting OCI blobs need to land in
-`/var/lib/shed-dev/firecracker/images/` ON THE REMOTE. There's no
+The build script needs to run on Linux. The cleanest path is to
+build on the remote itself (or, if you have Docker buildx with
+cross-build set up, build on Mac and ship the OCI tarball). No
 one-command target for this yet; the manual sequence is:
 
 ```sh
-# 1. Build the image on the remote (or on the dev workstation if
-#    Docker is set up to cross-build linux/arm64 or linux/amd64
-#    via buildx).
+# Setup
+# -----
+# 1. Build on the remote, writing blobs directly to the dev
+#    images_dir. `sudo env OUTPUT_DIR=...` (not `OUTPUT_DIR=... sudo`)
+#    is the load-bearing detail — sudo strips environment variables
+#    by default; `sudo env VAR=value ...` is the standard way to
+#    pass an env var through.
 ssh $SHED_FC_HOST "cd /path/to/shed && \
-  OUTPUT_DIR=/var/lib/shed-dev/firecracker/images \
-  sudo ./scripts/build-firecracker-rootfs.sh --variant base"
+  sudo env OUTPUT_DIR=/var/lib/shed-dev/firecracker/images \
+    ./scripts/build-firecracker-rootfs.sh --variant base"
 
 # 2. Restart the dev FC server so it sees the new blobs.
 make dev-server-restart-fc
 
 # 3. Run the suite.
 make test-integration-dev-fc
+
+# Teardown
+# --------
+# 4. Stop the dev FC server.
+make dev-server-down-fc
+
+# 5. Optionally remove the locally-built blobs on the remote.
+ssh $SHED_FC_HOST "sudo rm -rf \
+  /var/lib/shed-dev/firecracker/images/blobs \
+  /var/lib/shed-dev/firecracker/images/tags"
 ```
 
 A `make build-dev-image` / `build-dev-image-fc` Makefile helper that

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -185,6 +185,119 @@ servers:
     ssh_port: 12222
 ```
 
+#### Validating pre-release: build-tools image changes
+
+The parallel dev server uses `SHED_BUILD_TOOLS_REF` to pick which
+`shed-build-tools` image mints the pre-formatted upper template ext4
+on first VM create. By default that's the latest release tag
+(resolved from `git tag --list 'v*'` at recipe time). To validate a
+change to the `build-tools/` tree before cutting a release:
+
+```sh
+# 1. Build the local shed-build-tools image. Tags it as
+#    shed-build-tools:dev in the local Docker daemon.
+make build-tools
+
+# 2. Restart the dev server with the local image override.
+#    Works on either platform (Mac VZ or FC remote).
+RELEASE_BUILD_TOOLS_REF=shed-build-tools:dev make dev-server-restart
+# or:
+RELEASE_BUILD_TOOLS_REF=shed-build-tools:dev make dev-server-restart-fc
+
+# 3. Run the suite (or a focused subset). The dev shed-server will
+#    invoke shed-build-tools:dev for upper-template formatting.
+make test-integration-dev   # or test-integration-dev-fc
+```
+
+How to confirm the override took effect: after a `shed create` the
+PhaseTimer line should show `rootfs=` sub-100 ms (fast template
+clone), AND the server log should NOT contain a
+`[<shed-name>] upper template unavailable` line for the created
+shed. If you see `rootfs=` in the multi-second range, or the
+"unavailable" log line, the override didn't take and the dev binary
+fell back to in-guest mkfs.
+
+For an FC remote validation you may want to push `shed-build-tools:dev`
+to a registry the remote can pull from (or `docker save` + `docker load`
+across the SSH boundary). The local-only path works on Mac because
+the same Docker daemon serves both `make build-tools` and the
+shed-server's image-resolution call.
+
+#### Validating pre-release: base image changes (vz/firecracker Dockerfiles, shed-extensions)
+
+Base images (`shed-vz-base`, `shed-vz-extensions`, `shed-vz-full`,
+and the FC counterparts) are built by
+`scripts/build-vz-rootfs.sh` / `scripts/build-firecracker-rootfs.sh`,
+which write OCI blobs + a tag pointer into an `OUTPUT_DIR`. The
+default `OUTPUT_DIR` is the BREW server's `images_dir`
+(`~/Library/Application Support/shed/vz` for Mac VZ;
+`/var/lib/shed/firecracker/images` for Linux FC) — which means a
+naive local build lands in the brew/deb server's blob store, NOT the
+parallel dev server's.
+
+To make the local-built image visible to the dev server, override
+`OUTPUT_DIR` to point at the dev server's `images_dir`:
+
+**Mac VZ:**
+
+```sh
+# 1. Build the variant you changed. OUTPUT_DIR is the key override —
+#    it lands the blobs in the dev server's images_dir so `shed -s
+#    my-server-dev create --image base` picks them up.
+OUTPUT_DIR="$HOME/Library/Application Support/shed-dev/vz" \
+  ./scripts/build-vz-rootfs.sh --variant base
+
+# If your change is in shed-extensions or build-tools too:
+OUTPUT_DIR="$HOME/Library/Application Support/shed-dev/vz" \
+  ./scripts/build-vz-rootfs.sh --variant extensions \
+    --shed-ext-version dev \
+    --build-tools-version dev
+
+# 2. Restart the dev server (it picks up the new blobs automatically
+#    — the OCI store is content-addressed so a `shed image ls` will
+#    show the new tag pointing at the new manifest digest).
+make dev-server-restart
+
+# 3. Run the suite, or just a focused test that uses the variant.
+make test-integration-dev
+# or for a focused single test:
+SHED_VZ_SERVER=my-server-dev SHED_VZ_LOG_PATH=~/.shed/dev/server.log \
+  cd tests/integration && uv run pytest -v test_smoke.py::test_create_delete_lifecycle
+```
+
+**FC remote:**
+
+The build script needs to run on Linux (or cross-compile via Docker
+on Mac), and the resulting OCI blobs need to land in
+`/var/lib/shed-dev/firecracker/images/` ON THE REMOTE. There's no
+one-command target for this yet; the manual sequence is:
+
+```sh
+# 1. Build the image on the remote (or on the dev workstation if
+#    Docker is set up to cross-build linux/arm64 or linux/amd64
+#    via buildx).
+ssh $SHED_FC_HOST "cd /path/to/shed && \
+  OUTPUT_DIR=/var/lib/shed-dev/firecracker/images \
+  sudo ./scripts/build-firecracker-rootfs.sh --variant base"
+
+# 2. Restart the dev FC server so it sees the new blobs.
+make dev-server-restart-fc
+
+# 3. Run the suite.
+make test-integration-dev-fc
+```
+
+A `make build-dev-image` / `build-dev-image-fc` Makefile helper that
+wraps these flows is worth adding if these workflows become
+frequent — for now the explicit `OUTPUT_DIR` override is the
+load-bearing piece to know.
+
+How to confirm the override took effect: `shed -s my-server-dev
+image ls` (Mac) or `shed -s mini3-dev image ls` (FC) will list the
+locally-built image with its new manifest digest. If you don't see
+your change, `OUTPUT_DIR` didn't land the blobs in the dev server's
+images_dir.
+
 #### Performance validation against the released version
 
 For changes that touch the boot path, agent dial, healthPoll, upper-allocation, mount, image-resolution, or any other hot path: **measure the impact on each platform the change affects, against the most recent release binary, before merging.**


### PR DESCRIPTION
## What

Closes a gap surfaced after PR #164 landed: the parallel-dev workflow supports testing Go server-side changes, but the analogous workflows for the **other two** common pre-release validation cases (`shed-build-tools` changes, base image changes) weren't documented anywhere. A contributor wanting to validate a Dockerfile change or a `build-tools/` change before cutting a release would have to derive the `OUTPUT_DIR` / `RELEASE_BUILD_TOOLS_REF` overrides from scratch.

Three pre-release validation use cases, now all explicitly documented:

| Use case | Workflow |
|---|---|
| Go server-side changes | `make build && make dev-server-restart && make test-integration-dev` (already shipped in #161-163) |
| `shed-build-tools` image changes | `make build-tools` → `RELEASE_BUILD_TOOLS_REF=shed-build-tools:dev make dev-server-restart` → run suite |
| Base image changes (vz/fc Dockerfiles, shed-extensions) | `OUTPUT_DIR="$HOME/Library/Application Support/shed-dev/vz" ./scripts/build-vz-rootfs.sh --variant base` → `make dev-server-restart` → run suite |

## Files changed

- `docs/development/testing.md` — two new subsections under "Validating server-side changes":
  - "Validating pre-release: build-tools image changes"
  - "Validating pre-release: base image changes (vz/firecracker Dockerfiles, shed-extensions)"
  Both cover Mac VZ and (where applicable) FC remote. Each ends with a how-to-verify-the-override-took-effect paragraph.
- `CLAUDE.md` — short pointer in the "Server-side changes" section so contributors find both new sections from the canonical entry point.

## Why the docs need this

The `OUTPUT_DIR` insight is the load-bearing piece for use case 3: the default `OUTPUT_DIR` for `build-vz-rootfs.sh` is the **brew** server's `images_dir` (`~/Library/Application Support/shed/vz`). The parallel dev server's `images_dir` is `~/Library/Application Support/shed-dev/vz/` — **different**. So a naive `./scripts/build-vz-rootfs.sh --variant base` lands the blobs in the brew store and is invisible to the dev server. Knowing to override `OUTPUT_DIR` is the difference between "this just works" and "why doesn't my image change show up?"

The `RELEASE_BUILD_TOOLS_REF` override for use case 2 was always supported by `dev-server-up` (it's the same env var honored on launch), but the docs only mentioned it as "pin to an older release" — never as "test your local build-tools change." Now it's explicit.

## Validation

- **Use case 2 validated end-to-end** on the dev workstation:
  - `make build-tools` → produced `shed-build-tools:dev` in the local Docker daemon (145 MB).
  - `RELEASE_BUILD_TOOLS_REF=shed-build-tools:dev make dev-server-restart` → dev server up.
  - `shed -s my-server-dev create itest-buildtools-validation --image base --local-dir /tmp/...` → succeeded.
  - PhaseTimer line shows `rootfs=8ms` (sub-100 ms — fast template clone engaged); no `upper template unavailable` log line. Confirms the local image was used.
- **Use case 3 commands are mechanical given the `OUTPUT_DIR` override** — documented without running a full image build (~5 min per variant). The build script's `OUTPUT_DIR` handling was verified by reading `scripts/build-vz-rootfs.sh` lines 27 + 145 + 241.
- `make check` clean.
- `mkdocs --strict` clean for changed files (2 pre-existing CHANGELOG + docker-free-builds warnings unrelated).

## Future follow-up (not in this PR)

If the base-image-test workflow becomes frequent, a `make build-dev-image VARIANT=base` Makefile helper that wraps the script with the right `OUTPUT_DIR` is worth adding (Mac one-command path). The FC remote helper is more involved (cross-build or remote-build + sync blobs) — defer until use proves it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
