### PR TITLE
feat(release): adopt cc-plugins:release-workflows + retire HOMEBREW_TAP_TOKEN/APT_DISPATCH_TOKEN

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -353,6 +353,28 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # Tag/manifest invariant check — the local-bump flow's safety net.
+      # Replaces the deleted sync-version job's contract: instead of
+      # fixing plugin.json drift after the fact in CI, fail the release
+      # if the tagged commit's plugin.json doesn't match the tag. Cheap
+      # server-side check; the maintainer reruns
+      # /release-workflows:release against a corrected tag rather than
+      # shipping mismatched bytes.
+      - name: Verify plugin.json matches tag
+        run: |
+          set -euo pipefail
+          expect="${GITHUB_REF_NAME#v}"
+          # Use jq to anchor to the top-level .version field; a regex
+          # would also (incorrectly) match a future nested "version"
+          # field (e.g. in a future "dependencies" block). jq is
+          # preinstalled on ubuntu-latest and fails loudly on malformed
+          # JSON.
+          got="$(jq -r '.version' .claude-plugin/plugin.json)"
+          if [ "${got}" != "${expect}" ]; then
+            echo "::error::plugin.json .version=${got} != tag=${expect}. Re-run /release-workflows:release after correcting."
+            exit 1
+          fi
+
       - name: Run Tests
         run: go test ./...
 
@@ -361,6 +383,27 @@ jobs:
         with:
           version: v2.10.1
 
+      # Mint a release-bot App token scoped to charliek/homebrew-tap for
+      # GoReleaser's `brews:` step (formula push). The App must be
+      # installed on homebrew-tap (verify via sanity-check-app.yml).
+      # Replaces the legacy HOMEBREW_TAP_TOKEN PAT — GoReleaser is
+      # token-source-agnostic; it just uses HOMEBREW_TAP_TOKEN from the
+      # env for git authentication.
+      - name: Mint a homebrew-tap App token
+        id: tap
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          owner:        charliek
+          repositories: homebrew-tap
+          # Defense-in-depth: explicit permission floor on the minted
+          # token so a future widening of the App's installation perms
+          # doesn't silently broaden what this token can do. GoReleaser
+          # only needs contents:write on the tap repo (to push the
+          # formula).
+          permission-contents: write
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -368,61 +411,64 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # GoReleaser reads HOMEBREW_TAP_TOKEN from this env var (see
+          # .goreleaser.yaml: brews[].repository.token). Feed it the
+          # App-minted token instead of a PAT.
+          HOMEBREW_TAP_TOKEN: ${{ steps.tap.outputs.token }}
 
-      # Tell apt-charliek to pick up the new shed-server.deb attached to
-      # this release. The dispatch is fire-and-forget — apt-charliek's
-      # publish workflow re-scans every tracked package on every run, so
-      # a missed dispatch self-heals on the next one. Requires
-      # APT_DISPATCH_TOKEN (fine-grained PAT scoped to charliek/apt-charliek
-      # with Contents: write) to be set on this repo; skipped silently if
-      # the secret isn't present so the release still ships.
-      - name: Trigger apt-charliek publish
-        if: success() && env.APT_DISPATCH_TOKEN != ''
-        env:
-          GH_TOKEN: ${{ secrets.APT_DISPATCH_TOKEN }}
-          APT_DISPATCH_TOKEN: ${{ secrets.APT_DISPATCH_TOKEN }}
-        run: |
-          gh api repos/charliek/apt-charliek/dispatches \
-            --method POST \
-            -f event_type=publish \
-            -F "client_payload[package]=shed-server" \
-            -F "client_payload[tag]=${{ github.ref_name }}"
-          echo "::notice::Watch publish at https://github.com/charliek/apt-charliek/actions"
-
-  # Keep the committed .claude-plugin/plugin.json version in lockstep with the
-  # released tag, so Claude Code installs the right plugin version. Runs only
-  # after a real tag-push release (gated like the release job and needs it).
-  sync-version:
-    name: Commit plugin version to main
-    needs: release
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout main
-        uses: actions/checkout@v6
+      # Mint a release-bot App token scoped to charliek/apt-charliek for
+      # the publish dispatch. The App must be installed on apt-charliek
+      # (verify via sanity-check-app.yml). Replaces the legacy
+      # APT_DISPATCH_TOKEN PAT.
+      - name: Mint an apt-charliek App token
+        if: success()
+        id: apt
+        uses: actions/create-github-app-token@v3
         with:
-          ref: main
-          persist-credentials: false
+          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          owner:        charliek
+          repositories: apt-charliek
+          # POST /repos/.../dispatches requires contents:write.
+          permission-contents: write
 
-      - name: Set plugin version from tag
-        run: scripts/set-version.sh "${GITHUB_REF_NAME#v}"
-
-      - name: Commit and push if plugin.json drifted
-        # Idempotent: a no-op when the version was bumped by hand before
-        # tagging. The GITHUB_TOKEN push does not re-trigger workflows (GitHub
-        # blocks recursive runs).
+      - name: Trigger apt-charliek publish
+        if: success()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.apt.outputs.token }}
         run: |
-          if [ -z "$(git status --porcelain .claude-plugin/plugin.json)" ]; then
-            echo "plugin.json already matches ${GITHUB_REF_NAME}; nothing to commit"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .claude-plugin/plugin.json
-          git commit -m "chore: set plugin version ${GITHUB_REF_NAME}"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
+          # Retry the dispatch a few times — a transient network/API
+          # blip shouldn't fail the release after GoReleaser already
+          # succeeded. apt-charliek's publish workflow is idempotent so
+          # a missed dispatch self-heals on the next release, but we
+          # still want to flag genuinely persistent failures.
+          for attempt in 1 2 3; do
+            # Capture stderr so a real install-state failure (App not
+            # installed on apt-charliek, scoped-perms mismatch, etc.)
+            # is diagnosable from the workflow log without re-running.
+            if gh api repos/charliek/apt-charliek/dispatches \
+              --method POST \
+              -f event_type=publish \
+              -F "client_payload[package]=shed-server" \
+              -F "client_payload[tag]=${{ github.ref_name }}" 2>&1; then
+              echo "::notice::Watch apt publish at https://github.com/charliek/apt-charliek/actions"
+              exit 0
+            fi
+            echo "::warning::dispatch attempt $attempt failed; sleeping $((attempt * 5))s"
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::apt-charliek dispatch failed after 3 attempts — check the stderr above for the API error"
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
+
+# The earlier sync-version job that checked out main, ran
+# scripts/set-version.sh, and pushed the bumped
+# .claude-plugin/plugin.json back to main is REMOVED in this
+# migration. Plugin.json bumping is now LOCAL via
+# scripts/release/update-version.sh (the cc-plugins:release-workflows
+# convention's source-tree-bump-local rule). The release skill runs
+# update-version.sh before tagging, so main always has plugin.json at
+# the released tag's version before the workflow even fires. The
+# inline "Verify plugin.json matches tag" step above is the cross-check
+# that replaces sync-version's after-the-fact bump.

--- a/.github/workflows/sanity-check-app.yml
+++ b/.github/workflows/sanity-check-app.yml
@@ -1,0 +1,106 @@
+name: sanity-check-app
+
+# Manual verification that the release-bot App is installed on every
+# repo shed's release pipeline touches:
+#   1. charliek/shed itself (the running repo's secrets must resolve)
+#   2. charliek/homebrew-tap (GoReleaser's brews step pushes Formula/shed.rb)
+#   3. charliek/apt-charliek (publish dispatch sent at end of release)
+#
+# Run from the Actions UI ("Run workflow") after setting the
+# RELEASE_BOT_APP_* secrets and confirming the App is installed on all
+# three repos. Useful when:
+#   * first wiring the App into a new repo (verify before touching
+#     publish-images.yaml)
+#   * rotating the App's private key (re-verify after updating the secret)
+#   * migrating to a new App
+#   * after adopting a new cross-repo target
+#
+# Each block mints a short-lived installation token scoped to one repo
+# and calls a read-only endpoint. A failure to mint, or a 404 on the
+# reach check, means the App isn't installed on that repo — fix the
+# install before the next release runs.
+#
+# Bot identity comes from the action's `app-slug` output, NOT
+# `gh api /user`, which returns 403 for installation tokens (they
+# don't authenticate as a user).
+
+on:
+  workflow_dispatch: {}
+
+permissions: {}   # this workflow needs nothing from the workflow token
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      # ── 1. self (charliek/shed) ──
+      - id: self-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+
+      - name: Token sees shed + bot identity
+        env:
+          GH_TOKEN: ${{ steps.self-token.outputs.token }}
+          BOT_SLUG: ${{ steps.self-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          echo "::group::This repo (must print charliek/shed)"
+          gh api "/repos/${GITHUB_REPOSITORY}" --jq '.full_name'
+          echo "::endgroup::"
+
+          # Per-repo selective installs (the typical pattern) show count=1
+          # from each repo's own installation. Informational only; the
+          # per-target reach checks below are the real verification.
+          echo "::group::Installation repository count (informational)"
+          gh api /installation/repositories --jq '.total_count'
+          echo "::endgroup::"
+
+          echo "::group::Bot identity (should end with [bot])"
+          echo "${BOT_SLUG}[bot]"
+          echo "::endgroup::"
+
+      # ── 2. charliek/homebrew-tap (GoReleaser brews push target) ──
+      - id: tap-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          owner:        charliek
+          repositories: homebrew-tap
+          # Defense-in-depth: pin the permission floor to what the real
+          # mint step in publish-images.yaml requests. If this passes
+          # with contents:write, GoReleaser's `brews:` push (which
+          # needs the same permission) will too.
+          permission-contents: write
+
+      - name: Token can reach charliek/homebrew-tap
+        env:
+          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          echo "::group::Token can reach charliek/homebrew-tap"
+          gh api /repos/charliek/homebrew-tap --jq '.full_name'
+          echo "::endgroup::"
+
+      # ── 3. charliek/apt-charliek (publish dispatch target) ──
+      - id: apt-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          owner:        charliek
+          repositories: apt-charliek
+          # POST /repos/.../dispatches requires contents:write — match
+          # what the real publish-images.yaml mint step requests.
+          permission-contents: write
+
+      - name: Token can reach charliek/apt-charliek
+        env:
+          GH_TOKEN: ${{ steps.apt-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          echo "::group::Token can reach charliek/apt-charliek"
+          gh api /repos/charliek/apt-charliek --jq '.full_name'
+          echo "::endgroup::"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,257 @@
+# Releasing shed
+
+The general release framework is `cc-plugins:release-workflows`; this
+file documents what's specific to this repo (which is a lot — shed is
+the most complex consumer).
+
+## TL;DR
+
+    /release-workflows:release v0.5.9
+
+Everything else is automatic.
+
+## What happens
+
+1. **`release-workflows:release`** (LLM, local):
+   - Verifies branch (`main`) + clean tree + CI green on HEAD (shed
+     has no `ci-success` aggregator; the skill reports "missing" for
+     that check, which is expected — treat as non-blocking; ci.yml's
+     test/lint/plugin jobs run on every PR and serve as the gate)
+   - Asks/confirms version
+   - Drafts a CHANGELOG entry from `git log v<previous>..HEAD`, commits
+     as `docs(changelog): vX.Y.Z entry`
+   - Runs `scripts/release/update-version.sh X.Y.Z`:
+     - Delegates to `scripts/set-version.sh` (the existing in-repo
+       bumper) to update `.claude-plugin/plugin.json`'s top-level
+       `.version`
+     - jq-verifies the bump landed (defense against set-version.sh's
+       silent-failure mode on malformed JSON)
+   - Commits as `chore(version): bump to X.Y.Z`
+   - Tags `vX.Y.Z` (annotated) on the version commit
+   - `git push --follow-tags` (admin bypasses the ruleset)
+
+2. **`publish-images.yaml`** (CI, on tag push `v*`) — six jobs in
+   a strict dependency chain:
+
+   **`publish-build-tools`** (`ubuntu-latest`, multi-arch):
+   - Builds + pushes `ghcr.io/charliek/shed-build-tools:vX.Y.Z` (and
+     `:latest`) for `linux/amd64` + `linux/arm64`. The downstream
+     image-publish jobs FROM/docker-run this image during their builds,
+     so it must exist on ghcr.io before they start.
+
+   **`publish-vz`** (`ubuntu-24.04-arm`, needs build-tools):
+   - Builds shed-overlay initramfs + 3 OCI images
+     (`shed-vz-{base,extensions,full}` arm64), pushes to ghcr.io.
+
+   **`publish-fc`** (`ubuntu-latest`, needs build-tools):
+   - Same as `publish-vz` but for `linux/amd64` Firecracker images.
+     Runs in parallel with `publish-vz`.
+
+   **`smoke`** (reusable `smoke-linux.yml`):
+   - Install-only smoke against the tagged commit on GHA's
+     ubuntu-latest. KVM-required cycle is the maintainer's
+     responsibility (see `scripts/smoke-test-linux.sh --from-local`
+     for the matching local script).
+
+   **`release`** (`ubuntu-latest`, needs all four above; tag-push only):
+   - **Verifies plugin.json matches the tag** (inline `jq` check —
+     guards against a developer tagging the wrong commit; the release
+     skill should have bumped plugin.json before tagging, this is the
+     cross-check).
+   - Runs `go test ./...` + golangci-lint
+   - Mints a release-bot App token scoped to `charliek/homebrew-tap`
+   - Runs `goreleaser release --clean`:
+     - Builds 3 Go binaries × OS/arch matrix with ldflag versioning
+     - Tarballs + checksums.txt + `Formula/shed.rb` (pushed to
+       homebrew-tap with App-minted token) + `shed-server_*.deb` (via
+       nfpms)
+   - Mints a release-bot App token scoped to `charliek/apt-charliek`
+   - Dispatches `event_type=publish` with
+     `client_payload[package]=shed-server` to apt-charliek so the new
+     .deb gets indexed into apt.stridelabs.ai. Retry loop with stderr
+     capture for diagnosability.
+
+   `workflow_dispatch` (manual republish) re-runs only the
+   image-publish chain; the `release` job is gated on `tag-push`
+   events so manual republishes don't accidentally cut a new GitHub
+   Release.
+
+   The `sync-version` job that existed pre-migration is **removed** —
+   plugin.json is now bumped locally by the release skill before
+   tagging, matching the convention.
+
+The maintainer runs step 1; everything else is automated.
+
+## Version files this repo owns
+
+`scripts/release/update-version.sh` bumps:
+
+- `.claude-plugin/plugin.json` `.version` (via `scripts/set-version.sh`,
+  with a jq-verify safety net)
+
+The Go binaries' version comes from a build-time `-X` ldflag injected
+by GoReleaser via `.goreleaser.yaml`'s `builds[].ldflags`. The Docker
+images are tagged from `GITHUB_REF_NAME` at workflow time. None of
+those need a source-tree bump.
+
+`CHANGELOG.md` is maintained by the release skill for human-readable
+in-repo history. GoReleaser's auto-generated release notes (filtered:
+skip `docs:`, `test:`, `chore:`, `ci:`) go on the GitHub Release body.
+
+`pyproject.toml` is for mkdocs only and has its own version cadence;
+not touched by `update-version.sh`.
+
+## Snapshot / dev versioning
+
+Not used in the formal sense. `shed version` between releases shows
+the last released version (the binary's compiled-in ldflag).
+
+The `make dev-server-up*` targets DO inject a custom dev
+`SHED_BUILD_TOOLS_REF` env var so a parallel dev shed-server can run
+against the in-progress build-tools image without colliding with the
+brew/.deb production server. See `make help` for details — not a
+release-time concern.
+
+## Secrets
+
+| Secret | Purpose | Required? |
+|---|---|---|
+| `RELEASE_BOT_APP_ID` | `charliek-release-bot` GitHub App ID | required |
+| `RELEASE_BOT_APP_KEY` | App private key (.pem) | required |
+| `GITHUB_TOKEN` (workflow-provided) | All 3 Docker push jobs (build-tools, VZ, FC) to ghcr.io as `${{ github.actor }}` | provided automatically; do not set |
+
+Retired (deleted from `gh secret list -R charliek/shed` during the
+convention adoption):
+
+- `HOMEBREW_TAP_TOKEN` — replaced by the App-minted homebrew-tap
+  token. GoReleaser still reads the env var named
+  `HOMEBREW_TAP_TOKEN`; the workflow sets it from
+  `steps.tap.outputs.token` instead of from `secrets`.
+- `APT_DISPATCH_TOKEN` — replaced by the App-minted apt-charliek
+  token used for the `repository_dispatch` call.
+
+Confirm with `gh secret list -R charliek/shed` that only the
+`RELEASE_BOT_APP_*` pair remains.
+
+## Branch protection
+
+`main` is protected by a ruleset (created during the convention
+adoption) with rules `deletion` + `non_fast_forward` (no
+`required_status_checks` — shed's `ci.yml` runs separate jobs
+(test/lint/plugin) with no aggregator). Bypass actors:
+
+- `charliek-release-bot` (App, type `Integration`) — listed for future
+  flexibility (no workflow step pushes back to shed's main today now
+  that `sync-version` is gone)
+- Admin role (id `5`, type `RepositoryRole`) — lets
+  `/release-workflows:release`'s push of the changelog + version
+  commits + tag land
+
+Inspect or edit at https://github.com/charliek/shed/rules.
+
+## App installation
+
+The release-bot App must be installed on three repos:
+
+- `charliek/shed` itself (so the workflow's `RELEASE_BOT_APP_*` secrets
+  resolve)
+- `charliek/homebrew-tap` (so the minted token can push
+  `Formula/shed.rb`)
+- `charliek/apt-charliek` (so the minted token can dispatch
+  `event_type=publish`)
+
+The three Docker push jobs do NOT need the App on a separate repo —
+ghcr.io packages owned by this same repo accept pushes from the
+workflow's `GITHUB_TOKEN` as `${{ github.actor }}`. Canonical ghcr.io
+pattern. Intentionally unchanged.
+
+Verify all three via the `sanity-check-app.yml` workflow (Actions →
+Run workflow). Each block must print the expected repo name.
+
+## When things break
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `git push` rejected from local | Pusher not in ruleset bypass | Confirm App + admin role in `main`'s ruleset `bypass_actors` |
+| `release` job fails at "Verify plugin.json matches tag" | Plugin.json wasn't bumped before tagging; tag was created against the wrong commit; or developer ran `git tag` manually without using `/release-workflows:release` | Don't force-fix in CI — re-run `/release-workflows:release` against a corrected tag |
+| GoReleaser fails at `brews` with `Bad credentials` | `RELEASE_BOT_APP_ID` unset OR App not installed on `homebrew-tap` | Verify via `sanity-check-app.yml`'s homebrew-tap block; install the App on the tap |
+| apt-charliek dispatch fails after 3 retries | App not installed on `charliek/apt-charliek` OR scope mismatch | Verify via `sanity-check-app.yml`'s apt-charliek block; check `RELEASE_BOT_APP_KEY` is the current `.pem` |
+| `publish-vz` / `publish-fc` fails on `FROM ghcr.io/charliek/shed-build-tools:vX.Y.Z` (image not found) | The build-tools push hadn't propagated yet, OR a previous `workflow_dispatch` failed to publish the new tag | Re-run the failed image-publish job; it'll pick up the now-existent build-tools image |
+| Docker push fails at "Log in to ghcr.io" | `packages: write` permission missing on the job | Confirm `permissions.packages: write` at workflow + job level |
+| `brew install charliek/tap/shed` finds old version | Tap cache | `brew untap charliek/tap && brew tap charliek/tap` |
+| `apt update; apt install shed-server` finds old version | apt-charliek didn't run, OR it ran but didn't pick up the new .deb | Check apt-charliek Actions tab for the `repository_dispatch` run triggered by this release |
+| `.claude-plugin/plugin.json` on main is one version behind the tag | The pre-migration `sync-version` job would have fixed this; the new flow doesn't have it. Means the maintainer tagged without `/release-workflows:release` | Re-run `/release-workflows:release` to bump locally and re-tag |
+
+## Break-glass recovery
+
+### GoReleaser failed after some artifacts uploaded
+
+```bash
+RUN_ID=$(gh run list -R charliek/shed --workflow publish-images.yaml \
+                     --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run rerun "${RUN_ID}" -R charliek/shed --failed
+```
+
+GoReleaser's `mode: replace` reuses the existing Release.
+
+### Image-publish job failed (build-tools / VZ / FC)
+
+Re-run the failed job from the Actions UI. The downstream `release`
+job will start once the failed publish job + smoke pass on the rerun.
+
+### Wrong version got tagged (sync-version was the safety net, now it's gone)
+
+The plugin.json must be at the released tag's version on main, even
+without the sync-version job:
+
+```bash
+# Manually fix plugin.json on a hotfix branch:
+git checkout -b fix/plugin-version-resync
+scripts/set-version.sh X.Y.Z
+git commit -am "chore(version): resync plugin.json to vX.Y.Z"
+# Open a PR; merge through normal flow.
+```
+
+Then cut a fresh patch tag (`vX.Y.Z+1`) so the release pipeline picks
+up the corrected plugin.json. Don't try to retag `vX.Y.Z` — fight that
+URGE; force-updating tags strands published images and creates a
+confusing state.
+
+## Adopting the convention (for new contributors)
+
+If you're new to this repo and need to understand the release
+pipeline, read [`cc-plugins/plugins/release-workflows/references/convention.md`](https://github.com/charliek/cc-plugins/blob/main/plugins/release-workflows/references/convention.md)
+in the framework repo.
+
+## Notes for this repo
+
+- **All Docker pushes (build-tools, VZ, FC) use `GITHUB_TOKEN`, NOT the
+  release-bot App**: ghcr.io packages owned by this same repo accept
+  pushes from the workflow's `GITHUB_TOKEN` as `${{ github.actor }}`.
+  Canonical ghcr.io pattern. The App's value is single-identity for
+  *cross-repo* pushes; these are same-repo. Intentionally unchanged.
+- **Inline `Verify plugin.json matches tag` step**: the post-migration
+  replacement for the deleted `sync-version` job. The pre-migration
+  flow could tolerate a "tag was pushed before plugin.json was bumped"
+  state because sync-version would fix it after the fact. The new
+  flow REJECTS that state at release time — the maintainer reruns the
+  skill against a corrected tag rather than shipping mismatched bytes.
+- **No `ci-gate` job in the release pipeline**: the inline `go test` +
+  golangci-lint steps in the `release` job serve as the at-tag-time
+  gate. The smoke job is a separate gate on `release`'s `needs:`. CI
+  on PRs runs `ci.yml` (test/lint/plugin) but is informational —
+  there's no aggregator that the release skill blocks on.
+- **`publish-images.yaml`'s strict job ordering** is the v0.5.2-era
+  race fix: the apt-charliek dispatch must happen after all
+  referenced ghcr images exist, because the binary hard-fails on
+  missing `io.shed.rootfs.erofs.digest` if it tries to pull an image
+  the apt deb references but ghcr doesn't have yet. The dependency
+  chain `build-tools → vz+fc → smoke → release` enforces that.
+- **`scripts/set-version.sh` is preserved**: the convention's
+  `scripts/release/update-version.sh` delegates to it (with a
+  jq-verify wrap), so the in-repo bumper isn't duplicated.
+- **`workflow_dispatch` republishes are still useful**: if an image
+  build flakes after a release, you can re-run
+  `publish-images.yaml` manually with the version input and it'll
+  republish the images without creating a new Release (the `release`
+  job is gated on `tag-push` events).

--- a/scripts/release/update-version.sh
+++ b/scripts/release/update-version.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Bump shed's release version.
+#
+# shed has TWO version surfaces:
+#
+#   * Go binaries (shed, shed-server, shed-agent) — version comes from
+#     a build-time ldflag injected by GoReleaser at tag time:
+#         -X github.com/charliek/shed/internal/version.Version={{.Version}}
+#         -X github.com/charliek/shed/internal/version.GitCommit={{.ShortCommit}}
+#         -X github.com/charliek/shed/internal/version.BuildDate={{.Date}}
+#     NOT bumped in the source tree.
+#
+#   * Claude Code plugin (.claude-plugin/plugin.json) — lives in source.
+#     Read by Claude Code at install/update time. IS a source-tree
+#     manifest that must be bumped to match the released tag.
+#
+# This script bumps plugin.json by delegating to scripts/set-version.sh
+# (the existing, tested in-repo bumper) and then jq-verifies the bump
+# landed. The convention requires the script to live at
+# scripts/release/update-version.sh; this thin wrapper preserves the
+# existing scripts/set-version.sh entry point.
+#
+# Pre-migration shape: plugin.json was bumped by CI's `sync-version`
+# job AFTER the tag was pushed (the "inverse pattern"). post-migration
+# shape: plugin.json is bumped HERE, before tagging, by the
+# /release-workflows:release skill. The sync-version job is removed in
+# the same commit that adds this script.
+#
+# Contract (see cc-plugins:release-workflows references/update-version/README.md):
+#   - one arg: semver string, no `v` prefix
+#   - idempotent
+#   - no network
+#   - verifies its own work — explicit jq-back on plugin.json after
+#     delegating, because set-version.sh's sed substitution silently
+#     no-ops if the version field is missing or malformed
+#   - doesn't `git add` (release skill stages + commits)
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <X.Y.Z>   e.g. $0 0.5.9" >&2
+  exit 2
+fi
+V="$1"
+
+if [[ ! "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+  echo "error: '$V' is not semver (X.Y.Z or X.Y.Z-suffix)" >&2
+  exit 2
+fi
+
+PLUGIN_JSON="$(dirname "$0")/../../.claude-plugin/plugin.json"
+
+# Delegate to the existing plugin.json bumper.
+"$(dirname "$0")/../set-version.sh" "$V"
+
+# Verify the bump actually landed. set-version.sh's sed silently no-ops
+# if the `"version"` field is missing or formatted differently than
+# expected, then exits 0 — which would let the release skill commit a
+# stale plugin.json and tag it. Use jq to anchor to the TOP-LEVEL
+# .version field; a regex would also (incorrectly) match a future
+# nested "version" field (e.g. in a future "dependencies" block).
+if [ "$(jq -r '.version' "${PLUGIN_JSON}")" != "${V}" ]; then
+  echo "error: plugin.json top-level .version did not bump to ${V}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## What

Aligns shed's release pipeline with the [`cc-plugins:release-workflows`](https://github.com/charliek/cc-plugins/tree/main/plugins/release-workflows) convention now used by strix, roost, prox, codelens, envsecrets, and shed-extensions. shed is the most complex consumer:

| Surface | Detail |
|---|---|
| 3 Go binaries | `shed` (CLI), `shed-server`, `shed-agent` (linux-only, in-VM) |
| 4 archive families | shed, shed-server, shed-agent, shed-homebrew (the bundle) |
| Homebrew formula | `Formula/shed.rb` → charliek/homebrew-tap |
| .deb | `shed-server_*.deb` → apt-charliek dispatch |
| 9 Docker images | shed-build-tools + shed-vz-{base,extensions,full} + shed-fc-{base,extensions,full} |
| Claude Code plugin | `.claude-plugin/plugin.json` |

## Why

- Sunset of the legacy `HOMEBREW_TAP_TOKEN` + `APT_DISPATCH_TOKEN` PATs in favor of the same `charliek-release-bot` App that drives every other consumer.
- Move the plugin.json bump from CI (the post-tag `sync-version` job) to local (the new `scripts/release/update-version.sh`) — the convention's source-tree-bump-local rule. Replaces the after-the-fact `sync-version` reconcile with an at-tag-time `Verify plugin.json matches tag` cross-check.
- Get the `/release-workflows:release` skill driving releases, with the same shape every other repo already uses.

## File-by-file

### `scripts/release/update-version.sh` (new, executable)

Conforms to the convention's [`update-version.sh` contract](https://github.com/charliek/cc-plugins/blob/main/plugins/release-workflows/references/update-version/README.md). Wraps the existing `scripts/set-version.sh` (sed-edits `.claude-plugin/plugin.json`) and jq-verifies the bump landed (defense against set-version.sh's silent-failure mode if the JSON ever gains a nested `"version"` field).

### `RELEASING.md` (new)

Per-repo policy. Documents the 6-job pipeline (build-tools → vz+fc → smoke → release → apt-dispatch), the version-bump-local switch, the App-install matrix, a failure-mode table, and break-glass recovery for both GoReleaser failures and image-publish job failures ("the FROM ghcr.io/shed-build-tools image not found" case).

### `.github/workflows/sanity-check-app.yml` (new)

3 reach-check blocks — `self` (charliek/shed), `homebrew-tap`, `apt-charliek`. Each mints a scoped App token via `actions/create-github-app-token@v3` and exercises one real API call. Catches App-install-on-target mistakes BEFORE the first release tries to push. Uses `permissions: {}` (no implicit GITHUB_TOKEN — everything from minted tokens) and `app-slug` for bot identity (NOT `gh api user`, which 403s for installation tokens — caught by reviewer on shed-extensions#17 + already in the convention template).

### `.github/workflows/publish-images.yaml` (modified, +100 / -54)

Diff summary:

| Change | Where |
|---|---|
| Add inline `Verify plugin.json matches tag` step (jq cross-check) | release job, step 2 (after Set up Go) |
| Add `Mint a homebrew-tap App token` step | release job, after lint |
| Swap GoReleaser's `HOMEBREW_TAP_TOKEN` env source: `secrets.HOMEBREW_TAP_TOKEN` → `steps.tap.outputs.token` | release job |
| Add `Mint an apt-charliek App token` step | release job, after GoReleaser |
| Replace `Trigger apt-charliek publish` with App-token + 3-attempt retry loop + stderr capture | release job |
| **Delete `sync-version` job entirely** | bottom of file |
| Both mint steps use `actions/create-github-app-token@v3` (Node 24) from the start | release job |

Unchanged: `publish-build-tools`, `publish-vz`, `publish-fc`, `smoke`. The workflow's strict job ordering (the v0.5.2-era race fix ensuring apt-charliek dispatch only fires after every referenced ghcr image is live) is preserved. All 3 Docker pushes intentionally stay on `GITHUB_TOKEN` (canonical ghcr.io same-repo pattern).

## What's intentionally NOT changing

- **All Docker pushes (build-tools, VZ, FC) stay on `GITHUB_TOKEN`**: ghcr.io packages owned by this same repo accept pushes from the workflow's `GITHUB_TOKEN` as `${{ github.actor }}`. The App's value is single-identity for *cross-repo* pushes; these are same-repo.
- **GoReleaser's `.goreleaser.yaml`**: byte-identical. GoReleaser is token-source-agnostic — it just reads `HOMEBREW_TAP_TOKEN` from env.
- **`scripts/set-version.sh`**: preserved as the actual bumper; `update-version.sh` delegates to it.
- **`smoke-linux.yml`** + **`ci.yml`**: unchanged. ci.yml continues to run test/lint/plugin on every PR; smoke-linux.yml is still the reusable gate.

## Migration plan + status

| # | Step | Status |
|---|---|---|
| 1 | Worktree off origin/main `ec0320f` | done |
| 2 | scripts/release/update-version.sh | done — this PR |
| 3 | RELEASING.md | done — this PR |
| 4 | sanity-check-app.yml | done — this PR |
| 5 | publish-images.yaml: add concurrency (was already there) + mint App tokens + inline plugin.json check + delete sync-version + swap env sources | done — this PR |
| 6 | Branch protection ruleset on main (App + admin in bypass_actors) | pending — gh CLI after merge |
| 7 | Watch + review + merge this PR | in progress |
| 8 | Delete HOMEBREW_TAP_TOKEN + APT_DISPATCH_TOKEN | pending |
| 9 | Run sanity-check-app.yml; verify all 3 reach checks | pending |
| 10 | Cut v0.5.9 via `/release-workflows:release` | pending |
| 11 | Validate v0.5.9 artifacts (binaries + tarballs + .deb + formula + 9 Docker images + plugin.json + apt-charliek dispatch) | pending |
| 12 | Cleanup worktree | pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)