### PR TITLE
chore(ci): switch app-id → client-id (resolve create-github-app-token v3 deprecation)

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -393,7 +393,7 @@ jobs:
         id: tap
         uses: actions/create-github-app-token@v3
         with:
-          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id:      ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           owner:        charliek
           repositories: homebrew-tap
@@ -425,7 +425,7 @@ jobs:
         id: apt
         uses: actions/create-github-app-token@v3
         with:
-          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id:      ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           owner:        charliek
           repositories: apt-charliek

--- a/.github/workflows/sanity-check-app.yml
+++ b/.github/workflows/sanity-check-app.yml
@@ -37,7 +37,7 @@ jobs:
       - id: self-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id:      ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
 
       - name: Token sees shed + bot identity
@@ -65,7 +65,7 @@ jobs:
       - id: tap-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id:      ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           owner:        charliek
           repositories: homebrew-tap
@@ -88,7 +88,7 @@ jobs:
       - id: apt-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id:      ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           owner:        charliek
           repositories: apt-charliek


### PR DESCRIPTION
## What

Swaps deprecated `app-id` → `client-id` in `publish-images.yaml` (2 refs in the release job's mint steps) and `sanity-check-app.yml` (3 refs). Secret reference `RELEASE_BOT_APP_ID` → `RELEASE_BOT_CLIENT_ID`.

## Why

Visible warning on v0.5.9's release run (post-#166 convention adoption):

> ##[warning]Input 'app-id' has been deprecated with message: Use 'client-id' instead.

`app-id` still works; this is noise reduction.

## Compatibility

`@v3.1.0+` accepts both inputs. `RELEASE_BOT_APP_ID` left as a safety net.

## Impact

Workflow-only changes; no release fires (Docker jobs are independent of this change). Coordinated with cc-plugins#11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)