### PR TITLE
feat(images): ref-keyed image identity + pull_policy (breaking)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -173,11 +173,12 @@ brews:
               vfkit_path: vfkit
               kernel_path: ~/Library/Application Support/shed/vz/vmlinux
               initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-              base_rootfs: ghcr.io/charliek/shed-vz-full:v{{ .Version }}
-              images:
+              default_image: ghcr.io/charliek/shed-vz-full:v{{ .Version }}
+              image_aliases:
                 base: ghcr.io/charliek/shed-vz-base:v{{ .Version }}
                 extensions: ghcr.io/charliek/shed-vz-extensions:v{{ .Version }}
                 full: ghcr.io/charliek/shed-vz-full:v{{ .Version }}
+              pull_policy: missing
               instance_dir: ~/Library/Application Support/shed/vz/instances
               socket_dir: ~/.shed/vz/sockets
               default_cpus: 2
@@ -233,11 +234,12 @@ brews:
 
             firecracker:
               kernel_path: /var/lib/shed/firecracker/images/vmlinux
-              base_rootfs: ghcr.io/charliek/shed-fc-full:v{{ .Version }}
-              images:
+              default_image: ghcr.io/charliek/shed-fc-full:v{{ .Version }}
+              image_aliases:
                 base: ghcr.io/charliek/shed-fc-base:v{{ .Version }}
                 extensions: ghcr.io/charliek/shed-fc-extensions:v{{ .Version }}
                 full: ghcr.io/charliek/shed-fc-full:v{{ .Version }}
+              pull_policy: missing
               instance_dir: /var/lib/shed/firecracker/instances
               socket_dir: /var/run/shed/firecracker
               default_cpus: 2

--- a/README.md
+++ b/README.md
@@ -308,22 +308,24 @@ env_file: ~/.shed/env
 
 # VZ backend (macOS Apple Silicon)
 vz:
-  base_rootfs: ghcr.io/charliek/shed-vz-full:v{version}
-  images:
+  default_image: ghcr.io/charliek/shed-vz-full:v{version}
+  image_aliases:
     base: ghcr.io/charliek/shed-vz-base:v{version}
     extensions: ghcr.io/charliek/shed-vz-extensions:v{version}
     full: ghcr.io/charliek/shed-vz-full:v{version}
+  pull_policy: missing
   images_dir: ~/Library/Application Support/shed/vz/
   default_cpus: 2
   default_memory_mb: 4096
 
 # Firecracker backend (Linux with KVM)
 # firecracker:
-#   base_rootfs: ghcr.io/charliek/shed-fc-full:v{version}
-#   images:
+#   default_image: ghcr.io/charliek/shed-fc-full:v{version}
+#   image_aliases:
 #     base: ghcr.io/charliek/shed-fc-base:v{version}
 #     extensions: ghcr.io/charliek/shed-fc-extensions:v{version}
 #     full: ghcr.io/charliek/shed-fc-full:v{version}
+#   pull_policy: missing
 #   images_dir: /var/lib/shed/firecracker/images
 #   default_cpus: 2
 #   default_memory_mb: 4096

--- a/cmd/shed-server/config_validate.go
+++ b/cmd/shed-server/config_validate.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var configValidateCmd = &cobra.Command{
+	Use:   "config-validate",
+	Short: "Validate the server configuration and exit",
+	Long: `Load and validate the server configuration, exiting non-zero on any error.
+
+Intended for packaging preflight (e.g. a deb upgrade checks the installed
+config before restarting the service) and for operators verifying a config
+edit. A config still carrying pre-v0.6.0 keys (base_rootfs / images) fails
+here with a pointer to the upgrade guide.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := loadConfig()
+		if err != nil {
+			return err
+		}
+		if err := cfg.Validate(); err != nil {
+			return err
+		}
+		fmt.Println("config OK")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(configValidateCmd)
+}

--- a/cmd/shed-server/pull_images.go
+++ b/cmd/shed-server/pull_images.go
@@ -53,20 +53,30 @@ func runPullImages(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unsupported backend: %s", cfg.DefaultBackend)
 	}
 
-	images := imgCfg.GetImages()
+	// Pre-warm the default_image plus every image_aliases ref. Keyed by
+	// the ref itself (the io.shed.source-ref identity); duplicate refs
+	// (e.g. an alias equal to default_image) converge on one blob and one
+	// ref-index entry, so a second EnsureImage is an O(stat) cache hit.
+	refs := map[string]string{} // selector label -> ref
+	if dr := imgCfg.GetDefaultImage(); dr != "" {
+		refs["default_image"] = dr
+	}
+	for alias, ref := range imgCfg.GetImageAliases() {
+		refs[alias] = ref
+	}
 
-	// Filter to specific variant if requested
+	// Filter to a specific selector if requested.
 	if pullVariant != "" {
-		ref, ok := images[pullVariant]
+		ref, ok := refs[pullVariant]
 		if !ok {
 			var names []string
-			for name := range images {
+			for name := range refs {
 				names = append(names, name)
 			}
 			sort.Strings(names)
-			return fmt.Errorf("unknown variant %q; available: %v", pullVariant, names)
+			return fmt.Errorf("unknown selector %q; available: %v", pullVariant, names)
 		}
-		images = map[string]string{pullVariant: ref}
+		refs = map[string]string{pullVariant: ref}
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -75,15 +85,14 @@ func runPullImages(cmd *cobra.Command, args []string) error {
 	mgr := vmimage.NewManager(imgCfg, nil)
 	pulled := 0
 
-	// Sort variant names for deterministic output
 	var names []string
-	for name := range images {
+	for name := range refs {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
 	for _, name := range names {
-		ref := images[name]
+		ref := refs[name]
 		if !vmimage.IsDockerRef(ref) {
 			fmt.Printf("Skipping %s (local path: %s)\n", name, ref)
 			continue
@@ -92,7 +101,7 @@ func runPullImages(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Pulling %s (%s)...\n", name, ref)
 		_, err := mgr.EnsureImage(ctx, vmimage.ResolvedRef{
 			DockerRef: ref,
-			Name:      name,
+			Name:      vmimage.DeriveTagFromRef(ref),
 		}, func(stage, msg string) {
 			fmt.Printf("  [%s] %s\n", stage, msg)
 		})
@@ -101,52 +110,6 @@ func runPullImages(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Printf("Done: %s\n", name)
 		pulled++
-	}
-
-	// Hydrate _base from base_rootfs. With the content-addressed blob
-	// store, two tags (_base and a variant) sharing the same Docker ref
-	// converge on the same digest after first conversion — so all we
-	// need to do is pull/ensure for _base. If a sibling tag already has
-	// a matching blob installed, EnsureImage's cache hit makes this an
-	// O(stat) operation; otherwise it falls through to a full convert.
-	baseRootfs := imgCfg.GetBaseRootfs()
-	if vmimage.IsDockerRef(baseRootfs) {
-		imagesDir := imgCfg.GetImagesDir()
-		// Fast path: another tag in this run already installed the
-		// matching digest. Point _base at it directly.
-		var sourceTag string
-		for name, ref := range imgCfg.GetImages() {
-			if ref != baseRootfs || !vmimage.IsDockerRef(ref) {
-				continue
-			}
-			if vmimage.Resolve(imagesDir, name, ref) != "" {
-				sourceTag = name
-				break
-			}
-		}
-
-		if sourceTag != "" {
-			if err := mgr.TagImage(sourceTag, "_base"); err != nil {
-				fmt.Printf("  [warn] tagging _base from %s failed (%v); falling back to full pull\n", sourceTag, err)
-			} else {
-				fmt.Printf("Done: _base (tagged from %s)\n", sourceTag)
-				pulled++
-				goto baseDone
-			}
-		}
-
-		fmt.Printf("Pulling _base (%s)...\n", baseRootfs)
-		if _, err := mgr.EnsureImage(ctx, vmimage.ResolvedRef{
-			DockerRef: baseRootfs,
-			Name:      "_base",
-		}, func(stage, msg string) {
-			fmt.Printf("  [%s] %s\n", stage, msg)
-		}); err != nil {
-			return fmt.Errorf("failed to pull base rootfs: %w", err)
-		}
-		fmt.Println("Done: _base")
-		pulled++
-	baseDone:
 	}
 
 	if pulled == 0 {

--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -742,31 +742,10 @@ func runImagePush(_ *cobra.Command, args []string) error {
 
 // deriveTagFromRef extracts a sensible default tag from a Docker ref:
 // ghcr.io/charliek/shed-vz-experimental:v0.4.0 → "experimental".
+// Delegates to the shared implementation so the CLI-derived default tag can
+// never drift from the server's ref→tag derivation.
 func deriveTagFromRef(ref string) string {
-	// Strip everything after the last colon (tag/digest).
-	name := ref
-	if i := strings.LastIndexByte(name, '@'); i >= 0 {
-		name = name[:i]
-	}
-	if i := strings.LastIndexByte(name, ':'); i >= 0 {
-		// Avoid stripping registry-port colons by checking for '/' after.
-		if !strings.Contains(name[i:], "/") {
-			name = name[:i]
-		}
-	}
-	if i := strings.LastIndexByte(name, '/'); i >= 0 {
-		name = name[i+1:]
-	}
-	for _, prefix := range []string{"shed-vz-", "shed-fc-"} {
-		if strings.HasPrefix(name, prefix) {
-			name = strings.TrimPrefix(name, prefix)
-			break
-		}
-	}
-	if name == "" {
-		name = "default"
-	}
-	return name
+	return vmimage.DeriveTagFromRef(ref)
 }
 
 func runImagePrune(_ *cobra.Command, _ []string) error {

--- a/configs/server.dev-parallel.linux-fc.yaml
+++ b/configs/server.dev-parallel.linux-fc.yaml
@@ -40,11 +40,12 @@ firecracker:
   # Same as deb config — kernel + images pinned to the latest release
   # so the dev binary uses release-shaped image-resolution behavior.
   kernel_path: /var/lib/shed/firecracker/images/vmlinux
-  base_rootfs: ghcr.io/charliek/shed-fc-full:v0.5.8
-  images:
+  default_image: ghcr.io/charliek/shed-fc-full:v0.5.8
+  image_aliases:
     base:       ghcr.io/charliek/shed-fc-base:v0.5.8
     extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.8
     full:       ghcr.io/charliek/shed-fc-full:v0.5.8
+  pull_policy: missing
 
   # Separate state-dirs so prune from the deb server never touches
   # the dev server's blobs.

--- a/configs/server.dev-parallel.linux-fc.yaml
+++ b/configs/server.dev-parallel.linux-fc.yaml
@@ -40,11 +40,11 @@ firecracker:
   # Same as deb config — kernel + images pinned to the latest release
   # so the dev binary uses release-shaped image-resolution behavior.
   kernel_path: /var/lib/shed/firecracker/images/vmlinux
-  default_image: ghcr.io/charliek/shed-fc-full:v0.5.8
+  default_image: ghcr.io/charliek/shed-fc-full:v0.5.9
   image_aliases:
-    base:       ghcr.io/charliek/shed-fc-base:v0.5.8
-    extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.8
-    full:       ghcr.io/charliek/shed-fc-full:v0.5.8
+    base:       ghcr.io/charliek/shed-fc-base:v0.5.9
+    extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.9
+    full:       ghcr.io/charliek/shed-fc-full:v0.5.9
   pull_policy: missing
 
   # Separate state-dirs so prune from the deb server never touches

--- a/configs/server.dev-parallel.mac.yaml
+++ b/configs/server.dev-parallel.mac.yaml
@@ -45,11 +45,12 @@ vz:
   # Pin to the latest release's images so the dev binary uses the
   # release-shaped upper-template fast path (sub-100 ms rootfs phase).
   # Bump in lockstep with shed releases; see docs/reference/images.md.
-  base_rootfs: ghcr.io/charliek/shed-vz-full:v0.5.8
-  images:
+  default_image: ghcr.io/charliek/shed-vz-full:v0.5.8
+  image_aliases:
     base: ghcr.io/charliek/shed-vz-base:v0.5.8
     extensions: ghcr.io/charliek/shed-vz-extensions:v0.5.8
     full: ghcr.io/charliek/shed-vz-full:v0.5.8
+  pull_policy: missing
 
   # Separate state-dirs under `shed-dev/` so prune from the brew server
   # never touches the dev server's blobs (the v0.5.7 prune behavior

--- a/configs/server.dev-parallel.mac.yaml
+++ b/configs/server.dev-parallel.mac.yaml
@@ -45,11 +45,11 @@ vz:
   # Pin to the latest release's images so the dev binary uses the
   # release-shaped upper-template fast path (sub-100 ms rootfs phase).
   # Bump in lockstep with shed releases; see docs/reference/images.md.
-  default_image: ghcr.io/charliek/shed-vz-full:v0.5.8
+  default_image: ghcr.io/charliek/shed-vz-full:v0.5.9
   image_aliases:
-    base: ghcr.io/charliek/shed-vz-base:v0.5.8
-    extensions: ghcr.io/charliek/shed-vz-extensions:v0.5.8
-    full: ghcr.io/charliek/shed-vz-full:v0.5.8
+    base: ghcr.io/charliek/shed-vz-base:v0.5.9
+    extensions: ghcr.io/charliek/shed-vz-extensions:v0.5.9
+    full: ghcr.io/charliek/shed-vz-full:v0.5.9
   pull_policy: missing
 
   # Separate state-dirs under `shed-dev/` so prune from the brew server

--- a/configs/server.example.yaml
+++ b/configs/server.example.yaml
@@ -75,11 +75,12 @@ log_level: info
 #   vfkit_path: vfkit
 #   kernel_path: ~/Library/Application Support/shed/vz/vmlinux
 #   initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-#   base_rootfs: ghcr.io/charliek/shed-vz-full:{version}
-#   images:
+#   default_image: ghcr.io/charliek/shed-vz-full:{version}
+#   image_aliases:
 #     base: ghcr.io/charliek/shed-vz-base:{version}
 #     extensions: ghcr.io/charliek/shed-vz-extensions:{version}
 #     full: ghcr.io/charliek/shed-vz-full:{version}
+#   pull_policy: missing   # missing (default) | always | never
 #   images_dir: ~/Library/Application Support/shed/vz/
 #   instance_dir: ~/Library/Application Support/shed/vz/instances
 #   socket_dir: ~/.shed/vz/sockets
@@ -87,9 +88,10 @@ log_level: info
 # --- Firecracker Backend (Linux with KVM) ---
 # firecracker:
 #   kernel_path: /var/lib/shed/firecracker/vmlinux
-#   base_rootfs: ghcr.io/charliek/shed-fc-full:{version}
-#   images:
+#   default_image: ghcr.io/charliek/shed-fc-full:{version}
+#   image_aliases:
 #     base: ghcr.io/charliek/shed-fc-base:{version}
 #     extensions: ghcr.io/charliek/shed-fc-extensions:{version}
 #     full: ghcr.io/charliek/shed-fc-full:{version}
+#   pull_policy: missing   # missing (default) | always | never
 #   images_dir: /var/lib/shed/firecracker/images

--- a/configs/server.local.yaml
+++ b/configs/server.local.yaml
@@ -85,11 +85,12 @@ log_level: debug
 default_backend: firecracker
 
 firecracker:
-  base_rootfs: ghcr.io/charliek/shed-fc-full:v0.5.0-dev
-  images:
+  default_image: ghcr.io/charliek/shed-fc-full:v0.5.0-dev
+  image_aliases:
     base: ghcr.io/charliek/shed-fc-base:v0.5.0-dev
     extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.0-dev
     full: ghcr.io/charliek/shed-fc-full:v0.5.0-dev
+  pull_policy: missing
   instance_dir: /var/lib/shed/firecracker/instances
   socket_dir: /var/run/shed/firecracker
   default_cpus: 2

--- a/configs/server.localfc.yaml
+++ b/configs/server.localfc.yaml
@@ -53,11 +53,12 @@ extensions:
 default_backend: firecracker
 
 firecracker:
-  base_rootfs: ghcr.io/charliek/shed-fc-full:v0.5.0-dev
-  images:
+  default_image: ghcr.io/charliek/shed-fc-full:v0.5.0-dev
+  image_aliases:
     base: ghcr.io/charliek/shed-fc-base:v0.5.0-dev
     extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.0-dev
     full: ghcr.io/charliek/shed-fc-full:v0.5.0-dev
+  pull_policy: missing
   instance_dir: /var/lib/shed/firecracker/instances
   socket_dir: /var/run/shed/firecracker
   default_cpus: 2

--- a/configs/server.localmac.yaml
+++ b/configs/server.localmac.yaml
@@ -56,17 +56,18 @@ vz:
   vfkit_path: vfkit
   kernel_path: ~/Library/Application Support/shed/vz/vmlinux
   initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-  # base_rootfs: ~/Library/Application Support/shed/vz/full-rootfs.ext4
-  # images:
+  # default_image: ~/Library/Application Support/shed/vz/full-rootfs.ext4
+  # image_aliases:
   #   base: ~/Library/Application Support/shed/vz/base-rootfs.ext4
   #   extensions: ~/Library/Application Support/shed/vz/extensions-rootfs.ext4
   #   full: ~/Library/Application Support/shed/vz/full-rootfs.ext4
 
-  base_rootfs: ghcr.io/charliek/shed-vz-full:v0.5.0-dev
-  images:
+  default_image: ghcr.io/charliek/shed-vz-full:v0.5.0-dev
+  image_aliases:
     base: ghcr.io/charliek/shed-vz-base:v0.5.0-dev
     extensions: ghcr.io/charliek/shed-vz-extensions:v0.5.0-dev
     full: ghcr.io/charliek/shed-vz-full:v0.5.0-dev
+  pull_policy: missing
   
   instance_dir: ~/Library/Application Support/shed/vz/instances
   socket_dir: ~/.shed/vz/sockets

--- a/configs/server.localmac.yaml
+++ b/configs/server.localmac.yaml
@@ -56,11 +56,10 @@ vz:
   vfkit_path: vfkit
   kernel_path: ~/Library/Application Support/shed/vz/vmlinux
   initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-  # default_image: ~/Library/Application Support/shed/vz/full-rootfs.ext4
-  # image_aliases:
-  #   base: ~/Library/Application Support/shed/vz/base-rootfs.ext4
-  #   extensions: ~/Library/Application Support/shed/vz/extensions-rootfs.ext4
-  #   full: ~/Library/Application Support/shed/vz/full-rootfs.ext4
+  # default_image / image_aliases values are Docker refs (resolved and pulled
+  # on first use), e.g.:
+  #   default_image: ghcr.io/charliek/shed-vz-full:v0.5.9
+  # See docs/reference/configuration.md for the ref-keyed image model.
 
   default_image: ghcr.io/charliek/shed-vz-full:v0.5.0-dev
   image_aliases:

--- a/docs/getting-started/fc-setup.md
+++ b/docs/getting-started/fc-setup.md
@@ -132,11 +132,12 @@ env_file: /root/.shed/env
 #     - docker-credentials
 
 firecracker:
-  base_rootfs: ghcr.io/charliek/shed-fc-full:v0.5.1
-  images:
+  default_image: ghcr.io/charliek/shed-fc-full:v0.5.1
+  image_aliases:
     base: ghcr.io/charliek/shed-fc-base:v0.5.1
     extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.1
     full: ghcr.io/charliek/shed-fc-full:v0.5.1
+  pull_policy: missing
   instance_dir: /var/lib/shed/firecracker/instances
   socket_dir: /var/run/shed/firecracker
   # uppers_dir is optional. Defaults to <images_dir>/uppers. If you set
@@ -291,11 +292,12 @@ build needed.
 
 ```yaml
 firecracker:
-  base_rootfs: ghcr.io/charliek/shed-fc-full:v0.5.1
-  images:
+  default_image: ghcr.io/charliek/shed-fc-full:v0.5.1
+  image_aliases:
     base: ghcr.io/charliek/shed-fc-base:v0.5.1
     extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.1
     full: ghcr.io/charliek/shed-fc-full:v0.5.1
+  pull_policy: missing
   images_dir: /var/lib/shed/firecracker/images
 ```
 

--- a/docs/getting-started/vz-setup.md
+++ b/docs/getting-started/vz-setup.md
@@ -121,11 +121,12 @@ overlayfs lowers on first boot.
 
 ```yaml
 vz:
-  base_rootfs: ghcr.io/charliek/shed-vz-full:v0.5.1
-  images:
+  default_image: ghcr.io/charliek/shed-vz-full:v0.5.1
+  image_aliases:
     base: ghcr.io/charliek/shed-vz-base:v0.5.1
     extensions: ghcr.io/charliek/shed-vz-extensions:v0.5.1
     full: ghcr.io/charliek/shed-vz-full:v0.5.1
+  pull_policy: missing
 ```
 
 Pin a concrete version that matches the `shed-server` you built.
@@ -215,11 +216,12 @@ vz:
   # you're booting a legacy raw-rootfs image (rare).
   # kernel_path: ~/Library/Application Support/shed/vz/vmlinux
   # initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-  base_rootfs: ghcr.io/charliek/shed-vz-full:v0.5.1
-  images:
+  default_image: ghcr.io/charliek/shed-vz-full:v0.5.1
+  image_aliases:
     base: ghcr.io/charliek/shed-vz-base:v0.5.1
     extensions: ghcr.io/charliek/shed-vz-extensions:v0.5.1
     full: ghcr.io/charliek/shed-vz-full:v0.5.1
+  pull_policy: missing
   instance_dir: ~/Library/Application Support/shed/vz/instances
   socket_dir: ~/.shed/vz/sockets
   default_cpus: 2

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -58,7 +58,6 @@ sheds:
 name: mini-desktop
 http_port: 8080
 ssh_port: 2222
-default_image: full
 
 credentials:
   claude:
@@ -78,7 +77,6 @@ log_level: info
 | `http_port` | int | `8080` | HTTP API port |
 | `ssh_port` | int | `2222` | SSH server port |
 | `default_backend` | string | `detect` | Backend to use when none is specified (`detect`, `firecracker`, `vz`). `detect` auto-selects based on platform: `vz` on macOS, `firecracker` on Linux. |
-| `default_image` | string | `full` | Default image variant for sheds (one of `base`, `extensions`, `full`, or a tag in the `images:` map) |
 | `credentials` | map | `{}` | Credential directories to mount into sheds |
 | `env_file` | string | - | Path to environment variables file |
 | `log_level` | string | `info` | Logging level (debug, info, warn, error) |
@@ -204,11 +202,12 @@ When enabling Firecracker, configure the Firecracker-specific settings:
 default_backend: firecracker
 
 firecracker:
-  base_rootfs: ghcr.io/charliek/shed-fc-full:v{version}
-  images:
+  default_image: ghcr.io/charliek/shed-fc-full:v{version}
+  image_aliases:
     base: ghcr.io/charliek/shed-fc-base:v{version}
     extensions: ghcr.io/charliek/shed-fc-extensions:v{version}
     full: ghcr.io/charliek/shed-fc-full:v{version}
+  pull_policy: missing
   images_dir: /var/lib/shed/firecracker/images
   instance_dir: /var/lib/shed/firecracker/instances
   socket_dir: /var/run/shed/firecracker
@@ -232,9 +231,10 @@ Replace `{version}` with the version matching your `shed` binary — run `shed v
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `kernel_path` | string | `""` | Optional. Path to a Linux kernel image (auto-populated by published-image pulls). The Phase B initramfs prefers the kernel embedded in the image blob (`{images_dir}/blobs/sha256/<digest>/kernel`); this path is the fallback for legacy blobs that lack an embedded kernel. |
-| `base_rootfs` | string | `""` | Optional. Path or Docker ref for the default rootfs. Only consulted when `shed create` runs without `--image`. Empty is fine if every create passes `--image` explicitly; otherwise `shed create` errors with `INVALID_REQUEST: no --image specified and no base_rootfs configured`. |
-| `images` | map | - | Named image variants (ext4 paths or Docker refs) |
-| `images_dir` | string | `/var/lib/shed/firecracker/images` | Directory for converted/discovered ext4 images and the content-addressed blob store |
+| `default_image` | string | `""` | Path or Docker ref used for new sheds when `shed create` runs without `--image`. Empty is fine if every create passes `--image`; otherwise `shed create` errors with `INVALID_REQUEST: no --image specified and no default_image configured`. |
+| `image_aliases` | map | - | Optional short alias → Docker ref (or path) map for `shed create --image <alias>`. Listings always show the resolved ref, not the alias. |
+| `pull_policy` | string | `missing` | `missing` (use cache, pull if absent), `always` (always pull), or `never` (error if not cached). Ignored for local-path images. |
+| `images_dir` | string | `/var/lib/shed/firecracker/images` | Directory for the content-addressed blob store and the ref→digest index |
 | `upper_size_default` | string | `5G` | Default logical size of the per-shed writable overlay upper layer when `shed create --upper-size` is omitted. Validated to the range 1–100 GiB. |
 | `instance_dir` | string | - | Directory for VM instances |
 | `socket_dir` | string | - | Directory for API/vsock sockets |
@@ -251,9 +251,9 @@ Replace `{version}` with the version matching your `shed` binary — run `shed v
 | `tap_prefix` | string | `shed-tap` | TAP device name prefix |
 
 Path-existence validation only fires when **all** configured image sources
-are local paths. When `base_rootfs` (or any `images:` entry) is a Docker
-ref, the path-existence check is skipped because the file is created on
-first pull. `kernel_path` is still required to point at a real file when
+are local paths. When `default_image` (or any `image_aliases` entry) is a
+Docker ref, the path-existence check is skipped because the file is created
+on first pull. `kernel_path` is still required to point at a real file when
 set non-empty.
 
 See [Firecracker Setup](../getting-started/fc-setup.md) for setup details.
@@ -262,7 +262,7 @@ See [Firecracker Setup](../getting-started/fc-setup.md) for setup details.
 
 When enabling the VZ backend on macOS Apple Silicon, configure the VZ-specific settings:
 
-Image values in `base_rootfs` and `images` can be either ext4 file paths or Docker image references. Docker refs are auto-pulled and converted to ext4 on first use.
+Image values in `default_image` and `image_aliases` can be either ext4 file paths or Docker image references. Docker refs are auto-pulled and converted on first use.
 
 ```yaml
 default_backend: vz
@@ -271,11 +271,12 @@ vz:
   vfkit_path: vfkit
   kernel_path: ~/Library/Application Support/shed/vz/vmlinux
   initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-  base_rootfs: ghcr.io/charliek/shed-vz-full:v{version}
-  images:
+  default_image: ghcr.io/charliek/shed-vz-full:v{version}
+  image_aliases:
     base: ghcr.io/charliek/shed-vz-base:v{version}
     extensions: ghcr.io/charliek/shed-vz-extensions:v{version}
     full: ghcr.io/charliek/shed-vz-full:v{version}
+  pull_policy: missing
   images_dir: ~/Library/Application Support/shed/vz/
   instance_dir: ~/Library/Application Support/shed/vz/instances
   socket_dir: ~/.shed/vz/sockets
@@ -296,9 +297,10 @@ vz:
 | `vfkit_path` | string | `vfkit` | Path to vfkit binary |
 | `kernel_path` | string | `""` | Optional. Path to a decompressed Linux kernel (auto-populated by published-image pulls). Phase B prefers the kernel embedded in the image blob; this is the fallback for legacy blobs that lack an embedded kernel. |
 | `initrd_path` | string | `""` | Optional. Path to an initial RAM disk image. The shed-overlay initramfs lives inside the image blob, so this field is only consulted for legacy blobs. |
-| `base_rootfs` | string | `""` | Optional. Path or Docker ref for the default rootfs. Only consulted when `shed create` runs without `--image`. Empty is fine if every create passes `--image` explicitly; otherwise `shed create` errors with `INVALID_REQUEST: no --image specified and no base_rootfs configured`. |
-| `images` | map | - | Named image variants mapping variant name to rootfs path or Docker image reference (see [Image Variants](images.md)) |
-| `images_dir` | string | `~/Library/Application Support/shed/vz/` | Directory for converted/auto-discovered ext4 images and the content-addressed blob store |
+| `default_image` | string | `""` | Path or Docker ref used for new sheds when `shed create` runs without `--image`. Empty is fine if every create passes `--image`; otherwise `shed create` errors with `INVALID_REQUEST: no --image specified and no default_image configured`. |
+| `image_aliases` | map | - | Optional short alias → Docker ref (or path) map for `shed create --image <alias>` (see [Images](images.md)). Listings always show the resolved ref. |
+| `pull_policy` | string | `missing` | `missing` (use cache, pull if absent), `always` (always pull), or `never` (error if not cached). Ignored for local-path images. |
+| `images_dir` | string | `~/Library/Application Support/shed/vz/` | Directory for the content-addressed blob store and the ref→digest index |
 | `upper_size_default` | string | `5G` | Default logical size of the per-shed writable overlay upper layer when `shed create --upper-size` is omitted. Validated to the range 1–100 GiB. |
 | `instance_dir` | string | - | Directory for VM instances |
 | `socket_dir` | string | - | Directory for vsock Unix sockets (must not contain spaces) |

--- a/docs/upgrades/v0.5.9-to-v0.6.0.md
+++ b/docs/upgrades/v0.5.9-to-v0.6.0.md
@@ -90,9 +90,9 @@ image store and restart:
 
 ```bash
 # Optional fresh start — reclaims old blobs; new images re-pull on first create.
-rm -rf "~/Library/Application Support/shed/vz/blobs" \
-       "~/Library/Application Support/shed/vz/tags" \
-       "~/Library/Application Support/shed/vz/refs"
+rm -rf ~/Library/Application\ Support/shed/vz/blobs \
+       ~/Library/Application\ Support/shed/vz/tags \
+       ~/Library/Application\ Support/shed/vz/refs
 
 brew services restart shed
 shed -s <name> version   # expect v0.6.0

--- a/docs/upgrades/v0.5.9-to-v0.6.0.md
+++ b/docs/upgrades/v0.5.9-to-v0.6.0.md
@@ -1,0 +1,159 @@
+# Upgrade Guide: v0.5.9 to v0.6.0
+
+v0.6.0 reworks the VM image system to a **Docker-style, ref-keyed model**.
+This is a **breaking server-config change** with **no automatic migration** —
+the new binary rejects the old config keys at load. The change is small to
+apply, and the recommended path is "edit config, optionally wipe the image
+store, restart". No image *manifest* format change (so published images on
+ghcr.io are unaffected); the break is in the config schema and the on-disk
+image identity model.
+
+## What changed
+
+### Config: `default_image` + `image_aliases` + `pull_policy` replace `base_rootfs` + `images`
+
+Each backend block (`vz:` / `firecracker:`) previously had a `base_rootfs`
+(the image used when no `--image` was given) plus an `images:` map of named
+variants. The internal runtime collapsed `base_rootfs` to a private tag named
+`_base`, which leaked into `shed image ls` and made the configured image
+un-addressable after a version bump.
+
+v0.6.0 replaces those with:
+
+| Old (≤ v0.5.9) | New (v0.6.0) |
+|---|---|
+| `base_rootfs: <ref>` | `default_image: <ref>` |
+| `images: { base: …, full: … }` | `image_aliases: { base: …, full: … }` (optional) |
+| _(none)_ | `pull_policy: missing` *(missing \| always \| never)* |
+
+The unused top-level `default_image` key (sibling of `name:`/`http_port:`) is
+also removed; `default_image` now lives **only** inside each backend block.
+
+```yaml
+vz:
+  default_image: ghcr.io/charliek/shed-vz-full:v0.6.0
+  image_aliases:                       # optional; for `shed create --image <alias>`
+    base: ghcr.io/charliek/shed-vz-base:v0.6.0
+    extensions: ghcr.io/charliek/shed-vz-extensions:v0.6.0
+    full: ghcr.io/charliek/shed-vz-full:v0.6.0
+  pull_policy: missing                 # missing (default) | always | never
+```
+
+A config still containing `base_rootfs` or `images:` **fails to load** with a
+pointer to this guide — it is not silently ignored.
+
+### Images are identified by their Docker ref
+
+The internal `_base` tag is gone. An image's identity is now its
+`io.shed.source-ref` annotation (the registry ref it was pulled from), and
+`shed create` resolves the configured `default_image` ref against the local
+store. `shed image ls` shows the ref as the primary identity; cosmetic labels
+(`shed image pull <ref> -t <label>`) are decoupled from resolution.
+
+### Pull policy
+
+`shed create` reconciles the configured ref against the local store per
+`pull_policy`:
+
+- **`missing`** (default) — use the cached ref if present; pull only if absent.
+  Keeps create fast and offline-tolerant. **A configured version bump
+  (`…:v0.5.9` → `…:v0.6.0`) is a cache miss and pulls automatically** on the
+  next create — the v0.5.9 silent-no-pull behavior is fixed.
+- **`always`** — always pull, even if cached.
+- **`never`** — use the cached ref; error if absent (never contacts the registry).
+
+Avoid mutable tags (`:latest`, `:dev`) with `missing` — a republished mutable
+tag won't be noticed. Pin to versioned tags. (Auto-refresh of mutable tags is a
+future addition.)
+
+### Config is read at server boot
+
+`shed-server` loads its config once at startup. **After editing the config you
+must restart `shed-server`** for the change to take effect — editing the file
+alone does not re-resolve the image.
+
+## Operator upgrade steps
+
+The simplest, lowest-risk path is delete-and-start-fresh: wipe the image store,
+update the config, restart. New images re-pull on first `shed create`.
+
+### macOS (Homebrew)
+
+```bash
+brew update && brew upgrade shed
+```
+
+Edit `/opt/homebrew/etc/shed/server.yaml` (or `/usr/local/etc/shed/server.yaml`
+on Intel Macs): rename `base_rootfs` → `default_image`, `images:` →
+`image_aliases:`, and add `pull_policy: missing`. Then optionally wipe the old
+image store and restart:
+
+```bash
+# Optional fresh start — reclaims old blobs; new images re-pull on first create.
+rm -rf "~/Library/Application Support/shed/vz/blobs" \
+       "~/Library/Application Support/shed/vz/tags" \
+       "~/Library/Application Support/shed/vz/refs"
+
+brew services restart shed
+shed -s <name> version   # expect v0.6.0
+```
+
+### Linux (.deb)
+
+```bash
+curl -fsSL -o /tmp/shed-server.deb \
+  https://github.com/charliek/shed/releases/download/v0.6.0/shed-server_0.6.0_amd64.deb
+sudo dpkg -i /tmp/shed-server.deb
+```
+
+!!! warning "The upgrade will NOT restart into an un-migrated config"
+    The `.deb` keeps your existing `/etc/shed/server.yaml` (config is
+    `noreplace`). The postinstall now **preflights the config and skips the
+    automatic restart** if it still contains the removed keys, so the old
+    process keeps serving rather than crash-looping. You'll see a message
+    pointing here. Migrate the config, then:
+
+```bash
+# Edit /etc/shed/server.yaml (base_rootfs → default_image, images → image_aliases,
+# add pull_policy), then validate and restart:
+sudo shed-server --config /etc/shed/server.yaml config-validate
+sudo systemctl restart shed-server
+```
+
+Optional fresh start of the image store (Linux/Firecracker):
+
+```bash
+sudo rm -rf /var/lib/shed/firecracker/images/blobs \
+            /var/lib/shed/firecracker/images/tags \
+            /var/lib/shed/firecracker/images/refs
+```
+
+## Verify after upgrade
+
+```bash
+shed -s <name> image ls       # images shown by Docker ref; no "_base"
+shed -s <name> create smoke   # first create pulls the configured ref
+shed -s <name> list -vv        # shows the image each shed runs
+```
+
+## Local-build workflows
+
+If you build images locally (`shed image build … -t <label>`) and reference
+them with `--image <label>`, that still works — the label resolves from the
+local store by digest, independent of `pull_policy` and the configured
+`default_image`. Local builds are no longer overwritten by a published ref.
+
+## Rollback
+
+v0.6.0's config schema is incompatible with v0.5.9. To roll back:
+
+```bash
+# Linux
+sudo apt install --reinstall shed-server=0.5.9
+# macOS: reinstall the 0.5.9 formula
+```
+
+Then restore a `base_rootfs` + `images:` config (revert your edit) and restart.
+A fresh image store works on either version; the blobs themselves are
+format-compatible — only the config schema and on-disk `refs/` index differ
+(the `refs/` directory is ignored by v0.5.9 and rebuilt by v0.6.0).

--- a/internal/config/config_image_test.go
+++ b/internal/config/config_image_test.go
@@ -1,0 +1,245 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVZConfigApplyDefaultsImageFields(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	cfg := &VZConfig{
+		DefaultImage: "ghcr.io/charliek/shed-vz-full:v1",
+		ImageAliases: map[string]string{
+			"local":  "~/shed/base.ext4",
+			"remote": "ghcr.io/charliek/shed-vz-base:v1",
+		},
+	}
+	cfg.applyDefaults()
+
+	if cfg.PullPolicy != "missing" {
+		t.Errorf("PullPolicy = %q, want missing (default)", cfg.PullPolicy)
+	}
+	// Docker-ref default_image is left untouched.
+	if cfg.DefaultImage != "ghcr.io/charliek/shed-vz-full:v1" {
+		t.Errorf("DefaultImage = %q, want unchanged docker ref", cfg.DefaultImage)
+	}
+	// Local-path alias is tilde-expanded; docker-ref alias is not.
+	if want := filepath.Join(home, "shed/base.ext4"); cfg.ImageAliases["local"] != want {
+		t.Errorf("ImageAliases[local] = %q, want %q", cfg.ImageAliases["local"], want)
+	}
+	if cfg.ImageAliases["remote"] != "ghcr.io/charliek/shed-vz-base:v1" {
+		t.Errorf("ImageAliases[remote] = %q, want unchanged docker ref", cfg.ImageAliases["remote"])
+	}
+}
+
+// resolveImageRef is shared by both backends; exercise it through VZConfig.
+func TestResolveImageSelectors(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &VZConfig{
+		DefaultImage: "ghcr.io/charliek/shed-vz-full:v0.6.0",
+		ImageAliases: map[string]string{
+			"extensions": "ghcr.io/charliek/shed-vz-extensions:v0.6.0",
+		},
+		PullPolicy: "missing",
+		ImagesDir:  dir,
+	}
+
+	t.Run("empty selector resolves default_image as a ref", func(t *testing.T) {
+		got, err := cfg.ResolveImage("")
+		if err != nil {
+			t.Fatalf("ResolveImage(\"\"): %v", err)
+		}
+		if got.DockerRef != cfg.DefaultImage {
+			t.Errorf("DockerRef = %q, want %q", got.DockerRef, cfg.DefaultImage)
+		}
+		if got.Path != "" {
+			t.Errorf("Path = %q, want empty for an uncached ref", got.Path)
+		}
+		if got.PullPolicy != "missing" {
+			t.Errorf("PullPolicy = %q, want missing", got.PullPolicy)
+		}
+	})
+
+	t.Run("alias resolves to its underlying ref", func(t *testing.T) {
+		got, err := cfg.ResolveImage("extensions")
+		if err != nil {
+			t.Fatalf("ResolveImage(extensions): %v", err)
+		}
+		if got.DockerRef != "ghcr.io/charliek/shed-vz-extensions:v0.6.0" {
+			t.Errorf("DockerRef = %q, want the aliased ref", got.DockerRef)
+		}
+	})
+
+	t.Run("bare docker ref used directly", func(t *testing.T) {
+		got, err := cfg.ResolveImage("ghcr.io/other/img:v9")
+		if err != nil {
+			t.Fatalf("ResolveImage(ref): %v", err)
+		}
+		if got.DockerRef != "ghcr.io/other/img:v9" {
+			t.Errorf("DockerRef = %q", got.DockerRef)
+		}
+	})
+
+	t.Run("absolute path escape hatch", func(t *testing.T) {
+		got, err := cfg.ResolveImage("/dev/null")
+		if err != nil {
+			t.Fatalf("ResolveImage(/dev/null): %v", err)
+		}
+		if got.Path != "/dev/null" {
+			t.Errorf("Path = %q, want /dev/null", got.Path)
+		}
+	})
+
+	t.Run("local tag label resolves from the blob store", func(t *testing.T) {
+		labelDir := t.TempDir()
+		want := installCachedBlob(t, labelDir, "mylabel", "ghcr.io/example/custom:v1")
+		c := &VZConfig{DefaultImage: "ghcr.io/x/y:v1", ImagesDir: labelDir}
+		got, err := c.ResolveImage("mylabel")
+		if err != nil {
+			t.Fatalf("ResolveImage(mylabel): %v", err)
+		}
+		if got.Path != want {
+			t.Errorf("Path = %q, want %q (resolved from tag)", got.Path, want)
+		}
+	})
+
+	t.Run("bare word is treated as a docker.io ref (Docker semantics)", func(t *testing.T) {
+		// A bare token parses as docker.io/library/<token>, so it resolves
+		// to a Docker ref (the pull error, if any, surfaces at create time)
+		// rather than failing at config resolution.
+		got, err := cfg.ResolveImage("someimage")
+		if err != nil {
+			t.Fatalf("ResolveImage(someimage): %v", err)
+		}
+		if got.DockerRef == "" {
+			t.Errorf("bare word should resolve to a DockerRef, got %#v", got)
+		}
+	})
+
+	t.Run("missing local path errors", func(t *testing.T) {
+		_, err := cfg.ResolveImage("/nonexistent/rootfs.ext4")
+		if err == nil {
+			t.Fatal("expected error for a missing local path")
+		}
+	})
+
+	t.Run("empty selector with no default_image errors", func(t *testing.T) {
+		c := &VZConfig{ImagesDir: dir}
+		_, err := c.ResolveImage("")
+		if err == nil {
+			t.Fatal("expected error when no default_image configured")
+		}
+		if !strings.Contains(err.Error(), "default_image") {
+			t.Errorf("error = %q, want mention of default_image", err.Error())
+		}
+	})
+}
+
+func TestResolveBaseRootfsReturnsDefaultImage(t *testing.T) {
+	cfg := &VZConfig{
+		DefaultImage: "ghcr.io/charliek/shed-vz-full:v0.6.0",
+		PullPolicy:   "always",
+		ImagesDir:    t.TempDir(),
+	}
+	got, err := cfg.ResolveBaseRootfs()
+	if err != nil {
+		t.Fatalf("ResolveBaseRootfs: %v", err)
+	}
+	if got.DockerRef != cfg.DefaultImage {
+		t.Errorf("DockerRef = %q, want %q", got.DockerRef, cfg.DefaultImage)
+	}
+	if got.Name == "_base" {
+		t.Error("Name must not be the removed internal _base tag")
+	}
+	if got.PullPolicy != "always" {
+		t.Errorf("PullPolicy = %q, want always", got.PullPolicy)
+	}
+
+	empty := &VZConfig{ImagesDir: t.TempDir()}
+	if _, err := empty.ResolveBaseRootfs(); err == nil {
+		t.Error("ResolveBaseRootfs with no default_image should error")
+	}
+}
+
+func TestPullPolicyValidation(t *testing.T) {
+	for _, tc := range []struct {
+		policy  string
+		wantErr bool
+	}{
+		{"", false},
+		{"missing", false},
+		{"always", false},
+		{"never", false},
+		{"sometimes", true},
+	} {
+		cfg := validVZConfig()
+		cfg.PullPolicy = tc.policy
+		err := cfg.Validate()
+		if tc.wantErr && err == nil {
+			t.Errorf("pull_policy %q: expected validation error", tc.policy)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("pull_policy %q: unexpected error %v", tc.policy, err)
+		}
+	}
+}
+
+func TestValidateAliasPaths(t *testing.T) {
+	t.Run("docker-ref alias skips path validation", func(t *testing.T) {
+		cfg := validVZConfig()
+		cfg.ImageAliases = map[string]string{"custom": "ghcr.io/charliek/shed-vz-custom:v1"}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate() = %v, want nil", err)
+		}
+	})
+	t.Run("missing local-path alias fails", func(t *testing.T) {
+		cfg := validVZConfig()
+		cfg.ImageAliases = map[string]string{"local": "/nonexistent/rootfs.ext4"}
+		err := cfg.Validate()
+		if err == nil || !strings.Contains(err.Error(), "image_aliases") {
+			t.Errorf("Validate() = %v, want image_aliases path error", err)
+		}
+	})
+}
+
+func TestRejectRemovedImageKeys(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			name:    "base_rootfs rejected",
+			yaml:    "name: s\nvz:\n  base_rootfs: ghcr.io/x/y:v1\n",
+			wantErr: true,
+		},
+		{
+			name:    "images map rejected",
+			yaml:    "name: s\nfirecracker:\n  images:\n    full: ghcr.io/x/y:v1\n",
+			wantErr: true,
+		},
+		{
+			name:    "new keys accepted",
+			yaml:    "name: s\nvz:\n  default_image: ghcr.io/x/y:v1\n  pull_policy: missing\n",
+			wantErr: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			p := filepath.Join(dir, "server.yaml")
+			if err := os.WriteFile(p, []byte(tc.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			_, err := LoadServerConfigFromPath(p)
+			gotRejected := err != nil && strings.Contains(err.Error(), "removed in v0.6.0")
+			if tc.wantErr && !gotRejected {
+				t.Errorf("expected removed-key rejection, got err=%v", err)
+			}
+			if !tc.wantErr && gotRejected {
+				t.Errorf("unexpected removed-key rejection: %v", err)
+			}
+		})
+	}
+}

--- a/internal/config/config_image_test.go
+++ b/internal/config/config_image_test.go
@@ -221,6 +221,11 @@ func TestRejectRemovedImageKeys(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "top-level default_image rejected",
+			yaml:    "name: s\ndefault_image: full\nvz:\n  default_image: ghcr.io/x/y:v1\n",
+			wantErr: true,
+		},
+		{
 			name:    "new keys accepted",
 			yaml:    "name: s\nvz:\n  default_image: ghcr.io/x/y:v1\n  pull_policy: missing\n",
 			wantErr: false,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -403,7 +403,7 @@ func TestValidateSessionName(t *testing.T) {
 func validFirecrackerConfig() *FirecrackerConfig {
 	return &FirecrackerConfig{
 		KernelPath:      "/dev/null",
-		BaseRootfs:      "/dev/null",
+		DefaultImage:    "/dev/null",
 		InstanceDir:     "/tmp/shed-test-instances",
 		SnapshotsDir:    "/tmp/shed-test-snapshots",
 		SocketDir:       "/tmp/shed-test-sockets",
@@ -534,14 +534,14 @@ func TestFirecrackerConfigValidation(t *testing.T) {
 		},
 		{
 			name:    "rootfs path missing",
-			modify:  func(c *FirecrackerConfig) { c.BaseRootfs = "/nonexistent/rootfs.ext4" },
+			modify:  func(c *FirecrackerConfig) { c.DefaultImage = "/nonexistent/rootfs.ext4" },
 			wantErr: true,
 		},
 		{
 			// Empty base_rootfs is allowed under the content-addressed
 			// model — see Validate header.
 			name:    "empty base_rootfs is allowed",
-			modify:  func(c *FirecrackerConfig) { c.BaseRootfs = "" },
+			modify:  func(c *FirecrackerConfig) { c.DefaultImage = "" },
 			wantErr: false,
 		},
 		// Lower bounds still work
@@ -580,7 +580,7 @@ func validVZConfig() *VZConfig {
 	return &VZConfig{
 		VfkitPath:       "vfkit",
 		KernelPath:      "/dev/null",
-		BaseRootfs:      "/dev/null",
+		DefaultImage:    "/dev/null",
 		InstanceDir:     "/tmp/shed-test-vz-instances",
 		SnapshotsDir:    "/tmp/shed-test-vz-snapshots",
 		SocketDir:       "/tmp/shed-test-vz-sockets",
@@ -624,7 +624,7 @@ func TestVZConfigValidation(t *testing.T) {
 			// model — empty is valid; create-without-image errors later
 			// in the CreateShed path with a clear message.
 			name:    "missing base_rootfs is allowed",
-			modify:  func(c *VZConfig) { c.BaseRootfs = "" },
+			modify:  func(c *VZConfig) { c.DefaultImage = "" },
 			wantErr: false,
 		},
 		{
@@ -733,7 +733,7 @@ func TestVZConfigValidation(t *testing.T) {
 		},
 		{
 			name:    "rootfs path missing",
-			modify:  func(c *VZConfig) { c.BaseRootfs = "/nonexistent/rootfs.ext4" },
+			modify:  func(c *VZConfig) { c.DefaultImage = "/nonexistent/rootfs.ext4" },
 			wantErr: true,
 		},
 	}
@@ -914,10 +914,10 @@ func TestCredentialSourceMustBeDirectory(t *testing.T) {
 			backend, bcfg := platformTestBackend(t)
 			cfgYAML := "name: test-server\ndefault_backend: " + backend + "\ncredentials:\n  testcred:\n    source: " + tt.source + "\n    target: /home/shed/.test\n"
 			if bcfg.vz != nil {
-				cfgYAML += "vz:\n  vfkit_path: vfkit\n  kernel_path: /dev/null\n  base_rootfs: /dev/null\n  instance_dir: /tmp/test-instances\n  socket_dir: /tmp/test-sockets\n  default_cpus: 2\n  default_memory_mb: 4096\n  default_disk_gb: 20\n  console_port: 1024\n  notify_port: 1026\n"
+				cfgYAML += "vz:\n  vfkit_path: vfkit\n  kernel_path: /dev/null\n  default_image: /dev/null\n  instance_dir: /tmp/test-instances\n  socket_dir: /tmp/test-sockets\n  default_cpus: 2\n  default_memory_mb: 4096\n  default_disk_gb: 20\n  console_port: 1024\n  notify_port: 1026\n"
 			}
 			if bcfg.fc != nil {
-				cfgYAML += "firecracker:\n  kernel_path: /dev/null\n  base_rootfs: /dev/null\n  instance_dir: /tmp/test-instances\n  socket_dir: /tmp/test-sockets\n  default_cpus: 2\n  default_memory_mb: 4096\n  default_disk_gb: 20\n  vsock_base_cid: 100\n  console_port: 1024\n  notify_port: 1026\n  bridge_name: shed-br0\n  bridge_cidr: 172.30.0.1/24\n  tap_prefix: shed-tap\n"
+				cfgYAML += "firecracker:\n  kernel_path: /dev/null\n  default_image: /dev/null\n  instance_dir: /tmp/test-instances\n  socket_dir: /tmp/test-sockets\n  default_cpus: 2\n  default_memory_mb: 4096\n  default_disk_gb: 20\n  vsock_base_cid: 100\n  console_port: 1024\n  notify_port: 1026\n  bridge_name: shed-br0\n  bridge_cidr: 172.30.0.1/24\n  tap_prefix: shed-tap\n"
 			}
 			cfgPath := filepath.Join(t.TempDir(), "server.yaml")
 			if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0644); err != nil {
@@ -959,557 +959,4 @@ func TestVZConfigApplyDefaults(t *testing.T) {
 	if cfg2.TCPProxyPort != 2002 {
 		t.Errorf("TCPProxyPort = %d after applyDefaults, want 2002", cfg2.TCPProxyPort)
 	}
-}
-
-func TestVZConfigApplyDefaultsExpandsImagePaths(t *testing.T) {
-	cfg := &VZConfig{
-		Images: map[string]string{
-			"base":    "~/shed/base.ext4",
-			"default": "/absolute/path.ext4",
-		},
-	}
-	cfg.applyDefaults()
-
-	home, _ := os.UserHomeDir()
-	want := filepath.Join(home, "shed/base.ext4")
-	if cfg.Images["base"] != want {
-		t.Errorf("Images[base] = %q, want %q", cfg.Images["base"], want)
-	}
-	if cfg.Images["default"] != "/absolute/path.ext4" {
-		t.Errorf("Images[default] = %q, want %q", cfg.Images["default"], "/absolute/path.ext4")
-	}
-}
-
-func TestVZConfigResolveImage(t *testing.T) {
-	cfg := &VZConfig{
-		Images: map[string]string{
-			"base":         "/dev/null",
-			"default":      "/dev/null",
-			"experimental": "/dev/null",
-		},
-	}
-
-	t.Run("named variant", func(t *testing.T) {
-		resolved, err := cfg.ResolveImage("base")
-		if err != nil {
-			t.Fatalf("ResolveImage(base) error = %v", err)
-		}
-		if resolved.Path != "/dev/null" {
-			t.Errorf("ResolveImage(base).Path = %q, want /dev/null", resolved.Path)
-		}
-	})
-
-	t.Run("absolute path exists", func(t *testing.T) {
-		resolved, err := cfg.ResolveImage("/dev/null")
-		if err != nil {
-			t.Fatalf("ResolveImage(/dev/null) error = %v", err)
-		}
-		if resolved.Path != "/dev/null" {
-			t.Errorf("ResolveImage(/dev/null).Path = %q, want /dev/null", resolved.Path)
-		}
-	})
-
-	t.Run("absolute path missing", func(t *testing.T) {
-		_, err := cfg.ResolveImage("/nonexistent/file.ext4")
-		if err == nil {
-			t.Fatal("ResolveImage should fail for missing absolute path")
-		}
-		if !strings.Contains(err.Error(), "does not exist") {
-			t.Errorf("error = %q, want 'does not exist'", err.Error())
-		}
-	})
-
-	t.Run("unknown variant", func(t *testing.T) {
-		_, err := cfg.ResolveImage("rust")
-		if err == nil {
-			t.Fatal("ResolveImage should fail for unknown variant")
-		}
-		if !strings.Contains(err.Error(), "unknown image") {
-			t.Errorf("error = %q, want 'unknown image'", err.Error())
-		}
-		if !strings.Contains(err.Error(), "base") {
-			t.Errorf("error should list available variants, got: %q", err.Error())
-		}
-	})
-
-	t.Run("tilde path expands", func(t *testing.T) {
-		// ~/.. should be expanded and treated as an absolute path
-		resolved, err := cfg.ResolveImage("~/../../dev/null")
-		if err != nil {
-			t.Fatalf("ResolveImage(~/../../dev/null) error = %v", err)
-		}
-		if !filepath.IsAbs(resolved.Path) {
-			t.Errorf("expected absolute path, got %q", resolved.Path)
-		}
-	})
-
-	t.Run("empty images map", func(t *testing.T) {
-		emptyCfg := &VZConfig{Images: map[string]string{}}
-		_, err := emptyCfg.ResolveImage("anything")
-		if err == nil {
-			t.Fatal("ResolveImage should fail with empty images map")
-		}
-		if !strings.Contains(err.Error(), "no image variants configured") {
-			t.Errorf("error = %q, want 'no image variants configured'", err.Error())
-		}
-	})
-
-	t.Run("tag-auto-discovery carries digest", func(t *testing.T) {
-		// Plant a synthetic OCI image under a tag in a temp ImagesDir and
-		// confirm resolveImage's "not in images map → auto-discover by
-		// tag" branch returns the manifest digest in the ResolvedImage.
-		// Closes the race window where EnsureImage previously had to
-		// re-do the tag lookup based on Path alone.
-		dir := t.TempDir()
-		body := []byte("fake-rootfs-for-digest-carry-test")
-		digest, err := vmimage.InstallSyntheticImage(dir, "carry", "", body, nil, nil)
-		if err != nil {
-			t.Fatalf("InstallSyntheticImage: %v", err)
-		}
-
-		// images map is empty; auto-discovery path is the one we want
-		// to exercise.
-		cfg := &VZConfig{ImagesDir: dir, Images: map[string]string{}}
-		resolved, err := cfg.ResolveImage("carry")
-		if err != nil {
-			t.Fatalf("ResolveImage(carry) error = %v", err)
-		}
-		if resolved.Digest != digest {
-			t.Errorf("Digest = %q, want %q", resolved.Digest, digest)
-		}
-		if resolved.Path == "" {
-			t.Error("Path should be populated for tag-discovered image")
-		}
-	})
-}
-
-func TestVZConfigValidateImages(t *testing.T) {
-	t.Run("valid image paths", func(t *testing.T) {
-		cfg := validVZConfig()
-		cfg.Images = map[string]string{
-			"base": "/dev/null",
-		}
-		err := cfg.Validate()
-		if err != nil {
-			t.Errorf("Validate() error = %v, want nil", err)
-		}
-	})
-
-	t.Run("invalid image path", func(t *testing.T) {
-		cfg := validVZConfig()
-		cfg.Images = map[string]string{
-			"base": "/nonexistent/rootfs.ext4",
-		}
-		err := cfg.Validate()
-		if err == nil {
-			t.Fatal("Validate() should fail for missing image path")
-		}
-		if !strings.Contains(err.Error(), "image \"base\" path does not exist") {
-			t.Errorf("error = %q, want image path error", err.Error())
-		}
-	})
-
-	t.Run("docker ref skips validation", func(t *testing.T) {
-		cfg := validVZConfig()
-		cfg.Images = map[string]string{
-			"custom": "ghcr.io/charliek/shed-vz-custom:v1.0.0",
-		}
-		err := cfg.Validate()
-		if err != nil {
-			t.Errorf("Validate() error = %v, want nil (Docker refs should skip path validation)", err)
-		}
-	})
-
-	t.Run("docker ref base_rootfs skips validation", func(t *testing.T) {
-		cfg := validVZConfig()
-		cfg.BaseRootfs = "ghcr.io/charliek/shed-vz-default:v1.0.0"
-		err := cfg.Validate()
-		if err != nil {
-			t.Errorf("Validate() error = %v, want nil (Docker ref base_rootfs should skip validation)", err)
-		}
-	})
-
-	t.Run("mixed docker refs and paths", func(t *testing.T) {
-		cfg := validVZConfig()
-		cfg.Images = map[string]string{
-			"local":  "/dev/null",
-			"remote": "ghcr.io/charliek/shed-vz-default:v1.0.0",
-		}
-		err := cfg.Validate()
-		if err != nil {
-			t.Errorf("Validate() error = %v, want nil", err)
-		}
-	})
-}
-
-func TestVZConfigResolveImageDockerRef(t *testing.T) {
-	t.Run("docker ref returns DockerRef field", func(t *testing.T) {
-		cfg := &VZConfig{
-			Images:    map[string]string{"default": "ghcr.io/charliek/shed-vz-default:v1.0.0"},
-			ImagesDir: t.TempDir(),
-		}
-		resolved, err := cfg.ResolveImage("default")
-		if err != nil {
-			t.Fatalf("ResolveImage error = %v", err)
-		}
-		if resolved.DockerRef != "ghcr.io/charliek/shed-vz-default:v1.0.0" {
-			t.Errorf("DockerRef = %q, want ghcr.io/charliek/shed-vz-default:v1.0.0", resolved.DockerRef)
-		}
-		if resolved.Path != "" {
-			t.Errorf("Path = %q, want empty for uncached Docker ref", resolved.Path)
-		}
-		if resolved.Name != "default" {
-			t.Errorf("Name = %q, want default", resolved.Name)
-		}
-	})
-
-	t.Run("cached docker ref returns Path", func(t *testing.T) {
-		dir := t.TempDir()
-		rootfsPath := installCachedBlob(t, dir, "default", "ghcr.io/charliek/shed-vz-default:v1.0.0")
-
-		cfg := &VZConfig{
-			Images:    map[string]string{"default": "ghcr.io/charliek/shed-vz-default:v1.0.0"},
-			ImagesDir: dir,
-		}
-		resolved, err := cfg.ResolveImage("default")
-		if err != nil {
-			t.Fatalf("ResolveImage error = %v", err)
-		}
-		if resolved.Path != rootfsPath {
-			t.Errorf("Path = %q, want %q", resolved.Path, rootfsPath)
-		}
-		if resolved.DockerRef != "" {
-			t.Errorf("DockerRef = %q, want empty for cached image", resolved.DockerRef)
-		}
-	})
-
-	t.Run("stale cache triggers re-pull", func(t *testing.T) {
-		dir := t.TempDir()
-		installCachedBlob(t, dir, "default", "ghcr.io/charliek/shed-vz-default:v1.0.0")
-
-		cfg := &VZConfig{
-			Images:    map[string]string{"default": "ghcr.io/charliek/shed-vz-default:v2.0.0"},
-			ImagesDir: dir,
-		}
-		resolved, err := cfg.ResolveImage("default")
-		if err != nil {
-			t.Fatalf("ResolveImage error = %v", err)
-		}
-		if resolved.DockerRef != "ghcr.io/charliek/shed-vz-default:v2.0.0" {
-			t.Errorf("DockerRef = %q, want v2.0.0 (stale cache should trigger re-pull)", resolved.DockerRef)
-		}
-	})
-
-	t.Run("auto-discover from ImagesDir", func(t *testing.T) {
-		dir := t.TempDir()
-		rootfsPath := installCachedBlob(t, dir, "custom", "ghcr.io/example/custom:v1")
-
-		cfg := &VZConfig{
-			Images:    map[string]string{},
-			ImagesDir: dir,
-		}
-		resolved, err := cfg.ResolveImage("custom")
-		if err != nil {
-			t.Fatalf("ResolveImage error = %v", err)
-		}
-		if resolved.Path != rootfsPath {
-			t.Errorf("Path = %q, want %q (auto-discovered)", resolved.Path, rootfsPath)
-		}
-	})
-
-	t.Run("config takes precedence over discovery", func(t *testing.T) {
-		dir := t.TempDir()
-		// Create both a discovered file and a config entry
-		os.WriteFile(filepath.Join(dir, "base-rootfs.ext4"), []byte("discovered"), 0644)
-
-		cfg := &VZConfig{
-			Images:    map[string]string{"base": "/dev/null"},
-			ImagesDir: dir,
-		}
-		resolved, err := cfg.ResolveImage("base")
-		if err != nil {
-			t.Fatalf("ResolveImage error = %v", err)
-		}
-		if resolved.Path != "/dev/null" {
-			t.Errorf("Path = %q, want /dev/null (config should take precedence)", resolved.Path)
-		}
-	})
-}
-
-func TestFirecrackerConfigResolveImage(t *testing.T) {
-	cfg := &FirecrackerConfig{
-		Images: map[string]string{
-			"base":         "/dev/null",
-			"default":      "/dev/null",
-			"experimental": "/dev/null",
-		},
-	}
-
-	t.Run("named variant", func(t *testing.T) {
-		resolved, err := cfg.ResolveImage("base")
-		if err != nil {
-			t.Fatalf("ResolveImage(base) error = %v", err)
-		}
-		if resolved.Path != "/dev/null" {
-			t.Errorf("ResolveImage(base).Path = %q, want /dev/null", resolved.Path)
-		}
-	})
-
-	t.Run("absolute path exists", func(t *testing.T) {
-		resolved, err := cfg.ResolveImage("/dev/null")
-		if err != nil {
-			t.Fatalf("ResolveImage(/dev/null) error = %v", err)
-		}
-		if resolved.Path != "/dev/null" {
-			t.Errorf("ResolveImage(/dev/null).Path = %q, want /dev/null", resolved.Path)
-		}
-	})
-
-	t.Run("unknown variant", func(t *testing.T) {
-		_, err := cfg.ResolveImage("rust")
-		if err == nil {
-			t.Fatal("ResolveImage should fail for unknown variant")
-		}
-		if !strings.Contains(err.Error(), "unknown image") {
-			t.Errorf("error = %q, want 'unknown image'", err.Error())
-		}
-		if !strings.Contains(err.Error(), "base") {
-			t.Errorf("error should list available variants, got: %q", err.Error())
-		}
-	})
-
-	t.Run("empty images map", func(t *testing.T) {
-		emptyCfg := &FirecrackerConfig{Images: map[string]string{}}
-		_, err := emptyCfg.ResolveImage("anything")
-		if err == nil {
-			t.Fatal("ResolveImage should fail with empty images map")
-		}
-		if !strings.Contains(err.Error(), "no image variants configured") {
-			t.Errorf("error = %q, want 'no image variants configured'", err.Error())
-		}
-		if !strings.Contains(err.Error(), "firecracker.images") {
-			t.Errorf("error should mention firecracker.images, got: %q", err.Error())
-		}
-	})
-}
-
-func TestFirecrackerConfigResolveImageDockerRef(t *testing.T) {
-	t.Run("docker ref returns DockerRef field", func(t *testing.T) {
-		cfg := &FirecrackerConfig{
-			Images:    map[string]string{"default": "ghcr.io/charliek/shed-fc-default:v1.0.0"},
-			ImagesDir: t.TempDir(),
-		}
-		resolved, err := cfg.ResolveImage("default")
-		if err != nil {
-			t.Fatalf("ResolveImage error = %v", err)
-		}
-		if resolved.DockerRef != "ghcr.io/charliek/shed-fc-default:v1.0.0" {
-			t.Errorf("DockerRef = %q, want ghcr.io/charliek/shed-fc-default:v1.0.0", resolved.DockerRef)
-		}
-		if resolved.Path != "" {
-			t.Errorf("Path = %q, want empty for uncached Docker ref", resolved.Path)
-		}
-	})
-
-	t.Run("cached docker ref returns Path", func(t *testing.T) {
-		dir := t.TempDir()
-		rootfsPath := installCachedBlob(t, dir, "default", "ghcr.io/charliek/shed-fc-default:v1.0.0")
-
-		cfg := &FirecrackerConfig{
-			Images:    map[string]string{"default": "ghcr.io/charliek/shed-fc-default:v1.0.0"},
-			ImagesDir: dir,
-		}
-		resolved, err := cfg.ResolveImage("default")
-		if err != nil {
-			t.Fatalf("ResolveImage error = %v", err)
-		}
-		if resolved.Path != rootfsPath {
-			t.Errorf("Path = %q, want %q", resolved.Path, rootfsPath)
-		}
-	})
-
-	t.Run("auto-discover from ImagesDir", func(t *testing.T) {
-		dir := t.TempDir()
-		rootfsPath := installCachedBlob(t, dir, "custom", "ghcr.io/example/custom:v1")
-
-		cfg := &FirecrackerConfig{
-			Images:    map[string]string{},
-			ImagesDir: dir,
-		}
-		resolved, err := cfg.ResolveImage("custom")
-		if err != nil {
-			t.Fatalf("ResolveImage error = %v", err)
-		}
-		if resolved.Path != rootfsPath {
-			t.Errorf("Path = %q, want %q (auto-discovered)", resolved.Path, rootfsPath)
-		}
-	})
-}
-
-func TestFirecrackerConfigResolveBaseRootfs(t *testing.T) {
-	t.Run("local path", func(t *testing.T) {
-		cfg := &FirecrackerConfig{BaseRootfs: "/var/lib/shed/firecracker/base-rootfs.ext4"}
-		resolved := cfg.ResolveBaseRootfs()
-		if resolved.Path != "/var/lib/shed/firecracker/base-rootfs.ext4" {
-			t.Errorf("Path = %q", resolved.Path)
-		}
-		if resolved.DockerRef != "" {
-			t.Errorf("DockerRef = %q, want empty", resolved.DockerRef)
-		}
-	})
-
-	t.Run("docker ref cold cache", func(t *testing.T) {
-		cfg := &FirecrackerConfig{
-			BaseRootfs: "ghcr.io/charliek/shed-fc-default:v1.0.0",
-			ImagesDir:  t.TempDir(),
-		}
-		resolved := cfg.ResolveBaseRootfs()
-		if resolved.DockerRef != "ghcr.io/charliek/shed-fc-default:v1.0.0" {
-			t.Errorf("DockerRef = %q", resolved.DockerRef)
-		}
-		if resolved.Name != "_base" {
-			t.Errorf("Name = %q, want _base", resolved.Name)
-		}
-		if resolved.Digest != "" {
-			t.Errorf("Digest = %q, want empty on cold cache", resolved.Digest)
-		}
-	})
-
-	t.Run("docker ref warm cache populates Digest", func(t *testing.T) {
-		dir := t.TempDir()
-		ref := "ghcr.io/charliek/shed-fc-default:v1.0.0"
-		rootfsPath := installCachedBlob(t, dir, "_base", ref)
-
-		cfg := &FirecrackerConfig{BaseRootfs: ref, ImagesDir: dir}
-		resolved := cfg.ResolveBaseRootfs()
-		if resolved.Path != rootfsPath {
-			t.Errorf("Path = %q, want %q", resolved.Path, rootfsPath)
-		}
-		if resolved.Digest == "" {
-			t.Error("Digest is empty on warm cache (regression: EnsureImage needs it to refcount the blob)")
-		}
-		if resolved.DockerRef != "" {
-			t.Errorf("DockerRef = %q, want empty on warm cache", resolved.DockerRef)
-		}
-	})
-
-	t.Run("docker ref stale cache falls through to DockerRef", func(t *testing.T) {
-		dir := t.TempDir()
-		installCachedBlob(t, dir, "_base", "ghcr.io/charliek/shed-fc-default:v1.0.0")
-
-		cfg := &FirecrackerConfig{
-			BaseRootfs: "ghcr.io/charliek/shed-fc-default:v2.0.0",
-			ImagesDir:  dir,
-		}
-		resolved := cfg.ResolveBaseRootfs()
-		if resolved.DockerRef != "ghcr.io/charliek/shed-fc-default:v2.0.0" {
-			t.Errorf("DockerRef = %q, want v2.0.0 (stale source-ref should re-pull)", resolved.DockerRef)
-		}
-		if resolved.Path != "" {
-			t.Errorf("Path = %q, want empty when source-ref mismatches", resolved.Path)
-		}
-	})
-}
-
-func TestVZConfigResolveBaseRootfs(t *testing.T) {
-	t.Run("local path", func(t *testing.T) {
-		cfg := &VZConfig{BaseRootfs: "/var/lib/shed/vz/base-rootfs.ext4"}
-		resolved := cfg.ResolveBaseRootfs()
-		if resolved.Path != "/var/lib/shed/vz/base-rootfs.ext4" {
-			t.Errorf("Path = %q", resolved.Path)
-		}
-		if resolved.DockerRef != "" {
-			t.Errorf("DockerRef = %q, want empty", resolved.DockerRef)
-		}
-	})
-
-	t.Run("docker ref cold cache", func(t *testing.T) {
-		cfg := &VZConfig{
-			BaseRootfs: "ghcr.io/charliek/shed-vz-default:v1.0.0",
-			ImagesDir:  t.TempDir(),
-		}
-		resolved := cfg.ResolveBaseRootfs()
-		if resolved.DockerRef != "ghcr.io/charliek/shed-vz-default:v1.0.0" {
-			t.Errorf("DockerRef = %q", resolved.DockerRef)
-		}
-		if resolved.Name != "_base" {
-			t.Errorf("Name = %q, want _base", resolved.Name)
-		}
-	})
-
-	t.Run("docker ref warm cache populates Digest", func(t *testing.T) {
-		dir := t.TempDir()
-		ref := "ghcr.io/charliek/shed-vz-default:v1.0.0"
-		rootfsPath := installCachedBlob(t, dir, "_base", ref)
-
-		cfg := &VZConfig{BaseRootfs: ref, ImagesDir: dir}
-		resolved := cfg.ResolveBaseRootfs()
-		if resolved.Path != rootfsPath {
-			t.Errorf("Path = %q, want %q", resolved.Path, rootfsPath)
-		}
-		if resolved.Digest == "" {
-			t.Error("Digest is empty on warm cache (regression: EnsureImage needs it to refcount the blob)")
-		}
-		if resolved.DockerRef != "" {
-			t.Errorf("DockerRef = %q, want empty on warm cache", resolved.DockerRef)
-		}
-	})
-}
-
-func TestFirecrackerConfigValidateDockerRef(t *testing.T) {
-	t.Run("docker ref in BaseRootfs passes validation", func(t *testing.T) {
-		cfg := validFirecrackerConfig()
-		cfg.BaseRootfs = "ghcr.io/charliek/shed-fc-default:v1.0.0"
-		err := cfg.Validate()
-		if err != nil {
-			t.Errorf("Validate() error = %v, want nil (Docker refs should skip path validation)", err)
-		}
-	})
-
-	t.Run("docker ref in Images skips validation", func(t *testing.T) {
-		cfg := validFirecrackerConfig()
-		cfg.Images = map[string]string{
-			"custom": "ghcr.io/charliek/shed-fc-custom:v1.0.0",
-		}
-		err := cfg.Validate()
-		if err != nil {
-			t.Errorf("Validate() error = %v, want nil", err)
-		}
-	})
-
-	t.Run("invalid image path fails validation", func(t *testing.T) {
-		cfg := validFirecrackerConfig()
-		cfg.Images = map[string]string{
-			"base": "/nonexistent/rootfs.ext4",
-		}
-		err := cfg.Validate()
-		if err == nil {
-			t.Fatal("Validate() should fail for missing image path")
-		}
-		if !strings.Contains(err.Error(), "image \"base\" path does not exist") {
-			t.Errorf("error = %q, want image path error", err.Error())
-		}
-	})
-
-	t.Run("kernel_path validation deferred with Docker refs", func(t *testing.T) {
-		cfg := validFirecrackerConfig()
-		cfg.KernelPath = "/nonexistent/vmlinux"
-		cfg.BaseRootfs = "ghcr.io/charliek/shed-fc-base:v1.0.0"
-		err := cfg.Validate()
-		if err != nil {
-			t.Errorf("Validate() error = %v, want nil (kernel_path check deferred for Docker refs)", err)
-		}
-	})
-
-	t.Run("kernel_path validated without Docker refs", func(t *testing.T) {
-		cfg := validFirecrackerConfig()
-		cfg.KernelPath = "/nonexistent/vmlinux"
-		err := cfg.Validate()
-		if err == nil {
-			t.Fatal("Validate() should fail for missing kernel_path without Docker refs")
-		}
-		if !strings.Contains(err.Error(), "kernel_path does not exist") {
-			t.Errorf("error = %q, want kernel_path error", err.Error())
-		}
-	})
 }

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -877,6 +877,11 @@ func rejectRemovedImageKeys(data []byte) error {
 		// Malformed YAML — let the typed unmarshal surface the parse error.
 		return nil
 	}
+	if _, present := raw["default_image"]; present {
+		return fmt.Errorf(
+			"top-level config key %q was removed in v0.6.0; move it into the active backend block as vz.default_image / firecracker.default_image (see docs/upgrades/v0.5.9-to-v0.6.0.md)",
+			"default_image")
+	}
 	for _, backend := range []string{"vz", "firecracker"} {
 		sub, ok := raw[backend].(map[string]any)
 		if !ok {

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -27,14 +27,13 @@ var validCredentialName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
 
 // ServerConfig represents the server-side configuration.
 type ServerConfig struct {
-	Name         string                 `yaml:"name"`
-	HTTPPort     int                    `yaml:"http_port"`
-	SSHPort      int                    `yaml:"ssh_port"`
-	DefaultImage string                 `yaml:"default_image"`
-	Credentials  map[string]MountConfig `yaml:"credentials"`
-	EnvFile      string                 `yaml:"env_file"`
-	LogLevel     string                 `yaml:"log_level"`
-	Terminal     *terminal.Config       `yaml:"terminal"`
+	Name        string                 `yaml:"name"`
+	HTTPPort    int                    `yaml:"http_port"`
+	SSHPort     int                    `yaml:"ssh_port"`
+	Credentials map[string]MountConfig `yaml:"credentials"`
+	EnvFile     string                 `yaml:"env_file"`
+	LogLevel    string                 `yaml:"log_level"`
+	Terminal    *terminal.Config       `yaml:"terminal"`
 
 	// DefaultBackend specifies the backend type: "vz", "firecracker", or "detect".
 	// When set to "detect", the backend is chosen based on the platform
@@ -153,17 +152,22 @@ type FirecrackerConfig struct {
 	// KernelPath is the path to the Linux kernel image
 	KernelPath string `yaml:"kernel_path"`
 
-	// BaseRootfs is the path to the base rootfs image or a Docker image reference.
-	// Docker refs are lazily pulled and converted to ext4 on first use.
-	BaseRootfs string `yaml:"base_rootfs"`
+	// DefaultImage is the Docker ref (or local rootfs path) used for new
+	// sheds when no --image is given. Docker refs are resolved by their
+	// io.shed.source-ref identity and pulled per PullPolicy on first use.
+	DefaultImage string `yaml:"default_image"`
 
-	// Images maps variant names to rootfs paths or Docker image references.
-	// Users can reference these with: shed create mydev --image experimental
-	// Values can be ext4 file paths or Docker refs (e.g., "ghcr.io/charliek/shed-fc-default:v1.0.0").
-	Images map[string]string `yaml:"images,omitempty"`
+	// ImageAliases maps short alias names to Docker refs (or paths) for
+	// convenience with: shed create mydev --image <alias>. Aliases resolve
+	// to the underlying ref; image listings always show the resolved ref.
+	ImageAliases map[string]string `yaml:"image_aliases,omitempty"`
 
-	// ImagesDir is the directory for converted/discovered ext4 images.
-	// Images matching {name}-rootfs.ext4 are auto-discovered as available variants.
+	// PullPolicy controls cache-vs-pull at create: "missing" (default —
+	// use the cached ref, pull only if absent), "always" (always pull),
+	// or "never" (error if not cached). Ignored for local-path images.
+	PullPolicy string `yaml:"pull_policy,omitempty"`
+
+	// ImagesDir is the directory for the content-addressed image store.
 	ImagesDir string `yaml:"images_dir,omitempty"`
 
 	// InstanceDir is the directory for instance data
@@ -228,16 +232,22 @@ type VZConfig struct {
 	// InitrdPath is the path to the initial RAM disk image
 	InitrdPath string `yaml:"initrd_path"`
 
-	// BaseRootfs is the path to the base rootfs image (used when no --image is specified)
-	BaseRootfs string `yaml:"base_rootfs"`
+	// DefaultImage is the Docker ref (or local rootfs path) used for new
+	// sheds when no --image is given. Docker refs are resolved by their
+	// io.shed.source-ref identity and pulled per PullPolicy on first use.
+	DefaultImage string `yaml:"default_image"`
 
-	// Images maps variant names to rootfs paths or Docker image references.
-	// Users can reference these with: shed create mydev --image experimental
-	// Values can be ext4 file paths or Docker refs (e.g., "ghcr.io/charliek/shed-vz-default:v1.0.0").
-	Images map[string]string `yaml:"images,omitempty"`
+	// ImageAliases maps short alias names to Docker refs (or paths) for
+	// convenience with: shed create mydev --image <alias>. Aliases resolve
+	// to the underlying ref; image listings always show the resolved ref.
+	ImageAliases map[string]string `yaml:"image_aliases,omitempty"`
 
-	// ImagesDir is the directory for converted/discovered ext4 images.
-	// Images matching {name}-rootfs.ext4 are auto-discovered as available variants.
+	// PullPolicy controls cache-vs-pull at create: "missing" (default —
+	// use the cached ref, pull only if absent), "always" (always pull),
+	// or "never" (error if not cached). Ignored for local-path images.
+	PullPolicy string `yaml:"pull_policy,omitempty"`
+
+	// ImagesDir is the directory for the content-addressed image store.
 	ImagesDir string `yaml:"images_dir,omitempty"`
 
 	// InstanceDir is the directory for instance data
@@ -284,14 +294,17 @@ type VZConfig struct {
 	StopTimeout Duration `yaml:"stop_timeout"`
 }
 
-// GetImages implements vmimage.ImageConfig.
-func (c *VZConfig) GetImages() map[string]string { return c.Images }
+// GetDefaultImage implements vmimage.ImageConfig.
+func (c *VZConfig) GetDefaultImage() string { return c.DefaultImage }
+
+// GetImageAliases implements vmimage.ImageConfig.
+func (c *VZConfig) GetImageAliases() map[string]string { return c.ImageAliases }
+
+// GetPullPolicy implements vmimage.ImageConfig.
+func (c *VZConfig) GetPullPolicy() string { return c.PullPolicy }
 
 // GetImagesDir implements vmimage.ImageConfig.
 func (c *VZConfig) GetImagesDir() string { return c.ImagesDir }
-
-// GetBaseRootfs implements vmimage.ImageConfig.
-func (c *VZConfig) GetBaseRootfs() string { return c.BaseRootfs }
 
 // GetPlatform implements vmimage.ImageConfig.
 func (c *VZConfig) GetPlatform() string { return "linux/arm64" }
@@ -377,11 +390,17 @@ func (c *VZConfig) applyDefaults() {
 	// Expand ~ in paths
 	c.KernelPath = ExpandPath(c.KernelPath)
 	c.InitrdPath = ExpandPath(c.InitrdPath)
-	c.BaseRootfs = ExpandPath(c.BaseRootfs)
+	if !vmimage.IsDockerRef(c.DefaultImage) {
+		c.DefaultImage = ExpandPath(c.DefaultImage)
+	}
 	c.ImagesDir = ExpandPath(c.ImagesDir)
 	c.InstanceDir = ExpandPath(c.InstanceDir)
 	c.SnapshotsDir = ExpandPath(c.SnapshotsDir)
 	c.SocketDir = ExpandPath(c.SocketDir)
+
+	if c.PullPolicy == "" {
+		c.PullPolicy = string(vmimage.PullMissing)
+	}
 
 	// Default ImagesDir if not set
 	if c.ImagesDir == "" {
@@ -403,10 +422,10 @@ func (c *VZConfig) applyDefaults() {
 		c.UpperSizeDefault = DefaultUpperSize
 	}
 
-	// Expand ~ in image paths (only for filesystem paths, not Docker refs)
-	for name, val := range c.Images {
+	// Expand ~ in alias paths (only for filesystem paths, not Docker refs)
+	for name, val := range c.ImageAliases {
 		if !vmimage.IsDockerRef(val) {
-			c.Images[name] = ExpandPath(val)
+			c.ImageAliases[name] = ExpandPath(val)
 		}
 	}
 }
@@ -506,7 +525,7 @@ func (c *VZConfig) Validate() error {
 	// reads the kernel from the blob). The previous hasAnyDockerRef
 	// gate was too loose — a mix of local + remote sources still
 	// needs the legacy kernel/initrd for the local-spawn path.
-	if c.KernelPath != "" && !allSourcesAreDockerRefs(c.BaseRootfs, c.Images) {
+	if c.KernelPath != "" && !allSourcesAreDockerRefs(c.DefaultImage, c.ImageAliases) {
 		if _, err := os.Stat(c.KernelPath); err != nil {
 			return fmt.Errorf("vz: kernel_path does not exist: %s", c.KernelPath)
 		}
@@ -517,21 +536,25 @@ func (c *VZConfig) Validate() error {
 		}
 	}
 
-	// base_rootfs path-existence check only applies when configured as
+	// default_image path-existence check only applies when configured as
 	// a local path. An empty value is allowed (see Validate header).
-	if c.BaseRootfs != "" && !vmimage.IsDockerRef(c.BaseRootfs) {
-		if _, err := os.Stat(c.BaseRootfs); err != nil {
-			return fmt.Errorf("vz: base_rootfs does not exist: %s", c.BaseRootfs)
+	if c.DefaultImage != "" && !vmimage.IsDockerRef(c.DefaultImage) {
+		if _, err := os.Stat(c.DefaultImage); err != nil {
+			return fmt.Errorf("vz: default_image does not exist: %s", c.DefaultImage)
 		}
 	}
 
-	// Validate image variant paths exist (skip Docker refs)
-	for name, val := range c.Images {
+	// Validate alias paths exist (skip Docker refs)
+	for name, val := range c.ImageAliases {
 		if !vmimage.IsDockerRef(val) {
 			if _, err := os.Stat(val); err != nil {
-				return fmt.Errorf("vz: image %q path does not exist: %s", name, val)
+				return fmt.Errorf("vz: image_aliases %q path does not exist: %s", name, val)
 			}
 		}
+	}
+
+	if _, err := vmimage.ParsePullPolicy(c.PullPolicy); err != nil {
+		return fmt.Errorf("vz: %w", err)
 	}
 
 	return nil
@@ -556,121 +579,80 @@ type ResolvedImage struct {
 	// second lookup was both awkward and racey (tag could advance
 	// between resolve and ensure).
 	Digest string
+
+	// PullPolicy is the configured pull_policy ("missing"|"always"|"never",
+	// validated at config load) carried through to EnsureImage. Empty/local
+	// paths treat it as a no-op.
+	PullPolicy string
 }
 
-// resolveImage is the shared implementation for image name resolution.
-// configKey is used in error messages (e.g., "vz.images" or "firecracker.images").
+// resolveImageRef classifies an image selector into a ResolvedImage. It is a
+// thin classifier — all cache-vs-pull logic (the ref-index lookup and
+// pull_policy enforcement) lives in vmimage.EnsureImage, so this returns
+// either a Docker ref (to ensure) or a local path (escape hatch).
 //
-// Resolution order:
-//  1. Look up in images map — if value is a Docker ref, check the
-//     blob-store tag cache first
-//  2. Auto-discover existing tag in {imagesDir}/tags/
-//  3. Absolute path escape hatch
-//  4. Error with available variants
-func resolveImage(images map[string]string, imagesDir, image, configKey string) (ResolvedImage, error) {
-	if val, ok := images[image]; ok {
-		if vmimage.IsDockerRef(val) {
-			// ResolveTag returns the digest too — carry it through
-			// so EnsureImage doesn't have to re-do tag lookup
-			// (which races against concurrent `shed image pull`).
-			digest, cached, err := vmimage.ResolveTag(imagesDir, image)
-			if err == nil {
-				manifest, mErr := vmimage.LoadManifestByDigest(imagesDir, digest)
-				if mErr != nil && errors.Is(mErr, vmimage.ErrLegacyBundledBlob) {
-					return ResolvedImage{}, mErr
-				}
-				if mErr == nil && manifest.ShedSourceRef() == val {
-					return ResolvedImage{Path: cached, Name: image, Digest: digest}, nil
-				}
+// Selector resolution order:
+//  1. "" → default_image
+//  2. an alias key in image_aliases → its underlying ref/path
+//  3. a Docker ref → used directly
+//  4. a local tag label (set via `shed image pull/build -t`) → cached path+digest
+//  5. an existing local path → escape hatch
+//  6. otherwise → error listing available aliases
+func resolveImageRef(defaultImage string, aliases map[string]string, pullPolicy, imagesDir, selector, configKey string) (ResolvedImage, error) {
+	ref := selector
+	switch ref {
+	case "":
+		ref = defaultImage
+		if ref == "" {
+			return ResolvedImage{}, fmt.Errorf("%w: no --image specified and no default_image configured (set %s in server.yaml)", ErrUnknownImageSentinel, configKey)
+		}
+	default:
+		if aliased, ok := aliases[ref]; ok {
+			ref = aliased
+		} else if imagesDir != "" {
+			// A raw selector may be a cosmetic tag label set via
+			// `shed image pull/build -t`. Resolve that first — a bare
+			// word like "mylabel" otherwise parses as a Docker ref
+			// (docker.io/library/mylabel), which would mask the label.
+			if digest, cached, err := vmimage.ResolveTag(imagesDir, selector); err == nil {
+				return ResolvedImage{Path: cached, Name: selector, Digest: digest}, nil
 			} else if errors.Is(err, vmimage.ErrLegacyBundledBlob) {
 				return ResolvedImage{}, err
 			}
-			return ResolvedImage{DockerRef: val, Name: image}, nil
-		}
-		return ResolvedImage{Path: val, Name: image}, nil
-	}
-
-	// Auto-discover by tag in the blob store.
-	if imagesDir != "" {
-		digest, discovered, err := vmimage.ResolveTag(imagesDir, image)
-		if err == nil {
-			return ResolvedImage{Path: discovered, Name: image, Digest: digest}, nil
-		}
-		if errors.Is(err, vmimage.ErrLegacyBundledBlob) {
-			return ResolvedImage{}, err
 		}
 	}
 
-	// Absolute path escape hatch
-	expanded := ExpandPath(image)
-	if filepath.IsAbs(expanded) {
-		if _, err := os.Stat(expanded); err != nil {
-			if os.IsNotExist(err) {
-				return ResolvedImage{}, fmt.Errorf("%w: image path does not exist: %q", ErrUnknownImageSentinel, expanded)
-			}
-			return ResolvedImage{}, fmt.Errorf("failed to stat image path %q: %w", expanded, err)
-		}
-		return ResolvedImage{Path: expanded, Name: image}, nil
+	if vmimage.IsDockerRef(ref) {
+		return ResolvedImage{DockerRef: ref, Name: vmimage.DeriveTagFromRef(ref), PullPolicy: pullPolicy}, nil
 	}
 
-	// Not found — build error with available variants
-	available := availableImageVariants(images, imagesDir)
+	// Local-path escape hatch (behavior unchanged; pull_policy is a no-op).
+	expanded := ExpandPath(ref)
+	if _, err := os.Stat(expanded); err == nil {
+		return ResolvedImage{Path: expanded, Name: vmimage.DeriveTagFromRef(ref)}, nil
+	} else if !os.IsNotExist(err) {
+		return ResolvedImage{}, fmt.Errorf("failed to stat image path %q: %w", expanded, err)
+	}
+
+	available := availableImageVariants(aliases, imagesDir)
 	if len(available) > 0 {
-		return ResolvedImage{}, fmt.Errorf("%w %q; available variants: %s", ErrUnknownImageSentinel, image, strings.Join(available, ", "))
+		return ResolvedImage{}, fmt.Errorf("%w %q; available aliases: %s (or pass a Docker ref / local path)", ErrUnknownImageSentinel, selector, strings.Join(available, ", "))
 	}
-	return ResolvedImage{}, fmt.Errorf("%w %q; no image variants configured (set %s in server config)", ErrUnknownImageSentinel, image, configKey)
+	return ResolvedImage{}, fmt.Errorf("%w %q; no image_aliases configured (pass a Docker ref or local path, or set %s)", ErrUnknownImageSentinel, selector, configKey)
 }
 
-// resolveBaseRootfs is the shared implementation for base rootfs resolution.
-func resolveBaseRootfs(baseRootfs, imagesDir string) ResolvedImage {
-	if vmimage.IsDockerRef(baseRootfs) {
-		// Mirror the source-ref + Digest plumbing from resolveImage so
-		// EnsureImage receives a Digest alongside Path. Without it the
-		// backends reject the resolved image as "outside the blob store"
-		// (firecracker/client.go ~494, vz/client.go ~232) because they
-		// can't refcount a Path-only entry.
-		if imagesDir != "" {
-			if digest, cached, ok := resolveCachedBase(imagesDir, baseRootfs); ok {
-				return ResolvedImage{Path: cached, Name: "_base", Digest: digest}
-			}
-		}
-		return ResolvedImage{DockerRef: baseRootfs, Name: "_base"}
-	}
-	return ResolvedImage{Path: baseRootfs, Name: "_base"}
-}
-
-// resolveCachedBase looks up the "_base" tag and returns (digest, path)
-// when the manifest matches baseRootfs AND the cached lower image is
-// materialized on disk. Returns ok=false on any miss so the caller can
-// fall through to the DockerRef path (which forces a fresh pull).
-func resolveCachedBase(imagesDir, baseRootfs string) (string, string, bool) {
-	digest, cached, err := vmimage.ResolveTag(imagesDir, "_base")
-	if err != nil {
-		return "", "", false
-	}
-	manifest, err := vmimage.LoadManifestByDigest(imagesDir, digest)
-	if err != nil || manifest.ShedSourceRef() != baseRootfs {
-		return "", "", false
-	}
-	if _, err := os.Stat(cached); err != nil {
-		return "", "", false
-	}
-	return digest, cached, true
-}
-
-// availableImageVariants returns a sorted list of image names known to
-// the system: every key in the Images config map plus every tag present
-// in the blob store. The synthetic "_base" tag is excluded.
-func availableImageVariants(images map[string]string, imagesDir string) []string {
+// availableImageVariants returns a sorted list of selector names known to the
+// system: every alias key plus every local tag label in the blob store.
+func availableImageVariants(aliases map[string]string, imagesDir string) []string {
 	seen := make(map[string]bool)
-	for name := range images {
+	for name := range aliases {
 		seen[name] = true
 	}
 	if imagesDir != "" {
 		tags, err := vmimage.ListTags(imagesDir)
 		if err == nil {
 			for _, name := range tags {
-				if name != "" && name != "_base" {
+				if name != "" {
 					seen[name] = true
 				}
 			}
@@ -684,14 +666,14 @@ func availableImageVariants(images map[string]string, imagesDir string) []string
 	return available
 }
 
-// ResolveImage resolves an image name to a local ext4 path or Docker reference.
+// ResolveImage resolves an image selector to a local path or Docker ref.
 func (c *VZConfig) ResolveImage(image string) (ResolvedImage, error) {
-	return resolveImage(c.Images, c.ImagesDir, image, "vz.images")
+	return resolveImageRef(c.DefaultImage, c.ImageAliases, c.PullPolicy, c.ImagesDir, image, "vz.default_image")
 }
 
-// ResolveBaseRootfs resolves the base rootfs (used when no --image flag is specified).
-func (c *VZConfig) ResolveBaseRootfs() ResolvedImage {
-	return resolveBaseRootfs(c.BaseRootfs, c.ImagesDir)
+// ResolveBaseRootfs resolves the default image (used when no --image is given).
+func (c *VZConfig) ResolveBaseRootfs() (ResolvedImage, error) {
+	return resolveImageRef(c.DefaultImage, c.ImageAliases, c.PullPolicy, c.ImagesDir, "", "vz.default_image")
 }
 
 // Firecracker validation upper bounds.
@@ -747,14 +729,17 @@ func (d Duration) Duration() time.Duration {
 // with the kernel, instance directories, and sockets that already live there.
 const DefaultFirecrackerImagesDir = "/var/lib/shed/firecracker/images"
 
-// GetImages implements vmimage.ImageConfig.
-func (c *FirecrackerConfig) GetImages() map[string]string { return c.Images }
+// GetDefaultImage implements vmimage.ImageConfig.
+func (c *FirecrackerConfig) GetDefaultImage() string { return c.DefaultImage }
+
+// GetImageAliases implements vmimage.ImageConfig.
+func (c *FirecrackerConfig) GetImageAliases() map[string]string { return c.ImageAliases }
+
+// GetPullPolicy implements vmimage.ImageConfig.
+func (c *FirecrackerConfig) GetPullPolicy() string { return c.PullPolicy }
 
 // GetImagesDir implements vmimage.ImageConfig.
 func (c *FirecrackerConfig) GetImagesDir() string { return c.ImagesDir }
-
-// GetBaseRootfs implements vmimage.ImageConfig.
-func (c *FirecrackerConfig) GetBaseRootfs() string { return c.BaseRootfs }
 
 // GetPlatform implements vmimage.ImageConfig.
 func (c *FirecrackerConfig) GetPlatform() string { return "linux/amd64" }
@@ -769,14 +754,14 @@ func (c *FirecrackerConfig) GetExtractKernel() bool { return true }
 // be installed alongside every shed image regardless of backend.
 func (c *FirecrackerConfig) GetNeedsInitrd() bool { return true }
 
-// ResolveImage resolves an image name to a local ext4 path or Docker reference.
+// ResolveImage resolves an image selector to a local path or Docker ref.
 func (c *FirecrackerConfig) ResolveImage(image string) (ResolvedImage, error) {
-	return resolveImage(c.Images, c.ImagesDir, image, "firecracker.images")
+	return resolveImageRef(c.DefaultImage, c.ImageAliases, c.PullPolicy, c.ImagesDir, image, "firecracker.default_image")
 }
 
-// ResolveBaseRootfs resolves the base rootfs (used when no --image flag is specified).
-func (c *FirecrackerConfig) ResolveBaseRootfs() ResolvedImage {
-	return resolveBaseRootfs(c.BaseRootfs, c.ImagesDir)
+// ResolveBaseRootfs resolves the default image (used when no --image is given).
+func (c *FirecrackerConfig) ResolveBaseRootfs() (ResolvedImage, error) {
+	return resolveImageRef(c.DefaultImage, c.ImageAliases, c.PullPolicy, c.ImagesDir, "", "firecracker.default_image")
 }
 
 // DefaultFirecrackerConfig returns a FirecrackerConfig with default values.
@@ -880,6 +865,34 @@ func DefaultServerConfig() *ServerConfig {
 	}
 }
 
+// rejectRemovedImageKeys fails loudly if a config still carries the
+// pre-v0.6.0 per-backend image keys (base_rootfs / images). yaml.Unmarshal
+// silently ignores unknown fields, so without this an upgraded operator's
+// stale config would be accepted while the new binary quietly ignored their
+// configured image — exactly the silent-drift failure this rework exists to
+// fix. The raw-map scan runs before the typed unmarshal is trusted.
+func rejectRemovedImageKeys(data []byte) error {
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		// Malformed YAML — let the typed unmarshal surface the parse error.
+		return nil
+	}
+	for _, backend := range []string{"vz", "firecracker"} {
+		sub, ok := raw[backend].(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, removed := range []string{"base_rootfs", "images"} {
+			if _, present := sub[removed]; present {
+				return fmt.Errorf(
+					"config key %q under %q was removed in v0.6.0; replace base_rootfs + images with default_image + image_aliases + pull_policy (see docs/upgrades/v0.5.9-to-v0.6.0.md)",
+					removed, backend)
+			}
+		}
+	}
+	return nil
+}
+
 // LoadServerConfig loads server configuration from standard locations.
 // It checks in order: ./server.yaml, ~/.config/shed/server.yaml, /etc/shed/server.yaml
 func LoadServerConfig() (*ServerConfig, error) {
@@ -922,6 +935,9 @@ func LoadServerConfigFromPath(path string) (*ServerConfig, error) {
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config file %s: %w", configPath, err)
 	}
+	if err := rejectRemovedImageKeys(data); err != nil {
+		return nil, fmt.Errorf("%s: %w", configPath, err)
+	}
 
 	// Apply defaults for zero values
 	if cfg.HTTPPort == 0 {
@@ -930,8 +946,6 @@ func LoadServerConfigFromPath(path string) (*ServerConfig, error) {
 	if cfg.SSHPort == 0 {
 		cfg.SSHPort = 2222
 	}
-	// DefaultImage is unused for VM backends (they use BaseRootfs),
-	// but keep the field for potential future use.
 	if cfg.LogLevel == "" {
 		cfg.LogLevel = "info"
 	}
@@ -1074,6 +1088,9 @@ func loadServerConfigForCLI(path string) (*ServerConfig, error) {
 	}
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config file %s: %w", configPath, err)
+	}
+	if err := rejectRemovedImageKeys(data); err != nil {
+		return nil, fmt.Errorf("%s: %w", configPath, err)
 	}
 
 	if cfg.HTTPPort == 0 {
@@ -1298,10 +1315,17 @@ func (c *FirecrackerConfig) applyDefaults() {
 		c.KernelPath = c.ImagesDir + "/vmlinux"
 	}
 
-	// Expand ~ in image paths (only for filesystem paths, not Docker refs)
-	for name, val := range c.Images {
+	if !vmimage.IsDockerRef(c.DefaultImage) {
+		c.DefaultImage = ExpandPath(c.DefaultImage)
+	}
+	if c.PullPolicy == "" {
+		c.PullPolicy = string(vmimage.PullMissing)
+	}
+
+	// Expand ~ in alias paths (only for filesystem paths, not Docker refs)
+	for name, val := range c.ImageAliases {
 		if !vmimage.IsDockerRef(val) {
-			c.Images[name] = ExpandPath(val)
+			c.ImageAliases[name] = ExpandPath(val)
 		}
 	}
 }
@@ -1394,27 +1418,31 @@ func (c *FirecrackerConfig) Validate() error {
 	// reads the kernel from the blob). The previous hasAnyDockerRef
 	// gate was too loose — a mix of local + remote sources still
 	// needs the legacy kernel/initrd for the local-spawn path.
-	if c.KernelPath != "" && !allSourcesAreDockerRefs(c.BaseRootfs, c.Images) {
+	if c.KernelPath != "" && !allSourcesAreDockerRefs(c.DefaultImage, c.ImageAliases) {
 		if _, err := os.Stat(c.KernelPath); err != nil {
 			return fmt.Errorf("kernel_path does not exist: %s", c.KernelPath)
 		}
 	}
 
-	// Validate base rootfs path exists when configured as a local
+	// Validate default_image path exists when configured as a local
 	// path. An empty value is allowed (see Validate header).
-	if c.BaseRootfs != "" && !vmimage.IsDockerRef(c.BaseRootfs) {
-		if _, err := os.Stat(c.BaseRootfs); err != nil {
-			return fmt.Errorf("base_rootfs does not exist: %s", c.BaseRootfs)
+	if c.DefaultImage != "" && !vmimage.IsDockerRef(c.DefaultImage) {
+		if _, err := os.Stat(c.DefaultImage); err != nil {
+			return fmt.Errorf("default_image does not exist: %s", c.DefaultImage)
 		}
 	}
 
-	// Validate image variant paths exist (skip Docker refs)
-	for name, val := range c.Images {
+	// Validate alias paths exist (skip Docker refs)
+	for name, val := range c.ImageAliases {
 		if !vmimage.IsDockerRef(val) {
 			if _, err := os.Stat(val); err != nil {
-				return fmt.Errorf("image %q path does not exist: %s", name, val)
+				return fmt.Errorf("image_aliases %q path does not exist: %s", name, val)
 			}
 		}
+	}
+
+	if _, err := vmimage.ParsePullPolicy(c.PullPolicy); err != nil {
+		return fmt.Errorf("firecracker: %w", err)
 	}
 
 	// Validate network configuration
@@ -1555,15 +1583,15 @@ func loadEnvFile(path string) (map[string]string, error) {
 }
 
 // allSourcesAreDockerRefs returns true when the kernel/initrd validation
-// can be safely skipped: either base_rootfs is empty (the optional-Phase-B
-// case) or it's a Docker ref, AND every entry in images is either a Docker
-// ref or empty. A single local-path source means the legacy kernel/initrd
-// files must still exist to support spawning from it.
-func allSourcesAreDockerRefs(baseRootfs string, images map[string]string) bool {
-	if baseRootfs != "" && !vmimage.IsDockerRef(baseRootfs) {
+// can be safely skipped: either default_image is empty (the optional-Phase-B
+// case) or it's a Docker ref, AND every alias value is either a Docker ref or
+// empty. A single local-path source means the legacy kernel/initrd files must
+// still exist to support spawning from it.
+func allSourcesAreDockerRefs(defaultImage string, aliases map[string]string) bool {
+	if defaultImage != "" && !vmimage.IsDockerRef(defaultImage) {
 		return false
 	}
-	for _, val := range images {
+	for _, val := range aliases {
 		if val != "" && !vmimage.IsDockerRef(val) {
 			return false
 		}

--- a/internal/firecracker/orchestrator.go
+++ b/internal/firecracker/orchestrator.go
@@ -153,10 +153,13 @@ func (b *fcCreator) PreFlight(ctx context.Context, req config.CreateShedRequest,
 				return nil, err
 			}
 		} else {
-			if b.c.cfg.BaseRootfs == "" {
-				return nil, fmt.Errorf("%w: no --image specified and no base_rootfs configured in firecracker.base_rootfs; pass --image <tag> or set base_rootfs in server.yaml", config.ErrInvalidShedRequestSentinel)
+			if b.c.cfg.DefaultImage == "" {
+				return nil, fmt.Errorf("%w: no --image specified and no default_image configured in firecracker.default_image; pass --image <ref> or set default_image in server.yaml", config.ErrInvalidShedRequestSentinel)
 			}
-			resolved = b.c.cfg.ResolveBaseRootfs()
+			resolved, err = b.c.cfg.ResolveBaseRootfs()
+			if err != nil {
+				return nil, err
+			}
 		}
 		backend.Phase(ctx, "image")
 		backend.Status(ctx, "Resolving image...")
@@ -166,6 +169,7 @@ func (b *fcCreator) PreFlight(ctx context.Context, req config.CreateShedRequest,
 			DockerRef: resolved.DockerRef,
 			Name:      resolved.Name,
 			Digest:    resolved.Digest,
+			Policy:    vmimage.PullPolicy(resolved.PullPolicy),
 		}, func(stage, msg string) {
 			backend.Phase(ctx, stage)
 			backend.Status(ctx, msg)

--- a/internal/firecracker/system.go
+++ b/internal/firecracker/system.go
@@ -39,7 +39,7 @@ func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 			return du, fmt.Errorf("listing images: %w", err)
 		}
 		for _, img := range imgs {
-			if !img.Cached || img.Path == "" {
+			if !img.Cached {
 				continue
 			}
 			entry := config.ImageDiskEntry{
@@ -47,33 +47,16 @@ func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 				Path:      img.Path,
 				DockerRef: img.DockerRef,
 			}
-			entry.Size.LogicalBytes, entry.Size.PhysicalBytes, _ = diskstat.Stat(img.Path)
-			du.Images = append(du.Images, entry)
-		}
-
-		// _base is skipped by ListImages by design; resolve via the
-		// content-addressed blob store and stat the underlying rootfs.
-		// Skip when its path matches an existing entry — under content-
-		// addressing, _base often resolves to the same blob as a tagged
-		// variant, and double-counting would inflate `df` totals.
-		// Path comparison is digest-equivalent here: both go through
-		// BlobRootfsPath(imagesDir, digest), which is deterministic
-		// from the digest, and Resolve is called with no expectedRef so
-		// it never short-circuits on a mismatched manifest.SourceRef.
-		if basePath := vmimage.Resolve(imagesDir, "_base", ""); basePath != "" && !imagesContainPath(du.Images, basePath) {
-			if logical, physical, err := diskstat.Stat(basePath); err == nil {
-				baseRef := ""
-				if vmimage.IsDockerRef(c.cfg.BaseRootfs) {
-					baseRef = c.cfg.BaseRootfs
-				}
-				du.Images = append(du.Images, config.ImageDiskEntry{
-					Name:      "_base",
-					Path:      basePath,
-					DockerRef: baseRef,
-					Size:      config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
-					IsBase:    true,
-				})
+			if img.Path != "" {
+				entry.Size.LogicalBytes, entry.Size.PhysicalBytes, _ = diskstat.Stat(img.Path)
 			}
+			// Fall back to the manifest-computed footprint (layers + lower)
+			// when there's no single statable lower file.
+			if entry.Size.LogicalBytes == 0 {
+				entry.Size.LogicalBytes = img.SizeBytes
+				entry.Size.PhysicalBytes = img.SizeBytes
+			}
+			du.Images = append(du.Images, entry)
 		}
 
 		orphans, err := systemprune.FindOrphans(imagesDir)
@@ -444,16 +427,4 @@ func (c *Client) collectInstanceCandidates(ctx context.Context, mtimes map[strin
 		})
 	}
 	return cands, skipped, nil
-}
-
-// imagesContainPath reports whether any entry's Path equals path.
-// Used to dedupe `_base` when it resolves to the same blob as a
-// tagged variant under the content-addressed image layout.
-func imagesContainPath(entries []config.ImageDiskEntry, path string) bool {
-	for _, e := range entries {
-		if e.Path == path {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/firecracker/system.go
+++ b/internal/firecracker/system.go
@@ -38,6 +38,7 @@ func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 		if err != nil {
 			return du, fmt.Errorf("listing images: %w", err)
 		}
+		seenDigest := make(map[string]bool)
 		for _, img := range imgs {
 			if !img.Cached {
 				continue
@@ -47,14 +48,20 @@ func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 				Path:      img.Path,
 				DockerRef: img.DockerRef,
 			}
-			if img.Path != "" {
-				entry.Size.LogicalBytes, entry.Size.PhysicalBytes, _ = diskstat.Stat(img.Path)
-			}
-			// Fall back to the manifest-computed footprint (layers + lower)
-			// when there's no single statable lower file.
-			if entry.Size.LogicalBytes == 0 {
-				entry.Size.LogicalBytes = img.SizeBytes
-				entry.Size.PhysicalBytes = img.SizeBytes
+			// Count on-disk bytes once per content digest: multiple refs can
+			// point at the same cached manifest, but the blob exists once.
+			// Subsequent rows for the same digest stay visible with zero size.
+			if !seenDigest[img.Digest] {
+				if img.Path != "" {
+					entry.Size.LogicalBytes, entry.Size.PhysicalBytes, _ = diskstat.Stat(img.Path)
+				}
+				// Fall back to the manifest-computed footprint (layers + lower)
+				// when there's no single statable lower file.
+				if entry.Size.LogicalBytes == 0 {
+					entry.Size.LogicalBytes = img.SizeBytes
+					entry.Size.PhysicalBytes = img.SizeBytes
+				}
+				seenDigest[img.Digest] = true
 			}
 			du.Images = append(du.Images, entry)
 		}

--- a/internal/firecracker/system_test.go
+++ b/internal/firecracker/system_test.go
@@ -18,10 +18,10 @@ func newSystemTestClient(t *testing.T) (*Client, string, string) {
 	instanceDir := t.TempDir()
 
 	cfg := &config.FirecrackerConfig{
-		ImagesDir:   imagesDir,
-		InstanceDir: instanceDir,
-		Images:      map[string]string{},
-		BaseRootfs:  "ghcr.io/example/base:v1",
+		ImagesDir:    imagesDir,
+		InstanceDir:  instanceDir,
+		ImageAliases: map[string]string{},
+		DefaultImage: "ghcr.io/example/base:v1",
 	}
 	serverCfg := &config.ServerConfig{Name: "test-fc"}
 
@@ -78,9 +78,8 @@ func TestPrune_FC_LogsSkippedWithReason(t *testing.T) {
 func TestDiskUsage_Populated_FC(t *testing.T) {
 	client, imagesDir, instanceDir := newSystemTestClient(t)
 
-	// _base and a variant — install via the content-addressed blob
-	// store so DiskUsage can resolve them through the tag layer.
-	installTestBlob(t, imagesDir, "_base", make([]byte, 4096))
+	// Two installed images, listed by their Docker ref identity.
+	installTestBlob(t, imagesDir, "base", make([]byte, 4096))
 	installTestBlob(t, imagesDir, "default", make([]byte, 8192))
 
 	// One stopped shed with rootfs — but NO console.log (FC has no console log file).
@@ -104,8 +103,8 @@ func TestDiskUsage_Populated_FC(t *testing.T) {
 	for _, img := range du.Images {
 		names[img.Name] = true
 	}
-	if !names["_base"] || !names["default"] {
-		t.Errorf("expected both _base and default; got %+v", names)
+	if !names["ghcr.io/test/base:v1"] || !names["ghcr.io/test/default:v1"] {
+		t.Errorf("expected both base and default refs; got %+v", names)
 	}
 
 	if len(du.Sheds) != 1 {

--- a/internal/firecracker/testutil_test.go
+++ b/internal/firecracker/testutil_test.go
@@ -36,7 +36,7 @@ func testFirecrackerConfig(tmpDir string) *config.FirecrackerConfig {
 	return &config.FirecrackerConfig{
 		InstanceDir:     tmpDir,
 		KernelPath:      "/tmp/vmlinux",
-		BaseRootfs:      "/tmp/rootfs.ext4",
+		DefaultImage:    "/tmp/rootfs.ext4",
 		SocketDir:       filepath.Join(tmpDir, "sockets"),
 		BridgeName:      "fc-br0",
 		BridgeCIDR:      "172.30.0.1/24",

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -199,7 +199,12 @@ func (m *Manager) EnsureImage(ctx context.Context, ref ResolvedRef, progress Pro
 // one-time index rebuild (scan) when the entry is missing — e.g. images
 // pulled before the ref-index existed — so a cold index self-heals.
 func (m *Manager) resolveCachedRef(ctx context.Context, imagesDir, ref string) (EnsureResult, bool) {
-	digest, ok := ResolveRefDigest(imagesDir, ref)
+	// Sidecar-only: a create cache hit requires a ref-index entry written by
+	// a prior pull of THIS ref. We deliberately do NOT scan manifests by
+	// source-ref here — a blob left behind by `shed image rm` (which deletes
+	// the sidecar but leaves the blob for prune) must force a re-pull, not be
+	// silently reused.
+	digest, ok := RefIndexGet(imagesDir, ref)
 	if !ok {
 		return EnsureResult{}, false
 	}
@@ -712,7 +717,13 @@ func (m *Manager) resolveDeleteTarget(imagesDir, ident string) (string, error) {
 		return digest, nil
 	}
 	if IsDockerRef(ident) {
-		if digest, ok := ResolveRefDigest(imagesDir, ident); ok {
+		// Sidecar first (O(1)); fall back to a manifest scan so an image
+		// visible in `shed image ls` (which scans manifests) is also
+		// removable by ref even without a sidecar entry.
+		if digest, ok := RefIndexGet(imagesDir, ident); ok {
+			return digest, nil
+		}
+		if digest, ok := FindDigestBySourceRef(imagesDir, ident); ok {
 			return digest, nil
 		}
 	}
@@ -826,7 +837,13 @@ func (m *Manager) PruneImages(dryRun bool) ([]ImageInfo, error) {
 	// the derived tag and then pruning could GC the blob a fresh `shed
 	// create` still resolves to via the ref-index — a use-after-free.
 	for _, ref := range m.configuredRefs() {
-		if digest, ok := ResolveRefDigest(imagesDir, ref); ok && BlobExists(imagesDir, digest) {
+		digest, ok := RefIndexGet(imagesDir, ref)
+		if !ok {
+			// Cold (no sidecar yet): scan manifests so a configured image
+			// present from before the ref-index existed is still protected.
+			digest, ok = FindDigestBySourceRef(imagesDir, ref)
+		}
+		if ok && BlobExists(imagesDir, digest) {
 			liveManifests[digest] = true
 		}
 	}

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -199,18 +199,9 @@ func (m *Manager) EnsureImage(ctx context.Context, ref ResolvedRef, progress Pro
 // one-time index rebuild (scan) when the entry is missing — e.g. images
 // pulled before the ref-index existed — so a cold index self-heals.
 func (m *Manager) resolveCachedRef(ctx context.Context, imagesDir, ref string) (EnsureResult, bool) {
-	digest, ok := RefIndexGet(imagesDir, ref)
+	digest, ok := ResolveRefDigest(imagesDir, ref)
 	if !ok {
-		// Cold/stale index: rebuild once from the authoritative manifests,
-		// then retry. Bounded O(N-manifests), off the steady-state path.
-		if err := RebuildRefIndex(imagesDir); err != nil {
-			log.Printf("vmimage: ref-index rebuild failed: %v", err)
-			return EnsureResult{}, false
-		}
-		digest, ok = RefIndexGet(imagesDir, ref)
-		if !ok {
-			return EnsureResult{}, false
-		}
+		return EnsureResult{}, false
 	}
 	res, err := m.resolveManifestLower(ctx, imagesDir, digest)
 	if err != nil {
@@ -260,6 +251,12 @@ func (m *Manager) PullImage(ctx context.Context, dockerRef, tag, platform string
 	})
 	if err != nil {
 		return "", fmt.Errorf("pulling %s from registry: %w", dockerRef, err)
+	}
+	// Record the ref->digest mapping so `shed create` (and prune protection)
+	// can resolve this ref O(1) without a manifest scan, and so a configured
+	// default_image pulled via `shed image pull` is protected from prune.
+	if err := RefIndexPut(imagesDir, dockerRef, result.ManifestDigest); err != nil {
+		log.Printf("vmimage: failed to record ref-index entry for %s: %v", dockerRef, err)
 	}
 	return result.ManifestDigest, nil
 }
@@ -715,13 +712,8 @@ func (m *Manager) resolveDeleteTarget(imagesDir, ident string) (string, error) {
 		return digest, nil
 	}
 	if IsDockerRef(ident) {
-		if digest, ok := RefIndexGet(imagesDir, ident); ok {
+		if digest, ok := ResolveRefDigest(imagesDir, ident); ok {
 			return digest, nil
-		}
-		if err := RebuildRefIndex(imagesDir); err == nil {
-			if digest, ok := RefIndexGet(imagesDir, ident); ok {
-				return digest, nil
-			}
 		}
 	}
 	return "", ErrImageNotFound
@@ -834,7 +826,7 @@ func (m *Manager) PruneImages(dryRun bool) ([]ImageInfo, error) {
 	// the derived tag and then pruning could GC the blob a fresh `shed
 	// create` still resolves to via the ref-index — a use-after-free.
 	for _, ref := range m.configuredRefs() {
-		if digest, ok := RefIndexGet(imagesDir, ref); ok && BlobExists(imagesDir, digest) {
+		if digest, ok := ResolveRefDigest(imagesDir, ref); ok && BlobExists(imagesDir, digest) {
 			liveManifests[digest] = true
 		}
 	}

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -35,9 +35,10 @@ var (
 // ImageConfig provides the configuration data needed by image management operations.
 // Both VZConfig and FirecrackerConfig implement this interface.
 type ImageConfig interface {
-	GetImages() map[string]string
+	GetDefaultImage() string            // ref (or path) for new sheds when no --image
+	GetImageAliases() map[string]string // alias -> ref convenience map
+	GetPullPolicy() string              // "missing" (default) | "always" | "never"
 	GetImagesDir() string
-	GetBaseRootfs() string
 	GetPlatform() string    // "linux/arm64" or "linux/amd64"
 	GetExtractKernel() bool // true for both VZ and Firecracker
 	GetNeedsInitrd() bool   // true for VZ, false for Firecracker
@@ -78,8 +79,12 @@ type ProgressFunc func(stage, msg string)
 type ResolvedRef struct {
 	Path      string // set when the ext4 image already exists on disk
 	DockerRef string // set when the image needs to be pulled and converted
-	Name      string // variant name, used as a tag in the blob store
+	Name      string // cosmetic label derived from the ref; not an identity key
 	Digest    string // set when Path came from a tag in the blob store; preserved through to EnsureResult.Digest
+
+	// Policy governs cache-vs-pull for a DockerRef. Empty means PullMissing.
+	// Ignored for local-path refs.
+	Policy PullPolicy
 }
 
 // EnsureResult is what EnsureImage returns: the path to the
@@ -114,24 +119,39 @@ func (m *Manager) EnsureImage(ctx context.Context, ref ResolvedRef, progress Pro
 		return EnsureResult{}, err
 	}
 
-	// Cache hit fast path: tag points at a manifest whose source-ref
-	// annotation matches the requested DockerRef. Confirm every layer's
-	// ext4 is materialized, since a previous cache eviction might have
-	// removed them.
-	if res, ok := m.resolveCachedTag(ctx, imagesDir, ref.Name, ref.DockerRef); ok {
-		return res, nil
+	policy := ref.Policy
+	if policy == "" {
+		policy = PullMissing
 	}
 
-	// Serialize concurrent EnsureImage calls for the same tag.
-	tagLockPath := filepath.Join(imagesDir, tagsDir, ref.Name+".lock")
-	unlock, err := acquireFileLock(tagLockPath)
+	// Cache lookup by ref identity (the io.shed.source-ref annotation),
+	// resolved O(1) through the ref-index. PullAlways bypasses the cache
+	// entirely so a stale tag/index can't short-circuit the pull (F1).
+	if policy != PullAlways {
+		if res, ok := m.resolveCachedRef(ctx, imagesDir, ref.DockerRef); ok {
+			return res, nil
+		}
+	}
+
+	// Serialize concurrent EnsureImage calls for the SAME ref (keyed by a
+	// hash of the full ref, so distinct refs never block each other).
+	refLockPath := filepath.Join(imagesDir, tagsDir, refIndexKey(ref.DockerRef)+".lock")
+	unlock, err := acquireFileLock(refLockPath)
 	if err != nil {
-		return EnsureResult{}, fmt.Errorf("acquiring tag lock: %w", err)
+		return EnsureResult{}, fmt.Errorf("acquiring image lock: %w", err)
 	}
 	defer unlock()
 
-	if res, ok := m.resolveCachedTag(ctx, imagesDir, ref.Name, ref.DockerRef); ok {
-		return res, nil
+	// Re-check under lock (another caller may have just pulled this ref).
+	if policy != PullAlways {
+		if res, ok := m.resolveCachedRef(ctx, imagesDir, ref.DockerRef); ok {
+			return res, nil
+		}
+	}
+
+	// Cache miss. PullNever must not contact the registry (F2).
+	if policy == PullNever {
+		return EnsureResult{}, fmt.Errorf("%w: %s", ErrPullDisabled, ref.DockerRef)
 	}
 
 	if progress != nil {
@@ -161,7 +181,45 @@ func (m *Manager) EnsureImage(ctx context.Context, ref ResolvedRef, progress Pro
 	if err != nil {
 		return EnsureResult{}, fmt.Errorf("pulling %s from registry: %w", ref.DockerRef, err)
 	}
-	return m.resolveManifestLower(ctx, imagesDir, pullResult.ManifestDigest)
+	res, err := m.resolveManifestLower(ctx, imagesDir, pullResult.ManifestDigest)
+	if err != nil {
+		return EnsureResult{}, err
+	}
+	// Final commit: record ref -> digest only after the manifest + all
+	// blobs (verified by resolveManifestLower) and the OCI index are
+	// durable, so the ref-index can never point at an incomplete pull.
+	if err := RefIndexPut(imagesDir, ref.DockerRef, pullResult.ManifestDigest); err != nil {
+		log.Printf("vmimage: failed to record ref-index entry for %s: %v", ref.DockerRef, err)
+	}
+	return res, nil
+}
+
+// resolveCachedRef is the by-ref validated cache lookup used on the create
+// hot path. It consults the O(1) ref-index first and falls back to a
+// one-time index rebuild (scan) when the entry is missing — e.g. images
+// pulled before the ref-index existed — so a cold index self-heals.
+func (m *Manager) resolveCachedRef(ctx context.Context, imagesDir, ref string) (EnsureResult, bool) {
+	digest, ok := RefIndexGet(imagesDir, ref)
+	if !ok {
+		// Cold/stale index: rebuild once from the authoritative manifests,
+		// then retry. Bounded O(N-manifests), off the steady-state path.
+		if err := RebuildRefIndex(imagesDir); err != nil {
+			log.Printf("vmimage: ref-index rebuild failed: %v", err)
+			return EnsureResult{}, false
+		}
+		digest, ok = RefIndexGet(imagesDir, ref)
+		if !ok {
+			return EnsureResult{}, false
+		}
+	}
+	res, err := m.resolveManifestLower(ctx, imagesDir, digest)
+	if err != nil {
+		// Manifest present but a required blob (erofs) is gone. Drop the
+		// stale entry so policy (pull/never) governs the repair.
+		RefIndexDeleteByDigest(imagesDir, digest)
+		return EnsureResult{}, false
+	}
+	return res, true
 }
 
 // PullImage pulls a registry reference straight to the OCI layout (no
@@ -286,45 +344,6 @@ func (m *Manager) ResolveImageBlobs(manifestDigest string) (manifest *OCIManifes
 	return manifest, kernelPath, initrdPath, nil
 }
 
-// resolveCachedTag returns an EnsureResult derived from a cached tag
-// when one is available and every layer is materialized.
-//
-// Local tags always win over the configured registry ref: if a tag
-// named `name` exists locally and its layers are fully materialized,
-// we use it regardless of whether the manifest's io.shed.source-ref
-// matches the configured Docker ref. The previous strict equality
-// check forced a registry re-pull every time the server config or a
-// local build set a different source-ref — that overwrote
-// locally-built manifests with whatever was published, which is
-// exactly backwards for development workflows. To force a refresh
-// from the registry, run `shed image pull <ref> -t <name>` (or
-// `shed image rm <name>` first).
-//
-// `expectedRef` is still accepted for the signature compat but only
-// logged for debugging when there's a mismatch.
-func (m *Manager) resolveCachedTag(ctx context.Context, imagesDir, name, expectedRef string) (EnsureResult, bool) {
-	t, err := GetTag(imagesDir, name)
-	if err != nil {
-		return EnsureResult{}, false
-	}
-	if !BlobExists(imagesDir, t.Digest) {
-		return EnsureResult{}, false
-	}
-	manifest, err := LoadManifestByDigest(imagesDir, t.Digest)
-	if err != nil {
-		return EnsureResult{}, false
-	}
-	if expectedRef != "" && manifest.ShedSourceRef() != expectedRef {
-		log.Printf("vmimage: tag %q points at manifest with source-ref %q which differs from configured ref %q — using local tag anyway (run `shed image rm %s` then re-pull to refresh from registry)",
-			name, manifest.ShedSourceRef(), expectedRef, name)
-	}
-	res, err := m.resolveManifestLower(ctx, imagesDir, t.Digest)
-	if err != nil {
-		return EnsureResult{}, false
-	}
-	return res, true
-}
-
 // resolveManifestLower resolves the single read-only lower image for a
 // manifest. v0.5.2+ images carry a prebuilt erofs blob referenced by
 // the io.shed.rootfs.erofs.digest annotation — we return that blob's
@@ -377,9 +396,17 @@ func (m *Manager) ListImages() ([]ImageInfo, error) {
 		return nil, nil
 	}
 
-	configMap := m.cfg.GetImages()
-	if configMap == nil {
-		configMap = map[string]string{}
+	// Refs the server config points at (default_image + alias values).
+	// A manifest whose source-ref is in this set is sourced from config;
+	// anything else with a source-ref was pulled ad-hoc by the user.
+	configuredRefs := map[string]bool{}
+	if dr := m.cfg.GetDefaultImage(); IsDockerRef(dr) {
+		configuredRefs[dr] = true
+	}
+	for _, v := range m.cfg.GetImageAliases() {
+		if IsDockerRef(v) {
+			configuredRefs[v] = true
+		}
 	}
 
 	tags, err := ListTags(imagesDir)
@@ -480,22 +507,30 @@ func (m *Manager) ListImages() ([]ImageInfo, error) {
 			Tag:    mi.tag,
 			Cached: mi.manifest != nil,
 		}
-		if mi.tag != "" {
+		if mi.manifest != nil {
+			info.DockerRef = mi.manifest.ShedSourceRef()
+		}
+		// Identity is the Docker ref (io.shed.source-ref) when present.
+		switch {
+		case info.DockerRef != "":
+			info.Name = info.DockerRef
+		case mi.tag != "":
 			info.Name = mi.tag
-			if dockerRef, ok := configMap[mi.tag]; ok && IsDockerRef(dockerRef) {
-				info.Source = "config"
-				info.DockerRef = dockerRef
-			} else {
-				info.Source = "discovered"
-			}
-		} else {
+		default:
 			info.Name = ShortDigest(mi.digest)
+		}
+		// Source: config when the ref is what the server is configured to
+		// use; user when the operator labeled it with a cosmetic tag;
+		// dangling when it's an untagged, unconfigured leftover.
+		switch {
+		case configuredRefs[info.DockerRef]:
+			info.Source = "config"
+		case mi.tag != "":
+			info.Source = "user"
+		default:
 			info.Source = "dangling"
 		}
 		if mi.manifest != nil {
-			if info.DockerRef == "" {
-				info.DockerRef = mi.manifest.ShedSourceRef()
-			}
 			for _, layer := range mi.manifest.Layers {
 				info.SizeBytes += layer.Size
 				if layerRefs[layer.Digest] <= 1 {
@@ -546,13 +581,15 @@ func (m *Manager) InspectImage(tagOrDigest string) (*ImageInfo, *OCIManifest, er
 		Tag:       tagName,
 		Cached:    BlobExists(imagesDir, digest),
 		DockerRef: manifest.ShedSourceRef(),
-		Source:    "discovered",
+		Source:    "user",
 	}
-	if tagName != "" {
-		info.Name = tagName
-		if dockerRef, ok := m.cfg.GetImages()[tagName]; ok && IsDockerRef(dockerRef) {
+	if info.DockerRef != "" {
+		info.Name = info.DockerRef
+		if m.isConfiguredRef(info.DockerRef) {
 			info.Source = "config"
 		}
+	} else if tagName != "" {
+		info.Name = tagName
 	} else {
 		info.Name = ShortDigest(digest)
 		info.Source = "dangling"
@@ -637,27 +674,96 @@ func resolveDigestPrefix(imagesDir, prefix string) (string, error) {
 	}
 }
 
-// DeleteImage removes a tag. Following the Docker model, the underlying
-// manifest blob is NOT removed — call PruneImages to garbage-collect.
-func (m *Manager) DeleteImage(name string) error {
-	if err := ValidateImageName(name); err != nil {
-		return err
+// configuredRefs returns the Docker refs the server config currently points
+// at: the default_image plus every image_aliases value.
+func (m *Manager) configuredRefs() []string {
+	var out []string
+	if dr := m.cfg.GetDefaultImage(); IsDockerRef(dr) {
+		out = append(out, dr)
 	}
-	imagesDir := m.cfg.GetImagesDir()
-
-	if _, ok := m.cfg.GetImages()[name]; ok {
-		return ErrImageInUse
-	}
-	if name == "_base" && IsDockerRef(m.cfg.GetBaseRootfs()) {
-		return ErrImageInUse
-	}
-
-	if err := DeleteTag(imagesDir, name); err != nil {
-		if errors.Is(err, ErrTagNotFound) {
-			return ErrImageNotFound
+	for _, v := range m.cfg.GetImageAliases() {
+		if IsDockerRef(v) {
+			out = append(out, v)
 		}
+	}
+	return out
+}
+
+// isConfiguredRef reports whether ref is the configured default_image or one
+// of the configured image_aliases values.
+func (m *Manager) isConfiguredRef(ref string) bool {
+	if ref == "" {
+		return false
+	}
+	if m.cfg.GetDefaultImage() == ref {
+		return true
+	}
+	for _, v := range m.cfg.GetImageAliases() {
+		if v == ref {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveDeleteTarget maps a user-supplied identifier (a cosmetic tag label,
+// a digest, or a Docker ref) to a manifest digest. A bare label like "full"
+// parses as a Docker ref (docker.io/library/full), so tag/digest resolution
+// is tried first; the ref-index is the fallback for full registry refs.
+func (m *Manager) resolveDeleteTarget(imagesDir, ident string) (string, error) {
+	if digest, _, err := m.resolveTagOrDigest(ident); err == nil {
+		return digest, nil
+	}
+	if IsDockerRef(ident) {
+		if digest, ok := RefIndexGet(imagesDir, ident); ok {
+			return digest, nil
+		}
+		if err := RebuildRefIndex(imagesDir); err == nil {
+			if digest, ok := RefIndexGet(imagesDir, ident); ok {
+				return digest, nil
+			}
+		}
+	}
+	return "", ErrImageNotFound
+}
+
+// DeleteImage removes an image's addressability — every cosmetic tag and the
+// ref-index entry pointing at the resolved manifest. Following the Docker
+// model, the underlying manifest blob is NOT removed; call PruneImages to
+// garbage-collect once nothing references it. ident may be a Docker ref, a
+// digest, or a cosmetic tag label.
+//
+// Hard-blocks only when the manifest is pinned by a live shed or snapshot.
+// (Warning when the target is the configured default_image is a CLI concern.)
+func (m *Manager) DeleteImage(ident string) error {
+	imagesDir := m.cfg.GetImagesDir()
+	digest, err := m.resolveDeleteTarget(imagesDir, ident)
+	if err != nil {
 		return err
 	}
+
+	if m.scanner != nil {
+		refs, serr := m.scanner.ScanRefs(false)
+		if serr != nil {
+			return fmt.Errorf("scanning refs: %w", serr)
+		}
+		if len(ProtectiveRefs(refs, digest)) > 0 {
+			return ErrImageInUse
+		}
+	}
+
+	// Untag every cosmetic tag pointing at this manifest and drop its
+	// ref-index entry so the image is no longer resolvable.
+	tags, err := ListTags(imagesDir)
+	if err != nil {
+		return err
+	}
+	for _, tag := range tags {
+		if t, gerr := GetTag(imagesDir, tag); gerr == nil && t.Digest == digest {
+			_ = DeleteTag(imagesDir, tag)
+		}
+	}
+	RefIndexDeleteByDigest(imagesDir, digest)
 	return nil
 }
 
@@ -720,6 +826,17 @@ func (m *Manager) PruneImages(dryRun bool) ([]ImageInfo, error) {
 			continue
 		}
 		liveManifests[t.Digest] = true
+	}
+
+	// Protect the digests the server config currently resolves to
+	// (default_image + image_aliases), independent of cosmetic tags.
+	// Tags are now cosmetic labels a user can `rm`; without this, removing
+	// the derived tag and then pruning could GC the blob a fresh `shed
+	// create` still resolves to via the ref-index — a use-after-free.
+	for _, ref := range m.configuredRefs() {
+		if digest, ok := RefIndexGet(imagesDir, ref); ok && BlobExists(imagesDir, digest) {
+			liveManifests[digest] = true
+		}
 	}
 
 	// Expand to a full reachable-set: configs, layers, kernel, initrd
@@ -798,12 +915,14 @@ func (m *Manager) PruneImages(dryRun bool) ([]ImageInfo, error) {
 		if tagName, ok := tagMap[b]; ok {
 			info.Tag = tagName
 			info.Name = tagName
-			info.Source = "discovered"
 		} else {
 			info.Name = ShortDigest(b)
 		}
 		if m, ok := manifestCandidates[b]; ok {
 			info.DockerRef = m.ShedSourceRef()
+			if info.DockerRef != "" {
+				info.Name = info.DockerRef
+			}
 			for _, layer := range m.Layers {
 				info.SizeBytes += layer.Size
 			}
@@ -857,6 +976,9 @@ func (m *Manager) PruneImages(dryRun bool) ([]ImageInfo, error) {
 		// see a descriptor pointing at a now-missing blob.
 		if indexed[c.Digest] {
 			_ = IndexRemoveByDigest(imagesDir, c.Digest)
+			// Drop any ref-index entry pointing at this manifest so a
+			// later resolve can't hit a dangling sidecar entry (F5).
+			RefIndexDeleteByDigest(imagesDir, c.Digest)
 		}
 		deleted = append(deleted, c)
 	}

--- a/internal/vmimage/manager_test.go
+++ b/internal/vmimage/manager_test.go
@@ -9,20 +9,22 @@ import (
 
 // testConfig implements ImageConfig for testing.
 type testConfig struct {
-	images        map[string]string
+	defaultImage  string
+	imageAliases  map[string]string
+	pullPolicy    string
 	imagesDir     string
-	baseRootfs    string
 	platform      string
 	extractKernel bool
 	needsInitrd   bool
 }
 
-func (c *testConfig) GetImages() map[string]string { return c.images }
-func (c *testConfig) GetImagesDir() string         { return c.imagesDir }
-func (c *testConfig) GetBaseRootfs() string        { return c.baseRootfs }
-func (c *testConfig) GetPlatform() string          { return c.platform }
-func (c *testConfig) GetExtractKernel() bool       { return c.extractKernel }
-func (c *testConfig) GetNeedsInitrd() bool         { return c.needsInitrd }
+func (c *testConfig) GetDefaultImage() string            { return c.defaultImage }
+func (c *testConfig) GetImageAliases() map[string]string { return c.imageAliases }
+func (c *testConfig) GetPullPolicy() string              { return c.pullPolicy }
+func (c *testConfig) GetImagesDir() string               { return c.imagesDir }
+func (c *testConfig) GetPlatform() string                { return c.platform }
+func (c *testConfig) GetExtractKernel() bool             { return c.extractKernel }
+func (c *testConfig) GetNeedsInitrd() bool               { return c.needsInitrd }
 
 // fakeScanner is a static RefScanner used by tests.
 type fakeScanner struct {
@@ -46,8 +48,8 @@ func installFakeBlob(t *testing.T, imagesDir, tag, sourceRef string, body []byte
 func TestManagerListImages(t *testing.T) {
 	imagesDir := t.TempDir()
 	cfg := &testConfig{
-		images:    map[string]string{"default": "ghcr.io/example/default:v1"},
-		imagesDir: imagesDir,
+		defaultImage: "ghcr.io/example/default:v1",
+		imagesDir:    imagesDir,
 	}
 	mgr := NewManager(cfg, nil)
 
@@ -138,17 +140,27 @@ func TestManagerInspectAndTag(t *testing.T) {
 func TestManagerDeleteImage(t *testing.T) {
 	imagesDir := t.TempDir()
 	cfg := &testConfig{
-		images:    map[string]string{"managed": "ghcr.io/example/managed:v1"},
-		imagesDir: imagesDir,
+		defaultImage: "ghcr.io/example/managed:v1",
+		imagesDir:    imagesDir,
 	}
-	mgr := NewManager(cfg, nil)
 
-	installFakeBlob(t, imagesDir, "managed", "ghcr.io/example/managed:v1", []byte("a"))
+	managedDigest := installFakeBlob(t, imagesDir, "managed", "ghcr.io/example/managed:v1", []byte("a"))
 	installFakeBlob(t, imagesDir, "removable", "ghcr.io/example/removable:v1", []byte("b"))
 
-	// Refuse config-managed.
-	if err := mgr.DeleteImage("managed"); !errors.Is(err, ErrImageInUse) {
-		t.Errorf("DeleteImage(managed) = %v, want ErrImageInUse", err)
+	// A manifest pinned by a live shed/snapshot is hard-blocked.
+	pinnedMgr := NewManager(cfg, &fakeScanner{refs: []Reference{{Digest: managedDigest, Kind: RefKindShed, Name: "s1"}}})
+	if err := pinnedMgr.DeleteImage("managed"); !errors.Is(err, ErrImageInUse) {
+		t.Errorf("DeleteImage(pinned) = %v, want ErrImageInUse", err)
+	}
+
+	// Without a live ref, the configured default_image is NOT hard-blocked
+	// (warn-and-confirm is a CLI concern); delete untags it (blob remains).
+	mgr := NewManager(cfg, nil)
+	if err := mgr.DeleteImage("managed"); err != nil {
+		t.Errorf("DeleteImage(managed, unpinned): %v", err)
+	}
+	if _, err := GetTag(imagesDir, "managed"); !errors.Is(err, ErrTagNotFound) {
+		t.Errorf("expected managed tag gone, got %v", err)
 	}
 
 	// Removable tag deletes (Docker model: tag removed, blob remains).

--- a/internal/vmimage/refindex.go
+++ b/internal/vmimage/refindex.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -150,20 +149,35 @@ func RefIndexGet(imagesDir, ref string) (digest string, ok bool) {
 	return entry.Digest, true
 }
 
-// ResolveRefDigest maps a ref to its cached manifest digest via the O(1)
-// ref-index, falling back to a one-time index rebuild (so a cold/missing
-// sidecar self-heals for images whose publish ref matches the lookup ref).
-// Used by the create hot path, prune protection, and delete resolution so all
-// three agree on what "the image for this ref" is.
-func ResolveRefDigest(imagesDir, ref string) (digest string, ok bool) {
-	if d, ok := RefIndexGet(imagesDir, ref); ok {
-		return d, true
-	}
-	if err := RebuildRefIndex(imagesDir); err != nil {
-		log.Printf("vmimage: ref-index rebuild failed: %v", err)
+// FindDigestBySourceRef scans installed manifests for one whose
+// io.shed.source-ref equals ref, returning its digest. This is a READ-ONLY,
+// O(N-manifests) fallback for the cold paths (rm, prune protection) where a
+// ref may not have a sidecar entry yet (e.g. images present from before the
+// ref-index existed). It deliberately does NOT write the sidecar: the create
+// hot path resolves sidecar-only, so a manifest left behind by `shed image
+// rm` (blob persists until prune, Docker model) must not be silently
+// re-cached for create — `rm` then `create` should re-pull.
+func FindDigestBySourceRef(imagesDir, ref string) (digest string, ok bool) {
+	if imagesDir == "" || ref == "" {
 		return "", false
 	}
-	return RefIndexGet(imagesDir, ref)
+	indexed, err := IndexManifestDigests(imagesDir)
+	if err != nil {
+		return "", false
+	}
+	for d := range indexed {
+		if !BlobExists(imagesDir, d) {
+			continue
+		}
+		manifest, err := LoadManifestByDigest(imagesDir, d)
+		if err != nil {
+			continue
+		}
+		if manifest.ShedSourceRef() == ref {
+			return d, true
+		}
+	}
+	return "", false
 }
 
 // RefIndexDeleteByDigest removes every ref-index entry pointing at digest.
@@ -192,36 +206,4 @@ func RefIndexDeleteByDigest(imagesDir, digest string) {
 			_ = os.Remove(p)
 		}
 	}
-}
-
-// RebuildRefIndex repopulates the ref-index from the authoritative source —
-// every manifest in index.json that carries an io.shed.source-ref. Used as a
-// one-time self-healing fallback when a RefIndexGet misses (e.g. images
-// pulled before the index existed). A missing/stale index is therefore never
-// a correctness bug, only a one-time O(N-manifests) cost.
-func RebuildRefIndex(imagesDir string) error {
-	if imagesDir == "" {
-		return nil
-	}
-	indexed, err := IndexManifestDigests(imagesDir)
-	if err != nil {
-		return fmt.Errorf("reading OCI index for ref-index rebuild: %w", err)
-	}
-	for digest := range indexed {
-		if !BlobExists(imagesDir, digest) {
-			continue
-		}
-		manifest, err := LoadManifestByDigest(imagesDir, digest)
-		if err != nil {
-			continue
-		}
-		ref := manifest.ShedSourceRef()
-		if ref == "" {
-			continue
-		}
-		if err := RefIndexPut(imagesDir, ref, digest); err != nil {
-			log.Printf("vmimage: ref-index rebuild: failed to record %s: %v", ref, err)
-		}
-	}
-	return nil
 }

--- a/internal/vmimage/refindex.go
+++ b/internal/vmimage/refindex.go
@@ -1,0 +1,210 @@
+package vmimage
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PullPolicy controls how EnsureImage reconciles a configured Docker ref
+// against the local content-addressed store at create time. It mirrors the
+// Docker/Podman vocabulary so existing operator intuition transfers.
+type PullPolicy string
+
+const (
+	// PullMissing uses the cached ref if present, pulling only when absent.
+	// This is the default and keeps the create hot path O(1) and offline.
+	PullMissing PullPolicy = "missing"
+	// PullAlways always contacts the registry and pulls, bypassing the cache.
+	PullAlways PullPolicy = "always"
+	// PullNever uses the cached ref if present and errors on a miss; it never
+	// contacts the registry.
+	PullNever PullPolicy = "never"
+)
+
+// ErrPullDisabled is returned when pull_policy=never and the configured ref
+// is not present in the local store. Callers should surface this as a
+// client-actionable error (4xx), not an internal failure.
+var ErrPullDisabled = errors.New("image not present locally and pull_policy=never")
+
+// ParsePullPolicy validates a configured pull_policy string. An empty value
+// defaults to PullMissing.
+func ParsePullPolicy(s string) (PullPolicy, error) {
+	switch PullPolicy(s) {
+	case "":
+		return PullMissing, nil
+	case PullMissing, PullAlways, PullNever:
+		return PullPolicy(s), nil
+	default:
+		return "", fmt.Errorf("invalid pull_policy %q (want one of: missing, always, never)", s)
+	}
+}
+
+// DeriveTagFromRef reduces a Docker ref to a short, filesystem-safe cosmetic
+// name (e.g. ghcr.io/charliek/shed-vz-full:v0.5.9 -> "full"). It is NOT a
+// unique identity — multiple ref versions collapse to the same name — so it
+// is only used as a lock-adjacent label. Resolution identity is the full ref
+// via the ref-index.
+func DeriveTagFromRef(ref string) string {
+	name := ref
+	if i := strings.LastIndexByte(name, '@'); i >= 0 {
+		name = name[:i]
+	}
+	if i := strings.LastIndexByte(name, ':'); i >= 0 {
+		if !strings.Contains(name[i:], "/") {
+			name = name[:i]
+		}
+	}
+	if i := strings.LastIndexByte(name, '/'); i >= 0 {
+		name = name[i+1:]
+	}
+	for _, prefix := range []string{"shed-vz-", "shed-fc-"} {
+		if strings.HasPrefix(name, prefix) {
+			name = strings.TrimPrefix(name, prefix)
+			break
+		}
+	}
+	if name == "" {
+		name = "default"
+	}
+	return name
+}
+
+const refIndexSubdir = "refs"
+
+type refIndexEntry struct {
+	Ref    string `json:"ref"`
+	Digest string `json:"digest"`
+}
+
+func refIndexKey(ref string) string {
+	sum := sha256.Sum256([]byte(ref))
+	return hex.EncodeToString(sum[:])
+}
+
+func refIndexPath(imagesDir, ref string) string {
+	return filepath.Join(imagesDir, refIndexSubdir, refIndexKey(ref)+".json")
+}
+
+// RefIndexPut records ref -> manifest digest in the sidecar ref-index. It is
+// the final commit step of a successful pull/build: callers MUST invoke it
+// only after the manifest, config, layers, kernel/initrd/erofs, and
+// index.json are durable, so a crash can never leave the index pointing at
+// an incomplete digest. The write itself is atomic (temp+rename).
+func RefIndexPut(imagesDir, ref, digest string) error {
+	if imagesDir == "" || ref == "" || digest == "" {
+		return fmt.Errorf("RefIndexPut: imagesDir, ref, and digest are required")
+	}
+	dir := filepath.Join(imagesDir, refIndexSubdir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating ref-index dir: %w", err)
+	}
+	data, err := json.Marshal(refIndexEntry{Ref: ref, Digest: digest})
+	if err != nil {
+		return err
+	}
+	if err := atomicWriteFile(refIndexPath(imagesDir, ref), data, 0o644); err != nil {
+		return err
+	}
+	return fsyncDir(dir)
+}
+
+// RefIndexGet returns the cached manifest digest for ref as a VALIDATED hit:
+// the sidecar entry exists, its manifest blob is present, and the manifest's
+// io.shed.source-ref equals ref. On any validation failure it removes the
+// stale entry and reports a miss (ok=false), so the caller's pull_policy then
+// governs (missing repairs, never errors, always already bypassed this).
+//
+// Blob-completeness beyond the manifest (erofs/kernel/initrd) is validated by
+// resolveManifestLower at the call site, matching the tag fast path.
+func RefIndexGet(imagesDir, ref string) (digest string, ok bool) {
+	if imagesDir == "" || ref == "" {
+		return "", false
+	}
+	path := refIndexPath(imagesDir, ref)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	var entry refIndexEntry
+	if err := json.Unmarshal(data, &entry); err != nil || entry.Digest == "" {
+		_ = os.Remove(path)
+		return "", false
+	}
+	if !BlobExists(imagesDir, entry.Digest) {
+		_ = os.Remove(path)
+		return "", false
+	}
+	manifest, err := LoadManifestByDigest(imagesDir, entry.Digest)
+	if err != nil || manifest.ShedSourceRef() != ref {
+		_ = os.Remove(path)
+		return "", false
+	}
+	return entry.Digest, true
+}
+
+// RefIndexDeleteByDigest removes every ref-index entry pointing at digest.
+// Called by prune/rm after a manifest blob is deleted so a later resolve
+// can't hit a dangling entry. Best-effort: scan errors are logged, not fatal.
+func RefIndexDeleteByDigest(imagesDir, digest string) {
+	dir := filepath.Join(imagesDir, refIndexSubdir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		p := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		var entry refIndexEntry
+		if err := json.Unmarshal(data, &entry); err != nil {
+			continue
+		}
+		if entry.Digest == digest {
+			_ = os.Remove(p)
+		}
+	}
+}
+
+// RebuildRefIndex repopulates the ref-index from the authoritative source —
+// every manifest in index.json that carries an io.shed.source-ref. Used as a
+// one-time self-healing fallback when a RefIndexGet misses (e.g. images
+// pulled before the index existed). A missing/stale index is therefore never
+// a correctness bug, only a one-time O(N-manifests) cost.
+func RebuildRefIndex(imagesDir string) error {
+	if imagesDir == "" {
+		return nil
+	}
+	indexed, err := IndexManifestDigests(imagesDir)
+	if err != nil {
+		return fmt.Errorf("reading OCI index for ref-index rebuild: %w", err)
+	}
+	for digest := range indexed {
+		if !BlobExists(imagesDir, digest) {
+			continue
+		}
+		manifest, err := LoadManifestByDigest(imagesDir, digest)
+		if err != nil {
+			continue
+		}
+		ref := manifest.ShedSourceRef()
+		if ref == "" {
+			continue
+		}
+		if err := RefIndexPut(imagesDir, ref, digest); err != nil {
+			log.Printf("vmimage: ref-index rebuild: failed to record %s: %v", ref, err)
+		}
+	}
+	return nil
+}

--- a/internal/vmimage/refindex.go
+++ b/internal/vmimage/refindex.go
@@ -116,13 +116,19 @@ func RefIndexPut(imagesDir, ref, digest string) error {
 }
 
 // RefIndexGet returns the cached manifest digest for ref as a VALIDATED hit:
-// the sidecar entry exists, its manifest blob is present, and the manifest's
-// io.shed.source-ref equals ref. On any validation failure it removes the
-// stale entry and reports a miss (ok=false), so the caller's pull_policy then
-// governs (missing repairs, never errors, always already bypassed this).
+// the sidecar entry exists, its stored ref matches the lookup ref (guarding
+// against a sha256 key collision), and the manifest blob is still present. On
+// any validation failure it removes the stale entry and reports a miss
+// (ok=false), so the caller's pull_policy then governs.
 //
-// Blob-completeness beyond the manifest (erofs/kernel/initrd) is validated by
-// resolveManifestLower at the call site, matching the tag fast path.
+// Identity here is the ref the image was PULLED BY (the index key), NOT the
+// manifest's io.shed.source-ref annotation — those legitimately differ when
+// the configured ref is a mutable tag (:latest), a digest pin, or a mirror
+// host, while the annotation records the immutable publish ref. Validating
+// against the annotation would delete the entry EnsureImage just wrote.
+//
+// Blob-completeness beyond the manifest digest (erofs/kernel/initrd) is
+// validated by resolveManifestLower at the call site.
 func RefIndexGet(imagesDir, ref string) (digest string, ok bool) {
 	if imagesDir == "" || ref == "" {
 		return "", false
@@ -133,7 +139,7 @@ func RefIndexGet(imagesDir, ref string) (digest string, ok bool) {
 		return "", false
 	}
 	var entry refIndexEntry
-	if err := json.Unmarshal(data, &entry); err != nil || entry.Digest == "" {
+	if err := json.Unmarshal(data, &entry); err != nil || entry.Digest == "" || entry.Ref != ref {
 		_ = os.Remove(path)
 		return "", false
 	}
@@ -141,12 +147,23 @@ func RefIndexGet(imagesDir, ref string) (digest string, ok bool) {
 		_ = os.Remove(path)
 		return "", false
 	}
-	manifest, err := LoadManifestByDigest(imagesDir, entry.Digest)
-	if err != nil || manifest.ShedSourceRef() != ref {
-		_ = os.Remove(path)
+	return entry.Digest, true
+}
+
+// ResolveRefDigest maps a ref to its cached manifest digest via the O(1)
+// ref-index, falling back to a one-time index rebuild (so a cold/missing
+// sidecar self-heals for images whose publish ref matches the lookup ref).
+// Used by the create hot path, prune protection, and delete resolution so all
+// three agree on what "the image for this ref" is.
+func ResolveRefDigest(imagesDir, ref string) (digest string, ok bool) {
+	if d, ok := RefIndexGet(imagesDir, ref); ok {
+		return d, true
+	}
+	if err := RebuildRefIndex(imagesDir); err != nil {
+		log.Printf("vmimage: ref-index rebuild failed: %v", err)
 		return "", false
 	}
-	return entry.Digest, true
+	return RefIndexGet(imagesDir, ref)
 }
 
 // RefIndexDeleteByDigest removes every ref-index entry pointing at digest.

--- a/internal/vmimage/refindex_test.go
+++ b/internal/vmimage/refindex_test.go
@@ -61,6 +61,33 @@ func TestRefIndexDeleteByDigest(t *testing.T) {
 	}
 }
 
+// TestRmThenCreateDoesNotResurrect is the regression guard for the
+// rm-leaves-blob bug: `shed image rm` deletes the sidecar entry but leaves the
+// manifest blob (Docker model — prune GCs later). The create hot path
+// (RefIndexGet, sidecar-only) must NOT find the image, so `shed create`
+// re-pulls; only the cold rm/prune paths (FindDigestBySourceRef) still see it.
+func TestRmThenCreateDoesNotResurrect(t *testing.T) {
+	imagesDir := t.TempDir()
+	ref := "ghcr.io/x/y:v1"
+	digest := installFakeBlob(t, imagesDir, "full", ref, []byte("body"))
+	if err := RefIndexPut(imagesDir, ref, digest); err != nil {
+		t.Fatalf("RefIndexPut: %v", err)
+	}
+
+	// Simulate `shed image rm`: drop tag + sidecar, leave the blob.
+	_ = DeleteTag(imagesDir, "full")
+	RefIndexDeleteByDigest(imagesDir, digest)
+
+	// Create hot path: sidecar gone → miss → forces a re-pull.
+	if _, ok := RefIndexGet(imagesDir, ref); ok {
+		t.Error("RefIndexGet hit after rm — create would silently reuse a removed image")
+	}
+	// Cold rm/prune path: the leftover blob is still discoverable by source-ref.
+	if _, ok := FindDigestBySourceRef(imagesDir, ref); !ok {
+		t.Error("FindDigestBySourceRef should still locate the leftover blob for rm/prune")
+	}
+}
+
 // TestPruneProtectsConfiguredRefViaPullIndex is the regression guard for the
 // prune use-after-free: a configured default_image installed via PullImage
 // (not a create-triggered EnsureImage) and stripped of its cosmetic tag must

--- a/internal/vmimage/refindex_test.go
+++ b/internal/vmimage/refindex_test.go
@@ -1,0 +1,97 @@
+package vmimage
+
+import (
+	"testing"
+)
+
+// TestRefIndexGetDecoupledFromSourceRef is the regression guard for the
+// divergent-ref bug: an image pulled by a mutable tag / digest pin / mirror
+// host carries a publish-time io.shed.source-ref that differs from the ref the
+// operator configured. RefIndexGet must hit on the ref it was PUT under,
+// regardless of the manifest's source-ref annotation, or every create
+// re-pulls (missing) or errors (never) despite the image being local.
+func TestRefIndexGetDecoupledFromSourceRef(t *testing.T) {
+	imagesDir := t.TempDir()
+	// Manifest published as :v0.6.0 (its source-ref), but pulled by :latest.
+	digest := installFakeBlob(t, imagesDir, "full", "ghcr.io/x/y:v0.6.0", []byte("body"))
+
+	pulledRef := "ghcr.io/x/y:latest"
+	if err := RefIndexPut(imagesDir, pulledRef, digest); err != nil {
+		t.Fatalf("RefIndexPut: %v", err)
+	}
+
+	got, ok := RefIndexGet(imagesDir, pulledRef)
+	if !ok {
+		t.Fatal("RefIndexGet missed for the ref it was PUT under (source-ref mismatch must not delete the entry)")
+	}
+	if got != digest {
+		t.Errorf("RefIndexGet = %q, want %q", got, digest)
+	}
+}
+
+// TestRefIndexGetDropsStaleDigest confirms a missing blob (GC'd digest) is
+// treated as a miss and the stale entry removed.
+func TestRefIndexGetDropsStaleDigest(t *testing.T) {
+	imagesDir := t.TempDir()
+	if err := RefIndexPut(imagesDir, "ghcr.io/x/y:v1", "sha256:"+stale64); err != nil {
+		t.Fatalf("RefIndexPut: %v", err)
+	}
+	if _, ok := RefIndexGet(imagesDir, "ghcr.io/x/y:v1"); ok {
+		t.Error("RefIndexGet hit on a digest with no blob present")
+	}
+}
+
+const stale64 = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+// TestRefIndexDeleteByDigest removes every entry pointing at a digest.
+func TestRefIndexDeleteByDigest(t *testing.T) {
+	imagesDir := t.TempDir()
+	d := installFakeBlob(t, imagesDir, "full", "ghcr.io/x/y:v1", []byte("b"))
+	// Two refs converge on the same digest.
+	_ = RefIndexPut(imagesDir, "ghcr.io/x/y:v1", d)
+	_ = RefIndexPut(imagesDir, "ghcr.io/x/y:latest", d)
+
+	RefIndexDeleteByDigest(imagesDir, d)
+
+	if _, ok := RefIndexGet(imagesDir, "ghcr.io/x/y:v1"); ok {
+		t.Error("entry for :v1 survived DeleteByDigest")
+	}
+	if _, ok := RefIndexGet(imagesDir, "ghcr.io/x/y:latest"); ok {
+		t.Error("entry for :latest survived DeleteByDigest")
+	}
+}
+
+// TestPruneProtectsConfiguredRefViaPullIndex is the regression guard for the
+// prune use-after-free: a configured default_image installed via PullImage
+// (not a create-triggered EnsureImage) and stripped of its cosmetic tag must
+// still be protected from prune, because `shed create` would resolve it via
+// the ref-index.
+func TestPruneProtectsConfiguredRefViaPullIndex(t *testing.T) {
+	imagesDir := t.TempDir()
+	cfg := &testConfig{
+		defaultImage: "ghcr.io/x/configured:v1",
+		imagesDir:    imagesDir,
+	}
+	mgr := NewManager(cfg, &fakeScanner{}) // no shed/snapshot refs
+
+	// Install the configured image and record it in the ref-index the way
+	// PullImage would, then drop the cosmetic tag so only ref-index
+	// protection remains.
+	digest := installFakeBlob(t, imagesDir, "configured", "ghcr.io/x/configured:v1", []byte("body"))
+	if err := RefIndexPut(imagesDir, "ghcr.io/x/configured:v1", digest); err != nil {
+		t.Fatalf("RefIndexPut: %v", err)
+	}
+	if err := DeleteTag(imagesDir, "configured"); err != nil {
+		t.Fatalf("DeleteTag: %v", err)
+	}
+
+	cands, err := mgr.PruneImages(true)
+	if err != nil {
+		t.Fatalf("PruneImages(dryRun): %v", err)
+	}
+	for _, c := range cands {
+		if c.Digest == digest {
+			t.Fatalf("configured default_image %s is a prune candidate (use-after-free): %#v", digest, cands)
+		}
+	}
+}

--- a/internal/vz/client_test.go
+++ b/internal/vz/client_test.go
@@ -433,8 +433,8 @@ func TestCreateShedValidatesResources(t *testing.T) {
 
 	client := &Client{
 		cfg: &config.VZConfig{
-			BaseRootfs:  baseRootfs,
-			InstanceDir: tmpDir,
+			DefaultImage: baseRootfs,
+			InstanceDir:  tmpDir,
 		},
 		vms:     make(map[string]*VM),
 		credMgr: newTestCredMgr(),

--- a/internal/vz/image.go
+++ b/internal/vz/image.go
@@ -29,6 +29,7 @@ func (c *Client) EnsureImage(ctx context.Context, resolved config.ResolvedImage)
 		DockerRef: resolved.DockerRef,
 		Name:      resolved.Name,
 		Digest:    resolved.Digest,
+		Policy:    vmimage.PullPolicy(resolved.PullPolicy),
 	}, func(stage, msg string) {
 		backend.Phase(ctx, stage)
 		backend.Status(ctx, msg)

--- a/internal/vz/image_test.go
+++ b/internal/vz/image_test.go
@@ -94,9 +94,10 @@ func createFakeInstance(t *testing.T, instanceDir, name, image, lowerDigest stri
 
 // TestDeleteImage covers removal under the Docker model: `image rm` drops the
 // tag but leaves the blob. With ref-keyed identity, deletion is hard-blocked
-// only when a live shed/snapshot pins the manifest (the configured
-// default_image is no longer a blanket refusal — warn-and-confirm is a CLI
-// concern).
+// when ANY shed (running or stopped) or snapshot still pins the manifest —
+// matching `docker rmi`, which refuses while any container references the
+// image. The configured default_image is no longer a blanket refusal
+// (warn-and-confirm is a CLI concern).
 func TestDeleteImage(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/vz/image_test.go
+++ b/internal/vz/image_test.go
@@ -23,10 +23,10 @@ func newTestClient(t *testing.T) (*Client, string) {
 		ImagesDir:    imagesDir,
 		InstanceDir:  instanceDir,
 		SnapshotsDir: snapshotsDir,
-		Images: map[string]string{
+		DefaultImage: "ghcr.io/example/base:v1",
+		ImageAliases: map[string]string{
 			"managed": "ghcr.io/example/managed:v1",
 		},
-		BaseRootfs: "ghcr.io/example/base:v1",
 	}
 
 	client := &Client{cfg: cfg}
@@ -92,9 +92,11 @@ func createFakeInstance(t *testing.T, instanceDir, name, image, lowerDigest stri
 	}
 }
 
-// TestDeleteImage covers tag-level removal under the Docker model:
-// `image rm` drops the tag but leaves the blob; refusal of config-managed
-// tags works as before.
+// TestDeleteImage covers removal under the Docker model: `image rm` drops the
+// tag but leaves the blob. With ref-keyed identity, deletion is hard-blocked
+// only when a live shed/snapshot pins the manifest (the configured
+// default_image is no longer a blanket refusal — warn-and-confirm is a CLI
+// concern).
 func TestDeleteImage(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -110,15 +112,11 @@ func TestDeleteImage(t *testing.T) {
 			},
 		},
 		{
-			name:      "config-managed image refused",
-			imageName: "managed",
-			wantErr:   config.ErrImageInUseSentinel,
-		},
-		{
-			name:      "_base with docker ref refused",
-			imageName: "_base",
-			setup: func(t *testing.T, _ *Client, imagesDir string) {
-				createFakeImage(t, imagesDir, "_base")
+			name:      "pinned by live shed refused",
+			imageName: "pinned",
+			setup: func(t *testing.T, client *Client, imagesDir string) {
+				d := createFakeImage(t, imagesDir, "pinned")
+				createFakeInstance(t, client.cfg.InstanceDir, "live-shed", "pinned", d)
 			},
 			wantErr: config.ErrImageInUseSentinel,
 		},

--- a/internal/vz/orchestrator.go
+++ b/internal/vz/orchestrator.go
@@ -151,10 +151,14 @@ func (b *vzCreator) PreFlight(ctx context.Context, req config.CreateShedRequest,
 				return nil, err
 			}
 		} else {
-			if b.c.cfg.BaseRootfs == "" {
-				return nil, fmt.Errorf("%w: no --image specified and no base_rootfs configured in vz.base_rootfs; pass --image <tag> or set base_rootfs in server.yaml", config.ErrInvalidShedRequestSentinel)
+			if b.c.cfg.DefaultImage == "" {
+				return nil, fmt.Errorf("%w: no --image specified and no default_image configured in vz.default_image; pass --image <ref> or set default_image in server.yaml", config.ErrInvalidShedRequestSentinel)
 			}
-			resolved = b.c.cfg.ResolveBaseRootfs()
+			var err error
+			resolved, err = b.c.cfg.ResolveBaseRootfs()
+			if err != nil {
+				return nil, err
+			}
 		}
 		backend.Phase(ctx, "image")
 		backend.Status(ctx, "Resolving image...")

--- a/internal/vz/system.go
+++ b/internal/vz/system.go
@@ -37,14 +37,14 @@ func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 
 	imagesDir := c.cfg.ImagesDir
 	if imagesDir != "" {
-		// Discovered variants and config-referenced images. `ListImages`
-		// intentionally skips `_base`, so we stat it directly below.
+		// All installed images (config-sourced + user-pulled), keyed by
+		// their Docker ref via ListImages.
 		imgs, err := c.ListImages()
 		if err != nil {
 			return du, fmt.Errorf("listing images: %w", err)
 		}
 		for _, img := range imgs {
-			if !img.Cached || img.Path == "" {
+			if !img.Cached {
 				continue
 			}
 			entry := config.ImageDiskEntry{
@@ -52,34 +52,16 @@ func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 				Path:      img.Path,
 				DockerRef: img.DockerRef,
 			}
-			entry.Size.LogicalBytes, entry.Size.PhysicalBytes, _ = diskstat.Stat(img.Path)
-			du.Images = append(du.Images, entry)
-		}
-
-		// _base is produced by the runtime when base_rootfs is a Docker ref,
-		// and is intentionally omitted from ListImages(). Resolve via the
-		// content-addressed blob store and stat the underlying rootfs.
-		// Skip when its path matches an existing entry — under content-
-		// addressing, _base often resolves to the same blob as a tagged
-		// variant, and double-counting would inflate `df` totals.
-		// Path comparison is digest-equivalent here: both go through
-		// BlobRootfsPath(imagesDir, digest), which is deterministic
-		// from the digest, and Resolve is called with no expectedRef so
-		// it never short-circuits on a mismatched manifest.SourceRef.
-		if basePath := vmimage.Resolve(imagesDir, "_base", ""); basePath != "" && !imagesContainPath(du.Images, basePath) {
-			if logical, physical, err := diskstat.Stat(basePath); err == nil {
-				baseRef := ""
-				if vmimage.IsDockerRef(c.cfg.BaseRootfs) {
-					baseRef = c.cfg.BaseRootfs
-				}
-				du.Images = append(du.Images, config.ImageDiskEntry{
-					Name:      "_base",
-					Path:      basePath,
-					DockerRef: baseRef,
-					Size:      config.DiskSize{LogicalBytes: logical, PhysicalBytes: physical},
-					IsBase:    true,
-				})
+			if img.Path != "" {
+				entry.Size.LogicalBytes, entry.Size.PhysicalBytes, _ = diskstat.Stat(img.Path)
 			}
+			// Fall back to the manifest-computed footprint (layers + lower)
+			// when there's no single statable lower file.
+			if entry.Size.LogicalBytes == 0 {
+				entry.Size.LogicalBytes = img.SizeBytes
+				entry.Size.PhysicalBytes = img.SizeBytes
+			}
+			du.Images = append(du.Images, entry)
 		}
 
 		orphans, err := systemprune.FindOrphans(imagesDir)
@@ -617,16 +599,4 @@ func truncateConsoleLogInPlace(path string, origSize, tailBytes int64) error {
 		return fmt.Errorf("write tail: %w", err)
 	}
 	return nil
-}
-
-// imagesContainPath reports whether any entry's Path equals path.
-// Used to dedupe `_base` when it resolves to the same blob as a
-// tagged variant under the content-addressed image layout.
-func imagesContainPath(entries []config.ImageDiskEntry, path string) bool {
-	for _, e := range entries {
-		if e.Path == path {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/vz/system.go
+++ b/internal/vz/system.go
@@ -43,6 +43,7 @@ func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 		if err != nil {
 			return du, fmt.Errorf("listing images: %w", err)
 		}
+		seenDigest := make(map[string]bool)
 		for _, img := range imgs {
 			if !img.Cached {
 				continue
@@ -52,14 +53,20 @@ func (c *Client) DiskUsage(ctx context.Context) (config.DiskUsage, error) {
 				Path:      img.Path,
 				DockerRef: img.DockerRef,
 			}
-			if img.Path != "" {
-				entry.Size.LogicalBytes, entry.Size.PhysicalBytes, _ = diskstat.Stat(img.Path)
-			}
-			// Fall back to the manifest-computed footprint (layers + lower)
-			// when there's no single statable lower file.
-			if entry.Size.LogicalBytes == 0 {
-				entry.Size.LogicalBytes = img.SizeBytes
-				entry.Size.PhysicalBytes = img.SizeBytes
+			// Count on-disk bytes once per content digest: multiple refs can
+			// point at the same cached manifest, but the blob exists once.
+			// Subsequent rows for the same digest stay visible with zero size.
+			if !seenDigest[img.Digest] {
+				if img.Path != "" {
+					entry.Size.LogicalBytes, entry.Size.PhysicalBytes, _ = diskstat.Stat(img.Path)
+				}
+				// Fall back to the manifest-computed footprint (layers + lower)
+				// when there's no single statable lower file.
+				if entry.Size.LogicalBytes == 0 {
+					entry.Size.LogicalBytes = img.SizeBytes
+					entry.Size.PhysicalBytes = img.SizeBytes
+				}
+				seenDigest[img.Digest] = true
 			}
 			du.Images = append(du.Images, entry)
 		}

--- a/internal/vz/system_prune_test.go
+++ b/internal/vz/system_prune_test.go
@@ -24,10 +24,10 @@ func newPruneTestClient(t *testing.T) (*Client, string, string) {
 	instanceDir := t.TempDir()
 
 	cfg := &config.VZConfig{
-		ImagesDir:   imagesDir,
-		InstanceDir: instanceDir,
-		Images:      map[string]string{},
-		BaseRootfs:  "",
+		ImagesDir:    imagesDir,
+		InstanceDir:  instanceDir,
+		ImageAliases: map[string]string{},
+		DefaultImage: "",
 	}
 	serverCfg := &config.ServerConfig{Name: "test-prune"}
 

--- a/internal/vz/system_test.go
+++ b/internal/vz/system_test.go
@@ -18,10 +18,10 @@ func newSystemTestClient(t *testing.T) (*Client, string, string) {
 	instanceDir := t.TempDir()
 
 	cfg := &config.VZConfig{
-		ImagesDir:   imagesDir,
-		InstanceDir: instanceDir,
-		Images:      map[string]string{},
-		BaseRootfs:  "ghcr.io/example/base:v1",
+		ImagesDir:    imagesDir,
+		InstanceDir:  instanceDir,
+		ImageAliases: map[string]string{},
+		DefaultImage: "ghcr.io/example/base:v1",
 	}
 	serverCfg := &config.ServerConfig{Name: "test-server"}
 
@@ -53,8 +53,8 @@ func TestDiskUsage_Empty(t *testing.T) {
 func TestDiskUsage_Populated(t *testing.T) {
 	client, imagesDir, instanceDir := newSystemTestClient(t)
 
-	// _base (discovered via tag indirection) + one variant (auto-discovered via ListImages).
-	createFakeImage(t, imagesDir, "_base")
+	// Two installed images, listed by their Docker ref identity.
+	createFakeImage(t, imagesDir, "base")
 	createFakeImage(t, imagesDir, "experimental")
 
 	// One stopped shed with a rootfs copy and a console.log.
@@ -89,13 +89,13 @@ func TestDiskUsage_Populated(t *testing.T) {
 		t.Fatalf("DiskUsage: %v", err)
 	}
 
-	// Must include both _base and experimental.
+	// Must include both images, keyed by their Docker ref.
 	names := map[string]bool{}
 	for _, img := range du.Images {
 		names[img.Name] = true
 	}
-	if !names["_base"] || !names["experimental"] {
-		t.Errorf("expected both _base and experimental; got images %+v", names)
+	if !names["ghcr.io/example/base:v1"] || !names["ghcr.io/example/experimental:v1"] {
+		t.Errorf("expected both base and experimental refs; got images %+v", names)
 	}
 
 	if len(du.Sheds) != 1 || du.Sheds[0].Name != "api-dev" {

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -27,11 +27,34 @@ systemctl daemon-reload || true
 systemctl enable shed-server.service || true
 
 if [ -n "${2:-}" ]; then
-    # Upgrade path. `try-restart` is the Debian-standard primitive for
-    # "restart only if the unit is already active". If the operator had
-    # stopped the service deliberately (maintenance window, config
-    # debugging) we don't surprise them by auto-starting it; we just
-    # swap binaries and leave activation state alone.
+    # Upgrade path. Config files are installed `noreplace`, so an operator
+    # upgrading across a breaking config change keeps their old
+    # /etc/shed/server.yaml. v0.6.0 removed base_rootfs + images in favor of
+    # default_image + image_aliases + pull_policy, and the new binary
+    # rejects the old keys — so a blind restart would crash the service.
+    # Preflight the config and SKIP the restart (pointing at the upgrade
+    # guide) when it no longer validates, rather than take the service down.
+    if ! shed-server --config /etc/shed/server.yaml config-validate >/dev/null 2>&1; then
+        echo ""
+        echo "shed-server was upgraded, but /etc/shed/server.yaml did not validate"
+        echo "against the new binary, so the service was NOT restarted (the old"
+        echo "process keeps running)."
+        echo ""
+        echo "This usually means the config still uses keys removed in v0.6.0"
+        echo "(base_rootfs / images). Migrate to default_image + image_aliases +"
+        echo "pull_policy, then restart:"
+        echo "  sudo shed-server --config /etc/shed/server.yaml config-validate"
+        echo "  sudo systemctl restart shed-server"
+        echo ""
+        echo "Upgrade guide: https://github.com/charliek/shed/blob/main/docs/upgrades/v0.5.9-to-v0.6.0.md"
+        exit 0
+    fi
+
+    # `try-restart` is the Debian-standard primitive for "restart only if
+    # the unit is already active". If the operator had stopped the service
+    # deliberately (maintenance window, config debugging) we don't surprise
+    # them by auto-starting it; we just swap binaries and leave activation
+    # state alone.
     if command -v deb-systemd-invoke >/dev/null 2>&1; then
         deb-systemd-invoke try-restart shed-server.service || true
     else

--- a/packaging/server.yaml.tmpl
+++ b/packaging/server.yaml.tmpl
@@ -40,11 +40,14 @@ vz:
   vfkit_path: vfkit
   kernel_path: ~/Library/Application Support/shed/vz/vmlinux
   initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-  base_rootfs: ghcr.io/charliek/shed-vz-full:v{{VERSION}}
-  images:
+  default_image: ghcr.io/charliek/shed-vz-full:v{{VERSION}}
+  # Optional convenience aliases for `shed create --image <alias>`.
+  image_aliases:
     base: ghcr.io/charliek/shed-vz-base:v{{VERSION}}
     extensions: ghcr.io/charliek/shed-vz-extensions:v{{VERSION}}
     full: ghcr.io/charliek/shed-vz-full:v{{VERSION}}
+  # missing (default) | always | never
+  pull_policy: missing
   instance_dir: ~/Library/Application Support/shed/vz/instances
   socket_dir: ~/.shed/vz/sockets
   default_cpus: 2
@@ -58,11 +61,14 @@ vz:
 
 firecracker:
   kernel_path: /var/lib/shed/firecracker/images/vmlinux
-  base_rootfs: ghcr.io/charliek/shed-fc-full:v{{VERSION}}
-  images:
+  default_image: ghcr.io/charliek/shed-fc-full:v{{VERSION}}
+  # Optional convenience aliases for `shed create --image <alias>`.
+  image_aliases:
     base: ghcr.io/charliek/shed-fc-base:v{{VERSION}}
     extensions: ghcr.io/charliek/shed-fc-extensions:v{{VERSION}}
     full: ghcr.io/charliek/shed-fc-full:v{{VERSION}}
+  # missing (default) | always | never
+  pull_policy: missing
   instance_dir: /var/lib/shed/firecracker/instances
   socket_dir: /var/run/shed/firecracker
   default_cpus: 2


### PR DESCRIPTION
## Summary

Reworks the VM image system to a Docker-style, **ref-keyed** model (PR 1 of 2 toward the v0.6.0 image-UX milestone). Motivated by a real upgrade-day failure: after a brew bump + config edit, `shed image ls` still showed an internal `_base` tag pinned to the old version, the old blob was un-addressable, and `shed create` silently reused it.

**Breaking config change** (no migration code — see the upgrade guide):

| Old (≤0.5.9) | New (0.6.0) |
|---|---|
| `base_rootfs: <ref>` | `default_image: <ref>` |
| `images: {…}` | `image_aliases: {…}` (optional) |
| _(none)_ | `pull_policy: missing` *(missing\|always\|never)* |

The unused top-level `default_image` is removed; the loader **rejects** the removed keys (instead of silently ignoring them, which would recreate the original bug).

### What changed
- **Identity = the Docker ref**, resolved O(1) via a `refs/<sha256(ref)>.json` sidecar index. `_base` is gone everywhere user-visible.
- **`pull_policy`** enforced in `EnsureImage`: `missing` (cache, pull if absent — fast/offline), `always` (always pull), `never` (error if absent). A configured version bump is now a cache miss → auto-pull on next create.
- **`ls`/`rm`/`prune` are ref-keyed**: `rm` takes a ref/digest/label, blocks only on live shed/snapshot pins, and leaves the blob for prune (Docker model); prune protects the configured `default_image`/alias digests.
- **Packaging**: template, brew formula heredoc, example/dev configs migrated. New `shed-server config-validate`; the deb postinstall **preflights the config and skips the restart** on an un-migrated config (no crash-loop).
- **Docs** + `docs/upgrades/v0.5.9-to-v0.6.0.md`.

### Reviews incorporated (pre-merge self-review)
- `/simplify` caught a divergent-ref bug (`:latest`/digest-pin/mirror configs): `RefIndexGet` was validating against the manifest's publish-time `source-ref` while the index is keyed by the *configured* ref → cache never hit. Fixed: validate the entry's own stored ref.
- `/codex:rescue` caught that `rm` (which leaves the blob) could be undone by a source-ref rebuild on the next create. Fixed: create resolves **sidecar-only** (so `rm` forces a re-pull); `rm`/`prune` use a read-only source-ref scan that never resurrects the sidecar.
- Regression tests added for both.

## Validation (real sheds, both platforms)
- **VZ (Apple/vfkit, this host)** — integration suite **51 passed, 1 skipped** against a dev server running this branch. Create `image` phase **6–7 ms** (O(1) ref-index); `test_create_agent_p50[vz]` gate passed.
- **Firecracker (KVM, mini3)** — integration suite **51 passed, 1 skipped** against a dev server running this branch. Create `image` phase **3 ms**; `test_create_agent_p50[fc]` gate passed.
- `make fmt && lint && test` green; both `go build` + `GOOS=linux go build` clean.

## Test plan
- [x] Unit tests updated to the new model + new regression tests (resolver/policy/ref-index/prune/rejection/divergent-ref/rm-no-resurrect)
- [x] VZ integration suite vs. dev build (real create cycles)
- [x] FC integration suite vs. dev build on mini3 (real create cycles)
- [x] Per-backend create-latency gate (no hot-path regression)
- [ ] PR 2 (additive UX: `ls` columns, `rm` warn-confirm, `prune` grouping, `list -vv` image, SSE pull progress) — separate branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a config-validate command to check server config before restart.
  * New pull_policy setting to control image pulling (missing/always/never).

* **Breaking Changes**
  * Server config format changed: per-backend default_image + image_aliases replace the old image layout — follow the v0.5.9→v0.6.0 upgrade guide.

* **Improvements**
  * Faster image cache lookups and more accurate disk-usage reporting.
  * Installer upgrade now pre-validates config and skips restart on invalid configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->