### PR TITLE
feat(images): PR2 image UX — pull progress, ref-keyed ls/rm/prune, list image

### DIFF
--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -235,23 +235,59 @@ func (c *APIClient) CreateShedWithProgress(req *config.CreateShedRequest, onProg
 		return nil, c.parseError(resp)
 	}
 
-	return c.readSSEStream(resp.Body, onProgress)
+	shed, err := c.readShedSSEStream(resp.Body, onProgress)
+	return shed, err
 }
 
-// readSSEStream parses an SSE event stream, calling onProgress for progress events
-// and returning the final Shed from the complete event.
+// readShedSSEStream is the create-shed wrapper around readSSEStream: it
+// decodes the terminal "complete" payload into a config.Shed.
+func (c *APIClient) readShedSSEStream(body io.Reader, onProgress func(backend.ProgressEvent)) (*config.Shed, error) {
+	data, err := c.readSSEStream(body, onProgress)
+	if err != nil {
+		return nil, err
+	}
+	var shed config.Shed
+	if err := json.Unmarshal(data, &shed); err != nil {
+		return nil, fmt.Errorf("failed to parse complete event: %w", err)
+	}
+	return &shed, nil
+}
+
+// readSSEStream parses an SSE event stream, calling onProgress for progress
+// events and returning the RAW JSON payload of the terminal "complete" event
+// (the caller decodes it into the operation-specific type — a Shed for create,
+// an ImagePullResponse for pull). An "error" event is surfaced as a Go error.
 //
 // This implements the key parts of the SSE specification:
 //   - "event:" sets the event type for the next dispatch
 //   - "data:" lines are concatenated (with newlines) to form the event payload
 //   - Lines starting with ":" are comments (used for keep-alive pings)
 //   - A blank line dispatches the accumulated event
-func (c *APIClient) readSSEStream(body io.Reader, onProgress func(backend.ProgressEvent)) (*config.Shed, error) {
+func (c *APIClient) readSSEStream(body io.Reader, onProgress func(backend.ProgressEvent)) ([]byte, error) {
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 256*1024), 256*1024)
 
 	var eventType string
 	var dataBuf strings.Builder
+
+	dispatch := func(eventType, data string) (done bool, payload []byte, err error) {
+		switch eventType {
+		case "progress":
+			var event backend.ProgressEvent
+			if uerr := json.Unmarshal([]byte(data), &event); uerr == nil && onProgress != nil {
+				onProgress(event)
+			}
+		case "complete":
+			return true, []byte(data), nil
+		case "error":
+			var apiErr config.APIError
+			if uerr := json.Unmarshal([]byte(data), &apiErr); uerr != nil {
+				return true, nil, fmt.Errorf("server error: %s", data)
+			}
+			return true, nil, fmt.Errorf("%s: %s", apiErr.Error.Code, apiErr.Error.Message)
+		}
+		return false, nil, nil
+	}
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -261,25 +297,8 @@ func (c *APIClient) readSSEStream(body io.Reader, onProgress func(backend.Progre
 			if dataBuf.Len() > 0 {
 				data := dataBuf.String()
 				dataBuf.Reset()
-
-				switch eventType {
-				case "progress":
-					var event backend.ProgressEvent
-					if err := json.Unmarshal([]byte(data), &event); err == nil && onProgress != nil {
-						onProgress(event)
-					}
-				case "complete":
-					var shed config.Shed
-					if err := json.Unmarshal([]byte(data), &shed); err != nil {
-						return nil, fmt.Errorf("failed to parse complete event: %w", err)
-					}
-					return &shed, nil
-				case "error":
-					var apiErr config.APIError
-					if err := json.Unmarshal([]byte(data), &apiErr); err != nil {
-						return nil, fmt.Errorf("server error: %s", data)
-					}
-					return nil, fmt.Errorf("%s: %s", apiErr.Error.Code, apiErr.Error.Message)
+				if done, payload, err := dispatch(eventType, data); done {
+					return payload, err
 				}
 			}
 			eventType = ""
@@ -308,25 +327,8 @@ func (c *APIClient) readSSEStream(body io.Reader, onProgress func(backend.Progre
 
 	// Handle a final event if EOF occurs before a trailing blank line.
 	if dataBuf.Len() > 0 {
-		data := dataBuf.String()
-		switch eventType {
-		case "complete":
-			var shed config.Shed
-			if err := json.Unmarshal([]byte(data), &shed); err != nil {
-				return nil, fmt.Errorf("failed to parse complete event: %w", err)
-			}
-			return &shed, nil
-		case "error":
-			var apiErr config.APIError
-			if err := json.Unmarshal([]byte(data), &apiErr); err != nil {
-				return nil, fmt.Errorf("server error: %s", data)
-			}
-			return nil, fmt.Errorf("%s: %s", apiErr.Error.Code, apiErr.Error.Message)
-		case "progress":
-			var event backend.ProgressEvent
-			if err := json.Unmarshal([]byte(data), &event); err == nil && onProgress != nil {
-				onProgress(event)
-			}
+		if done, payload, err := dispatch(eventType, dataBuf.String()); done {
+			return payload, err
 		}
 	}
 
@@ -436,6 +438,48 @@ func (c *APIClient) PullImage(dockerRef, tag, platform string) (*config.ImagePul
 		return nil, err
 	}
 	return &resp, nil
+}
+
+// PullImageWithProgress pulls a Docker reference and streams per-stage
+// progress via SSE (mirrors CreateShedWithProgress). Falls back to the
+// non-streaming PullImage path only if the server rejects the stream.
+func (c *APIClient) PullImageWithProgress(dockerRef, tag, platform string, onProgress func(backend.ProgressEvent)) (*config.ImagePullResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	bodyData, err := json.Marshal(config.ImagePullRequest{DockerRef: dockerRef, Tag: tag, Platform: platform})
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/images/pull", bytes.NewReader(bodyData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+
+	resp, err := (&http.Client{}).Do(httpReq)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("pull timed out after 30m")
+		}
+		return nil, fmt.Errorf("failed to connect to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	data, err := c.readSSEStream(resp.Body, onProgress)
+	if err != nil {
+		return nil, err
+	}
+	var out config.ImagePullResponse
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("failed to parse complete event: %w", err)
+	}
+	return &out, nil
 }
 
 // PushImage uploads the manifest held by source (tag or digest) to a

--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -471,11 +471,21 @@ func (c *APIClient) PullImageWithProgress(dockerRef, tag, platform string, onPro
 		return nil, c.parseError(resp)
 	}
 
+	var out config.ImagePullResponse
+	// Fall back to the non-streaming path against a server that ignores the
+	// Accept header (e.g. a pre-SSE shed-server): it returns a plain JSON
+	// ImagePullResponse with Content-Type application/json.
+	if !strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			return nil, fmt.Errorf("failed to decode pull response: %w", err)
+		}
+		return &out, nil
+	}
+
 	data, err := c.readSSEStream(resp.Body, onProgress)
 	if err != nil {
 		return nil, err
 	}
-	var out config.ImagePullResponse
 	if err := json.Unmarshal(data, &out); err != nil {
 		return nil, fmt.Errorf("failed to parse complete event: %w", err)
 	}

--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -799,6 +799,11 @@ func runImagePrune(_ *cobra.Command, _ []string) error {
 	// + aggregate size) and the constituent blobs (config/layers/kernel/
 	// initrd/erofs, size folded into their manifest). Group for display: one
 	// row per image by default, with the blob digests behind --verbose.
+	//
+	// Server contract (internal/vmimage Manager.PruneImages): only manifest
+	// candidates get DockerRef + aggregate SizeBytes set; blobs have both
+	// zero. This partition relies on that — if the server ever sizes blobs
+	// individually, give ImageInfo an explicit manifest/blob discriminator.
 	var images, blobs []config.ImageInfo
 	var totalSize int64
 	for _, img := range dryResp.Deleted {

--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -574,8 +574,13 @@ func runImageDelete(_ *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to list images: %w", err)
 		}
 		for i := range resp.Images {
-			if resp.Images[i].Name == name {
-				targetImage = &resp.Images[i]
+			img := &resp.Images[i]
+			// Match however the user referred to the image: by ref (Name),
+			// cosmetic tag, full or short digest.
+			if img.Name == name || img.Tag == name ||
+				img.Digest == name || vmimage.ShortDigest(img.Digest) == name ||
+				(img.Digest != "" && strings.HasPrefix(img.Digest, name)) {
+				targetImage = img
 				break
 			}
 		}

--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/version"
 	"github.com/charliek/shed/internal/vmimage"
@@ -78,9 +79,10 @@ var (
 	imageBuildOCIArchive   string
 	imageBuildToolsVersion string
 
-	imageDeleteForce bool
-	imagePruneForce  bool
-	imagePruneDryRun bool
+	imageDeleteForce  bool
+	imagePruneForce   bool
+	imagePruneDryRun  bool
+	imagePruneVerbose bool
 )
 
 var imageBuildCmd = &cobra.Command{
@@ -211,6 +213,7 @@ func init() {
 	imageDeleteCmd.Flags().BoolVar(&imageDeleteForce, "force", false, "Skip confirmation prompt")
 	imagePruneCmd.Flags().BoolVar(&imagePruneForce, "force", false, "Skip confirmation prompt")
 	imagePruneCmd.Flags().BoolVar(&imagePruneDryRun, "dry-run", false, "List candidates without deleting")
+	imagePruneCmd.Flags().BoolVarP(&imagePruneVerbose, "verbose", "v", false, "Show individual blob digests, not just per-image rows")
 	imagePullCmd.Flags().StringVarP(&imagePullTag, "tag", "t", "", "Tag name (default: derived from docker ref)")
 	imagePullCmd.Flags().StringVar(&imagePullPlatform, "platform", "", "Platform override for multi-arch images (e.g. linux/arm64). Empty means the backend's native platform.")
 	imagePushCmd.Flags().BoolVar(&imagePushLocal, "local", false, "Push from the local OCI store (no shed-server required). Implied when -c is set without -s.")
@@ -524,7 +527,8 @@ func runImageList(_ *cobra.Command, _ []string) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tDIGEST\tSOURCE\tSIZE\tIN USE\tREF")
+	// IMAGE is the Docker ref (the identity); SOURCE is config|user|dangling.
+	fmt.Fprintln(w, "IMAGE\tDIGEST\tSOURCE\tSIZE\tIN USE")
 	for _, img := range resp.Images {
 		size := "-"
 		if img.SizeBytes > 0 {
@@ -538,16 +542,12 @@ func runImageList(_ *cobra.Command, _ []string) error {
 		if img.InUse {
 			inUse = "yes"
 		}
-		ref := img.DockerRef
-		if ref == "" {
-			ref = "-"
-		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", img.Name, digest, img.Source, size, inUse, ref)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", img.Name, digest, img.Source, size, inUse)
 	}
 	w.Flush()
 	if !jsonFlag && len(resp.Images) > 0 {
 		fmt.Println()
-		fmt.Println("Use 'shed image rm <name>' to remove a tag, or 'shed image prune' to GC unused blobs.")
+		fmt.Println("Use 'shed image rm <image>' to remove an image, or 'shed image prune' to GC unused blobs.")
 	}
 	return nil
 }
@@ -582,6 +582,10 @@ func runImageDelete(_ *cobra.Command, args []string) error {
 	}
 
 	if !imageDeleteForce {
+		if targetImage != nil && targetImage.Source == "config" {
+			fmt.Fprintf(os.Stderr, "Warning: %q is referenced by the server config (default_image / image_aliases).\n", name)
+			fmt.Fprintln(os.Stderr, "Removing it means the next 'shed create' for this image will re-pull it.")
+		}
 		prompt := fmt.Sprintf("Delete image %q", name)
 		if targetImage != nil && targetImage.SizeBytes > 0 {
 			prompt += fmt.Sprintf(" (%s)", formatSize(targetImage.SizeBytes))
@@ -692,7 +696,16 @@ func runImagePull(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	client := NewAPIClientFromEntry(entry, DefaultTimeout)
-	resp, err := client.PullImage(dockerRef, tag, imagePullPlatform)
+	resp, err := client.PullImageWithProgress(dockerRef, tag, imagePullPlatform, func(event backend.ProgressEvent) {
+		if jsonFlag {
+			return
+		}
+		if event.Warning {
+			fmt.Fprintf(os.Stderr, "  Warning: %s\n", event.Message)
+		} else {
+			fmt.Printf("  %s\n", event.Message)
+		}
+	})
 	if err != nil {
 		return fmt.Errorf("failed to pull image: %w", err)
 	}
@@ -777,28 +790,44 @@ func runImagePrune(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	// Compute total size across all candidates
+	// Candidates are a mix of image-level rows (manifests, which carry a ref
+	// + aggregate size) and the constituent blobs (config/layers/kernel/
+	// initrd/erofs, size folded into their manifest). Group for display: one
+	// row per image by default, with the blob digests behind --verbose.
+	var images, blobs []config.ImageInfo
 	var totalSize int64
 	for _, img := range dryResp.Deleted {
-		totalSize += img.SizeBytes
+		if img.SizeBytes > 0 || img.DockerRef != "" {
+			images = append(images, img)
+			totalSize += img.SizeBytes
+		} else {
+			blobs = append(blobs, img)
+		}
 	}
 
-	// Show candidates table in non-JSON mode
 	if !jsonFlag {
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tSIZE\tREF")
-		for _, img := range dryResp.Deleted {
+		fmt.Fprintln(w, "IMAGE\tSIZE")
+		for _, img := range images {
+			name := img.Name
+			if img.DockerRef != "" {
+				name = img.DockerRef
+			}
 			size := "-"
 			if img.SizeBytes > 0 {
 				size = formatSize(img.SizeBytes)
 			}
-			ref := img.DockerRef
-			if ref == "" {
-				ref = "-"
-			}
-			fmt.Fprintf(w, "%s\t%s\t%s\n", img.Name, size, ref)
+			fmt.Fprintf(w, "%s\t%s\n", name, size)
 		}
 		w.Flush()
+		if imagePruneVerbose && len(blobs) > 0 {
+			fmt.Printf("\n%d constituent blob(s):\n", len(blobs))
+			for _, b := range blobs {
+				fmt.Printf("  %s\n", vmimage.ShortDigest(b.Digest))
+			}
+		} else if len(blobs) > 0 {
+			fmt.Printf("(+ %d constituent blob(s); use --verbose to list)\n", len(blobs))
+		}
 		fmt.Println()
 	}
 
@@ -806,7 +835,7 @@ func runImagePrune(_ *cobra.Command, _ []string) error {
 		if jsonFlag {
 			return outputJSON(config.PruneImagesResponse{Deleted: dryResp.Deleted})
 		}
-		fmt.Printf("Would prune %d image(s)", len(dryResp.Deleted))
+		fmt.Printf("Would prune %d image(s)", len(images))
 		if totalSize > 0 {
 			fmt.Printf(" (%s)", formatSize(totalSize))
 		}
@@ -815,7 +844,7 @@ func runImagePrune(_ *cobra.Command, _ []string) error {
 	}
 
 	if !imagePruneForce {
-		prompt := fmt.Sprintf("Delete %d image(s)", len(dryResp.Deleted))
+		prompt := fmt.Sprintf("Delete %d image(s)", len(images))
 		if totalSize > 0 {
 			prompt += fmt.Sprintf(" (%s)", formatSize(totalSize))
 		}
@@ -837,10 +866,14 @@ func runImagePrune(_ *cobra.Command, _ []string) error {
 	}
 
 	var freedSize int64
+	var prunedImages int
 	for _, img := range pruneResp.Deleted {
 		freedSize += img.SizeBytes
+		if img.SizeBytes > 0 || img.DockerRef != "" {
+			prunedImages++
+		}
 	}
-	msg := fmt.Sprintf("Pruned %d image(s)", len(pruneResp.Deleted))
+	msg := fmt.Sprintf("Pruned %d image(s)", prunedImages)
 	if freedSize > 0 {
 		msg += fmt.Sprintf(" (freed %s)", formatSize(freedSize))
 	}

--- a/cmd/shed/shed.go
+++ b/cmd/shed/shed.go
@@ -19,6 +19,7 @@ import (
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/sync"
 	"github.com/charliek/shed/internal/tunnels"
+	"github.com/charliek/shed/internal/vmimage"
 )
 
 var createCmd = &cobra.Command{
@@ -435,6 +436,9 @@ func runList(cmd *cobra.Command, args []string) error {
 				fmt.Printf("Server:         %s\n", s.server)
 			}
 			fmt.Printf("Created:        %s\n", s.shed.CreatedAt.Format("2006-01-02 15:04:05"))
+			if img := formatShedImage(s.shed); img != "" {
+				fmt.Printf("Image:          %s\n", img)
+			}
 			if s.shed.Status == config.StatusRunning {
 				// Use agent boot time for uptime if available
 				if s.shed.StartedAt != nil {
@@ -617,6 +621,22 @@ func valueOrDash(s string) string {
 		return "-"
 	}
 	return s
+}
+
+// formatShedImage renders the image a shed runs as "<label> (sha256:short)".
+// The label is the variant/ref the shed was created from; the short digest
+// pins the exact manifest. Returns "" when neither is known. Use
+// `shed image inspect <digest>` for the full ref.
+func formatShedImage(s config.Shed) string {
+	label := s.Image
+	if s.ImageDigest == "" {
+		return label
+	}
+	short := vmimage.ShortDigest(s.ImageDigest)
+	if label == "" {
+		return short
+	}
+	return fmt.Sprintf("%s (%s)", label, short)
 }
 
 func runDelete(cmd *cobra.Command, args []string) error {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
@@ -656,6 +657,7 @@ func (s *Server) handlePullImageSSE(w http.ResponseWriter, r *http.Request, req 
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
+	start := time.Now()
 	events := make(chan backend.ProgressEvent, 16)
 	sseFn := func(event backend.ProgressEvent) {
 		if event.Message == "" {
@@ -700,10 +702,11 @@ drain:
 	}
 
 	if res.err != nil {
-		log.Printf("PullImage failed for %q: %v", req.DockerRef, res.err)
+		log.Printf("PullImage failed for %q after %s: %v", req.DockerRef, time.Since(start).Round(time.Millisecond), res.err)
 		_, errCode, msg := mapBackendError(res.err)
 		writeSSEEvent(w, "error", config.NewAPIError(errCode, msg))
 	} else {
+		log.Printf("PullImage %q -> %s in %s", req.DockerRef, vmimage.ShortDigest(res.digest), time.Since(start).Round(time.Millisecond))
 		writeSSEEvent(w, "complete", config.ImagePullResponse{Tag: req.Tag, Digest: res.digest})
 	}
 	flusher.Flush()

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -628,6 +628,10 @@ func (s *Server) handlePullImage(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "tag: "+err.Error())
 		return
 	}
+	if strings.Contains(r.Header.Get("Accept"), "text/event-stream") {
+		s.handlePullImageSSE(w, r, req)
+		return
+	}
 	digest, err := s.backend.PullImage(r.Context(), req.DockerRef, req.Tag, req.Platform)
 	if err != nil {
 		code, errCode, msg := mapBackendError(err)
@@ -635,6 +639,74 @@ func (s *Server) handlePullImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, config.ImagePullResponse{Tag: req.Tag, Digest: digest})
+}
+
+// handlePullImageSSE streams pull progress as Server-Sent Events. The backend
+// already emits per-stage progress into the context via backend.Phase/Status
+// (see internal/vz/image.go, internal/firecracker/image.go), so we only need
+// to install a progress sink and forward the human-readable messages.
+func (s *Server) handlePullImageSSE(w http.ResponseWriter, r *http.Request, req config.ImagePullRequest) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, config.ErrBackendError, "streaming not supported")
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	events := make(chan backend.ProgressEvent, 16)
+	sseFn := func(event backend.ProgressEvent) {
+		if event.Message == "" {
+			return
+		}
+		select {
+		case events <- event:
+		default:
+		}
+	}
+	ctx := backend.ContextWithProgress(r.Context(), sseFn)
+
+	type pullResult struct {
+		digest string
+		err    error
+	}
+	done := make(chan pullResult, 1)
+	go func() {
+		digest, err := s.backend.PullImage(ctx, req.DockerRef, req.Tag, req.Platform)
+		done <- pullResult{digest, err}
+	}()
+
+	var res pullResult
+	for streaming := true; streaming; {
+		select {
+		case event := <-events:
+			writeSSEEvent(w, "progress", event)
+			flusher.Flush()
+		case res = <-done:
+			streaming = false
+		}
+	}
+drain:
+	for {
+		select {
+		case event := <-events:
+			writeSSEEvent(w, "progress", event)
+			flusher.Flush()
+		default:
+			break drain
+		}
+	}
+
+	if res.err != nil {
+		log.Printf("PullImage failed for %q: %v", req.DockerRef, res.err)
+		_, errCode, msg := mapBackendError(res.err)
+		writeSSEEvent(w, "error", config.NewAPIError(errCode, msg))
+	} else {
+		writeSSEEvent(w, "complete", config.ImagePullResponse{Tag: req.Tag, Digest: res.digest})
+	}
+	flusher.Flush()
 }
 
 // handlePushImage uploads the manifest held by the named tag (or by a

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -139,6 +139,7 @@ type Shed struct {
 	RootfsPath  string    `json:"rootfs_path,omitempty" yaml:"rootfs_path,omitempty"`
 	LocalDir    string    `json:"local_dir,omitempty" yaml:"local_dir,omitempty"`
 	Image       string    `json:"image,omitempty" yaml:"image,omitempty"`
+	ImageDigest string    `json:"image_digest,omitempty" yaml:"image_digest,omitempty"` // pinned manifest digest (sha256:...)
 	// FromSnapshot records the snapshot name this shed was spawned from (immediate parent only).
 	FromSnapshot string                         `json:"from_snapshot,omitempty" yaml:"from_snapshot,omitempty"`
 	LastHealthy  *time.Time                     `json:"last_healthy,omitempty" yaml:"last_healthy,omitempty"` // last heartbeat from agent (VM backends only)

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -389,6 +389,7 @@ func metadataToShed(meta *Metadata) *config.Shed {
 		RootfsPath:   meta.RootfsPath,
 		LocalDir:     meta.LocalDir,
 		Image:        meta.Image,
+		ImageDigest:  meta.LowerDigest,
 		FromSnapshot: meta.FromSnapshot,
 	}
 }

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -618,9 +618,13 @@ func (m *Manager) InspectImage(tagOrDigest string) (*ImageInfo, *OCIManifest, er
 	var configured, pulled bool
 	for _, ref := range m.configuredRefs() {
 		configuredRefSet[ref] = true
-		if d, ok := RefIndexGet(imagesDir, ref); ok && d == digest {
-			info.DockerRef = ref
-			configured = true
+		// First match wins (configuredRefs is default-first, sorted aliases),
+		// matching ListImages so inspect + list agree on the displayed ref.
+		if !configured {
+			if d, ok := RefIndexGet(imagesDir, ref); ok && d == digest {
+				info.DockerRef = ref
+				configured = true
+			}
 		}
 	}
 	if !configured {

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -398,18 +398,22 @@ func (m *Manager) ListImages() ([]ImageInfo, error) {
 		return nil, nil
 	}
 
-	// Refs the server config points at (default_image + alias values).
-	// A manifest whose source-ref is in this set is sourced from config;
-	// anything else with a source-ref was pulled ad-hoc by the user.
-	configuredRefs := map[string]bool{}
-	if dr := m.cfg.GetDefaultImage(); IsDockerRef(dr) {
-		configuredRefs[dr] = true
-	}
-	for _, v := range m.cfg.GetImageAliases() {
-		if IsDockerRef(v) {
-			configuredRefs[v] = true
+	// Map manifest digests to the ref the server config points at
+	// (default_image + alias values), resolved through the ref-index. A
+	// manifest in this set is sourced from config and displayed by its
+	// configured ref. Anything else with a ref-index entry was pulled
+	// ad-hoc by the user and displayed by the ref it was pulled by — NOT
+	// the manifest's publish-time source-ref, which differs for mutable
+	// tags / digest pins / mirrors.
+	configuredDigests := map[string]string{}
+	configuredRefSet := map[string]bool{}
+	for _, ref := range m.configuredRefs() {
+		configuredRefSet[ref] = true
+		if d, ok := RefIndexGet(imagesDir, ref); ok {
+			configuredDigests[d] = ref
 		}
 	}
+	pulledRefs := RefIndexReverse(imagesDir)
 
 	tags, err := ListTags(imagesDir)
 	if err != nil {
@@ -509,10 +513,28 @@ func (m *Manager) ListImages() ([]ImageInfo, error) {
 			Tag:    mi.tag,
 			Cached: mi.manifest != nil,
 		}
+		// Identity is the ref the image was pulled by (ref-index), with the
+		// configured ref taking precedence. Source-ref is the cold fallback
+		// for images that predate the ref-index (and lets a configured image
+		// still be recognized via its publish ref).
+		srcRef := ""
 		if mi.manifest != nil {
-			info.DockerRef = mi.manifest.ShedSourceRef()
+			srcRef = mi.manifest.ShedSourceRef()
 		}
-		// Identity is the Docker ref (io.shed.source-ref) when present.
+		var configured, pulled bool
+		switch {
+		case configuredDigests[mi.digest] != "":
+			info.DockerRef = configuredDigests[mi.digest]
+			configured = true
+		case configuredRefSet[srcRef]:
+			info.DockerRef = srcRef
+			configured = true
+		case pulledRefs[mi.digest] != "":
+			info.DockerRef = pulledRefs[mi.digest]
+			pulled = true
+		default:
+			info.DockerRef = srcRef // provenance only
+		}
 		switch {
 		case info.DockerRef != "":
 			info.Name = info.DockerRef
@@ -521,13 +543,13 @@ func (m *Manager) ListImages() ([]ImageInfo, error) {
 		default:
 			info.Name = ShortDigest(mi.digest)
 		}
-		// Source: config when the ref is what the server is configured to
-		// use; user when the operator labeled it with a cosmetic tag;
-		// dangling when it's an untagged, unconfigured leftover.
+		// Source: config when configured; user when addressable by a pulled
+		// ref or a cosmetic tag; dangling when it's an untagged, unconfigured
+		// leftover (even if it still carries a provenance source-ref).
 		switch {
-		case configuredRefs[info.DockerRef]:
+		case configured:
 			info.Source = "config"
-		case mi.tag != "":
+		case pulled || mi.tag != "":
 			info.Source = "user"
 		default:
 			info.Source = "dangling"
@@ -579,21 +601,52 @@ func (m *Manager) InspectImage(tagOrDigest string) (*ImageInfo, *OCIManifest, er
 	}
 
 	info := &ImageInfo{
-		Digest:    digest,
-		Tag:       tagName,
-		Cached:    BlobExists(imagesDir, digest),
-		DockerRef: manifest.ShedSourceRef(),
-		Source:    "user",
+		Digest: digest,
+		Tag:    tagName,
+		Cached: BlobExists(imagesDir, digest),
+		Source: "user",
 	}
-	if info.DockerRef != "" {
-		info.Name = info.DockerRef
-		if m.isConfiguredRef(info.DockerRef) {
-			info.Source = "config"
+	// Display by the ref the image was pulled by (ref-index), configured ref
+	// first; manifest source-ref is the cold fallback. Mirrors ListImages.
+	srcRef := manifest.ShedSourceRef()
+	configuredRefSet := map[string]bool{}
+	var configured, pulled bool
+	for _, ref := range m.configuredRefs() {
+		configuredRefSet[ref] = true
+		if d, ok := RefIndexGet(imagesDir, ref); ok && d == digest {
+			info.DockerRef = ref
+			configured = true
 		}
-	} else if tagName != "" {
-		info.Name = tagName
-	} else {
-		info.Name = ShortDigest(digest)
+	}
+	if !configured {
+		switch {
+		case configuredRefSet[srcRef]:
+			info.DockerRef = srcRef
+			configured = true
+		case RefIndexReverse(imagesDir)[digest] != "":
+			info.DockerRef = RefIndexReverse(imagesDir)[digest]
+			pulled = true
+		default:
+			info.DockerRef = srcRef // provenance only
+		}
+	}
+	switch {
+	case configured:
+		info.Name = info.DockerRef
+		info.Source = "config"
+	case pulled || tagName != "":
+		if info.DockerRef != "" {
+			info.Name = info.DockerRef
+		} else {
+			info.Name = tagName
+		}
+		info.Source = "user"
+	default:
+		if info.DockerRef != "" {
+			info.Name = info.DockerRef
+		} else {
+			info.Name = ShortDigest(digest)
+		}
 		info.Source = "dangling"
 	}
 	for _, layer := range manifest.Layers {
@@ -689,23 +742,6 @@ func (m *Manager) configuredRefs() []string {
 		}
 	}
 	return out
-}
-
-// isConfiguredRef reports whether ref is the configured default_image or one
-// of the configured image_aliases values.
-func (m *Manager) isConfiguredRef(ref string) bool {
-	if ref == "" {
-		return false
-	}
-	if m.cfg.GetDefaultImage() == ref {
-		return true
-	}
-	for _, v := range m.cfg.GetImageAliases() {
-		if v == ref {
-			return true
-		}
-	}
-	return false
 }
 
 // resolveDeleteTarget maps a user-supplied identifier (a cosmetic tag label,

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -410,7 +410,12 @@ func (m *Manager) ListImages() ([]ImageInfo, error) {
 	for _, ref := range m.configuredRefs() {
 		configuredRefSet[ref] = true
 		if d, ok := RefIndexGet(imagesDir, ref); ok {
-			configuredDigests[d] = ref
+			// First writer wins (configuredRefs is deterministically ordered:
+			// default_image, then sorted aliases) so two configured refs
+			// sharing one digest display stably.
+			if _, seen := configuredDigests[d]; !seen {
+				configuredDigests[d] = ref
+			}
 		}
 	}
 	pulledRefs := RefIndexReverse(imagesDir)
@@ -623,11 +628,13 @@ func (m *Manager) InspectImage(tagOrDigest string) (*ImageInfo, *OCIManifest, er
 		case configuredRefSet[srcRef]:
 			info.DockerRef = srcRef
 			configured = true
-		case RefIndexReverse(imagesDir)[digest] != "":
-			info.DockerRef = RefIndexReverse(imagesDir)[digest]
-			pulled = true
 		default:
-			info.DockerRef = srcRef // provenance only
+			if pref := RefIndexReverse(imagesDir)[digest]; pref != "" {
+				info.DockerRef = pref
+				pulled = true
+			} else {
+				info.DockerRef = srcRef // provenance only
+			}
 		}
 	}
 	switch {
@@ -730,18 +737,22 @@ func resolveDigestPrefix(imagesDir, prefix string) (string, error) {
 }
 
 // configuredRefs returns the Docker refs the server config currently points
-// at: the default_image plus every image_aliases value.
+// at: the default_image first, then every image_aliases value in sorted order.
+// The deterministic ordering lets callers (e.g. ListImages' first-writer-wins
+// digest map) display a stable ref when several configured refs share a digest.
 func (m *Manager) configuredRefs() []string {
 	var out []string
 	if dr := m.cfg.GetDefaultImage(); IsDockerRef(dr) {
 		out = append(out, dr)
 	}
+	var aliases []string
 	for _, v := range m.cfg.GetImageAliases() {
 		if IsDockerRef(v) {
-			out = append(out, v)
+			aliases = append(aliases, v)
 		}
 	}
-	return out
+	sort.Strings(aliases)
+	return append(out, aliases...)
 }
 
 // resolveDeleteTarget maps a user-supplied identifier (a cosmetic tag label,

--- a/internal/vmimage/manager_test.go
+++ b/internal/vmimage/manager_test.go
@@ -98,6 +98,42 @@ func TestManagerListImages(t *testing.T) {
 	}
 }
 
+// TestListImagesDisplaysConfiguredRefForDivergentTag guards the ref-keyed
+// display fix: an image pulled by a mutable tag (whose manifest source-ref is
+// the publish version) must be listed by the CONFIGURED ref and classified
+// "config" — not by the publish source-ref, which would drop it from the
+// config bucket.
+func TestListImagesDisplaysConfiguredRefForDivergentTag(t *testing.T) {
+	imagesDir := t.TempDir()
+	// Manifest published as :v0.6.0, but the operator configured/pulled :latest.
+	digest := installFakeBlob(t, imagesDir, "full", "ghcr.io/x/y:v0.6.0", []byte("body"))
+	if err := RefIndexPut(imagesDir, "ghcr.io/x/y:latest", digest); err != nil {
+		t.Fatalf("RefIndexPut: %v", err)
+	}
+	cfg := &testConfig{defaultImage: "ghcr.io/x/y:latest", imagesDir: imagesDir}
+	mgr := NewManager(cfg, nil)
+
+	got, err := mgr.ListImages()
+	if err != nil {
+		t.Fatalf("ListImages: %v", err)
+	}
+	var found *ImageInfo
+	for i := range got {
+		if got[i].Digest == digest {
+			found = &got[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("manifest %s not listed: %#v", digest, got)
+	}
+	if found.DockerRef != "ghcr.io/x/y:latest" {
+		t.Errorf("DockerRef = %q, want the configured ref ghcr.io/x/y:latest (not the publish source-ref)", found.DockerRef)
+	}
+	if found.Source != "config" {
+		t.Errorf("Source = %q, want config", found.Source)
+	}
+}
+
 func TestManagerInspectAndTag(t *testing.T) {
 	imagesDir := t.TempDir()
 	cfg := &testConfig{imagesDir: imagesDir}

--- a/internal/vmimage/refindex.go
+++ b/internal/vmimage/refindex.go
@@ -204,6 +204,11 @@ func RefIndexReverse(imagesDir string) map[string]string {
 		if err := json.Unmarshal(data, &entry); err != nil || entry.Digest == "" || entry.Ref == "" {
 			continue
 		}
+		// Skip entries whose manifest blob is gone so a broken/half-pruned
+		// image isn't displayed under a stale ref.
+		if !BlobExists(imagesDir, entry.Digest) {
+			continue
+		}
 		if _, ok := out[entry.Digest]; !ok {
 			out[entry.Digest] = entry.Ref
 		}

--- a/internal/vmimage/refindex.go
+++ b/internal/vmimage/refindex.go
@@ -180,6 +180,37 @@ func FindDigestBySourceRef(imagesDir, ref string) (digest string, ok bool) {
 	return "", false
 }
 
+// RefIndexReverse returns a digest -> ref map built from all sidecar entries
+// (first entry wins when several refs share a digest). Read-only; used by
+// `ls`/`inspect` so an image is displayed by the ref it was pulled by, not the
+// manifest's publish-time io.shed.source-ref (which differs for mutable tags,
+// digest pins, and mirrors).
+func RefIndexReverse(imagesDir string) map[string]string {
+	out := map[string]string{}
+	dir := filepath.Join(imagesDir, refIndexSubdir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return out
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var entry refIndexEntry
+		if err := json.Unmarshal(data, &entry); err != nil || entry.Digest == "" || entry.Ref == "" {
+			continue
+		}
+		if _, ok := out[entry.Digest]; !ok {
+			out[entry.Digest] = entry.Ref
+		}
+	}
+	return out
+}
+
 // RefIndexDeleteByDigest removes every ref-index entry pointing at digest.
 // Called by prune/rm after a manifest blob is deleted so a later resolve
 // can't hit a dangling entry. Best-effort: scan errors are logged, not fatal.

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -411,6 +411,7 @@ func metadataToShed(meta *Metadata, ipAddress string) *config.Shed {
 		RootfsPath:   meta.RootfsPath,
 		LocalDir:     meta.LocalDir,
 		Image:        meta.Image,
+		ImageDigest:  meta.LowerDigest,
 		FromSnapshot: meta.FromSnapshot,
 	}
 }


### PR DESCRIPTION
## Summary

PR 2 of 2 for the v0.6.0 image-UX milestone — the **additive UX layer** on top of the ref-keyed model from #168. No `shed create` behavior change; nothing here touches the boot/create hot path.

- **`shed image pull` streams progress** over SSE (like `shed create`). The server's `handlePullImage` gained an `Accept: text/event-stream` branch; `readSSEStream` was generalized to return the raw `complete` payload so create (`Shed`) and pull (`ImagePullResponse`) share it; `PullImageWithProgress` includes a Content-Type fallback to plain JSON so a new CLI still works against a pre-SSE server.
- **`shed image ls` is ref-keyed**: the `IMAGE` column is the Docker ref, and `ls`/`inspect` derive the displayed ref from the **ref-index** (configured ref first, then the pulled ref, then the manifest source-ref only as a cold fallback) — so a divergent tag (`:latest`, digest pin, mirror) shows the configured/pulled ref and stays in the `config` bucket. This completes the display finding CodeRabbit deferred from #168.
- **`shed image rm`** warns + confirms when the target is referenced by server config (`default_image` / `image_aliases`), matched by ref / tag / digest.
- **`shed image prune`** groups output by image (ref + reclaimed size + total); `--verbose` lists the constituent blob digests.
- **`shed list -vv`** shows each shed's image as `<label> (sha256:short)` (new `config.Shed.ImageDigest`, populated in both backends).

## Reviews incorporated (pre-merge)
- `/simplify`: added the missing non-streaming fallback in `PullImageWithProgress` (new-CLI/old-server pulls were spuriously failing); made the `ls` ref display deterministic when two configured refs share a digest; gated `RefIndexReverse` on blob presence; de-duplicated a double ref-index scan in `inspect`; broadened the `rm` warning match to digest/label.
- `/codex:rescue`: made `InspectImage` first-match-wins to agree with `ListImages`.

## Validation (real sheds, both platforms)
- **VZ (this host)** — integration suite **51 passed, 1 skipped** against a dev server on this branch.
- **Firecracker (mini3)** — integration suite **51 passed, 1 skipped** against a dev server on this branch.
- Manual against the VZ dev server: `shed image ls` shows full refs with `SOURCE=config`; `shed image pull` streams progress and completes over SSE.
- `make fmt && lint && test` green; both `go build` + `GOOS=linux go build` clean.

## Test plan
- [x] Unit tests: ref-index reverse/divergent-ref display, generalized SSE stream, prune grouping
- [x] VZ + FC integration suites vs. dev build (real create cycles)
- [x] Manual smoke of `ls` / `pull` (SSE) / `list -vv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image pull shows real-time streaming progress updates
  * Added verbose flag (-v/--verbose) to show blob digests during image prune

* **Improvements**
  * Shed verbose listing now shows backing image digest info
  * Image deletion accepts name, tag, full or partial digest for matching
  * Updated image list display format and improved prune output/messages

* **Tests**
  * Added coverage ensuring configured refs are preferred in image listings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->