### PR TITLE
docs(images): finish ref-keyed model docs pass + config/cleanup follow-ups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ Since v0.5.2 the read-only rootfs **erofs is built at image-publish time** by `m
 
 ## Storage Model
 
-Images are stored content-addressed under `{images_dir}/blobs/sha256/<digest>` (flat files, one per blob — manifests, configs, layer tar.gz, kernel, initrd, rootfs erofs). Tags live at `{images_dir}/tags/<tag>.json`. Each shed and snapshot pins the manifest digest in metadata so `shed image prune` can refcount-GC unreferenced blobs. Tags do NOT protect blobs from prune (Docker model). See `docs/reference/storage-model.md` for the full layout and the lifecycle commands (`shed image ls/inspect/tag/pull/rm/prune`).
+Images are stored content-addressed under `{images_dir}/blobs/sha256/<digest>` (flat files, one per blob — manifests, configs, layer tar.gz, kernel, initrd, rootfs erofs). Since v0.6.0 an image's identity is its **Docker ref** (the `io.shed.source-ref` annotation value), resolved O(1) through a ref-index at `{images_dir}/refs/<sha256(ref)>.json` (ref → manifest digest, written as the final commit of every pull/build). `shed create` resolves the configured ref (`default_image`, or `--image <alias|ref|/abs/path|label>`) through this index per `pull_policy` (missing|always|never). Tags (`{images_dir}/tags/<tag>.json`) are now optional cosmetic labels, decoupled from resolution; the internal `_base` tag was removed. Each shed and snapshot pins the manifest digest in metadata; `shed image prune` walks reachability (sheds, snapshots, every tag, and the configured `default_image`/`image_aliases` digests are protective). See `docs/reference/storage-model.md` for the full layout and lifecycle commands (`shed image ls/inspect/tag/pull/rm/prune`).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ shed create my-project --repo git@github.com:user/repo.git
 # Or mount a local directory as the workspace
 shed create my-project --local-dir ~/projects/my-project
 
-# Pick a specific image variant (base / extensions / full — full is the default)
+# Pick a specific image alias or ref (base / extensions / full; default_image is used otherwise)
 shed create big-project --image full --upper-size 20G
 ```
 
@@ -104,9 +104,9 @@ shed ssh-config >> ~/.ssh/config
 Both backends boot from **layered OCI images**. Each shed's rootfs is a
 stack of read-only ext4 layers (pulled registry-direct from `ghcr.io`,
 no Docker daemon needed) plus a per-shed writable upper layer, mounted
-together via overlayfs inside the guest. Three variants ship per
-backend: `base`, `extensions`, and `full`. See
-[Image Variants](docs/reference/images.md).
+together via overlayfs inside the guest. Three images ship per backend —
+`base`, `extensions`, and `full` — wired up as the backend's
+`default_image` and `image_aliases`. See [Images](docs/reference/images.md).
 
 ### VZ (macOS)
 
@@ -201,7 +201,7 @@ shed exec <name> <cmd>           # Run command in shed
 
 # Image Management
 shed image build                 # Build an OCI image from a Dockerfile
-shed image ls                    # List cached images (alias: list)
+shed image ls                    # List images by ref (SOURCE: config/user/dangling; alias: list)
 shed image history <tag>         # Show the layer stack for an image
 shed image inspect <tag-or-digest>  # Show manifest + annotations + digest
 shed image pull <ref>            # Pull an OCI image registry-direct
@@ -209,7 +209,7 @@ shed image push <src> <dst>      # Push a tag/digest to a registry (byte-perfect
 shed image save <tag> -o <file>  # Save an image to an OCI archive
 shed image load -i <file>        # Load an OCI archive into the local store
 shed image tag <src> <new>       # Point a new tag at an existing digest
-shed image rm <name>             # Remove a tag (alias: delete)
+shed image rm <ref|digest|label> # Remove an image from the ref-index (alias: delete)
 shed image prune                 # Reclaim unreferenced layer blobs
 
 # Session Management

--- a/cmd/shed/system_test.go
+++ b/cmd/shed/system_test.go
@@ -37,8 +37,8 @@ func sampleDiskUsage() config.DiskUsage {
 		Backend:     "vz",
 		GeneratedAt: time.Date(2026, 4, 20, 11, 23, 45, 0, time.UTC),
 		Images: []config.ImageDiskEntry{
-			{Name: "default", DockerRef: "ghcr.io/x/default:v1", Size: config.DiskSize{LogicalBytes: 5 * 1024 * 1024 * 1024, PhysicalBytes: 4 * 1024 * 1024 * 1024}},
-			{Name: "_base", IsBase: true, Size: config.DiskSize{LogicalBytes: 5 * 1024 * 1024 * 1024, PhysicalBytes: 0}},
+			{Name: "ghcr.io/x/default:v1", DockerRef: "ghcr.io/x/default:v1", Size: config.DiskSize{LogicalBytes: 5 * 1024 * 1024 * 1024, PhysicalBytes: 4 * 1024 * 1024 * 1024}},
+			{Name: "ghcr.io/x/extensions:v1", DockerRef: "ghcr.io/x/extensions:v1", Size: config.DiskSize{LogicalBytes: 5 * 1024 * 1024 * 1024, PhysicalBytes: 0}},
 		},
 		Kernel: &config.FileEntry{Path: "/tmp/vmlinux", Size: config.DiskSize{LogicalBytes: 8 * 1024 * 1024, PhysicalBytes: 8 * 1024 * 1024}, Kind: "kernel"},
 		Initrd: &config.FileEntry{Path: "/tmp/initrd", Size: config.DiskSize{LogicalBytes: 100 * 1024, PhysicalBytes: 100 * 1024}, Kind: "initrd"},
@@ -107,8 +107,8 @@ func TestRenderDF_Verbose(t *testing.T) {
 
 	for _, want := range []string{
 		"IMAGES (2)",
-		"default",
-		"_base",
+		"ghcr.io/x/default:v1",
+		"ghcr.io/x/extensions:v1",
 		"SHEDS (2)",
 		"api-dev",
 		"api-test",

--- a/configs/server.local.yaml
+++ b/configs/server.local.yaml
@@ -85,11 +85,11 @@ log_level: debug
 default_backend: firecracker
 
 firecracker:
-  default_image: ghcr.io/charliek/shed-fc-full:v0.5.0-dev
+  default_image: ghcr.io/charliek/shed-fc-full:v0.5.9
   image_aliases:
-    base: ghcr.io/charliek/shed-fc-base:v0.5.0-dev
-    extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.0-dev
-    full: ghcr.io/charliek/shed-fc-full:v0.5.0-dev
+    base: ghcr.io/charliek/shed-fc-base:v0.5.9
+    extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.9
+    full: ghcr.io/charliek/shed-fc-full:v0.5.9
   pull_policy: missing
   instance_dir: /var/lib/shed/firecracker/instances
   socket_dir: /var/run/shed/firecracker

--- a/configs/server.localfc.yaml
+++ b/configs/server.localfc.yaml
@@ -53,11 +53,11 @@ extensions:
 default_backend: firecracker
 
 firecracker:
-  default_image: ghcr.io/charliek/shed-fc-full:v0.5.0-dev
+  default_image: ghcr.io/charliek/shed-fc-full:v0.5.9
   image_aliases:
-    base: ghcr.io/charliek/shed-fc-base:v0.5.0-dev
-    extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.0-dev
-    full: ghcr.io/charliek/shed-fc-full:v0.5.0-dev
+    base: ghcr.io/charliek/shed-fc-base:v0.5.9
+    extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.9
+    full: ghcr.io/charliek/shed-fc-full:v0.5.9
   pull_policy: missing
   instance_dir: /var/lib/shed/firecracker/instances
   socket_dir: /var/run/shed/firecracker

--- a/configs/server.localmac.yaml
+++ b/configs/server.localmac.yaml
@@ -61,11 +61,11 @@ vz:
   #   default_image: ghcr.io/charliek/shed-vz-full:v0.5.9
   # See docs/reference/configuration.md for the ref-keyed image model.
 
-  default_image: ghcr.io/charliek/shed-vz-full:v0.5.0-dev
+  default_image: ghcr.io/charliek/shed-vz-full:v0.5.9
   image_aliases:
-    base: ghcr.io/charliek/shed-vz-base:v0.5.0-dev
-    extensions: ghcr.io/charliek/shed-vz-extensions:v0.5.0-dev
-    full: ghcr.io/charliek/shed-vz-full:v0.5.0-dev
+    base: ghcr.io/charliek/shed-vz-base:v0.5.9
+    extensions: ghcr.io/charliek/shed-vz-extensions:v0.5.9
+    full: ghcr.io/charliek/shed-vz-full:v0.5.9
   pull_policy: missing
   
   instance_dir: ~/Library/Application Support/shed/vz/instances

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -416,7 +416,7 @@ The core smoke tests in `test_smoke.py`:
 | `test_create_agent_p50` | `agent` phase p50 (5 samples) stays under a per-backend ceiling. Skips cleanly when the VZ upper-template fast path was unavailable (in-guest mkfs cost would inflate `agent_ms` for a structural reason that's not a real regression). |
 | `test_create_rootfs_template_present` | VZ-only: the host-side upper-template fast path is active (`rootfs_ms ≤ 100 ms`). Skips on FC (no host-side template path) and on VZ dev mode (where the fast path is unavailable by design). |
 | `test_shed_exec_smoke` | `shed exec <name> -- echo hello` returns `hello`. |
-| `test_extensions_image_smoke` | The `extensions` image variant carries the shed-extensions binaries at the documented paths with the executable bit. Skips when no `extensions` tag is configured. |
+| `test_extensions_image_smoke` | The `extensions` image carries the shed-extensions binaries at the documented paths with the executable bit. Skips when no `extensions` alias is configured. |
 
 `test_create_agent_p50` + `test_create_rootfs_template_present` are the **dynamic perf-regression gates** PR-time CI can't be (no `/dev/kvm` on GHA). The split replaced the single-gate `test_plain_create_timing` (renamed during PR #157) so the suite runs against either a brew/deb release binary or a `make build` dev binary without false-positive failures from the dev-build in-guest `mkfs.ext4` fallback. See the module-level comment in `tests/integration/test_smoke.py` for the split rationale, and `tests/integration/README.md` for the workflow guide.
 

--- a/docs/getting-started/fc-setup.md
+++ b/docs/getting-started/fc-setup.md
@@ -331,29 +331,28 @@ The script writes directly into the local blob store at
 
 ##### Configure server for local builds
 
-When you build images locally, the source `server.yaml` should **omit**
-`base_rootfs` and the `images:` map entirely. The runtime falls back to
-tag auto-discovery, and you pass the tag explicitly on `shed create`:
+When you build images locally, label them with `shed image build/pull -t
+<label>` and reference the label. Either set `default_image` to a label
+(used when no `--image` is passed) or pass `--image <label>` per create:
 
 ```yaml
 firecracker:
   instance_dir: /var/lib/shed/firecracker/instances
   socket_dir: /var/run/shed/firecracker
   images_dir: /var/lib/shed/firecracker/images
-  # no base_rootfs, no images: — tags resolved from the local blob store
+  default_image: full   # a local label, or a ghcr.io/...:vX ref
 ```
 
-Then pass `--image <tag>` on every create:
+Then create (omit `--image` to use `default_image`, or override per shed):
 
 ```bash
-shed create test --image full
-shed create dev  --image base
+shed create test            # uses default_image
+shed create dev --image base
 ```
 
-`base_rootfs` is treated as a literal path when it doesn't look like a
-Docker reference, so the bare tag form (`base_rootfs: full`) does not
-work today. Use either a fully-qualified `ghcr.io/...:vX` ref or omit
-the field and pass `--image`.
+`default_image` may be a Docker ref (`ghcr.io/...:vX`), an `image_aliases`
+name, a local label set with `-t`, or an absolute path to an ext4/erofs
+image. Docker refs are pulled on first use per `pull_policy`.
 
 ### Set Up Bridge Network
 

--- a/docs/getting-started/fc-setup.md
+++ b/docs/getting-started/fc-setup.md
@@ -91,10 +91,10 @@ Pull and convert VM images before creating your first shed:
 sudo shed-server pull-images
 ```
 
-This pulls each configured image registry-direct and lands the OCI
-blobs under `images_dir/blobs/sha256/`. The flattened erofs lower at
-`images_dir/cache/sha256/<manifest-digest>.erofs` is materialized
-lazily on first boot via host-native `mkfs.erofs --tar=f`.
+This pulls the `default_image` and every `image_aliases` ref
+registry-direct and lands the OCI blobs under `images_dir/blobs/sha256/`,
+including the pre-built rootfs erofs blob — mounted as-is on boot, with no
+host-side `mkfs.erofs` (since v0.5.2).
 
 The OCI image store lives under `/var/lib/shed/firecracker/images/`. See
 [Storage Model](../reference/storage-model.md) for the full layout and
@@ -305,7 +305,7 @@ Pin a concrete version. Once `v0.5.1` is tagged the corresponding
 images become available — check
 <https://github.com/charliek/shed/pkgs/container/shed-fc-full> for tags.
 
-See [Image Variants](../reference/images.md) for available images and
+See [Images](../reference/images.md) for available images and
 configuration details.
 
 #### Option B: Build from source

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -195,5 +195,5 @@ shed tunnels start myproj -t 3000:3000 -d
 - [Firecracker Setup (Linux)](fc-setup.md) - Set up the Firecracker backend
 - [CLI Reference](../reference/cli.md) - All available commands
 - [Configuration](../reference/configuration.md) - Client and server config options
-- [Extensions](../reference/extensions.md) - Credential brokering with the experimental image variant
+- [Extensions](../reference/extensions.md) - Credential brokering with the `extensions` image
 - [Tunnels](../reference/tunnels.md) - Port forwarding configuration

--- a/docs/getting-started/vz-setup.md
+++ b/docs/getting-started/vz-setup.md
@@ -137,11 +137,10 @@ not work with v0.5.0+ `shed-server`; v0.5.0 cached images use the
 per-layer cache layout and need a one-time
 `rm -rf {images_dir}/cache` on upgrade to v0.5.1.
 
-The first `shed create` pulls each layer blob, flattens them into a
-single erofs lower at `cache/sha256/<manifest-digest>.erofs`, and
-boots. Subsequent sheds from the same manifest reuse the cached erofs
-directly; other variants that share layer blobs skip the registry pull
-but build their own flattened erofs the first time they're used.
+The first `shed create` pulls the layer blobs plus the pre-built rootfs
+erofs blob (built at publish time, not on the host since v0.5.2) and
+boots from it directly. Subsequent sheds from the same manifest reuse the
+cached blobs; images that share layer blobs skip re-downloading them.
 
 #### Build images from source
 
@@ -160,7 +159,7 @@ This builds the `full` variant. Build other variants with `--variant`:
 The script writes directly into the local blob store and advances the
 `base`, `extensions`, and `full` tags. Confirm with `shed image ls`.
 
-See [Image Variants](../reference/images.md) for details. The OCI image
+See [Images](../reference/images.md) for details. The OCI image
 store lives under `~/Library/Application Support/shed/vz/` — see
 [Storage Model](../reference/storage-model.md) and the
 [upgrade-and-reclaim cookbook](../reference/images.md#cookbook-upgrading-image-versions) for how to manage disk space.

--- a/docs/getting-started/vz-setup.md
+++ b/docs/getting-started/vz-setup.md
@@ -167,29 +167,29 @@ store lives under `~/Library/Application Support/shed/vz/` — see
 
 #### Configure server for local builds
 
-When you build images locally, the source `server.yaml` should **omit**
-`base_rootfs` and the `images:` map entirely. The runtime falls back to
-tag auto-discovery, and you pass the tag explicitly on `shed create`:
+When you build images locally, label them with `shed image build/pull -t
+<label>` and reference the label. You can either set `default_image` to a
+label (used when no `--image` is passed) or omit it and pass `--image
+<label>` on every create:
 
 ```yaml
 vz:
   vfkit_path: vfkit
   instance_dir: ~/Library/Application Support/shed/vz/instances
   socket_dir: ~/.shed/vz/sockets
-  # no base_rootfs, no images: — tags resolved from the local blob store
+  default_image: full   # a local label, or a ghcr.io/...:vX ref
 ```
 
-Then pass `--image <tag>` on every create:
+Then create (omit `--image` to use `default_image`, or override per shed):
 
 ```bash
-shed create test --image full
-shed create dev  --image base
+shed create test            # uses default_image
+shed create dev --image base
 ```
 
-`base_rootfs` is treated as a literal path when it doesn't look like a
-Docker reference, so the bare tag form (`base_rootfs: full`) does not
-work today. Use either a fully-qualified `ghcr.io/...:vX` ref or omit
-the field and pass `--image`.
+`default_image` may be a Docker ref (`ghcr.io/...:vX`), an `image_aliases`
+name, a local label set with `-t`, or an absolute path to an ext4/erofs
+image. Docker refs are pulled on first use per `pull_policy`.
 
 ### 4. Create directories
 
@@ -269,7 +269,7 @@ working directory. `shed-server` without `--config` only looks at
 ```bash
 shed server add localhost
 shed server list                  # shows the registered name (e.g. "my-mac")
-shed create test --image full     # required when base_rootfs is omitted
+shed create test --image full     # required when default_image is omitted
 shed console test
 ```
 
@@ -297,7 +297,7 @@ The rootfs is a standard ext4 image, same as Firecracker. Each instance gets its
 : Check that you're running macOS 13+ (Ventura or later).
 
 **VM fails to boot**
-: Verify `kernel_path`, `initrd_path`, and `base_rootfs` point to valid files. Check that the rootfs was built successfully. Check the console log at `<instance_dir>/<name>/console.log` for boot messages.
+: Verify `kernel_path`, `initrd_path`, and `default_image` point to valid files (or a pullable ref). Check that the rootfs was built successfully. Check the console log at `<instance_dir>/<name>/console.log` for boot messages.
 
 **Health check timeout**
 : Check that vsock socket files exist in `~/.shed/vz/sockets/`. Verify vfkit is running with `ps aux | grep vfkit`. Check the console log for systemd boot errors.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -112,7 +112,7 @@ Creates a new shed.
 {
   "name": "codelens",
   "repo": "charliek/codelens",
-  "image": "shed-base:latest"
+  "image": "full"
 }
 ```
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -27,7 +27,7 @@ The `shed-server` exposes a REST API for managing sheds.
 | POST | `/api/snapshots` | Create a snapshot from a stopped shed |
 | GET | `/api/snapshots/{name}` | Get snapshot details |
 | DELETE | `/api/snapshots/{name}` | Delete a snapshot |
-| GET | `/api/images` | List available image variants |
+| GET | `/api/images` | List installed images (by Docker ref) |
 | GET | `/api/images/inspect/{name}` | Inspect a tag or digest (manifest + info) |
 | POST | `/api/images/tag` | Point a new tag at an existing digest |
 | POST | `/api/images/pull` | Pull a Docker reference into the blob store |
@@ -120,7 +120,7 @@ Creates a new shed.
 |-------|----------|---------|-------------|
 | `name` | Yes | - | Shed name (alphanumeric + hyphens) |
 | `repo` | No | null | Repository to clone (`owner/repo` shorthand or full URL) |
-| `image` | No | Server config | Image variant name (see [Image Variants](images.md)) |
+| `image` | No | `default_image` | Docker ref, `image_aliases` name, or local label (see [Images](images.md)) |
 | `backend` | No | Server default | Backend to use: `firecracker`, `vz`, or `detect` |
 | `local_dir` | No | null | Absolute path to host directory to mount as workspace (mutually exclusive with `repo`) |
 | `cpus` | No | Backend default | Number of vCPUs |
@@ -180,7 +180,7 @@ Without the `Accept: text/event-stream` header, the endpoint behaves synchronous
 | 400 | `INVALID_SHED_NAME` | Invalid name format |
 | 400 | `INVALID_REPO_URL` | Invalid repository URL |
 | 400 | `INVALID_LOCAL_DIR` | Invalid local directory path |
-| 400 | `INVALID_REQUEST` | No `image` specified and `base_rootfs` is not configured on the chosen backend, or `upper_size_bytes` is outside the 1–100 GiB range, or `from_snapshot` was passed together with `image`/`repo`. |
+| 400 | `INVALID_REQUEST` | No `image` specified and `default_image` is not configured on the chosen backend, or `upper_size_bytes` is outside the 1–100 GiB range, or `from_snapshot` was passed together with `image`/`repo`. |
 | 409 | `SHED_ALREADY_EXISTS` | Shed already exists |
 | 500 | `CLONE_FAILED` / `BACKEND_ERROR` | Backend or clone failure |
 
@@ -454,7 +454,7 @@ Lists all tmux sessions across all running sheds.
 
 ### GET /api/images
 
-Returns available image variants across all backends. Each entry is an
+Returns installed images across all backends, keyed by Docker ref. Each entry is an
 `ImageInfo`: tag-or-dangling-digest plus content-addressed metadata.
 
 **Response:**
@@ -674,16 +674,16 @@ Returns disk usage information for the server: image cache, per-instance rootfs 
   "generated_at": "2026-04-20T11:23:45Z",
   "images": [
     {
-      "name": "default",
-      "path": "/Users/alice/Library/Application Support/shed/vz/default-rootfs.ext4",
-      "docker_ref": "ghcr.io/example/default:v1",
+      "name": "ghcr.io/charliek/shed-vz-full:v0.6.0",
+      "path": "/Users/alice/Library/Application Support/shed/vz/blobs/sha256/abc.../rootfs.erofs",
+      "docker_ref": "ghcr.io/charliek/shed-vz-full:v0.6.0",
       "size": {"logical_bytes": 5368709120, "physical_bytes": 4831838208}
     },
     {
-      "name": "_base",
-      "path": "/Users/alice/Library/Application Support/shed/vz/_base-rootfs.ext4",
-      "size": {"logical_bytes": 5368709120, "physical_bytes": 0},
-      "is_base": true
+      "name": "ghcr.io/charliek/shed-vz-base:v0.6.0",
+      "path": "/Users/alice/Library/Application Support/shed/vz/blobs/sha256/def.../rootfs.erofs",
+      "docker_ref": "ghcr.io/charliek/shed-vz-base:v0.6.0",
+      "size": {"logical_bytes": 5368709120, "physical_bytes": 0}
     }
   ],
   "kernel": {
@@ -740,7 +740,7 @@ Returns disk usage information for the server: image cache, per-instance rootfs 
 - `console_log` is always absent on Firecracker (the FC SDK writes to stderr, not a per-instance file).
 - `initrd` is VZ-only — Firecracker has no initrd.
 - `physical_bytes` comes from `stat.Blocks * 512`. Files that share extents via clonefile/FICLONE or hardlinks may have those bytes counted against each referencing file, inflating sums.
-- `is_base` marks the runtime-managed `_base-rootfs.ext4` cache.
+- Images are keyed by their Docker ref (`name` == `docker_ref`); on-disk bytes are counted once per content digest even when several refs share it.
 
 **Multi-server aggregation:** the server never fans out; `shed system df --all` issues one request per configured server from the client and assembles the per-server results.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,7 +8,7 @@ Complete reference for the `shed` command-line interface.
     - `shed image build --from <ref>` — use [`shed image pull`](#shed-image-pull) instead. Pulls are now registry-direct via `go-containerregistry` and don't require a Docker daemon.
     - `shed image install` — host-side blob install. The same effect is now produced by `shed image build`, `shed image pull`, or `shed image load`.
 
-    The variant lineup also changed. The old `default`, `devtools`, and `experimental` variants are replaced by `base`, `extensions`, and `full`. See [Image Variants](images.md) for the new lineup.
+    The variant lineup also changed. The old `default`, `devtools`, and `experimental` variants are replaced by `base`, `extensions`, and `full`. See [Images](images.md) for the new lineup.
 
 ## Global Flags
 
@@ -420,10 +420,10 @@ If `--tag` is omitted, the tag is derived from the last path segment of
 the ref minus the `shed-{vz,fc}-` prefix and the version suffix (e.g.
 `ghcr.io/charliek/shed-vz-extensions:v0.5.1` → `extensions`).
 
-The flattened erofs lower at
-`cache/sha256/<manifest-digest>.erofs` is materialized lazily on first
-boot via host-native `mkfs.erofs --tar=f` — `pull` itself only writes
-blobs into `blobs/sha256/`.
+`pull` writes the image's blobs into `blobs/sha256/` — including the
+pre-built rootfs erofs blob (built at publish time since v0.5.2, mounted
+as-is with no host-side `mkfs.erofs`) — and records the ref→digest
+mapping in the ref-index.
 
 ### shed image push
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -332,7 +332,11 @@ removed in the OCI rollout.
 
 ### shed image ls
 
-Lists installed images by their Docker ref. The `SOURCE` column is `config` (the ref is the configured `default_image` or an `image_aliases` value), `user` (pulled or labeled ad-hoc), or `dangling` (an untagged, unconfigured leftover). `shed image list` is a deprecated alias.
+Lists installed images with their resolved Docker ref in the `IMAGE`
+column. The `SOURCE` column is `config` (the ref is the configured
+`default_image` or an `image_aliases` value), `user` (pulled or labeled
+ad-hoc), or `dangling` (an untagged, unconfigured leftover). `shed image
+list` is a deprecated alias.
 
 ```bash
 shed image ls
@@ -341,11 +345,11 @@ shed image ls
 **Output:**
 
 ```text
-NAME          DIGEST          SOURCE      SIZE      LAYERS   IN USE   REF
-base          sha256:abc123…  config      2.1 GB    1        yes      ghcr.io/charliek/shed-vz-base:v0.5.1
-extensions    sha256:7c2e5d…  config      2.3 GB    2        no       ghcr.io/charliek/shed-vz-extensions:v0.5.1
-full          sha256:def456…  config      3.8 GB    3        no       ghcr.io/charliek/shed-vz-full:v0.5.1
-sha256:ff…    sha256:ff8800…  dangling    2.0 GB    1        yes      ghcr.io/test/legacy:v1
+IMAGE                                       DIGEST          SOURCE    SIZE     IN USE
+ghcr.io/charliek/shed-vz-base:v0.6.0        sha256:abc123…  config    2.1 GB   yes
+ghcr.io/charliek/shed-vz-extensions:v0.6.0  sha256:7c2e5d…  config    2.3 GB   no
+ghcr.io/charliek/shed-vz-full:v0.6.0        sha256:def456…  config    3.8 GB   no
+ghcr.io/test/legacy:v1                      sha256:ff8800…  dangling  2.0 GB   no
 ```
 
 ### shed image history

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -332,7 +332,7 @@ removed in the OCI rollout.
 
 ### shed image ls
 
-Lists available image variants from server config plus any tags discovered in the blob store. `shed image list` is a deprecated alias.
+Lists installed images by their Docker ref. The `SOURCE` column is `config` (the ref is the configured `default_image` or an `image_aliases` value), `user` (pulled or labeled ad-hoc), or `dangling` (an untagged, unconfigured leftover). `shed image list` is a deprecated alias.
 
 ```bash
 shed image ls
@@ -510,7 +510,7 @@ shed image rm <name> [flags]
 |------|-------|---------|-------------|
 | `--force` | | `false` | Skip confirmation prompt |
 
-Following the Docker model, this removes the **tag** only — the underlying blob persists for `shed image prune` to garbage-collect once nothing references it. Config-managed tags (those listed in `images:` in server config, plus `_base` while `base_rootfs` is a Docker ref) cannot be removed by `image rm` — bump them via config instead.
+Accepts a Docker ref, a digest, or a cosmetic tag label. Following the Docker model, this drops the image's addressability (tags + ref-index entry) but leaves the underlying blob for `shed image prune` to garbage-collect once nothing references it. Removal is hard-blocked only when a live shed or snapshot still pins the manifest (matching `docker rmi`); removing an image referenced by server config (`default_image` / `image_aliases`) prompts for confirmation and means the next `shed create` for it re-pulls.
 
 **Note:** When using `--json`, the `--force` flag is required.
 
@@ -926,17 +926,17 @@ shed-server pull-images [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--variant` | All | Pull a specific image variant only |
+| `--variant` | All | Pre-pull only one selector (`default_image`, or an `image_aliases` name) |
 | `--config` | Auto-detect | Path to server config file |
 
 **Examples:**
 
 ```bash
-sudo shed-server pull-images                  # Pull all configured variants
-sudo shed-server pull-images --variant base   # Pull only the base variant
+sudo shed-server pull-images                  # Pull default_image + all aliases
+sudo shed-server pull-images --variant base   # Pull only the "base" alias
 ```
 
-Works on both macOS (VZ) and Linux (Firecracker). Uses the images configured in `server.yaml` for the active backend. When `base_rootfs` shares an OCI ref with any `images:` entry, the underlying manifest is deduplicated — `_base` and the variant tag point at the same digest without a second pull. See [Storage Model](storage-model.md) for the on-disk layout and the [upgrade cookbook](images.md#cookbook-upgrading-image-versions) in the images reference.
+Works on both macOS (VZ) and Linux (Firecracker). Pre-pulls the `default_image` and every `image_aliases` ref configured in `server.yaml` for the active backend. Refs that resolve to the same content-addressed manifest are pulled once. See [Storage Model](storage-model.md) for the on-disk layout and the [upgrade cookbook](images.md#cookbook-upgrading-image-versions) in the images reference.
 
 ### shed-server install
 

--- a/docs/reference/disk-management.md
+++ b/docs/reference/disk-management.md
@@ -25,7 +25,8 @@ Each server stores four kinds of data in its backend directory:
 | Orphan sidecars | `*.tmp` from a crashed install staging dir | Same | Partial or crashed image conversions | `shed system prune --orphans` |
 
 See [Storage Model](storage-model.md) for the content-addressed layout
-and [Image Variants](images.md) for how named tags resolve to digests.
+and [Images](images.md) for how Docker refs resolve to digests via the
+ref-index.
 
 ## Measuring usage with `shed system df`
 
@@ -63,7 +64,7 @@ The full flag table is in the [CLI reference](cli.md#system-disk-usage). The raw
 
 `shed system prune` runs a scoped cleanup pass with four scopes that can be combined:
 
-- `--images` — remove cached image variants that aren't referenced by config or any existing shed.
+- `--images` — remove cached images that aren't referenced by config (`default_image`/`image_aliases`) or any existing shed.
 - `--instances` — delete stopped sheds older than `--until` (default 72 h).
 - `--logs` — truncate VZ console logs to the last `--log-tail-bytes` (default 5 MiB). No-op on Firecracker.
 - `--orphans` — remove leftover state from crashed operations: `*.tmp` staging directories from interrupted image installs, partial snapshot directories whose `snapshot.json` never landed, and per-shed `uppers/<name>/` directories whose `metadata.json` was never written. Lock files are preserved to avoid an inode-reuse race, and any `.creating` marker fresher than 1 h keeps its directory in skipped status so in-flight operations aren't swept.
@@ -77,9 +78,9 @@ $ shed system prune
 SERVER: prod-mac (dry-run) --until 72h0m0s scope=images+instances+orphans
 
 IMAGES (2, 40.0 GB)
-NAME          PATH                                                                                       LOGICAL  PHYSICAL
-base          /Users/alice/Library/Application Support/shed/vz/blobs/sha256/abc123.../rootfs.ext4        20.0 GB  1.9 GB
-full          /Users/alice/Library/Application Support/shed/vz/blobs/sha256/def456.../rootfs.ext4        20.0 GB  3.2 GB
+NAME                                          PATH                                                                                  LOGICAL  PHYSICAL
+ghcr.io/charliek/shed-vz-base:v0.6.0          /Users/alice/Library/Application Support/shed/vz/blobs/sha256/abc123.../rootfs.erofs  20.0 GB  1.9 GB
+ghcr.io/charliek/shed-vz-full:v0.6.0          /Users/alice/Library/Application Support/shed/vz/blobs/sha256/def456.../rootfs.erofs  20.0 GB  3.2 GB
 
 SKIPPED (3)
 KIND      NAME/PATH                                                                            REASON

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -317,7 +317,7 @@ for env := range ch {
 
 ## shed-extensions
 
-The `extensions` and `full` image variants come with [shed-extensions](https://charliek.github.io/shed-extensions/) pre-installed, providing SSH agent forwarding and AWS credential proxying. `extensions` is the lightweight starting point (base OS + shed-extensions + Docker creds helper, no coding agents); `full` layers the coding agents on top. Create a shed with `--image extensions` (or `--image full` for the kitchen-sink default), enable extensions in your server config, and run the host agent to enable credential brokering.
+The `extensions` and `full` images come with [shed-extensions](https://charliek.github.io/shed-extensions/) pre-installed, providing SSH agent forwarding and AWS credential proxying. `extensions` is the lightweight starting point (base OS + shed-extensions + Docker creds helper, no coding agents); `full` layers the coding agents on top. Create a shed with `--image extensions` (or `--image full` for the kitchen-sink default), enable extensions in your server config, and run the host agent to enable credential brokering.
 
 shed-extensions is a concrete implementation built on this plugin bus. See the [shed-extensions documentation](https://charliek.github.io/shed-extensions/) for credential brokering setup and usage.
 

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -1,4 +1,4 @@
-# Image Variants
+# Images
 
 Shed images are OCI-compliant container images. The on-disk store is an
 [OCI image-layout-v1](https://github.com/opencontainers/image-spec/blob/main/image-layout.md)
@@ -36,7 +36,7 @@ If you're upgrading from v0.5.1 or earlier, see the
 breaking-change details and the required `shed image rm` / `pull-images`
 steps.
 
-## Available Variants
+## Available images
 
 | Variant | Description |
 |---------|-------------|

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -276,11 +276,12 @@ first `shed create` (no Docker daemon needed for pull):
 
     ```yaml
     vz:
-      base_rootfs: ghcr.io/charliek/shed-vz-full:v{version}
-      images:
+      default_image: ghcr.io/charliek/shed-vz-full:v{version}
+      image_aliases:
         base: ghcr.io/charliek/shed-vz-base:v{version}
         extensions: ghcr.io/charliek/shed-vz-extensions:v{version}
         full: ghcr.io/charliek/shed-vz-full:v{version}
+      pull_policy: missing
       images_dir: ~/Library/Application Support/shed/vz/
     ```
 
@@ -288,56 +289,76 @@ first `shed create` (no Docker daemon needed for pull):
 
     ```yaml
     firecracker:
-      base_rootfs: ghcr.io/charliek/shed-fc-full:v{version}
-      images:
+      default_image: ghcr.io/charliek/shed-fc-full:v{version}
+      image_aliases:
         base: ghcr.io/charliek/shed-fc-base:v{version}
         extensions: ghcr.io/charliek/shed-fc-extensions:v{version}
         full: ghcr.io/charliek/shed-fc-full:v{version}
+      pull_policy: missing
       images_dir: /var/lib/shed/firecracker/images
     ```
 
 ### Using local images
 
-If you build images locally, point to OCI references in a local
-registry or to tags already present in the blob store:
+If you build images locally, point `default_image` (and any aliases) at a
+local OCI ref, a ref in a local registry, or a cosmetic tag you applied with
+`shed image build/pull -t <label>`:
 
 ```yaml
 vz:
-  base_rootfs: full
-  images:
-    base: base
-    extensions: extensions
-    full: full
+  default_image: ghcr.io/charliek/shed-vz-full:dev
+  image_aliases:
+    base: my-base-label
 ```
 
-You can mix registry refs and local tags in the same config.
+You can mix registry refs and local labels in the same config.
 
-The `base_rootfs` field is the default when no `--image` flag is passed
-to `shed create`. The `images` map enables per-shed variant selection.
-`images_dir` is the OCI store root.
+`default_image` is the image used when no `--image` flag is passed to
+`shed create`. `image_aliases` is an optional convenience map for
+`shed create --image <alias>`. `images_dir` is the content-addressed OCI
+store root.
 
-### `base_rootfs` vs `images:`
+### Identity, `default_image`, and `image_aliases`
 
-- `images:` is a map of named variants. Each entry is selectable via
-  `shed create --image <name>`, pre-pullable via
-  `shed-server pull-images`, and visible in `shed image ls`.
-- `base_rootfs` is the fallback for `shed create` invocations without
-  `--image`. It's stored as the underscore-prefixed tag `_base` so it
-  doesn't collide with user-facing variant names.
+- An image's identity is its **Docker ref** (recorded as the
+  `io.shed.source-ref` manifest annotation and indexed by the ref it was
+  pulled by). `shed image ls` lists images by ref.
+- `default_image` is the ref `shed create` resolves when given no `--image`.
+- `image_aliases` are short names that resolve to a ref — `shed create
+  --image full` is shorthand for the aliased ref. Listings always show the
+  resolved ref, never the alias.
+- `pull_policy` controls cache-vs-pull (see [Pull policy](#pull-policy)
+  below). A version bump to `default_image` is a cache miss and re-pulls on
+  the next `shed create`.
 
-When `base_rootfs` matches an `images:` entry, the underlying manifest
-digest is shared — `_base` and the variant tag point at the same OCI
-manifest, and pulls deduplicate to a single layer set.
+When `default_image` and an alias point at the same ref, they converge on one
+content-addressed manifest — a single pull, shared layers.
 
-## Using Variants
+### Pull policy
+
+`pull_policy` (per backend) governs how `shed create` reconciles the
+configured ref against the local store:
+
+| Value | Behavior |
+|-------|----------|
+| `missing` (default) | Use the cached ref; pull only if absent. Fast and offline-tolerant. |
+| `always` | Always contact the registry and pull, even if cached. |
+| `never` | Use the cached ref; error if absent. Never contacts the registry. |
+
+Policy is ignored for local-path images and for the explicit
+`shed image pull` command. Avoid mutable tags (`:latest`) with `missing` —
+pin versioned tags so a cache hit is always the right image.
+
+## Using image aliases
 
 ```bash
 shed create myproject --image full        # batteries-included
 shed create myproject --image extensions  # credential brokering, no agents
 shed create tools --image base            # minimal
+shed create app --image ghcr.io/you/custom:v1   # any ref directly
 ```
 
-Default (no `--image` flag) uses `base_rootfs`:
+Default (no `--image` flag) uses `default_image`:
 
 ```bash
 shed create myproject

--- a/docs/reference/provisioning.md
+++ b/docs/reference/provisioning.md
@@ -245,7 +245,7 @@ The shed agent loads environment variables from `/etc/environment.d/*.conf` file
 
 Files are read in alphabetical order — later files can override values from earlier ones. Each file contains one `KEY=VALUE` pair per line. Blank lines and lines starting with `#` are ignored.
 
-The `full` image variant uses this mechanism to configure shed-extensions:
+The `full` image uses this mechanism to configure shed-extensions:
 
 ```dotenv
 # /etc/environment.d/shed-extensions.conf

--- a/docs/reference/snapshots.md
+++ b/docs/reference/snapshots.md
@@ -146,16 +146,17 @@ hosts), the pin's protection is bypassed and the lower may go missing.
 Lower digest:   sha256:abc123... (MISSING — pull or rebuild the image before spawning)
 
 Warning: this snapshot's lower image is no longer cached.
-  shed create --from-snapshot <snap> will fail until you pull/rebuild <tag>.
+  shed create --from-snapshot <snap> will fail until you pull/rebuild the original image <ref>.
 ```
 
 `shed create --from-snapshot` then fails fast with
 `BACKEND_ERROR: snapshot ... references lower digest sha256:... which is no
-longer cached; pull the original image (<tag>) first`. Recover by pulling
-the original image:
+longer cached; pull the original image (<ref>) first`. Recover by pulling
+the original image (the digest is what the snapshot pins; the tag/label is
+optional):
 
 ```bash
-shed image pull <docker-ref> -t <tag>
+shed image pull <docker-ref>
 shed create my-new-shed --from-snapshot <snap>
 ```
 

--- a/docs/reference/storage-model.md
+++ b/docs/reference/storage-model.md
@@ -17,7 +17,8 @@ For each VM backend, all on-disk state lives under a single `images_dir`:
   blobs/sha256/<hex>                            # FILES, not dirs — OCI blobs:
                                                 #   manifests, configs, layer tar.gz,
                                                 #   kernel, initrd, rootfs erofs
-  tags/<tag>.json                               # {"digest":"sha256:...","updated_at":"..."}
+  refs/<sha256(ref)>.json                       # {"ref":"...","digest":"sha256:..."} — Docker-ref index (drives create-time resolution)
+  tags/<tag>.json                               # {"digest":"sha256:...","updated_at":"..."} — optional cosmetic labels
   uppers/<shed>/upper.ext4                      # per-shed writable overlay upper
   instances/<shed>/metadata.json                # per-shed bookkeeping
   snapshots/<snap>/snapshot.json                # per-snapshot bookkeeping
@@ -53,18 +54,23 @@ See the [v0.5.1 → v0.5.2 upgrade guide](../upgrades/v0.5.1-to-v0.5.2.md).
 | **Layer blob** — gzipped tar at `blobs/sha256/<hex>` | Image layer |
 | **Rootfs erofs blob** — raw erofs at `blobs/sha256/<hex>` referenced by `io.shed.rootfs.erofs.digest` | (no direct analog — read-only root the VM mounts) |
 | **Kernel / initrd blobs** — raw binaries at `blobs/sha256/<hex>` referenced by `io.shed.kernel.digest` / `io.shed.initrd.digest` | (no direct analog — VM boot artifacts) |
-| **Tag** — `tags/<name>.json` pointing at a manifest digest | Image tag |
-| **Dangling manifest** — manifest with no tag and no shed/snapshot reference | `<none>:<none>` image |
+| **Ref-index entry** — `refs/<sha256(ref)>.json` mapping a Docker ref to a manifest digest | Registry name → digest (the resolution path) |
+| **Tag** — `tags/<name>.json` pointing at a manifest digest (optional cosmetic label) | Image tag |
+| **Dangling image** — manifest with no ref-index entry, no tag, and no shed/snapshot reference | `<none>:<none>` image |
 
-Two tags can point at the same manifest digest, and two manifests can
+Two refs can point at the same manifest digest, and two manifests can
 share layer blobs — both forms of sharing are zero extra disk cost.
 
 ## How a shed pins an image
 
-When `shed create --image extensions` runs, the server:
+When `shed create` runs (no `--image` uses the backend's `default_image`;
+`--image <alias|ref|/abs/path|label>` overrides it), the server:
 
-1. Resolves the `extensions` tag to a manifest digest via
-   `tags/extensions.json`.
+1. Resolves the configured ref (mapping an `image_aliases` name to its ref
+   first) to a manifest digest via the ref-index at
+   `refs/<sha256(ref)>.json`. This is an O(1) sidecar read; `pull_policy`
+   governs whether a cache miss pulls (`missing`/`always`) or errors
+   (`never`).
 2. Writes `instances/<name>/metadata.json` with
    `"lower_digest": "sha256:<manifest-digest>"`, `"schema_version": 3`,
    and the list of layer digests captured at create time.
@@ -74,8 +80,8 @@ When `shed create --image extensions` runs, the server:
 4. Creates the per-shed upper at `uppers/<name>/upper.ext4`.
 
 Subsequent `shed start` reads the same metadata. The shed boots from the
-exact manifest it was created against — re-tagging `extensions` to a new
-digest after the fact does not change what an existing shed boots.
+exact manifest it was created against — re-pulling the ref to a new digest
+after the fact does not change what an existing shed boots.
 
 ## Reachability and prune
 
@@ -91,9 +97,14 @@ digest after the fact does not change what an existing shed boots.
    kernel / initrd loose blobs, and the rootfs erofs blob via their
    respective annotations.)
 
-Tags do **not** protect blobs. Following the Docker model,
-`shed image rm <tag>` only removes the tag — the manifest and its layers
-stay until prune walks them out.
+The seed set also includes the digests the server config currently points
+at (`default_image` + every `image_aliases` ref, resolved through the
+ref-index) and every cosmetic tag, so a configured or labeled image isn't
+swept out from under a future `shed create`. Following the Docker model,
+`shed image rm <ref|digest|label>` removes an image's addressability (its
+ref-index entry + any tags) but leaves the manifest and its layers for
+prune to GC; it is hard-blocked only when a live shed or snapshot pins the
+manifest.
 
 Stopped sheds count as references. In-flight creates protect their
 target manifest for up to 1 hour via a `.creating` marker in
@@ -138,7 +149,7 @@ code. Quick reference:
 | `SHED-INIT-08` | Mounting the upper as ext4 failed |
 | `SHED-INIT-09` | `switch_root` failed (should never reach the user) |
 
-See [Image Variants → Boot stack](images.md#boot-stack) for the full
+See [Images → Boot stack](images.md#boot-stack) for the full
 description of each code.
 
 ## Atomicity and concurrency
@@ -149,13 +160,18 @@ Blob install is atomic:
 2. `fsync` the file.
 3. `rename` to `blobs/sha256/<hex>`; `fsync` the parent dir.
 
-Tag advancement follows the same pattern on `tags/<name>.json`.
+Ref-index and tag advancement follow the same temp-write + rename pattern
+on `refs/<sha256(ref)>.json` and `tags/<name>.json`. The ref-index entry
+is the final commit of a pull — written only after the manifest, all
+blobs, and the OCI index are durable, so a crash never leaves the index
+pointing at an incomplete digest.
 
 Concurrent installs of the same blob are serialized by a flock on
 `blobs/sha256/.<hex>.lock`. Concurrent `EnsureImage` calls for the same
-tag take a flock on `tags/<name>.lock`. Since v0.5.2 ships the erofs as
-a content-addressed blob there's no separate cache materialization
-lock — `EnsureImage` is pure pull + path resolution.
+ref take a flock keyed by the ref hash (so distinct refs never block each
+other). Since v0.5.2 ships the erofs as a content-addressed blob there's
+no separate cache materialization lock — `EnsureImage` is pure pull +
+path resolution.
 
 ## Lifecycle commands
 
@@ -166,27 +182,28 @@ lock — `EnsureImage` is pure pull + path resolution.
 | `shed image push <src> <dst>` | Push a tag or digest to a registry, byte-perfect |
 | `shed image save <tag> -o <file>` | Write a tag to an OCI archive (for air-gap transport) |
 | `shed image load -i <file>` | Load an OCI archive into the store |
-| `shed image ls` | List tags + dangling manifests |
+| `shed image ls` | List images by ref with a SOURCE column (config / user / dangling) |
 | `shed image history <tag>` | List layers (top-down) for a manifest |
-| `shed image inspect <tag-or-digest>` | Show manifest + annotations + cached path |
-| `shed image tag <src> <new>` | Point a new tag at an existing digest |
-| `shed image rm <tag>` | Remove a tag (blobs persist for prune to GC) |
-| `shed image prune` | Reachability-sweep unreachable blobs and flattened erofs files |
+| `shed image inspect <ref-or-digest>` | Show manifest + annotations + cached path |
+| `shed image tag <src> <new>` | Point a new cosmetic tag at an existing digest |
+| `shed image rm <ref\|digest\|label>` | Remove an image from the ref-index (blobs persist for prune to GC; blocked if a live shed/snapshot pins it) |
+| `shed image prune` | Reachability-sweep unreachable blobs, grouped by image |
 
-`shed create --image <tag>` resolves through the tag → manifest digest
-chain and materializes the flattened erofs lower lazily if it's not
-already cached.
+`shed create` with no `--image` resolves the backend's `default_image`;
+`--image <alias\|ref\|/abs/path\|label>` resolves through the ref-index to
+a manifest digest. The read-only lower is the pre-built erofs blob the
+manifest references — no host-side materialization.
 
-## Tag updates don't propagate to existing sheds
+## Re-pulling a ref doesn't propagate to existing sheds
 
 A shed's metadata pins the manifest digest its lower was resolved from
-at create time, not the tag string. After
-`shed image pull <ref> -t full` advances the `full` tag to a new digest,
+at create time, not the ref string. After
+`shed image pull <ref>` advances the ref-index to a new digest,
 existing sheds keep booting from the old digest. `shed stop && shed start`
-re-reads the metadata and does not re-resolve the tag. This is
+re-reads the metadata and does not re-resolve the ref. This is
 intentional: live re-resolution would change the read-only lowers out
 from under a running guest. To roll a shed onto new content,
-`shed delete <name>` and `shed create <name> --image full`.
+`shed delete <name>` and `shed create <name> --image <ref>`.
 
 ## Why this matters
 
@@ -198,8 +215,8 @@ from under a running guest. To roll a shed onto new content,
 - **Byte-perfect push.** `shed image push <local-tag> <remote-ref>`
   produces a manifest at the destination whose digest matches the local
   manifest digest.
-- **Layer sharing across variants.** `base`, `extensions`, and `full`
-  share base layers; pulling all three is barely more than pulling
+- **Layer sharing across images.** The `base`, `extensions`, and `full`
+  images share base layers; pulling all three is barely more than pulling
   `full`.
 - **Reachability-based GC.** Prune walks from the live shed and
   snapshot set, so unreferenced layers go away even if they were once
@@ -208,6 +225,6 @@ from under a running guest. To roll a shed onto new content,
   across every shed pinning the same manifest; host filesystem reflink
   support is no longer load-bearing.
 
-See also: [Image Variants](images.md),
+See also: [Images](images.md),
 [Disk Management](disk-management.md), [Snapshots](snapshots.md),
 [Layer storage optimization](../discovery/layer-storage-optimization.md).

--- a/docs/tutorials/build-your-own-image.md
+++ b/docs/tutorials/build-your-own-image.md
@@ -265,12 +265,13 @@ default, edit your server config:
 
 ```yaml
 vz:
-  base_rootfs: my-image          # or the full ghcr.io ref
-  images:
+  default_image: my-image        # a local label (-t), or the full ghcr.io ref
+  image_aliases:
     base: ghcr.io/charliek/shed-vz-base:v0.5.1
     extensions: ghcr.io/charliek/shed-vz-extensions:v0.5.1
     full: ghcr.io/charliek/shed-vz-full:v0.5.1
     my-image: ghcr.io/myorg/my-shed-image:v1
+  pull_policy: missing
 ```
 
 Restart the server. Subsequent `shed create <name>` calls without

--- a/docs/tutorials/build-your-own-image.md
+++ b/docs/tutorials/build-your-own-image.md
@@ -294,7 +294,7 @@ To roll a shed onto the new image, `shed delete devbox` and recreate.
 
 ## See also
 
-- [Image Variants](../reference/images.md) — the full variant lineup,
+- [Images](../reference/images.md) — the full variant lineup,
   annotations, and the boot stack.
 - [Storage Model](../reference/storage-model.md) — how the OCI store
   is laid out on disk.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -348,8 +348,6 @@ type ImageDiskEntry struct {
 	Path      string   `json:"path"`
 	DockerRef string   `json:"docker_ref,omitempty"`
 	Size      DiskSize `json:"size"`
-	// IsBase is true for the _base-rootfs.ext4 cache entry.
-	IsBase bool `json:"is_base,omitempty"`
 }
 
 // ShedDiskEntry describes one shed's per-instance disk footprint.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,7 +109,7 @@ nav:
       - Provisioning: reference/provisioning.md
       - Firecracker Operations: reference/fc-operations.md
       - VZ Operations (macOS): reference/vz-operations.md
-      - Image Variants: reference/images.md
+      - Images: reference/images.md
       - Build Tools: reference/build-tools.md
       - Extensions: reference/extensions.md
       - HTTP API: reference/api.md


### PR DESCRIPTION
## Summary

Follow-up cleanup to the v0.6.0 image rework (#168 / #169) — docs, example configs, and a dead-field removal. No behavior change beyond removing an unused API field.

- **Docs pass** for the residual prose still describing the old `base_rootfs` + `images:` + `_base` + tag-auto-discovery model:
  - `reference/images.md` — rewrote the identity / `default_image` / `image_aliases` / `pull_policy` sections (added a pull-policy table).
  - `reference/cli.md` — `ls` SOURCE semantics, `rm` (ref/digest/label + live-pin-only block + config warning), `pull-images` (default_image + aliases).
  - `reference/api.md` — `/api/system/df` example (ref-keyed, dropped `is_base`), `/api/images` description, create `INVALID_REQUEST` (`default_image`).
  - `getting-started/{vz,fc}-setup.md` — local-build config (label/ref, no more "omit + auto-discover").
  - `tutorials/build-your-own-image.md`, `development/testing.md`.
- **configs/**: bumped the stale `v0.5.0-dev` local examples (`server.local` / `localfc` / `localmac`) to `v0.5.9` so they reference pullable images.
- **Cleanup**: removed the now-dead `ImageDiskEntry.IsBase` field (nothing produces it after the `_base` removal) + updated the `df` renderer test to ref-keyed names.

## Test plan
- [x] `make fmt && lint && test` green; `go build` + `GOOS=linux go build` clean
- [x] Repo grep confirms no stale `base_rootfs` / `_base` / `is_base` / `images:`-map references remain outside the historical + v0.5.9→v0.6.0 upgrade guides

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features & Updates**
  * Pinned container images to v0.5.9 and formalized default_image + image_aliases usage.

* **Bug Fixes**
  * Removed an obsolete disk-usage field from the API output.

* **Documentation**
  * Revised setup guides, API reference, CLI docs, storage-model and tutorials to reflect image alias/ref behavior, pull policies, and storage layout.

* **Tests**
  * Updated test fixtures and expectations to use the new image identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->