### PR TITLE
feat(images): expose alias + is_default on the images API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Images API: `alias` + `is_default` metadata (#171)
+
+`GET /api/images` (and `shed --json image ls`) now label each config-sourced
+image with its friendly `image_aliases` key (`alias`) and flag the
+`default_image` entry (`is_default`). Both fields are additive and
+`omitempty`, so existing clients and the `shed image ls` table view are
+unchanged. This lets the shed-desktop New-Shed picker list aliases by name
+with the default preselected, instead of requiring a raw ref. Also corrects
+the documented `source` values to `config` / `user` / `dangling`.
+
 ## v0.6.0 — 2026-06-03
 
 Image-system milestone: VM images move to a **Docker-style, ref-keyed

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -471,7 +471,9 @@ Returns installed images across all backends, keyed by Docker ref. Each entry is
       "cached": true,
       "digest": "sha256:abc123...",
       "tag": "base",
-      "in_use": true
+      "in_use": true,
+      "alias": "base",
+      "is_default": true
     },
     {
       "name": "sha256:ff8800...",
@@ -491,11 +493,13 @@ Returns installed images across all backends, keyed by Docker ref. Each entry is
 | `path` | string | Blob rootfs path (empty if not cached) |
 | `docker_ref` | string | Docker image reference (empty for local-only images) |
 | `size_bytes` | int | File size in bytes (0 if not cached) |
-| `source` | string | `config` (from server config), `discovered` (in blob store), or `dangling` (blob with no tag) |
+| `source` | string | `config` (from server config), `user` (pulled or tagged ad-hoc), or `dangling` (blob with no tag) |
 | `cached` | bool | Whether the underlying blob exists locally |
 | `digest` | string | Content digest (`sha256:...`) of the blob; empty when the image is uncached |
 | `tag` | string | Tag name pointing at this blob; empty for dangling entries |
 | `in_use` | bool | True when any existing shed or snapshot pins this digest |
+| `alias` | string | Friendly `image_aliases` key (e.g. `base`); set only on `config` images, omitted otherwise |
+| `is_default` | bool | True for the `config` image whose ref is the backend's `default_image`; omitted otherwise |
 
 ### GET /api/images/inspect/{name}
 
@@ -516,7 +520,9 @@ truncated).
     "cached": true,
     "digest": "sha256:abc123...",
     "tag": "full",
-    "in_use": false
+    "in_use": false,
+    "alias": "full",
+    "is_default": true
   },
   "manifest": {
     "schema_version": 1,

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -234,11 +234,16 @@ type ImageInfo struct {
 	Path      string `json:"path,omitempty"`
 	DockerRef string `json:"docker_ref,omitempty"`
 	SizeBytes int64  `json:"size_bytes,omitempty"`
-	Source    string `json:"source"` // "config", "discovered", or "dangling"
+	Source    string `json:"source"` // "config", "user", or "dangling"
 	Cached    bool   `json:"cached"`
 	Digest    string `json:"digest,omitempty"` // "sha256:..." digest of the blob
 	Tag       string `json:"tag,omitempty"`    // tag name pointing at this blob
 	InUse     bool   `json:"in_use,omitempty"` // protected by a shed/snapshot reference
+	// Alias is the friendly image_aliases key (e.g. "base"), set only for
+	// config-sourced images; empty for user-pulled or dangling blobs.
+	Alias string `json:"alias,omitempty"`
+	// IsDefault is true for the config image whose ref is default_image.
+	IsDefault bool `json:"is_default,omitempty"`
 }
 
 // ImageInspectResponse is returned by GET /api/images/{tag-or-digest}.

--- a/internal/firecracker/image.go
+++ b/internal/firecracker/image.go
@@ -199,6 +199,8 @@ func toConfigImageInfo(img vmimage.ImageInfo) config.ImageInfo {
 		Digest:    img.Digest,
 		Tag:       img.Tag,
 		InUse:     img.InUse,
+		Alias:     img.Alias,
+		IsDefault: img.IsDefault,
 	}
 }
 

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -55,9 +55,11 @@ type ImageInfo struct {
 	SizeBytes   int64  // sum of layer descriptor sizes + cached ext4 bytes
 	UniqueBytes int64  // bytes attributable to layers only this manifest references
 	SharedBytes int64  // bytes attributable to layers also referenced by other manifests
-	Source      string // "config", "discovered", or "dangling"
+	Source      string // "config", "user", or "dangling"
 	Cached      bool   // manifest blob is installed
 	InUse       bool   // protected by a shed or snapshot reference
+	Alias       string // friendly image_aliases key (empty for user/dangling)
+	IsDefault   bool   // this image's ref is the configured default_image
 }
 
 // Manager handles image lifecycle: ensure, list, delete, prune.
@@ -418,6 +420,8 @@ func (m *Manager) ListImages() ([]ImageInfo, error) {
 			}
 		}
 	}
+	// Labels for config-sourced images: alias key + which ref is the default.
+	aliasByRef, defaultRef := m.configuredImageLabels()
 	pulledRefs := RefIndexReverse(imagesDir)
 
 	tags, err := ListTags(imagesDir)
@@ -540,6 +544,10 @@ func (m *Manager) ListImages() ([]ImageInfo, error) {
 		default:
 			info.DockerRef = srcRef // provenance only
 		}
+		if configured {
+			info.Alias = aliasByRef[info.DockerRef]
+			info.IsDefault = info.DockerRef == defaultRef
+		}
 		switch {
 		case info.DockerRef != "":
 			info.Name = info.DockerRef
@@ -611,6 +619,7 @@ func (m *Manager) InspectImage(tagOrDigest string) (*ImageInfo, *OCIManifest, er
 		Cached: BlobExists(imagesDir, digest),
 		Source: "user",
 	}
+	aliasByRef, defaultRef := m.configuredImageLabels()
 	// Display by the ref the image was pulled by (ref-index), configured ref
 	// first; manifest source-ref is the cold fallback. Mirrors ListImages.
 	srcRef := manifest.ShedSourceRef()
@@ -645,6 +654,8 @@ func (m *Manager) InspectImage(tagOrDigest string) (*ImageInfo, *OCIManifest, er
 	case configured:
 		info.Name = info.DockerRef
 		info.Source = "config"
+		info.Alias = aliasByRef[info.DockerRef]
+		info.IsDefault = info.DockerRef == defaultRef
 	case pulled || tagName != "":
 		if info.DockerRef != "" {
 			info.Name = info.DockerRef
@@ -757,6 +768,26 @@ func (m *Manager) configuredRefs() []string {
 	}
 	sort.Strings(aliases)
 	return append(out, aliases...)
+}
+
+// configuredImageLabels returns a configured-ref -> friendly image_aliases key
+// map plus the default_image ref, for labelling config-sourced images in
+// ListImages / InspectImage. Sorted + first-writer-wins so two aliases sharing
+// one ref resolve to a stable name (mirrors configuredRefs' ordering).
+func (m *Manager) configuredImageLabels() (aliasByRef map[string]string, defaultRef string) {
+	aliases := m.cfg.GetImageAliases()
+	aliasByRef = make(map[string]string, len(aliases))
+	names := make([]string, 0, len(aliases))
+	for name := range aliases {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if ref := aliases[name]; aliasByRef[ref] == "" {
+			aliasByRef[ref] = name
+		}
+	}
+	return aliasByRef, m.cfg.GetDefaultImage()
 }
 
 // resolveDeleteTarget maps a user-supplied identifier (a cosmetic tag label,

--- a/internal/vmimage/manager_test.go
+++ b/internal/vmimage/manager_test.go
@@ -134,6 +134,66 @@ func TestListImagesDisplaysConfiguredRefForDivergentTag(t *testing.T) {
 	}
 }
 
+// TestListImagesAliasAndDefault pins the picker-enabling metadata: a
+// config image carries its friendly image_aliases key, exactly the
+// default_image entry reports IsDefault, and a user-pulled image (neither
+// default nor aliased) carries neither.
+func TestListImagesAliasAndDefault(t *testing.T) {
+	imagesDir := t.TempDir()
+	cfg := &testConfig{
+		defaultImage: "ghcr.io/example/full:v1",
+		imageAliases: map[string]string{
+			"full": "ghcr.io/example/full:v1", // also the default
+			"base": "ghcr.io/example/base:v1",
+		},
+		imagesDir: imagesDir,
+	}
+	mgr := NewManager(cfg, nil)
+
+	installFakeBlob(t, imagesDir, "full", "ghcr.io/example/full:v1", []byte("full-body"))
+	installFakeBlob(t, imagesDir, "base", "ghcr.io/example/base:v1", []byte("base-body"))
+	// A user-pulled image: addressable by its ref-index entry, not configured.
+	pulled := installFakeBlob(t, imagesDir, "scratch", "ghcr.io/example/scratch:v1", []byte("scratch-body"))
+	if err := RefIndexPut(imagesDir, "ghcr.io/example/scratch:v1", pulled); err != nil {
+		t.Fatalf("RefIndexPut: %v", err)
+	}
+
+	got, err := mgr.ListImages()
+	if err != nil {
+		t.Fatalf("ListImages: %v", err)
+	}
+	byRef := map[string]ImageInfo{}
+	for _, img := range got {
+		byRef[img.DockerRef] = img
+	}
+
+	if d := byRef["ghcr.io/example/full:v1"]; d.Alias != "full" || !d.IsDefault {
+		t.Errorf("default image: Alias=%q IsDefault=%v, want full/true (%#v)", d.Alias, d.IsDefault, d)
+	}
+	if a := byRef["ghcr.io/example/base:v1"]; a.Alias != "base" || a.IsDefault {
+		t.Errorf("alias image: Alias=%q IsDefault=%v, want base/false (%#v)", a.Alias, a.IsDefault, a)
+	}
+	if u := byRef["ghcr.io/example/scratch:v1"]; u.Alias != "" || u.IsDefault || u.Source != "user" {
+		t.Errorf("user image: Alias=%q IsDefault=%v Source=%q, want \"\"/false/user (%#v)", u.Alias, u.IsDefault, u.Source, u)
+	}
+
+	// InspectImage must agree with ListImages on the alias/default metadata.
+	di, _, err := mgr.InspectImage("full")
+	if err != nil {
+		t.Fatalf("InspectImage(full): %v", err)
+	}
+	if di.Alias != "full" || !di.IsDefault {
+		t.Errorf("inspect default: Alias=%q IsDefault=%v, want full/true (%#v)", di.Alias, di.IsDefault, di)
+	}
+	bi, _, err := mgr.InspectImage("base")
+	if err != nil {
+		t.Fatalf("InspectImage(base): %v", err)
+	}
+	if bi.Alias != "base" || bi.IsDefault {
+		t.Errorf("inspect alias: Alias=%q IsDefault=%v, want base/false (%#v)", bi.Alias, bi.IsDefault, bi)
+	}
+}
+
 func TestManagerInspectAndTag(t *testing.T) {
 	imagesDir := t.TempDir()
 	cfg := &testConfig{imagesDir: imagesDir}

--- a/internal/vz/image.go
+++ b/internal/vz/image.go
@@ -222,6 +222,8 @@ func toConfigImageInfo(img vmimage.ImageInfo) config.ImageInfo {
 		Digest:    img.Digest,
 		Tag:       img.Tag,
 		InUse:     img.InUse,
+		Alias:     img.Alias,
+		IsDefault: img.IsDefault,
 	}
 }
 

--- a/internal/vz/image_test.go
+++ b/internal/vz/image_test.go
@@ -92,6 +92,31 @@ func createFakeInstance(t *testing.T, instanceDir, name, image, lowerDigest stri
 	}
 }
 
+// TestListImagesPropagatesAliasAndDefault confirms the vz backend wrapper's
+// toConfigImageInfo carries the new alias/is_default metadata out to the
+// wire shape. newTestClient's config sets default_image=base:v1 (not an
+// alias) and alias managed=managed:v1, so the two fields exercise independently.
+func TestListImagesPropagatesAliasAndDefault(t *testing.T) {
+	client, imagesDir := newTestClient(t)
+	createFakeImage(t, imagesDir, "base")    // == cfg.DefaultImage ref
+	createFakeImage(t, imagesDir, "managed") // == alias "managed" ref
+
+	imgs, err := client.ListImages()
+	if err != nil {
+		t.Fatalf("ListImages: %v", err)
+	}
+	byRef := map[string]config.ImageInfo{}
+	for _, img := range imgs {
+		byRef[img.DockerRef] = img
+	}
+	if d := byRef["ghcr.io/example/base:v1"]; !d.IsDefault || d.Alias != "" {
+		t.Errorf("default entry: IsDefault=%v Alias=%q, want true/\"\" (%#v)", d.IsDefault, d.Alias, d)
+	}
+	if a := byRef["ghcr.io/example/managed:v1"]; a.Alias != "managed" || a.IsDefault {
+		t.Errorf("alias entry: Alias=%q IsDefault=%v, want managed/false (%#v)", a.Alias, a.IsDefault, a)
+	}
+}
+
 // TestDeleteImage covers removal under the Docker model: `image rm` drops the
 // tag but leaves the blob. With ref-keyed identity, deletion is hard-blocked
 // when ANY shed (running or stopped) or snapshot still pins the manifest —

--- a/tests/integration/fixtures/server.py
+++ b/tests/integration/fixtures/server.py
@@ -396,6 +396,29 @@ class LocalServer:
             return []
         return [s["name"] for s in sheds if isinstance(s, dict) and "name" in s]
 
+    def list_images(self) -> list[dict]:
+        """Return the server's images (the `GET /api/images` wire shape).
+
+        `shed --json image ls` emits `config.ImagesResponse`
+        (`{"images": [...]}`, see `cmd/shed/image.go:runImageList`); we
+        return that array of image dicts. Raises on a failed call so a
+        misconfigured server surfaces loudly (unlike `list_shed_names`,
+        callers here assert on field presence, not just membership).
+        """
+        r = subprocess.run(
+            ["shed", "--json", "-s", self.name, "image", "ls"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if r.returncode != 0:
+            raise AssertionError(
+                f"shed image ls failed (exit {r.returncode}) on {self.name}: "
+                f"stdout={r.stdout!r} stderr={r.stderr!r}"
+            )
+        resp = json.loads(r.stdout)
+        return resp.get("images") or []
+
     # ------------------------------------------------------------------
     # Log handling (overridden in RemoteServer)
     # ------------------------------------------------------------------

--- a/tests/integration/test_images.py
+++ b/tests/integration/test_images.py
@@ -1,0 +1,50 @@
+"""Image API tests: the alias + is_default metadata on GET /api/images.
+
+These pin the picker-enabling fields the shed-desktop image picker reads
+(PR adding `alias` / `is_default` to `config.ImageInfo`). Parameterized
+across `["vz", "fc"]` via `shed_server`, so they run on both backends.
+
+We create from the `full` alias — which is the configured `default_image`
+in the dev/test configs — so that image is pulled and cached and therefore
+appears in `image ls` carrying BOTH its alias label and `is_default: true`.
+(A smaller alias like `base` would leave the default uncached, making an
+is_default assertion vacuous.)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_images_expose_alias_and_default(shed_server, test_shed_name):
+    """`image ls` labels config images with their alias + marks the default."""
+    # The "full" alias == default_image, so this warms the default. Generous
+    # timeout: the full image may need a first-time pull.
+    shed_server.create(test_shed_name, image="full", timeout=420)
+
+    images = shed_server.list_images()
+    assert images, "image ls returned no images after a create"
+
+    config_imgs = [i for i in images if i.get("source") == "config"]
+    assert config_imgs, f"no config-sourced images after create: {images}"
+
+    # The fields are additive + omitempty: a shed-server that predates them
+    # (e.g. the brew/deb prod server in a mixed-version dev run) simply omits
+    # them. Skip cleanly there rather than red-fail — like the rest of the
+    # suite skips on an environment that can't exercise the behavior.
+    if not any("alias" in i or "is_default" in i for i in config_imgs):
+        pytest.skip("shed-server predates the alias/is_default image metadata")
+
+    # "full" is both the default_image and an alias → it carries both labels.
+    full = [i for i in images if i.get("alias") == "full"]
+    assert full, f"no image carrying alias 'full' after create --image full: {images}"
+    assert full[0].get("source") == "config", full[0]
+    assert full[0].get("is_default") is True, full[0]
+    assert full[0].get("docker_ref"), f"aliased image missing docker_ref: {full[0]}"
+
+    # is_default is mutually exclusive (exactly one), and alias/is_default only
+    # ever appear on config-sourced images.
+    assert sum(1 for i in images if i.get("is_default")) == 1, images
+    for img in images:
+        if img.get("alias") or img.get("is_default"):
+            assert img.get("source") == "config", img


### PR DESCRIPTION
## What

Adds two additive, `omitempty` fields to the images API so a UI image picker can label config images by their friendly alias and preselect the default:

- `config.ImageInfo` + `vmimage.ImageInfo` gain **`alias`** (the `image_aliases` key, e.g. `base`) and **`is_default`** (true for the entry whose ref is `default_image`).
- `ListImages` **and** `InspectImage` populate them via a shared `configuredImageLabels()` helper (configured-ref → alias-name, sorted/first-writer-wins, + the default ref), so list and inspect agree.
- Corrects the stale `source` values in the doc/comment to `config` / `user` / `dangling`.

`ImagesResponse` is unchanged — the default is derivable per-entry. Existing clients and `shed image ls` are unaffected (the fields are omitted when empty).

This unblocks the shed-desktop New-Shed image picker (companion PR in `shed-desktop`).

## Testing

- **Unit:** `go test ./...` green. New `vmimage` test pins exactly-one `is_default`, per-alias `alias`, and that user/dangling images carry neither; a vz-converter test confirms the fields reach the wire shape; `InspectImage` is asserted to agree with `ListImages`.
- **Integration (real backends):** `tests/integration/test_images.py` (parameterized vz/fc) creates from the `full` alias (== `default_image`) and asserts the listing reports `is_default: true` + the alias. Ran the full suite against dev servers built from this branch:
  - **VZ** (local dev server): `test_images[vz]` ✓ + full suite ✓
  - **FC** (mini3 dev server): `test_images[fc]` ✓ + full `[fc]` suite ✓
  - The test skips cleanly against a server that predates the fields (mixed-version dev runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Images API and `shed image ls` command now expose additional metadata fields for config-sourced images: `alias` (friendly alias name) and `is_default` (marks the default configured image).

* **Documentation**
  * Updated API reference to document the new metadata fields and clarified `source` field enumeration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->