### PR TITLE
fix(images): rm/inspect resolve full Docker refs via ?ref= query

### DIFF
--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -409,15 +410,29 @@ func (c *APIClient) KillSession(shedName, sessionName string) error {
 	return c.doRequest(http.MethodDelete, path, nil, nil, http.StatusNoContent, http.StatusOK)
 }
 
-// DeleteImage removes a tag (Docker model). The blob is GC'd by PruneImages.
-func (c *APIClient) DeleteImage(name string) error {
-	return c.doRequest(http.MethodDelete, "/api/images/"+name, nil, nil, http.StatusNoContent, http.StatusOK)
+// imageIdentURL builds the request URL for an endpoint that targets a single
+// image by identifier (a Docker ref, digest, or cosmetic tag). A Docker ref
+// contains slashes, which can't ride in a single URL path segment (the
+// server's chi {name} param stops at the first '/'), so slash-bearing
+// identifiers are passed as a ?ref= query. Slash-free identifiers (digests,
+// tags) keep the path form so a newer CLI still drives an older server.
+func imageIdentURL(collection, ident string) string {
+	if strings.Contains(ident, "/") {
+		return collection + "?ref=" + url.QueryEscape(ident)
+	}
+	return collection + "/" + ident
 }
 
-// InspectImage returns full details for a tag or digest.
-func (c *APIClient) InspectImage(name string) (*config.ImageInspectResponse, error) {
+// DeleteImage removes an image's addressability (Docker model). The blob is
+// GC'd by PruneImages. ident may be a Docker ref, a digest, or a tag label.
+func (c *APIClient) DeleteImage(ident string) error {
+	return c.doRequest(http.MethodDelete, imageIdentURL("/api/images", ident), nil, nil, http.StatusNoContent, http.StatusOK)
+}
+
+// InspectImage returns full details for a ref, tag, or digest.
+func (c *APIClient) InspectImage(ident string) (*config.ImageInspectResponse, error) {
 	var resp config.ImageInspectResponse
-	if err := c.doRequest(http.MethodGet, "/api/images/inspect/"+name, nil, &resp); err != nil {
+	if err := c.doRequest(http.MethodGet, imageIdentURL("/api/images/inspect", ident), nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/cmd/shed/client_image_url_test.go
+++ b/cmd/shed/client_image_url_test.go
@@ -1,0 +1,47 @@
+package main
+
+import "testing"
+
+// TestImageIdentURL locks the client half of the rm/inspect-by-ref fix: a
+// slash-bearing Docker ref must go out as a ?ref= query (url-encoded), while
+// slash-free identifiers (digests, cosmetic tags) keep the path form.
+func TestImageIdentURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		collection string
+		ident      string
+		want       string
+	}{
+		{
+			name:       "ref with slashes -> query",
+			collection: "/api/images",
+			ident:      "ghcr.io/charliek/shed-vz-full:v0.6.0",
+			want:       "/api/images?ref=ghcr.io%2Fcharliek%2Fshed-vz-full%3Av0.6.0",
+		},
+		{
+			name:       "inspect ref with slashes -> query",
+			collection: "/api/images/inspect",
+			ident:      "ghcr.io/charliek/shed-vz-full:v0.6.0",
+			want:       "/api/images/inspect?ref=ghcr.io%2Fcharliek%2Fshed-vz-full%3Av0.6.0",
+		},
+		{
+			name:       "digest -> path",
+			collection: "/api/images",
+			ident:      "sha256:2d9669bcf0cd",
+			want:       "/api/images/sha256:2d9669bcf0cd",
+		},
+		{
+			name:       "cosmetic tag -> path",
+			collection: "/api/images",
+			ident:      "full",
+			want:       "/api/images/full",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := imageIdentURL(tt.collection, tt.ident); got != tt.want {
+				t.Errorf("imageIdentURL(%q, %q) = %q, want %q", tt.collection, tt.ident, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -534,10 +534,25 @@ func (s *Server) handleListImages(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, config.ImagesResponse{Images: images})
 }
 
-// handleDeleteImage removes a cached image by name.
-// DELETE /api/images/{name}
+// imageIdent extracts the image identifier (a Docker ref, digest, or cosmetic
+// tag) a single-image request targets. A Docker ref contains slashes that
+// chi's {name} path param can't carry, so it rides in ?ref=; the {name} path
+// param remains for slash-free identifiers from older clients.
+func imageIdent(r *http.Request) string {
+	if ref := r.URL.Query().Get("ref"); ref != "" {
+		return ref
+	}
+	return chi.URLParam(r, "name")
+}
+
+// handleDeleteImage removes a cached image by ref, digest, or tag.
+// DELETE /api/images?ref={ref} (preferred) or DELETE /api/images/{name} (legacy)
 func (s *Server) handleDeleteImage(w http.ResponseWriter, r *http.Request) {
-	name := chi.URLParam(r, "name")
+	name := imageIdent(r)
+	if name == "" {
+		writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "missing image identifier (pass ?ref=)")
+		return
+	}
 
 	if err := s.backend.DeleteImage(r.Context(), name); err != nil {
 		code, errCode, msg := mapBackendError(err)
@@ -574,10 +589,14 @@ func (s *Server) handlePruneImages(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, config.PruneImagesResponse{Deleted: deleted})
 }
 
-// handleInspectImage returns the manifest + info for a tag or digest.
-// GET /api/images/inspect/{name}
+// handleInspectImage returns the manifest + info for a ref, tag, or digest.
+// GET /api/images/inspect?ref={ref} (preferred) or GET /api/images/inspect/{name} (legacy)
 func (s *Server) handleInspectImage(w http.ResponseWriter, r *http.Request) {
-	name := chi.URLParam(r, "name")
+	name := imageIdent(r)
+	if name == "" {
+		writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "missing image identifier (pass ?ref=)")
+		return
+	}
 	resp, err := s.backend.InspectImage(r.Context(), name)
 	if err != nil {
 		code, errCode, msg := mapBackendError(err)

--- a/internal/api/image_ref_route_test.go
+++ b/internal/api/image_ref_route_test.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+// capturingBackend records the identifier the image handlers resolve so the
+// route tests can assert a slash-bearing Docker ref survives the wire intact.
+type capturingBackend struct {
+	routesFakeBackend
+	deletedIdent string
+	inspectIdent string
+}
+
+func (b *capturingBackend) DeleteImage(_ context.Context, name string) error {
+	b.deletedIdent = name
+	return nil
+}
+
+func (b *capturingBackend) InspectImage(_ context.Context, name string) (config.ImageInspectResponse, error) {
+	b.inspectIdent = name
+	return config.ImageInspectResponse{}, nil
+}
+
+func newCapturingServer() (*Server, *capturingBackend) {
+	be := &capturingBackend{}
+	return newRoutesTestServerWith(be), be
+}
+
+// TestImageDeleteInspectByRef is the regression guard for the bug where
+// `shed image rm <ref>` / `shed image inspect <ref>` 404'd: a Docker ref
+// contains slashes, and the old path-only routes (/api/images/{name},
+// /api/images/inspect/{name}) couldn't carry a multi-segment ref through chi's
+// single-segment {name} param. The ?ref= query form fixes it; the path form
+// stays for slash-free identifiers (digests, cosmetic tags).
+func TestImageDeleteInspectByRef(t *testing.T) {
+	const ref = "ghcr.io/charliek/shed-vz-full:v0.6.0"
+
+	t.Run("delete by ref (query)", func(t *testing.T) {
+		srv, be := newCapturingServer()
+		target := "/api/images?ref=" + url.QueryEscape(ref)
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, httptest.NewRequest(http.MethodDelete, target, nil))
+
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("DELETE %s = %d, want %d", target, w.Code, http.StatusNoContent)
+		}
+		if be.deletedIdent != ref {
+			t.Fatalf("backend received ident %q, want %q (ref mangled in transit)", be.deletedIdent, ref)
+		}
+	})
+
+	t.Run("inspect by ref (query)", func(t *testing.T) {
+		srv, be := newCapturingServer()
+		target := "/api/images/inspect?ref=" + url.QueryEscape(ref)
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, httptest.NewRequest(http.MethodGet, target, nil))
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET %s = %d, want %d", target, w.Code, http.StatusOK)
+		}
+		if be.inspectIdent != ref {
+			t.Fatalf("backend received ident %q, want %q (ref mangled in transit)", be.inspectIdent, ref)
+		}
+	})
+
+	// Slash-free identifiers (digests, cosmetic tags) keep working via the
+	// legacy path form so an older CLI still drives a newer server.
+	t.Run("delete by digest (legacy path)", func(t *testing.T) {
+		srv, be := newCapturingServer()
+		const digest = "sha256:2d9669bcf0cd"
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/images/"+digest, nil))
+
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("DELETE by digest = %d, want %d", w.Code, http.StatusNoContent)
+		}
+		if be.deletedIdent != digest {
+			t.Fatalf("backend received ident %q, want %q", be.deletedIdent, digest)
+		}
+	})
+
+	t.Run("inspect by tag (legacy path)", func(t *testing.T) {
+		srv, be := newCapturingServer()
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/images/inspect/full", nil))
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET inspect by tag = %d, want %d", w.Code, http.StatusOK)
+		}
+		if be.inspectIdent != "full" {
+			t.Fatalf("backend received ident %q, want %q", be.inspectIdent, "full")
+		}
+	})
+
+	// A missing identifier must be a clean 400, not a delete of "".
+	t.Run("delete with no ident is 400", func(t *testing.T) {
+		srv, be := newCapturingServer()
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/images", nil))
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("DELETE with no ref = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+		if be.deletedIdent != "" {
+			t.Fatalf("backend.DeleteImage called with %q, want no call", be.deletedIdent)
+		}
+	})
+
+	// Document the original bug: a raw slash-bearing ref on the path form does
+	// not route. This is precisely why the ?ref= query form exists.
+	t.Run("ref on legacy path form 404s", func(t *testing.T) {
+		srv, _ := newCapturingServer()
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/images/"+ref, nil))
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("DELETE /api/images/%s = %d, want %d (path form can't carry a ref)", ref, w.Code, http.StatusNotFound)
+		}
+	})
+}

--- a/internal/api/routes_test.go
+++ b/internal/api/routes_test.go
@@ -77,11 +77,15 @@ func (routesFakeBackend) GetSnapshot(_ context.Context, _ string) (*config.Snaps
 }
 func (routesFakeBackend) DeleteSnapshot(_ context.Context, _ string) error { return nil }
 
-func newRoutesTestServer() *Server {
-	return NewServer(routesFakeBackend{}, &config.ServerConfig{
+func newRoutesTestServerWith(b backend.Backend) *Server {
+	return NewServer(b, &config.ServerConfig{
 		Name:     "test-server",
 		HTTPPort: 8080,
 	}, "", nil, nil)
+}
+
+func newRoutesTestServer() *Server {
+	return newRoutesTestServerWith(routesFakeBackend{})
 }
 
 // TestRouteImagesNo405 is a regression test for a chi trie precedence bug

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -52,6 +52,11 @@ func (s *Server) Router() chi.Router {
 		// Images
 		r.Route("/images", func(r chi.Router) {
 			r.Get("/", s.handleListImages)
+			// Ref-keyed forms (?ref=) for slash-bearing Docker refs; see
+			// imageIdent. The legacy /{name} + /inspect/{name} forms below
+			// stay for slash-free identifiers from older clients.
+			r.Delete("/", s.handleDeleteImage)
+			r.Get("/inspect", s.handleInspectImage)
 			r.Post("/prune", s.handlePruneImages)
 			r.Post("/tag", s.handleTagImage)
 			r.Post("/pull", s.handlePullImage)


### PR DESCRIPTION
## Problem

`shed image rm <ref>` and `shed image inspect <ref>` returned **"not found"** for any registry ref containing slashes (the common case, e.g. `ghcr.io/charliek/shed-vz-full:v0.6.0`), even though `shed image ls` advertises that ref as the handle:

```
$ shed image ls
IMAGE                                 DIGEST               SOURCE  SIZE      IN USE
ghcr.io/charliek/shed-vz-full:v0.6.0  sha256:2d9669bcf0cd  config  840.6 MB  no

$ shed image rm ghcr.io/charliek/shed-vz-full:v0.6.0   # -> not found
$ shed image rm sha256:2d9669bcf0cd                     # -> works
```

## Root cause

The identifier was carried in the URL **path** as a single segment (`DELETE /api/images/{name}`, `GET /api/images/inspect/{name}`). chi's `{name}` param matches one path segment and stops at the first `/`, so a multi-segment Docker ref never matched the route and 404'd. Only slash-free identifiers (digest `sha256:…`, cosmetic tag) routed — hence rm-by-digest worked while rm-by-ref didn't. The manager resolver (`resolveDeleteTarget`) already accepted refs; the ref just never reached it.

Reproduced against chi v5.2.4: a raw slash-bearing ref → 404; a digest → 200; even a `%2F`-escaped ref came back to the handler still-encoded, so a client-only escape wouldn't have fixed it either.

## Fix

Carry the identifier as a `?ref=` query param (url-encoded) for slash-bearing refs, keeping the legacy path form for slash-free identifiers:

| Operation | Preferred (new) | Legacy fallback (slash-free) |
|-----------|-----------------|------------------------------|
| Remove    | `DELETE /api/images?ref=<enc>` | `DELETE /api/images/{name}` |
| Inspect   | `GET /api/images/inspect?ref=<enc>` | `GET /api/images/inspect/{name}` |

- **Server** (`internal/api/server.go`, `handlers.go`): new collection-level `DELETE` + `/inspect` routes; `imageIdent(r)` reads `?ref=` first, then the `{name}` path param; both handlers 400 on an empty identifier.
- **Client** (`cmd/shed/client.go`): `imageIdentURL` sends slash-bearing idents via `?ref=` (`url.QueryEscape`), slash-free idents via the path form — so a newer CLI still drives an older server for digests/tags (refs never resolved against an older server anyway).

The legacy path routes are retained so this stays backward-compatible with older clients and with the project's new-CLI-vs-installed-server integration-test model.

## Scope

Limited to `rm` + `inspect` (the only image endpoints that take the identifier in the path; `tag`/`pull`/`push` use POST bodies, `prune` uses query flags). No CLI surface change.

## Tests
- `internal/api/image_ref_route_test.go` — slash-bearing ref round-trips intact to the handler (capturing backend); legacy slash-free path still works; missing identifier → 400; raw ref on the legacy path form still 404s (documents the original bug).
- `cmd/shed/client_image_url_test.go` — locks the client URL builder (slash → `?ref=` encoded; no-slash → path).

`make check` (lint + full unit suite) passes.

## Reviews
- `/simplify` (4 cleanup agents) — applied comment/dedup + test-helper reuse fixes.
- `/codex:rescue` — one LOW/hypothesis note (empty-string ident routes to the legacy handler but the `imageIdent` guard still returns 400; not reachable via the cobra-validated CLI). No correctness findings on encoding round-trip, route shadowing, or the slash discriminator (digests, bare names, port-bearing refs all classify correctly).

## Follow-up
- shed-desktop is **not** affected (it only calls `GET /api/images`). Forward-looking ticket filed: charliek/shed-desktop#6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
