### PR TITLE
feat(cli): add hidden ls/rm/images command aliases

### DIFF
--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -62,9 +62,10 @@ func buildToolsRefDefault(override string) string {
 }
 
 var imageCmd = &cobra.Command{
-	Use:   "image",
-	Short: "Manage rootfs images",
-	Long:  "Build, list, and manage rootfs images for VM backends.",
+	Use:     "image",
+	Aliases: []string{"images"},
+	Short:   "Manage rootfs images",
+	Long:    "Build, list, and manage rootfs images for VM backends.",
 }
 
 var (

--- a/cmd/shed/shed.go
+++ b/cmd/shed/shed.go
@@ -33,19 +33,21 @@ If a repository URL is provided, it will be cloned into the shed.`,
 }
 
 var listCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List sheds",
-	Long:  "List all sheds on the configured servers.",
-	Args:  cobra.NoArgs,
-	RunE:  runList,
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List sheds",
+	Long:    "List all sheds on the configured servers.",
+	Args:    cobra.NoArgs,
+	RunE:    runList,
 }
 
 var deleteCmd = &cobra.Command{
-	Use:   "delete <name>",
-	Short: "Delete a shed",
-	Long:  "Delete a shed and optionally its data volume.",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runDelete,
+	Use:     "delete <name>",
+	Aliases: []string{"rm"},
+	Short:   "Delete a shed",
+	Long:    "Delete a shed and optionally its data volume.",
+	Args:    cobra.ExactArgs(1),
+	RunE:    runDelete,
 }
 
 var startCmd = &cobra.Command{


### PR DESCRIPTION
## What

Adds Cobra aliases for the three most common muscle-memory typos so they run the expected command instead of erroring out:

| You type | Runs |
|---|---|
| `shed ls` | `shed list` |
| `shed rm <name>` | `shed delete <name>` |
| `shed images …` | `shed image …` (e.g. `shed images ls`) |

## Why

These are the spellings fingers reach for (Docker/coreutils habits). Today they error and you have to retype the canonical command.

## How

Three one-line `Aliases: []string{…}` additions on the existing `listCmd`, `deleteCmd`, and `imageCmd` — no new commands, no new logic, no behavior change to the canonical commands. This is the same pattern already used by `shed image ls` (alias `list`) and `shed image rm` (alias `delete`).

Cobra keeps aliases **out of the parent's "Available Commands" listing**, so the top-level `shed --help` is unchanged. An alias only surfaces under its own command's `--help` "Aliases:" line. `shed rm` keeps the delete confirmation prompt and `-f/--force`; `shed images` alone shows the image group help, while `shed images ls`/`inspect`/etc. descend as expected.

## Testing

- `go build ./cmd/shed/` — ok
- `go test ./cmd/shed/` — pass
- `golangci-lint run ./cmd/shed/` — 0 issues
- Manual smoke test confirmed: `ls`/`rm`/`images` resolve to the right commands, and none of the aliases appear in the top-level `shed --help` "Available Commands" list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)