### PR TITLE
fix(images): report cached layers in pull progress

### DIFF
--- a/internal/vmimage/registry.go
+++ b/internal/vmimage/registry.go
@@ -377,6 +377,13 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		digest := ld.String()
 		layerDigests = append(layerDigests, digest)
 		if BlobExists(opts.ImagesDir, digest) {
+			// Report cached layers instead of skipping silently. Without
+			// this, the i+1/N counter leaves gaps (e.g. "1/7 … 4/7") for
+			// layers already on disk, which reads as "missing layers".
+			// Mirrors Docker's "Already exists".
+			if opts.Progress != nil {
+				opts.Progress("image", fmt.Sprintf("Layer %d/%d %s already present", i+1, len(layers), ShortDigest(digest)))
+			}
 			continue
 		}
 		if opts.Progress != nil {

--- a/internal/vmimage/registry_pull_test.go
+++ b/internal/vmimage/registry_pull_test.go
@@ -1,0 +1,119 @@
+package vmimage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http/httptest"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// startTestRegistry spins up an in-memory OCI registry served over plain
+// HTTP on loopback and returns its host:port. Reusable across pull tests
+// (cached-layer reporting, byte counting, parallel/dedup) — pulls target it
+// with PullOptions{Insecure: true}.
+func startTestRegistry(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(registry.New(registry.Logger(log.New(io.Discard, "", 0))))
+	t.Cleanup(srv.Close)
+	return strings.TrimPrefix(srv.URL, "http://")
+}
+
+// pushRandomImage builds a random image with the given number of layers and
+// pushes it to refStr (e.g. "<host>/test/img:v1") on the test registry,
+// returning the full reference string for PullToOCILayout.
+func pushRandomImage(t *testing.T, refStr string, layers int) string {
+	t.Helper()
+	img, err := random.Image(1024, int64(layers))
+	if err != nil {
+		t.Fatalf("random.Image: %v", err)
+	}
+	ref, err := name.ParseReference(refStr, name.Insecure)
+	if err != nil {
+		t.Fatalf("parse ref %q: %v", refStr, err)
+	}
+	if err := remote.Write(ref, img); err != nil {
+		t.Fatalf("push %q: %v", refStr, err)
+	}
+	return refStr
+}
+
+// pullCollecting runs PullToOCILayout against the test registry and returns
+// every progress message it emitted.
+func pullCollecting(t *testing.T, ref, imagesDir string) []string {
+	t.Helper()
+	var msgs []string
+	_, err := PullToOCILayout(context.Background(), PullOptions{
+		Ref:       ref,
+		ImagesDir: imagesDir,
+		Insecure:  true,
+		Progress: func(_, msg string) {
+			msgs = append(msgs, msg)
+		},
+	})
+	if err != nil {
+		t.Fatalf("PullToOCILayout(%q): %v", ref, err)
+	}
+	return msgs
+}
+
+var layerCounterRe = regexp.MustCompile(`\b(\d+/\d+)\b`)
+
+// layerProgressSeq returns the "i/N" counter tokens, in emission order, from
+// the layer-progress messages that contain marker. This asserts the exact
+// contiguous 1/N..N/N sequence — the substring being fixed is a *gap* in that
+// sequence, so counting occurrences alone would not catch a regression that
+// repeated "1/N" instead of advancing.
+func layerProgressSeq(msgs []string, marker string) []string {
+	var seq []string
+	for _, m := range msgs {
+		if !strings.Contains(m, marker) {
+			continue
+		}
+		if tok := layerCounterRe.FindString(m); tok != "" {
+			seq = append(seq, tok)
+		}
+	}
+	return seq
+}
+
+// TestPullToOCILayout_CachedLayerProgress asserts that a re-pull reports every
+// already-present layer (no silent skips), so the i+1/N counter never leaves
+// gaps that read as "missing layers".
+func TestPullToOCILayout_CachedLayerProgress(t *testing.T) {
+	host := startTestRegistry(t)
+	const layers = 3
+	ref := pushRandomImage(t, fmt.Sprintf("%s/test/cached:v1", host), layers)
+	dir := t.TempDir()
+	want := []string{"1/3", "2/3", "3/3"}
+
+	// First pull populates the blob store: every layer is freshly pulled in
+	// a contiguous 1/3..3/3 sequence, and none are reported as cached.
+	first := pullCollecting(t, ref, dir)
+	if got := layerProgressSeq(first, "Pulling layer"); !slices.Equal(got, want) {
+		t.Errorf("first pull: 'Pulling layer' sequence = %v, want %v (msgs: %v)", got, want, first)
+	}
+	if got := layerProgressSeq(first, "already present"); len(got) != 0 {
+		t.Errorf("first pull: got %d 'already present' messages, want 0 (msgs: %v)", len(got), first)
+	}
+
+	// Second pull into the same dir: every layer is cached, so each one is
+	// reported as already present in the same contiguous 1/3..3/3 sequence
+	// (no gaps) and none are re-pulled.
+	second := pullCollecting(t, ref, dir)
+	if got := layerProgressSeq(second, "already present"); !slices.Equal(got, want) {
+		t.Errorf("re-pull: 'already present' sequence = %v, want %v (msgs: %v)", got, want, second)
+	}
+	if got := layerProgressSeq(second, "Pulling layer"); len(got) != 0 {
+		t.Errorf("re-pull: got %d 'Pulling layer' messages, want 0 (msgs: %v)", len(got), second)
+	}
+}

--- a/internal/vmimage/registry_pull_test.go
+++ b/internal/vmimage/registry_pull_test.go
@@ -89,6 +89,11 @@ func layerProgressSeq(msgs []string, marker string) []string {
 // TestPullToOCILayout_CachedLayerProgress asserts that a re-pull reports every
 // already-present layer (no silent skips), so the i+1/N counter never leaves
 // gaps that read as "missing layers".
+//
+// The cases run in order against the SAME store: the fresh pull populates the
+// cache that the re-pull then reports. Each case asserts the layer counter is
+// the exact contiguous 1/N..N/N sequence (the bug being fixed is a *gap* in
+// that sequence) and that the opposite marker never appears.
 func TestPullToOCILayout_CachedLayerProgress(t *testing.T) {
 	host := startTestRegistry(t)
 	const layers = 3
@@ -96,24 +101,23 @@ func TestPullToOCILayout_CachedLayerProgress(t *testing.T) {
 	dir := t.TempDir()
 	want := []string{"1/3", "2/3", "3/3"}
 
-	// First pull populates the blob store: every layer is freshly pulled in
-	// a contiguous 1/3..3/3 sequence, and none are reported as cached.
-	first := pullCollecting(t, ref, dir)
-	if got := layerProgressSeq(first, "Pulling layer"); !slices.Equal(got, want) {
-		t.Errorf("first pull: 'Pulling layer' sequence = %v, want %v (msgs: %v)", got, want, first)
+	cases := []struct {
+		name         string
+		wantMarker   string // marker whose lines must form the 1/N..N/N sequence
+		absentMarker string // marker that must not appear
+	}{
+		{"fresh pull pulls every layer", "Pulling layer", "already present"},
+		{"re-pull reports every cached layer", "already present", "Pulling layer"},
 	}
-	if got := layerProgressSeq(first, "already present"); len(got) != 0 {
-		t.Errorf("first pull: got %d 'already present' messages, want 0 (msgs: %v)", len(got), first)
-	}
-
-	// Second pull into the same dir: every layer is cached, so each one is
-	// reported as already present in the same contiguous 1/3..3/3 sequence
-	// (no gaps) and none are re-pulled.
-	second := pullCollecting(t, ref, dir)
-	if got := layerProgressSeq(second, "already present"); !slices.Equal(got, want) {
-		t.Errorf("re-pull: 'already present' sequence = %v, want %v (msgs: %v)", got, want, second)
-	}
-	if got := layerProgressSeq(second, "Pulling layer"); len(got) != 0 {
-		t.Errorf("re-pull: got %d 'Pulling layer' messages, want 0 (msgs: %v)", len(got), second)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msgs := pullCollecting(t, ref, dir)
+			if got := layerProgressSeq(msgs, tc.wantMarker); !slices.Equal(got, want) {
+				t.Errorf("%q sequence = %v, want %v (msgs: %v)", tc.wantMarker, got, want, msgs)
+			}
+			if got := layerProgressSeq(msgs, tc.absentMarker); len(got) != 0 {
+				t.Errorf("got %d %q messages, want 0 (msgs: %v)", len(got), tc.absentMarker, msgs)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem

When re-pulling an image (or pulling one that shares layers with an already-present image), `PullToOCILayout` skipped cached layers silently with a bare `continue` **before** emitting any progress. Because the line uses an `i+1/N` counter, skipped layers left gaps — e.g. `Pulling layer 1/7 … Pulling layer 4/7` — which reads to users as "layers went missing." This is the UI artifact behind the reported "sometimes a layer doesn't show" observation.

## Change

Emit a `Layer N/M <short-digest> already present` line for cached layers instead of skipping silently, mirroring Docker's `Already exists`. The counter is now always contiguous.

Intentionally minimal and string-only — a follow-up PR replaces string progress with structured per-blob events, where this becomes a `Status:"exists"` event. This is the first of a phased series (see `docs/discovery/pull-parallelism-and-progress-ui.md`).

## Tests

- New reusable in-memory `go-containerregistry` test fixture (`startTestRegistry` / `pushRandomImage` / `pullCollecting`) — shared infra for the upcoming structured-progress and parallel-pull PRs.
- `TestPullToOCILayout_CachedLayerProgress` pulls a 3-layer image, then re-pulls into the same store and asserts the cached pull reports the **exact** `1/3, 2/3, 3/3` sequence (not just counts — tightened per review so it actually catches a future gap regression).

## Verification

- `make check` — lint clean (0 issues), full unit suite green.
- `make test-integration-dev` (VZ dev server) — 51 passed, 3 skipped (expected skips).
- Manual re-pull against the dev server:
  ```
    Layer 1/6 sha256:818154cda96d already present
    Layer 2/6 sha256:b24f924b8d73 already present
    ... (contiguous through 6/6)
  ```

This change is in shared, backend-agnostic `internal/vmimage` code (no build tags) and is exercised by the unit test's real pull path, so FC behaves identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image pull operations now report progress for layers already cached locally, showing per-layer status ("already present") alongside normal download progress for clearer visibility during pulls.

* **Tests**
  * Added automated test coverage that validates progress reporting for cached vs. newly pulled layers to ensure consistent user-facing progress messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->