### PR TITLE
feat(images): structured per-blob progress events for pulls

### DIFF
--- a/cmd/shed-server/pull_images.go
+++ b/cmd/shed-server/pull_images.go
@@ -102,8 +102,11 @@ func runPullImages(cmd *cobra.Command, args []string) error {
 		_, err := mgr.EnsureImage(ctx, vmimage.ResolvedRef{
 			DockerRef: ref,
 			Name:      vmimage.DeriveTagFromRef(ref),
-		}, func(stage, msg string) {
-			fmt.Printf("  [%s] %s\n", stage, msg)
+		}, func(ev vmimage.ProgressEvent) {
+			if ev.IsBlob() {
+				return // byte-tick events would spam the server log
+			}
+			fmt.Printf("  [%s] %s\n", ev.Stage, ev.Message)
 		})
 		if err != nil {
 			return fmt.Errorf("failed to pull image %s: %w", name, err)

--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -734,8 +734,11 @@ func runImagePush(_ *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		if err := mgr.PushImage(context.Background(), source, dest, func(stage, msg string) {
-			fmt.Printf("  %s: %s\n", stage, msg)
+		if err := mgr.PushImage(context.Background(), source, dest, func(ev vmimage.ProgressEvent) {
+			if ev.IsBlob() {
+				return
+			}
+			fmt.Printf("  %s: %s\n", ev.Stage, ev.Message)
 		}); err != nil {
 			return fmt.Errorf("failed to push image: %w", err)
 		}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -165,6 +165,38 @@ func (s *Server) createTimer(req config.CreateShedRequest) *backend.PhaseTimer {
 		fmt.Sprintf("create name=%s backend=%s", req.Name, s.backend.Type()), nil)
 }
 
+// sseProgressBuffer is the depth of the per-request progress channel. The
+// sink send is ctx-aware-blocking (never a silent drop), so this is just
+// decoupling headroom for bursts; byte ticks are coalesced at the source.
+const sseProgressBuffer = 64
+
+// newProgressSink builds the SSE progress sink. It forwards user-visible
+// events into ch and:
+//   - gates structured byte-progress (Kind=="blob") behind the client's
+//     ?progress=blob opt-in, so older / line-mode clients never receive
+//     byte-tick events (no spam, no behavior change);
+//   - drops phase-only (Message=="") events, which are server-side timer
+//     boundaries, not user-visible lines;
+//   - blocks until the drain goroutine catches up or the request is
+//     cancelled, so a status transition is never silently dropped (the old
+//     `default:`-drop could lose a terminal "done", freezing a bar at 99%).
+func newProgressSink(r *http.Request, ch chan<- backend.ProgressEvent) backend.ProgressFunc {
+	blobCapable := r.URL.Query().Get("progress") == backend.KindBlob
+	done := r.Context().Done()
+	return func(event backend.ProgressEvent) {
+		if event.Kind == backend.KindBlob && !blobCapable {
+			return
+		}
+		if event.Message == "" {
+			return
+		}
+		select {
+		case ch <- event:
+		case <-done:
+		}
+	}
+}
+
 // handleCreateShedSSE streams create progress as Server-Sent Events.
 func (s *Server) handleCreateShedSSE(w http.ResponseWriter, r *http.Request, req config.CreateShedRequest) {
 	flusher, ok := w.(http.Flusher)
@@ -179,20 +211,8 @@ func (s *Server) handleCreateShedSSE(w http.ResponseWriter, r *http.Request, req
 	flusher.Flush()
 
 	timer := s.createTimer(req)
-	events := make(chan backend.ProgressEvent, 16)
-	sseFn := func(event backend.ProgressEvent) {
-		// Phase-only events (Message == "") are server-side timer
-		// boundaries; they should not appear as user-visible SSE
-		// progress lines. The PhaseTimer (via TeeProgress) still
-		// receives them through `timer.Track`.
-		if event.Message == "" {
-			return
-		}
-		select {
-		case events <- event:
-		default:
-		}
-	}
+	events := make(chan backend.ProgressEvent, sseProgressBuffer)
+	sseFn := newProgressSink(r, events)
 
 	// Tee the progress stream: the timer records per-phase durations
 	// server-side (logged below), while sseFn forwards the human-readable
@@ -677,16 +697,8 @@ func (s *Server) handlePullImageSSE(w http.ResponseWriter, r *http.Request, req 
 	flusher.Flush()
 
 	start := time.Now()
-	events := make(chan backend.ProgressEvent, 16)
-	sseFn := func(event backend.ProgressEvent) {
-		if event.Message == "" {
-			return
-		}
-		select {
-		case events <- event:
-		default:
-		}
-	}
+	events := make(chan backend.ProgressEvent, sseProgressBuffer)
+	sseFn := newProgressSink(r, events)
 	ctx := backend.ContextWithProgress(r.Context(), sseFn)
 
 	type pullResult struct {

--- a/internal/api/progress_sink_test.go
+++ b/internal/api/progress_sink_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -19,43 +20,54 @@ func drain(ch chan backend.ProgressEvent) []backend.ProgressEvent {
 	return got
 }
 
-// TestProgressSinkGatesBlobWithoutOptIn: a client that did not request
-// ?progress=blob gets the plain line and never the byte-tick events, and
-// phase-only (Message-less) events are dropped. This is the compat guard —
-// older/line-mode clients see exactly today's output.
-func TestProgressSinkGatesBlobWithoutOptIn(t *testing.T) {
-	r := httptest.NewRequest("POST", "/api/images/pull", nil)
-	ch := make(chan backend.ProgressEvent, 8)
-	sink := newProgressSink(r, ch)
-
-	sink(backend.ProgressEvent{Message: "Pulling layer 1/2"})
-	sink(backend.ProgressEvent{Kind: backend.KindBlob, Message: "blob", Status: "downloading", Current: 1, Total: 2})
-	sink(backend.ProgressEvent{Phase: "image"}) // Message == "" → dropped
-
-	got := drain(ch)
-	if len(got) != 1 || got[0].Message != "Pulling layer 1/2" {
-		t.Fatalf("without opt-in got %+v, want only the plain line", got)
+// TestProgressSinkGating covers the ?progress=blob opt-in: a client that did
+// not opt in gets the plain line and never byte-tick events (the compat
+// guard), and phase-only (Message-less) events are always dropped; an
+// opted-in client receives the structured events verbatim.
+func TestProgressSinkGating(t *testing.T) {
+	blobEvent := backend.ProgressEvent{Kind: backend.KindBlob, Message: "blob", Status: "downloading", Current: 1, Total: 2}
+	cases := []struct {
+		name string
+		url  string
+		send []backend.ProgressEvent
+		want []backend.ProgressEvent
+	}{
+		{
+			name: "without opt-in: blob dropped, plain kept, phase-only dropped",
+			url:  "/api/images/pull",
+			send: []backend.ProgressEvent{
+				{Message: "Pulling layer 1/2"},
+				blobEvent,
+				{Phase: "image"}, // Message == "" → dropped
+			},
+			want: []backend.ProgressEvent{{Message: "Pulling layer 1/2"}},
+		},
+		{
+			name: "with opt-in: blob forwarded verbatim",
+			url:  "/api/images/pull?progress=blob",
+			send: []backend.ProgressEvent{blobEvent},
+			want: []backend.ProgressEvent{blobEvent},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("POST", tc.url, nil)
+			ch := make(chan backend.ProgressEvent, 8)
+			sink := newProgressSink(r, ch)
+			for _, ev := range tc.send {
+				sink(ev)
+			}
+			if got := drain(ch); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %+v, want %+v", got, tc.want)
+			}
+		})
 	}
 }
 
-// TestProgressSinkForwardsBlobWithOptIn: a client that requested
-// ?progress=blob receives the structured byte events verbatim.
-func TestProgressSinkForwardsBlobWithOptIn(t *testing.T) {
-	r := httptest.NewRequest("POST", "/api/images/pull?progress=blob", nil)
-	ch := make(chan backend.ProgressEvent, 8)
-	sink := newProgressSink(r, ch)
-
-	sink(backend.ProgressEvent{Kind: backend.KindBlob, Message: "blob", Status: "downloading", Current: 1, Total: 2})
-
-	got := drain(ch)
-	if len(got) != 1 || got[0].Kind != backend.KindBlob || got[0].Current != 1 || got[0].Total != 2 {
-		t.Fatalf("with opt-in got %+v, want the blob event", got)
-	}
-}
-
-// TestProgressSinkSendUnblocksOnCancel: the send is non-dropping (blocks
-// rather than silently discarding a status transition), but a cancelled
-// request must release it instead of deadlocking the pull goroutine.
+// TestProgressSinkSendUnblocksOnCancel exercises a distinct concurrency
+// invariant (not a data case): the send is non-dropping — it blocks rather
+// than silently discarding a status transition — but a cancelled request must
+// release it instead of deadlocking the pull goroutine.
 func TestProgressSinkSendUnblocksOnCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	r := httptest.NewRequest("POST", "/api/images/pull", nil).WithContext(ctx)

--- a/internal/api/progress_sink_test.go
+++ b/internal/api/progress_sink_test.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/charliek/shed/internal/backend"
+)
+
+// drain collects everything buffered in ch after it is closed.
+func drain(ch chan backend.ProgressEvent) []backend.ProgressEvent {
+	close(ch)
+	var got []backend.ProgressEvent
+	for ev := range ch {
+		got = append(got, ev)
+	}
+	return got
+}
+
+// TestProgressSinkGatesBlobWithoutOptIn: a client that did not request
+// ?progress=blob gets the plain line and never the byte-tick events, and
+// phase-only (Message-less) events are dropped. This is the compat guard —
+// older/line-mode clients see exactly today's output.
+func TestProgressSinkGatesBlobWithoutOptIn(t *testing.T) {
+	r := httptest.NewRequest("POST", "/api/images/pull", nil)
+	ch := make(chan backend.ProgressEvent, 8)
+	sink := newProgressSink(r, ch)
+
+	sink(backend.ProgressEvent{Message: "Pulling layer 1/2"})
+	sink(backend.ProgressEvent{Kind: backend.KindBlob, Message: "blob", Status: "downloading", Current: 1, Total: 2})
+	sink(backend.ProgressEvent{Phase: "image"}) // Message == "" → dropped
+
+	got := drain(ch)
+	if len(got) != 1 || got[0].Message != "Pulling layer 1/2" {
+		t.Fatalf("without opt-in got %+v, want only the plain line", got)
+	}
+}
+
+// TestProgressSinkForwardsBlobWithOptIn: a client that requested
+// ?progress=blob receives the structured byte events verbatim.
+func TestProgressSinkForwardsBlobWithOptIn(t *testing.T) {
+	r := httptest.NewRequest("POST", "/api/images/pull?progress=blob", nil)
+	ch := make(chan backend.ProgressEvent, 8)
+	sink := newProgressSink(r, ch)
+
+	sink(backend.ProgressEvent{Kind: backend.KindBlob, Message: "blob", Status: "downloading", Current: 1, Total: 2})
+
+	got := drain(ch)
+	if len(got) != 1 || got[0].Kind != backend.KindBlob || got[0].Current != 1 || got[0].Total != 2 {
+		t.Fatalf("with opt-in got %+v, want the blob event", got)
+	}
+}
+
+// TestProgressSinkSendUnblocksOnCancel: the send is non-dropping (blocks
+// rather than silently discarding a status transition), but a cancelled
+// request must release it instead of deadlocking the pull goroutine.
+func TestProgressSinkSendUnblocksOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	r := httptest.NewRequest("POST", "/api/images/pull", nil).WithContext(ctx)
+	ch := make(chan backend.ProgressEvent) // unbuffered, no reader
+	sink := newProgressSink(r, ch)
+
+	cancel() // client disconnected
+	done := make(chan struct{})
+	go func() {
+		sink(backend.ProgressEvent{Message: "x"})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sink blocked forever on a cancelled request (should unblock via ctx.Done)")
+	}
+}

--- a/internal/backend/progress.go
+++ b/internal/backend/progress.go
@@ -109,7 +109,11 @@ func EmitProgress(ctx context.Context, ev ProgressEvent) {
 		Phase(ctx, ev.Phase)
 	}
 	if ev.Message != "" {
-		Status(ctx, ev.Message)
+		if ev.Warning {
+			StatusWarning(ctx, ev.Message)
+		} else {
+			Status(ctx, ev.Message)
+		}
 	}
 }
 

--- a/internal/backend/progress.go
+++ b/internal/backend/progress.go
@@ -15,14 +15,34 @@ import "context"
 //     (where `Phase` is empty) are forwarded to SSE consumers but do
 //     NOT advance the timer; they "attach" to the current phase.
 //
-// The wire shape stays the same; old `shed` CLIs continue to render
-// progress identically because they only read `Message` + `Warning`
-// (see `cmd/shed/shed.go` for the rendering loop).
+// The base wire fields are unchanged; old `shed` CLIs continue to render
+// progress identically because they only read `Message` + `Warning` (see
+// `cmd/shed/shed.go` for the rendering loop).
+//
+// The `Kind=="blob"` fields are additive and optional (all `omitempty`).
+// They carry structured per-blob byte progress for the CLI's live renderer.
+// The server only forwards blob events to clients that opt in via the
+// `?progress=blob` query param on the pull/create SSE request, so older and
+// line-mode clients never receive them (no byte-tick spam) — see the SSE
+// handlers in internal/api. A new CLI against an old server simply never
+// sees a `Kind`, and stays in line mode.
 type ProgressEvent struct {
 	Phase   string `json:"phase"`
 	Message string `json:"message"`
 	Warning bool   `json:"warning,omitempty"`
+
+	// Structured per-blob byte progress (Kind=="blob"); zero on plain
+	// status/phase events. ID is the full digest (the renderer keys on it
+	// and shortens for display); Current/Total are bytes.
+	Kind    string `json:"kind,omitempty"`
+	ID      string `json:"id,omitempty"`
+	Status  string `json:"status,omitempty"`
+	Current int64  `json:"current,omitempty"`
+	Total   int64  `json:"total,omitempty"`
 }
+
+// KindBlob marks a ProgressEvent as structured per-blob byte progress.
+const KindBlob = "blob"
 
 // ProgressFunc is a callback for receiving progress events.
 type ProgressFunc func(ProgressEvent)
@@ -36,30 +56,60 @@ func ContextWithProgress(ctx context.Context, fn ProgressFunc) context.Context {
 	return context.WithValue(ctx, progressKey, fn)
 }
 
+// emit delivers ev to the context progress sink (nil-safe).
+func emit(ctx context.Context, ev ProgressEvent) {
+	if fn, ok := ctx.Value(progressKey).(ProgressFunc); ok && fn != nil {
+		fn(ev)
+	}
+}
+
 // Phase advances the PhaseTimer to a new phase. No user-visible SSE
 // message is emitted. Use this when the boundary matters but you don't
 // have a useful display string yet (or a separate Status call describes
 // what's happening).
 func Phase(ctx context.Context, name string) {
-	if fn, ok := ctx.Value(progressKey).(ProgressFunc); ok && fn != nil {
-		fn(ProgressEvent{Phase: name})
-	}
+	emit(ctx, ProgressEvent{Phase: name})
 }
 
 // Status emits a user-visible progress message tied to the current
 // phase. The PhaseTimer ignores status-only events; they show up as
 // SSE lines on the `shed` CLI but do not split or rename a phase span.
 func Status(ctx context.Context, message string) {
-	if fn, ok := ctx.Value(progressKey).(ProgressFunc); ok && fn != nil {
-		fn(ProgressEvent{Message: message})
-	}
+	emit(ctx, ProgressEvent{Message: message})
 }
 
 // StatusWarning is Status with the Warning flag set. The CLI renders
 // it with a "Warning:" prefix on stderr.
 func StatusWarning(ctx context.Context, message string) {
-	if fn, ok := ctx.Value(progressKey).(ProgressFunc); ok && fn != nil {
-		fn(ProgressEvent{Message: message, Warning: true})
+	emit(ctx, ProgressEvent{Message: message, Warning: true})
+}
+
+// BlobProgress emits a structured per-blob byte event WITHOUT advancing the
+// PhaseTimer (Phase is forced empty), so it is safe to call concurrently
+// from parallel download goroutines. The event must carry a non-empty
+// Message (the SSE handler drops Message-less events); the renderer uses the
+// structured fields and line-mode clients fall back to Message.
+func BlobProgress(ctx context.Context, ev ProgressEvent) {
+	ev.Phase = ""
+	ev.Kind = KindBlob
+	emit(ctx, ev)
+}
+
+// EmitProgress routes a progress event from an image operation (the backend
+// bridges translate vmimage's progress events into this) to the context
+// sink. Blob events (Kind=="blob") go straight through without advancing the
+// phase; plain events preserve the historical two-event behavior — advance
+// the phase, then emit a status line.
+func EmitProgress(ctx context.Context, ev ProgressEvent) {
+	if ev.Kind == KindBlob {
+		BlobProgress(ctx, ev)
+		return
+	}
+	if ev.Phase != "" {
+		Phase(ctx, ev.Phase)
+	}
+	if ev.Message != "" {
+		Status(ctx, ev.Message)
 	}
 }
 

--- a/internal/backend/progress_emit_test.go
+++ b/internal/backend/progress_emit_test.go
@@ -13,42 +13,65 @@ func collectProgress(t *testing.T, fn func(ctx context.Context)) []ProgressEvent
 	return got
 }
 
-// TestEmitProgressPlain keeps the historical two-event behavior for plain
-// events: a phase advance followed by a status line.
-func TestEmitProgressPlain(t *testing.T) {
-	got := collectProgress(t, func(ctx context.Context) {
-		EmitProgress(ctx, ProgressEvent{Phase: "image", Message: "Pulling layer 1/2"})
-	})
-	if len(got) != 2 {
-		t.Fatalf("got %d events, want 2 (phase + status): %+v", len(got), got)
+func TestEmitProgress(t *testing.T) {
+	cases := []struct {
+		name  string
+		event ProgressEvent
+		check func(t *testing.T, got []ProgressEvent)
+	}{
+		{
+			name:  "plain event advances the phase then emits a status line",
+			event: ProgressEvent{Phase: "image", Message: "Pulling layer 1/2"},
+			check: func(t *testing.T, got []ProgressEvent) {
+				if len(got) != 2 {
+					t.Fatalf("got %d events, want 2 (phase + status): %+v", len(got), got)
+				}
+				if got[0].Phase != "image" || got[0].Message != "" {
+					t.Errorf("event 0 = %+v, want phase-only {image}", got[0])
+				}
+				if got[1].Message != "Pulling layer 1/2" || got[1].Phase != "" || got[1].Warning {
+					t.Errorf("event 1 = %+v, want a plain status line", got[1])
+				}
+			},
+		},
+		{
+			// EmitProgress must not strip Warning when routing a plain event.
+			name:  "warning is preserved on plain events",
+			event: ProgressEvent{Message: "heads up", Warning: true},
+			check: func(t *testing.T, got []ProgressEvent) {
+				if len(got) != 1 || !got[0].Warning || got[0].Message != "heads up" {
+					t.Fatalf("got %+v, want a single warning status line", got)
+				}
+			},
+		},
+		{
+			// PhaseTimer-safety guard: a blob event must emit a single
+			// structured event with Phase forced empty, so parallel download
+			// goroutines (PR 4) can't corrupt phase accounting.
+			name: "blob event never advances the phase",
+			event: ProgressEvent{
+				Phase: "image", // must be discarded
+				Kind:  KindBlob, Message: "blob", ID: "sha256:x",
+				Status: "downloading", Current: 5, Total: 10,
+			},
+			check: func(t *testing.T, got []ProgressEvent) {
+				if len(got) != 1 {
+					t.Fatalf("got %d events, want 1 (no phase advance for blob): %+v", len(got), got)
+				}
+				ev := got[0]
+				if ev.Phase != "" {
+					t.Errorf("blob event advanced the phase: %+v", ev)
+				}
+				if ev.Kind != KindBlob || ev.ID != "sha256:x" || ev.Current != 5 || ev.Total != 10 {
+					t.Errorf("blob event fields not preserved: %+v", ev)
+				}
+			},
+		},
 	}
-	if got[0].Phase != "image" || got[0].Message != "" {
-		t.Errorf("event 0 = %+v, want phase-only {image}", got[0])
-	}
-	if got[1].Message != "Pulling layer 1/2" || got[1].Phase != "" {
-		t.Errorf("event 1 = %+v, want status-only line", got[1])
-	}
-}
-
-// TestEmitProgressBlobNeverAdvancesPhase is the PhaseTimer-safety guard: a
-// blob event must emit a single structured event with Phase forced empty, so
-// parallel download goroutines (PR 4) can't corrupt phase accounting.
-func TestEmitProgressBlobNeverAdvancesPhase(t *testing.T) {
-	got := collectProgress(t, func(ctx context.Context) {
-		EmitProgress(ctx, ProgressEvent{
-			Phase: "image", // must be discarded
-			Kind:  KindBlob, Message: "blob", ID: "sha256:x",
-			Status: "downloading", Current: 5, Total: 10,
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectProgress(t, func(ctx context.Context) { EmitProgress(ctx, tc.event) })
+			tc.check(t, got)
 		})
-	})
-	if len(got) != 1 {
-		t.Fatalf("got %d events, want 1 (no phase advance for blob): %+v", len(got), got)
-	}
-	ev := got[0]
-	if ev.Phase != "" {
-		t.Errorf("blob event advanced the phase: %+v", ev)
-	}
-	if ev.Kind != KindBlob || ev.ID != "sha256:x" || ev.Current != 5 || ev.Total != 10 {
-		t.Errorf("blob event fields not preserved: %+v", ev)
 	}
 }

--- a/internal/backend/progress_emit_test.go
+++ b/internal/backend/progress_emit_test.go
@@ -1,0 +1,54 @@
+package backend
+
+import (
+	"context"
+	"testing"
+)
+
+func collectProgress(t *testing.T, fn func(ctx context.Context)) []ProgressEvent {
+	t.Helper()
+	var got []ProgressEvent
+	ctx := ContextWithProgress(context.Background(), func(ev ProgressEvent) { got = append(got, ev) })
+	fn(ctx)
+	return got
+}
+
+// TestEmitProgressPlain keeps the historical two-event behavior for plain
+// events: a phase advance followed by a status line.
+func TestEmitProgressPlain(t *testing.T) {
+	got := collectProgress(t, func(ctx context.Context) {
+		EmitProgress(ctx, ProgressEvent{Phase: "image", Message: "Pulling layer 1/2"})
+	})
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2 (phase + status): %+v", len(got), got)
+	}
+	if got[0].Phase != "image" || got[0].Message != "" {
+		t.Errorf("event 0 = %+v, want phase-only {image}", got[0])
+	}
+	if got[1].Message != "Pulling layer 1/2" || got[1].Phase != "" {
+		t.Errorf("event 1 = %+v, want status-only line", got[1])
+	}
+}
+
+// TestEmitProgressBlobNeverAdvancesPhase is the PhaseTimer-safety guard: a
+// blob event must emit a single structured event with Phase forced empty, so
+// parallel download goroutines (PR 4) can't corrupt phase accounting.
+func TestEmitProgressBlobNeverAdvancesPhase(t *testing.T) {
+	got := collectProgress(t, func(ctx context.Context) {
+		EmitProgress(ctx, ProgressEvent{
+			Phase: "image", // must be discarded
+			Kind:  KindBlob, Message: "blob", ID: "sha256:x",
+			Status: "downloading", Current: 5, Total: 10,
+		})
+	})
+	if len(got) != 1 {
+		t.Fatalf("got %d events, want 1 (no phase advance for blob): %+v", len(got), got)
+	}
+	ev := got[0]
+	if ev.Phase != "" {
+		t.Errorf("blob event advanced the phase: %+v", ev)
+	}
+	if ev.Kind != KindBlob || ev.ID != "sha256:x" || ev.Current != 5 || ev.Total != 10 {
+		t.Errorf("blob event fields not preserved: %+v", ev)
+	}
+}

--- a/internal/firecracker/image.go
+++ b/internal/firecracker/image.go
@@ -49,10 +49,25 @@ func (c *Client) TagImage(srcTagOrDigest, newTag string) error {
 // the backend's native platform.
 func (c *Client) PullImage(ctx context.Context, dockerRef, tag, platform string) (string, error) {
 	mgr := vmimage.NewManager(c.cfg, c.refScanner())
-	return mgr.PullImage(ctx, dockerRef, tag, platform, func(stage, msg string) {
-		backend.Phase(ctx, stage)
-		backend.Status(ctx, msg)
-	})
+	return mgr.PullImage(ctx, dockerRef, tag, platform, progressBridge(ctx))
+}
+
+// progressBridge translates vmimage progress events into backend SSE events.
+// Plain events advance the phase and emit a status line; blob events emit
+// structured byte progress without advancing the phase (safe under parallel
+// download). vmimage must not import backend, so this lives in the backend.
+func progressBridge(ctx context.Context) vmimage.ProgressFunc {
+	return func(ev vmimage.ProgressEvent) {
+		backend.EmitProgress(ctx, backend.ProgressEvent{
+			Phase:   ev.Stage,
+			Message: ev.Message,
+			Kind:    ev.Kind,
+			ID:      ev.ID,
+			Status:  ev.Status,
+			Current: ev.Current,
+			Total:   ev.Total,
+		})
+	}
 }
 
 // PushImage uploads the manifest currently held by tagOrDigest to the
@@ -60,10 +75,7 @@ func (c *Client) PullImage(ctx context.Context, dockerRef, tag, platform string)
 // on-disk OCI store.
 func (c *Client) PushImage(ctx context.Context, tagOrDigest, dstRef string) error {
 	mgr := vmimage.NewManager(c.cfg, c.refScanner())
-	return mapSentinelErrors(mgr.PushImage(ctx, tagOrDigest, dstRef, func(stage, msg string) {
-		backend.Phase(ctx, stage)
-		backend.Status(ctx, msg)
-	}))
+	return mapSentinelErrors(mgr.PushImage(ctx, tagOrDigest, dstRef, progressBridge(ctx)))
 }
 
 // DeleteImage removes a tag (Docker model). The underlying blob is GC'd

--- a/internal/firecracker/orchestrator.go
+++ b/internal/firecracker/orchestrator.go
@@ -170,10 +170,7 @@ func (b *fcCreator) PreFlight(ctx context.Context, req config.CreateShedRequest,
 			Name:      resolved.Name,
 			Digest:    resolved.Digest,
 			Policy:    vmimage.PullPolicy(resolved.PullPolicy),
-		}, func(stage, msg string) {
-			backend.Phase(ctx, stage)
-			backend.Status(ctx, msg)
-		})
+		}, progressBridge(ctx))
 		if err != nil {
 			return nil, fmt.Errorf("failed to ensure image: %w", err)
 		}

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -74,8 +74,7 @@ func NewManager(cfg ImageConfig, scanner RefScanner) *Manager {
 	return &Manager{cfg: cfg, scanner: scanner}
 }
 
-// ProgressFunc is called to report progress during long-running operations.
-type ProgressFunc func(stage, msg string)
+// ProgressFunc and ProgressEvent are defined in progress.go.
 
 // ResolvedRef describes an image to ensure: either a local path or a Docker ref to pull.
 type ResolvedRef struct {
@@ -156,9 +155,7 @@ func (m *Manager) EnsureImage(ctx context.Context, ref ResolvedRef, progress Pro
 		return EnsureResult{}, fmt.Errorf("%w: %s", ErrPullDisabled, ref.DockerRef)
 	}
 
-	if progress != nil {
-		progress("image", fmt.Sprintf("Pulling %s...", ref.DockerRef))
-	}
+	emitStatus(progress, "image", fmt.Sprintf("Pulling %s...", ref.DockerRef))
 
 	// Registry-direct pull only — v0.5.2 dropped the legacy
 	// docker-daemon fallback. The fallback flattened to a single

--- a/internal/vmimage/progress.go
+++ b/internal/vmimage/progress.go
@@ -1,0 +1,156 @@
+package vmimage
+
+import (
+	"io"
+	"time"
+)
+
+// ProgressEvent is a progress update from a long-running image operation
+// (pull / push / ensure). Stage + Message are the plain status fields used
+// since the beginning. The Kind=="blob" fields carry structured per-blob
+// byte progress for the `shed` CLI's live renderer; line-mode and older
+// clients ignore them and render Message.
+//
+// Backends translate this to backend.ProgressEvent at the API boundary
+// (vmimage must not import backend), so the wire shape is owned by the
+// backend package — this struct is the in-process carrier.
+type ProgressEvent struct {
+	Stage   string // phase/stage label (e.g. "image"); advances the PhaseTimer
+	Message string // human-readable status line; always set for emitted events
+
+	// Structured per-blob byte progress. Zero on plain status events.
+	Kind    string // "" plain status; "blob" per-blob byte progress
+	ID      string // full digest (blob events); renderer keys on this
+	Status  string // BlobStatus* (blob events)
+	Current int64  // bytes fetched so far (blob events)
+	Total   int64  // total bytes — compressed descriptor size (blob events)
+}
+
+// ProgressFunc receives progress events during long-running operations.
+type ProgressFunc func(ProgressEvent)
+
+// IsBlob reports whether e carries structured per-blob byte progress. Plain
+// line-oriented consumers (logs, the bulk pull-images command) use this to
+// skip byte-tick events they would otherwise spam.
+func (e ProgressEvent) IsBlob() bool { return e.Kind == progressKind }
+
+// Blob status values for ProgressEvent.Status when Kind=="blob". These
+// string values cross the wire (the backend forwards Status verbatim), so
+// they are the single source of truth for both sides.
+const (
+	BlobStatusDownloading = "downloading" // a byte tick or the initial 0-byte start
+	BlobStatusExists      = "exists"      // blob already present in the store
+	BlobStatusDone        = "done"        // fully fetched + verified (Current == Total)
+)
+
+// progressKind marks a blob event.
+const progressKind = "blob"
+
+// safeEmit delivers ev to p when p is non-nil. The single nil-check point
+// for all progress emission in this package.
+func safeEmit(p ProgressFunc, ev ProgressEvent) {
+	if p != nil {
+		p(ev)
+	}
+}
+
+// emitStatus delivers a plain status line to p (nil-safe). Use this for the
+// human-readable progress lines that line-mode clients render.
+func emitStatus(p ProgressFunc, stage, msg string) {
+	safeEmit(p, ProgressEvent{Stage: stage, Message: msg})
+}
+
+// emitBlob delivers a one-shot structured per-blob event to p (nil-safe),
+// e.g. the "exists" event for a cached blob. human is carried as Message
+// for line-mode fallback.
+func emitBlob(p ProgressFunc, digest, human, status string, current, total int64) {
+	safeEmit(p, ProgressEvent{
+		Stage:   "image",
+		Message: human,
+		Kind:    progressKind,
+		ID:      digest,
+		Status:  status,
+		Current: current,
+		Total:   total,
+	})
+}
+
+// blobThrottle rate-limits byte-tick emission to at most once per interval,
+// so a fast download doesn't flood the SSE channel. now is injectable for
+// tests; a zero now defaults to time.Now.
+type blobThrottle struct {
+	interval time.Duration
+	last     time.Time
+	now      func() time.Time
+}
+
+// ready reports whether enough time has elapsed since the last tick. The
+// first call always returns true (last is zero).
+func (t *blobThrottle) ready() bool {
+	nowFn := t.now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	n := nowFn()
+	if t.last.IsZero() || n.Sub(t.last) >= t.interval {
+		t.last = n
+		return true
+	}
+	return false
+}
+
+// defaultBlobTickInterval bounds byte-tick events to ~10/sec per blob.
+const defaultBlobTickInterval = 100 * time.Millisecond
+
+// progressReader wraps a blob's compressed reader and emits throttled
+// "downloading" byte-tick events as bytes flow. The initial 0-byte start
+// and the terminal "done" event are emitted explicitly by the caller (see
+// streamBlobWithProgress) so they are never coalesced away.
+type progressReader struct {
+	r        io.Reader
+	id       string // full digest
+	human    string // human message carried on every blob event
+	total    int64
+	current  int64
+	progress ProgressFunc
+	throttle blobThrottle
+}
+
+func (p *progressReader) Read(b []byte) (int, error) {
+	n, err := p.r.Read(b)
+	if n > 0 {
+		p.current += int64(n)
+		if p.throttle.ready() {
+			p.emit(BlobStatusDownloading)
+		}
+	}
+	return n, err
+}
+
+// emit sends a blob event with the reader's current byte count.
+func (p *progressReader) emit(status string) {
+	emitBlob(p.progress, p.id, p.human, status, p.current, p.total)
+}
+
+// streamBlobWithProgress streams rc into the blob store under digest while
+// emitting per-blob byte progress: a 0-byte "downloading" start, throttled
+// byte ticks, and a terminal "done" (Current==Total). human is the message
+// carried on each event for line-mode fallback. write performs the actual
+// hash-verified write (writeBlobFromReader-shaped).
+func streamBlobWithProgress(digest, human string, total int64, progress ProgressFunc, rc io.Reader, write func(io.Reader) error) error {
+	pr := &progressReader{
+		r:        rc,
+		id:       digest,
+		human:    human,
+		total:    total,
+		progress: progress,
+		throttle: blobThrottle{interval: defaultBlobTickInterval},
+	}
+	pr.emit(BlobStatusDownloading) // 0-byte start so the renderer learns Total up front
+	if err := write(pr); err != nil {
+		return err
+	}
+	pr.current = total
+	pr.emit(BlobStatusDone)
+	return nil
+}

--- a/internal/vmimage/progress_test.go
+++ b/internal/vmimage/progress_test.go
@@ -1,0 +1,156 @@
+package vmimage
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBlobThrottle(t *testing.T) {
+	now := time.Unix(0, 0)
+	th := blobThrottle{interval: 100 * time.Millisecond, now: func() time.Time { return now }}
+
+	if !th.ready() {
+		t.Fatal("first ready() must be true (last is zero)")
+	}
+	if th.ready() {
+		t.Fatal("second immediate ready() must be false (no time elapsed)")
+	}
+	now = now.Add(50 * time.Millisecond)
+	if th.ready() {
+		t.Fatal("ready() before the interval elapses must be false")
+	}
+	now = now.Add(60 * time.Millisecond) // 110ms since the last tick
+	if !th.ready() {
+		t.Fatal("ready() after the interval elapses must be true")
+	}
+}
+
+func TestProgressReaderByteTicks(t *testing.T) {
+	var events []ProgressEvent
+	now := time.Unix(0, 0)
+	pr := &progressReader{
+		r:        bytes.NewReader(make([]byte, 1000)),
+		id:       "sha256:abc",
+		human:    "Pulling",
+		total:    1000,
+		progress: func(ev ProgressEvent) { events = append(events, ev) },
+		throttle: blobThrottle{interval: 100 * time.Millisecond, now: func() time.Time { return now }},
+	}
+	buf := make([]byte, 100)
+	for {
+		now = now.Add(200 * time.Millisecond) // advance past the interval every read
+		_, err := pr.Read(buf)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+	}
+	if len(events) == 0 {
+		t.Fatal("expected byte-tick events")
+	}
+	for i, ev := range events {
+		if !ev.IsBlob() {
+			t.Errorf("event %d is not a blob event: %+v", i, ev)
+		}
+		if ev.Status != BlobStatusDownloading {
+			t.Errorf("event %d status = %q, want downloading", i, ev.Status)
+		}
+		if ev.Total != 1000 {
+			t.Errorf("event %d total = %d, want 1000", i, ev.Total)
+		}
+	}
+	if last := events[len(events)-1]; last.Current != 1000 {
+		t.Errorf("last tick current = %d, want 1000", last.Current)
+	}
+}
+
+func TestProgressReaderThrottleSuppresses(t *testing.T) {
+	var events []ProgressEvent
+	now := time.Unix(0, 0)
+	pr := &progressReader{
+		r:        bytes.NewReader(make([]byte, 1000)),
+		total:    1000,
+		progress: func(ev ProgressEvent) { events = append(events, ev) },
+		throttle: blobThrottle{interval: 100 * time.Millisecond, now: func() time.Time { return now }},
+	}
+	// Clock never advances: only the very first read emits a tick.
+	buf := make([]byte, 100)
+	for {
+		_, err := pr.Read(buf)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+	}
+	if len(events) != 1 {
+		t.Errorf("with a frozen clock want exactly 1 tick, got %d", len(events))
+	}
+}
+
+func TestStreamBlobWithProgressStartAndDone(t *testing.T) {
+	var events []ProgressEvent
+	var written bytes.Buffer
+	err := streamBlobWithProgress("sha256:x", "Pulling x", 500,
+		func(ev ProgressEvent) { events = append(events, ev) },
+		bytes.NewReader(make([]byte, 500)),
+		func(r io.Reader) error { _, e := io.Copy(&written, r); return e },
+	)
+	if err != nil {
+		t.Fatalf("streamBlobWithProgress: %v", err)
+	}
+	if written.Len() != 500 {
+		t.Fatalf("wrote %d bytes, want 500", written.Len())
+	}
+	if len(events) < 2 {
+		t.Fatalf("want at least a start and a done event, got %d", len(events))
+	}
+	if first := events[0]; first.Status != BlobStatusDownloading || first.Current != 0 || first.Total != 500 || first.ID != "sha256:x" {
+		t.Errorf("first event = %+v, want downloading 0/500 id sha256:x", first)
+	}
+	if last := events[len(events)-1]; last.Status != BlobStatusDone || last.Current != 500 || last.Total != 500 {
+		t.Errorf("last event = %+v, want done 500/500", last)
+	}
+}
+
+// TestPullToOCILayout_BlobByteProgress asserts the live pull emits structured
+// per-blob events keyed by full digest, each opening with a 0-byte
+// downloading start and closing with a done event at Current==Total.
+func TestPullToOCILayout_BlobByteProgress(t *testing.T) {
+	host := startTestRegistry(t)
+	ref := pushRandomImage(t, fmt.Sprintf("%s/test/bytes:v1", host), 2)
+
+	var blobEvents []ProgressEvent
+	for _, ev := range pullCollectingEvents(t, ref, t.TempDir()) {
+		if ev.IsBlob() {
+			blobEvents = append(blobEvents, ev)
+		}
+	}
+	if len(blobEvents) == 0 {
+		t.Fatal("no blob events emitted")
+	}
+
+	byID := map[string][]ProgressEvent{}
+	for _, ev := range blobEvents {
+		if !strings.HasPrefix(ev.ID, "sha256:") {
+			t.Errorf("blob event ID is not a full digest: %q", ev.ID)
+		}
+		byID[ev.ID] = append(byID[ev.ID], ev)
+	}
+	for id, evs := range byID {
+		first, last := evs[0], evs[len(evs)-1]
+		if first.Status != BlobStatusDownloading || first.Current != 0 {
+			t.Errorf("%s: first event = %+v, want downloading at 0 bytes", ShortDigest(id), first)
+		}
+		if last.Status != BlobStatusDone || last.Total <= 0 || last.Current != last.Total {
+			t.Errorf("%s: last event = %+v, want done with Current==Total>0", ShortDigest(id), last)
+		}
+	}
+}

--- a/internal/vmimage/progress_test.go
+++ b/internal/vmimage/progress_test.go
@@ -30,68 +30,63 @@ func TestBlobThrottle(t *testing.T) {
 }
 
 func TestProgressReaderByteTicks(t *testing.T) {
-	var events []ProgressEvent
-	now := time.Unix(0, 0)
-	pr := &progressReader{
-		r:        bytes.NewReader(make([]byte, 1000)),
-		id:       "sha256:abc",
-		human:    "Pulling",
-		total:    1000,
-		progress: func(ev ProgressEvent) { events = append(events, ev) },
-		throttle: blobThrottle{interval: 100 * time.Millisecond, now: func() time.Time { return now }},
+	cases := []struct {
+		name           string
+		advancePerRead time.Duration
+		wantTicks      func(t *testing.T, events []ProgressEvent)
+	}{
+		{
+			name:           "advancing clock emits a tick per read up to the full byte count",
+			advancePerRead: 200 * time.Millisecond, // past the 100ms interval every read
+			wantTicks: func(t *testing.T, events []ProgressEvent) {
+				if len(events) == 0 {
+					t.Fatal("expected byte-tick events")
+				}
+				if last := events[len(events)-1]; last.Current != 1000 {
+					t.Errorf("last tick current = %d, want 1000", last.Current)
+				}
+			},
+		},
+		{
+			name:           "frozen clock emits only the first tick",
+			advancePerRead: 0,
+			wantTicks: func(t *testing.T, events []ProgressEvent) {
+				if len(events) != 1 {
+					t.Errorf("with a frozen clock want exactly 1 tick, got %d", len(events))
+				}
+			},
+		},
 	}
-	buf := make([]byte, 100)
-	for {
-		now = now.Add(200 * time.Millisecond) // advance past the interval every read
-		_, err := pr.Read(buf)
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("read: %v", err)
-		}
-	}
-	if len(events) == 0 {
-		t.Fatal("expected byte-tick events")
-	}
-	for i, ev := range events {
-		if !ev.IsBlob() {
-			t.Errorf("event %d is not a blob event: %+v", i, ev)
-		}
-		if ev.Status != BlobStatusDownloading {
-			t.Errorf("event %d status = %q, want downloading", i, ev.Status)
-		}
-		if ev.Total != 1000 {
-			t.Errorf("event %d total = %d, want 1000", i, ev.Total)
-		}
-	}
-	if last := events[len(events)-1]; last.Current != 1000 {
-		t.Errorf("last tick current = %d, want 1000", last.Current)
-	}
-}
-
-func TestProgressReaderThrottleSuppresses(t *testing.T) {
-	var events []ProgressEvent
-	now := time.Unix(0, 0)
-	pr := &progressReader{
-		r:        bytes.NewReader(make([]byte, 1000)),
-		total:    1000,
-		progress: func(ev ProgressEvent) { events = append(events, ev) },
-		throttle: blobThrottle{interval: 100 * time.Millisecond, now: func() time.Time { return now }},
-	}
-	// Clock never advances: only the very first read emits a tick.
-	buf := make([]byte, 100)
-	for {
-		_, err := pr.Read(buf)
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("read: %v", err)
-		}
-	}
-	if len(events) != 1 {
-		t.Errorf("with a frozen clock want exactly 1 tick, got %d", len(events))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var events []ProgressEvent
+			now := time.Unix(0, 0)
+			pr := &progressReader{
+				r:        bytes.NewReader(make([]byte, 1000)),
+				id:       "sha256:abc",
+				human:    "Pulling",
+				total:    1000,
+				progress: func(ev ProgressEvent) { events = append(events, ev) },
+				throttle: blobThrottle{interval: 100 * time.Millisecond, now: func() time.Time { return now }},
+			}
+			buf := make([]byte, 100)
+			for {
+				now = now.Add(tc.advancePerRead)
+				_, err := pr.Read(buf)
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Fatalf("read: %v", err)
+				}
+			}
+			for i, ev := range events {
+				if !ev.IsBlob() || ev.Status != BlobStatusDownloading || ev.Total != 1000 {
+					t.Errorf("event %d = %+v, want a downloading blob tick with total 1000", i, ev)
+				}
+			}
+			tc.wantTicks(t, events)
+		})
 	}
 }
 

--- a/internal/vmimage/registry.go
+++ b/internal/vmimage/registry.go
@@ -156,9 +156,7 @@ func PushFromOCILayout(ctx context.Context, opts PushOptions) error {
 		if d == "" {
 			continue
 		}
-		if opts.Progress != nil {
-			opts.Progress("image", fmt.Sprintf("Pushing %s %s", ann, ShortDigest(d)))
-		}
+		emitStatus(opts.Progress, "image", fmt.Sprintf("Pushing %s %s", ann, ShortDigest(d)))
 		if err := pushLooseBlob(ctx, dst, d, opts.ImagesDir, remoteOpts, nameOpts); err != nil {
 			return fmt.Errorf("pushing %s blob: %w", ann, err)
 		}
@@ -180,9 +178,7 @@ func PushFromOCILayout(ctx context.Context, opts PushOptions) error {
 	if err != nil {
 		return fmt.Errorf("loading image from layout: %w", err)
 	}
-	if opts.Progress != nil {
-		opts.Progress("image", fmt.Sprintf("Pushing manifest %s → %s", ShortDigest(opts.ManifestDigest), opts.Ref))
-	}
+	emitStatus(opts.Progress, "image", fmt.Sprintf("Pushing manifest %s → %s", ShortDigest(opts.ManifestDigest), opts.Ref))
 	if err := remote.Write(dst, img, remoteOpts...); err != nil {
 		return fmt.Errorf("uploading image: %w", err)
 	}
@@ -312,9 +308,7 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		remoteOpts = append(remoteOpts, remote.WithPlatform(*p))
 	}
 
-	if opts.Progress != nil {
-		opts.Progress("image", fmt.Sprintf("Fetching manifest %s...", ref.String()))
-	}
+	emitStatus(opts.Progress, "image", fmt.Sprintf("Fetching manifest %s...", ref.String()))
 
 	var desc *remote.Descriptor
 	err = withRetry(ctx, "fetching manifest "+ref.String(), func() error {
@@ -381,23 +375,26 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 			// this, the i+1/N counter leaves gaps (e.g. "1/7 … 4/7") for
 			// layers already on disk, which reads as "missing layers".
 			// Mirrors Docker's "Already exists".
-			if opts.Progress != nil {
-				opts.Progress("image", fmt.Sprintf("Layer %d/%d %s already present", i+1, len(layers), ShortDigest(digest)))
-			}
+			human := fmt.Sprintf("Layer %d/%d %s already present", i+1, len(layers), ShortDigest(digest))
+			emitStatus(opts.Progress, "image", human)
+			size, _ := layer.Size()
+			emitBlob(opts.Progress, digest, human, BlobStatusExists, size, size)
 			continue
 		}
-		if opts.Progress != nil {
-			opts.Progress("image", fmt.Sprintf("Pulling layer %d/%d %s", i+1, len(layers), ShortDigest(digest)))
-		}
+		human := fmt.Sprintf("Pulling layer %d/%d %s", i+1, len(layers), ShortDigest(digest))
+		emitStatus(opts.Progress, "image", human)
+		size, _ := layer.Size()
 		rc, err := layer.Compressed()
 		if err != nil {
 			return nil, fmt.Errorf("opening layer %s: %w", digest, err)
 		}
-		if err := writeBlobFromReader(opts.ImagesDir, digest, rc); err != nil {
-			rc.Close()
+		err = streamBlobWithProgress(digest, human, size, opts.Progress, rc, func(r io.Reader) error {
+			return writeBlobFromReader(opts.ImagesDir, digest, r)
+		})
+		rc.Close()
+		if err != nil {
 			return nil, fmt.Errorf("streaming layer %s: %w", digest, err)
 		}
-		rc.Close()
 	}
 
 	// Write the manifest verbatim (preserves the registry digest).
@@ -411,7 +408,7 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		// Kernel is a sibling blob in the registry — fetch it as a
 		// loose blob (the registry doesn't surface it via Image()
 		// because it isn't a layer).
-		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts); err != nil {
+		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts, opts.Progress, "Pulling kernel "+ShortDigest(d)); err != nil {
 			return nil, fmt.Errorf("pulling kernel blob %s: %w", d, err)
 		}
 		kernelDigest = d
@@ -423,7 +420,7 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		kernelDigest = d
 	}
 	if d := annotationFromManifest(manifestDesc, AnnotationInitrdDigest); d != "" {
-		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts); err != nil {
+		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts, opts.Progress, "Pulling initrd "+ShortDigest(d)); err != nil {
 			return nil, fmt.Errorf("pulling initrd blob %s: %w", d, err)
 		}
 		initrdDigest = d
@@ -441,7 +438,7 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 	// against v0.5.2+ tooling" error so the user knows the upgrade
 	// path. See internal/vmimage/manager.go.
 	if d := annotationFromManifest(manifestDesc, AnnotationRootfsErofsDigest); d != "" {
-		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts); err != nil {
+		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts, opts.Progress, "Pulling rootfs "+ShortDigest(d)); err != nil {
 			return nil, fmt.Errorf("pulling rootfs erofs blob %s: %w", d, err)
 		}
 	}
@@ -555,8 +552,17 @@ func streamHashCopy(dst io.Writer, src io.Reader) (string, int64, error) {
 // from the same repo as `ref`, writing it under blobs/sha256/<hex>.
 // The caller passes the same insecure flag they set on the originating
 // pull so the sibling-blob request honors the same TLS policy.
-func pullLooseBlob(ctx context.Context, ref name.Reference, digest, imagesDir string, insecure bool, remoteOpts []remote.Option) error {
+// progress + human carry structured per-blob byte progress for the loose
+// blob (kernel / initrd / rootfs erofs). Unlike layers these emit NO plain
+// status line — they were silent before, so line-mode output is unchanged;
+// only the structured (renderer-only) blob events are added.
+func pullLooseBlob(ctx context.Context, ref name.Reference, digest, imagesDir string, insecure bool, remoteOpts []remote.Option, progress ProgressFunc, human string) error {
 	if BlobExists(imagesDir, digest) {
+		// Report the on-disk size (like cached layers do) so an opted-in
+		// renderer shows a full bar and can tell a real zero-byte blob from
+		// "size unknown".
+		size := BlobSize(imagesDir, digest)
+		emitBlob(progress, digest, human+" (already present)", BlobStatusExists, size, size)
 		return nil
 	}
 	blobRef, err := name.NewDigest(ref.Context().Name()+"@"+digest, nameOptsForInsecure(insecure)...)
@@ -575,12 +581,17 @@ func pullLooseBlob(ctx context.Context, ref name.Reference, digest, imagesDir st
 		if lerr != nil {
 			return fmt.Errorf("requesting layer %s: %w", digest, lerr)
 		}
+		size, _ := layer.Size()
 		rc, oerr := layer.Compressed()
 		if oerr != nil {
 			return fmt.Errorf("opening loose blob: %w", oerr)
 		}
 		defer rc.Close()
-		return writeBlobFromReader(imagesDir, digest, rc)
+		// New progressReader per attempt: a retry restarts the byte count
+		// from 0 (the renderer shows the restart), which is correct.
+		return streamBlobWithProgress(digest, human, size, progress, rc, func(r io.Reader) error {
+			return writeBlobFromReader(imagesDir, digest, r)
+		})
 	})
 }
 

--- a/internal/vmimage/registry_pull_test.go
+++ b/internal/vmimage/registry_pull_test.go
@@ -48,22 +48,37 @@ func pushRandomImage(t *testing.T, refStr string, layers int) string {
 }
 
 // pullCollecting runs PullToOCILayout against the test registry and returns
-// every progress message it emitted.
+// the plain (line-mode) progress messages it emitted. Structured blob events
+// are excluded so these assertions track exactly what a line-mode client
+// renders; the byte-progress events are exercised by pullCollectingEvents.
 func pullCollecting(t *testing.T, ref, imagesDir string) []string {
 	t.Helper()
 	var msgs []string
+	for _, ev := range pullCollectingEvents(t, ref, imagesDir) {
+		if ev.IsBlob() {
+			continue
+		}
+		msgs = append(msgs, ev.Message)
+	}
+	return msgs
+}
+
+// pullCollectingEvents runs PullToOCILayout and returns every progress event.
+func pullCollectingEvents(t *testing.T, ref, imagesDir string) []ProgressEvent {
+	t.Helper()
+	var events []ProgressEvent
 	_, err := PullToOCILayout(context.Background(), PullOptions{
 		Ref:       ref,
 		ImagesDir: imagesDir,
 		Insecure:  true,
-		Progress: func(_, msg string) {
-			msgs = append(msgs, msg)
+		Progress: func(ev ProgressEvent) {
+			events = append(events, ev)
 		},
 	})
 	if err != nil {
 		t.Fatalf("PullToOCILayout(%q): %v", ref, err)
 	}
-	return msgs
+	return events
 }
 
 var layerCounterRe = regexp.MustCompile(`\b(\d+/\d+)\b`)

--- a/internal/vz/image.go
+++ b/internal/vz/image.go
@@ -30,14 +30,29 @@ func (c *Client) EnsureImage(ctx context.Context, resolved config.ResolvedImage)
 		Name:      resolved.Name,
 		Digest:    resolved.Digest,
 		Policy:    vmimage.PullPolicy(resolved.PullPolicy),
-	}, func(stage, msg string) {
-		backend.Phase(ctx, stage)
-		backend.Status(ctx, msg)
-	})
+	}, progressBridge(ctx))
 	if err != nil {
 		return "", "", err
 	}
 	return res.Path, res.Digest, nil
+}
+
+// progressBridge translates vmimage progress events into backend SSE events.
+// Plain events advance the phase and emit a status line; blob events emit
+// structured byte progress without advancing the phase (safe under parallel
+// download). vmimage must not import backend, so this lives in the backend.
+func progressBridge(ctx context.Context) vmimage.ProgressFunc {
+	return func(ev vmimage.ProgressEvent) {
+		backend.EmitProgress(ctx, backend.ProgressEvent{
+			Phase:   ev.Stage,
+			Message: ev.Message,
+			Kind:    ev.Kind,
+			ID:      ev.ID,
+			Status:  ev.Status,
+			Current: ev.Current,
+			Total:   ev.Total,
+		})
+	}
 }
 
 // ListImages returns available image variants from config and the blob store.
@@ -74,10 +89,7 @@ func (c *Client) TagImage(srcTagOrDigest, newTag string) error {
 // the backend's native platform.
 func (c *Client) PullImage(ctx context.Context, dockerRef, tag, platform string) (string, error) {
 	mgr := vmimage.NewManager(c.cfg, c.refScanner())
-	return mgr.PullImage(ctx, dockerRef, tag, platform, func(stage, msg string) {
-		backend.Phase(ctx, stage)
-		backend.Status(ctx, msg)
-	})
+	return mgr.PullImage(ctx, dockerRef, tag, platform, progressBridge(ctx))
 }
 
 // PushImage uploads the manifest currently held by tagOrDigest to the
@@ -85,10 +97,7 @@ func (c *Client) PullImage(ctx context.Context, dockerRef, tag, platform string)
 // on-disk OCI store.
 func (c *Client) PushImage(ctx context.Context, tagOrDigest, dstRef string) error {
 	mgr := vmimage.NewManager(c.cfg, c.refScanner())
-	return mapSentinelErrors(mgr.PushImage(ctx, tagOrDigest, dstRef, func(stage, msg string) {
-		backend.Phase(ctx, stage)
-		backend.Status(ctx, msg)
-	}))
+	return mapSentinelErrors(mgr.PushImage(ctx, tagOrDigest, dstRef, progressBridge(ctx)))
 }
 
 // DeleteImage removes a tag (Docker model). The underlying blob is GC'd


### PR DESCRIPTION
## Summary

Foundational PR for Docker-style pull progress. Adds **byte-level, per-blob structured progress events** to the image-pull path, while keeping line-mode and older-CLI output **byte-for-byte unchanged**. Second of a phased series (see `docs/discovery/pull-parallelism-and-progress-ui.md`); the TTY renderer that consumes these events lands in the next PR.

## What changed

**Wire** (`internal/backend/progress.go`): `ProgressEvent` gains optional `Kind`/`ID`/`Status`/`Current`/`Total` fields (all `omitempty`). `ID` is the **full digest** (renderer keys on it). `BlobProgress` forces `Phase=""` so blob events never advance the PhaseTimer — the safety invariant that lets a future parallel-download PR emit them from goroutines. `EmitProgress` routes blob vs plain (plain keeps the historical phase+status two-event behavior).

**Counting** (`internal/vmimage/progress.go`, `registry.go`): a counting reader + time throttle (~10/s per blob) emit `downloading`/`exists`/`done` events for layers **and** the loose kernel/initrd/erofs blobs (the erofs is the biggest blob, so its bar matters most). `vmimage` must not import `backend`, so it has its own `ProgressEvent`; the vz/firecracker bridges translate at the API boundary.

**Compat / no spam** (`internal/api/handlers.go`): the server only forwards blob events to clients that **opt in via `?progress=blob`**, so older / line-mode clients never receive byte-tick events. The SSE sink also replaces the silent `default:`-drop with a **ctx-aware blocking send**, so a status transition (e.g. a terminal `done`) is never dropped under buffer pressure; it unblocks on request cancellation (no deadlock/leak).

## Compatibility

- new server + old CLI → unchanged (`Message` still drives line rendering; no `?progress=blob` → no blob events).
- new CLI + old server → no `Kind` ever seen → stays in line mode.
- This PR is **server-side only with no visible effect for any current client** — the opt-in renderer arrives next.

## Verification

- `make check` — lint clean (0 issues), full unit suite green. New tests: throttle + counting-reader + byte-progress against a real in-memory registry; `backend.EmitProgress` phase-safety; SSE sink gating / non-dropping-send / cancel.
- `make test-integration-dev` (VZ dev server) — **50 passed**, 3 expected skips. (One FC raw-SSH test flaked on the remote deb server, unrelated to pull progress; re-ran green.)
- Manual:
  - CLI re-pull (no opt-in) → line output identical to before, **0** blob events.
  - `curl .../api/images/pull?progress=blob` → blob events present with full-digest `id`, real `current/total` byte sizes, `status:"exists"`, `phase:""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced progress reporting with optional per-blob byte-level events and clearer event types.

* **Bug Fixes**
  * More reliable SSE progress delivery (buffering, no silent drops) and reduced log spam by defaulting to hide blob-level noise unless opted in.

* **Tests**
  * Added tests covering progress gating, blob byte-tick behavior, and send-unblock-on-cancel semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->