### PR TITLE
feat(images): Docker-style live progress bars for image pull

### DIFF
--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -458,7 +458,7 @@ func (c *APIClient) PullImage(dockerRef, tag, platform string) (*config.ImagePul
 // PullImageWithProgress pulls a Docker reference and streams per-stage
 // progress via SSE (mirrors CreateShedWithProgress). Falls back to the
 // non-streaming PullImage path only if the server rejects the stream.
-func (c *APIClient) PullImageWithProgress(dockerRef, tag, platform string, onProgress func(backend.ProgressEvent)) (*config.ImagePullResponse, error) {
+func (c *APIClient) PullImageWithProgress(dockerRef, tag, platform string, wantBlobProgress bool, onProgress func(backend.ProgressEvent)) (*config.ImagePullResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
@@ -466,7 +466,14 @@ func (c *APIClient) PullImageWithProgress(dockerRef, tag, platform string, onPro
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode request: %w", err)
 	}
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/images/pull", bytes.NewReader(bodyData))
+	// Opt into structured per-blob byte events only when the caller can
+	// render them (interactive TTY). Older servers ignore the param and a
+	// non-opted-in request keeps today's plain line stream.
+	url := c.baseURL + "/api/images/pull"
+	if wantBlobProgress {
+		url += "?progress=blob"
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyData))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -702,16 +702,37 @@ func runImagePull(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	client := NewAPIClientFromEntry(entry, DefaultTimeout)
-	resp, err := client.PullImageWithProgress(dockerRef, tag, imagePullPlatform, func(event backend.ProgressEvent) {
-		if jsonFlag {
-			return
-		}
-		if event.Warning {
-			fmt.Fprintf(os.Stderr, "  Warning: %s\n", event.Message)
-		} else {
+
+	// On an interactive terminal, opt into structured byte progress and draw
+	// a live block of per-blob bars. Otherwise (pipe, --json, redirected, or
+	// an old server) fall back to the plain line stream.
+	useLive := !jsonFlag && isProgressTTY(os.Stdout)
+	var renderer *liveRenderer
+	if useLive {
+		renderer = newLiveRenderer(os.Stdout, func() (int, int) { return terminalSize(os.Stdout) })
+	}
+	resp, err := client.PullImageWithProgress(dockerRef, tag, imagePullPlatform, useLive, func(event backend.ProgressEvent) {
+		switch {
+		case jsonFlag:
+			// --json suppresses progress; only the final response is printed.
+		case event.Warning:
+			// Warnings go to stderr; when a live block is up, erase and
+			// redraw around the write so the block isn't corrupted.
+			warn := func() { fmt.Fprintf(os.Stderr, "  Warning: %s\n", event.Message) }
+			if renderer != nil {
+				renderer.printAbove(warn)
+			} else {
+				warn()
+			}
+		case renderer != nil:
+			renderer.handle(event)
+		default:
 			fmt.Printf("  %s\n", event.Message)
 		}
 	})
+	if renderer != nil {
+		renderer.finish()
+	}
 	if err != nil {
 		return fmt.Errorf("failed to pull image: %w", err)
 	}

--- a/cmd/shed/progress_render.go
+++ b/cmd/shed/progress_render.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/vmimage"
+	"golang.org/x/term"
+)
+
+// isProgressTTY reports whether f is an interactive terminal we can draw a
+// live progress block on.
+func isProgressTTY(f *os.File) bool {
+	return term.IsTerminal(int(f.Fd()))
+}
+
+// terminalSize returns the (cols, rows) of f, falling back to 80x24 for any
+// dimension it can't read. Re-read per frame so the renderer follows a resize.
+func terminalSize(f *os.File) (cols, rows int) {
+	cols, rows = 80, 24
+	if w, h, err := term.GetSize(int(f.Fd())); err == nil {
+		if w > 0 {
+			cols = w
+		}
+		if h > 0 {
+			rows = h
+		}
+	}
+	return cols, rows
+}
+
+// renderBar renders a fixed-width progress bar for current/total. width is the
+// number of cells between the brackets. A non-positive total renders an
+// indeterminate (all-dash) bar; current is clamped to [0, total].
+func renderBar(current, total int64, width int) string {
+	if width < 1 {
+		width = 1
+	}
+	if total <= 0 {
+		return "[" + strings.Repeat("-", width) + "]"
+	}
+	if current < 0 {
+		current = 0
+	}
+	if current > total {
+		current = total
+	}
+	filled := int(float64(width) * float64(current) / float64(total))
+	if filled > width {
+		filled = width
+	}
+	return "[" + strings.Repeat("#", filled) + strings.Repeat("-", width-filled) + "]"
+}
+
+// truncate clamps s to at most width runes, appending an ellipsis when cut.
+func truncate(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= width {
+		return s
+	}
+	if width == 1 {
+		return "…"
+	}
+	return string(r[:width-1]) + "…"
+}
+
+// blobState is the latest known state of one downloading/cached blob.
+type blobState struct {
+	human   string
+	status  string
+	current int64
+	total   int64
+}
+
+// liveRenderer draws a Docker-style block of per-blob progress bars that
+// redraw in place. It is fed backend.ProgressEvent values and owns a
+// contiguous block of lines at the bottom of the terminal.
+type liveRenderer struct {
+	w       io.Writer
+	size    func() (cols, rows int) // re-read per frame so a resize is honored
+	order   []string                // blob IDs (full digests) in first-seen order
+	blobs   map[string]*blobState
+	drawn   int  // lines drawn in the last block (for in-place redraw)
+	sawBlob bool // a blob event has arrived → per-layer plain lines are now redundant
+}
+
+// newLiveRenderer builds a renderer writing to w. size reports the current
+// terminal (cols, rows); it is queried each frame so the block follows a
+// resize and never grows past the visible viewport. A nil size defaults to
+// a fixed 80x24.
+func newLiveRenderer(w io.Writer, size func() (int, int)) *liveRenderer {
+	if size == nil {
+		size = func() (int, int) { return 80, 24 }
+	}
+	return &liveRenderer{w: w, size: size, blobs: map[string]*blobState{}}
+}
+
+// handle consumes one progress event and updates the live display.
+func (r *liveRenderer) handle(ev backend.ProgressEvent) {
+	if ev.Kind == backend.KindBlob {
+		r.sawBlob = true
+		b, ok := r.blobs[ev.ID]
+		if !ok {
+			b = &blobState{}
+			r.blobs[ev.ID] = b
+			r.order = append(r.order, ev.ID)
+		}
+		b.human, b.status, b.current, b.total = ev.Message, ev.Status, ev.Current, ev.Total
+		r.redraw()
+		return
+	}
+	// Plain (non-blob) event. Show it until bars take over: the pre-blob
+	// "Fetching manifest..." header shows, and once blob events start the
+	// per-layer plain lines ("Pulling layer 2/6") are redundant with the
+	// bars, so suppress them. Crucially, if NO blob events ever arrive (an
+	// older server that ignores ?progress=blob and streams only plain
+	// lines), nothing is suppressed and the user still sees full progress.
+	if ev.Message == "" || r.sawBlob {
+		return
+	}
+	r.printAbove(func() { fmt.Fprintf(r.w, "  %s\n", ev.Message) })
+}
+
+// printAbove erases the live block, runs emit (which scrolls text into
+// history above the block), then redraws the block beneath it.
+func (r *liveRenderer) printAbove(emit func()) {
+	r.erase()
+	emit()
+	r.draw()
+}
+
+func (r *liveRenderer) redraw() {
+	r.erase()
+	r.draw()
+}
+
+func (r *liveRenderer) erase() {
+	if r.drawn > 0 {
+		// Move up r.drawn lines and clear from the cursor to end of screen.
+		fmt.Fprintf(r.w, "\x1b[%dA\x1b[J", r.drawn)
+		r.drawn = 0
+	}
+}
+
+func (r *liveRenderer) draw() {
+	cols, rows := r.size()
+	// Never draw a block taller than the viewport: erasing more rows than
+	// are visible would clamp at the top and clear unrelated scrollback. When
+	// there are more blobs than fit, show the most recent ones plus a
+	// "… N more" line so the block stays bounded and the cursor math exact.
+	ids := r.order
+	maxRows := rows - 1
+	if maxRows < 1 {
+		maxRows = 1
+	}
+	if len(ids) > maxRows {
+		hidden := len(ids) - (maxRows - 1)
+		fmt.Fprintln(r.w, truncate(fmt.Sprintf("  … %d more", hidden), cols-1))
+		ids = ids[len(ids)-(maxRows-1):]
+		r.drawn = 1
+	} else {
+		r.drawn = 0
+	}
+	for _, id := range ids {
+		fmt.Fprintln(r.w, r.line(id, r.blobs[id], cols))
+	}
+	r.drawn += len(ids)
+}
+
+// line formats one blob's display line, clamped to width-1 columns (leaving a
+// cell of slack so the terminal never autowraps the line into a second row,
+// which would break the redraw row count).
+func (r *liveRenderer) line(id string, b *blobState, width int) string {
+	const barWidth = 24
+	label := b.human
+	if label == "" {
+		label = vmimage.ShortDigest(id)
+	}
+	var s string
+	switch b.status {
+	case vmimage.BlobStatusExists:
+		s = fmt.Sprintf("  ✓ %s  (cached)", label)
+	case vmimage.BlobStatusDone:
+		s = fmt.Sprintf("  %s  %s  ✓ %s", label, renderBar(b.current, b.total, barWidth), formatSize(b.total))
+	default: // downloading
+		pct := int64(0)
+		if b.total > 0 {
+			pct = 100 * b.current / b.total
+		}
+		s = fmt.Sprintf("  %s  %s %3d%%  %s/%s", label, renderBar(b.current, b.total, barWidth), pct, formatSize(b.current), formatSize(b.total))
+	}
+	return truncate(s, width-1)
+}
+
+// finish redraws the final state and leaves the block in the scrollback.
+func (r *liveRenderer) finish() {
+	r.redraw()
+}

--- a/cmd/shed/progress_render_test.go
+++ b/cmd/shed/progress_render_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/vmimage"
+)
+
+func TestRenderBar(t *testing.T) {
+	cases := []struct {
+		name           string
+		current, total int64
+		width          int
+		want           string
+	}{
+		{"empty", 0, 100, 10, "[----------]"},
+		{"half", 50, 100, 10, "[#####-----]"},
+		{"full", 100, 100, 10, "[##########]"},
+		{"over clamps to full", 150, 100, 10, "[##########]"},
+		{"negative clamps to empty", -5, 100, 10, "[----------]"},
+		{"unknown total is indeterminate", 5, 0, 10, "[----------]"},
+		{"zero width floors to one cell", 5, 100, 0, "[-]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renderBar(tc.current, tc.total, tc.width); got != tc.want {
+				t.Errorf("renderBar(%d,%d,%d) = %q, want %q", tc.current, tc.total, tc.width, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		s     string
+		width int
+		want  string
+	}{
+		{"hello", 10, "hello"},
+		{"hello", 5, "hello"},
+		{"hello", 3, "he…"},
+		{"hello", 1, "…"},
+		{"hello", 0, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.s+"/"+tc.want, func(t *testing.T) {
+			if got := truncate(tc.s, tc.width); got != tc.want {
+				t.Errorf("truncate(%q,%d) = %q, want %q", tc.s, tc.width, got, tc.want)
+			}
+		})
+	}
+}
+
+// blob builds a per-blob progress event for the renderer scripts.
+func blob(id, msg, status string, cur, total int64) backend.ProgressEvent {
+	return backend.ProgressEvent{Kind: backend.KindBlob, ID: id, Message: msg, Status: status, Current: cur, Total: total}
+}
+
+func TestLiveRenderer(t *testing.T) {
+	cases := []struct {
+		name       string
+		cols, rows int
+		events     []backend.ProgressEvent
+		wantSubstr []string
+		notSubstr  []string
+	}{
+		{
+			name: "header shows, then per-layer plain lines suppressed once bars start",
+			cols: 200, rows: 50,
+			events: []backend.ProgressEvent{
+				{Message: "Fetching manifest ghcr.io/x:v1..."}, // header (pre-blob)
+				blob("sha256:aaa", "layer 1/1 sha256:aaa", vmimage.BlobStatusDownloading, 0, 100),
+				blob("sha256:aaa", "layer 1/1 sha256:aaa", vmimage.BlobStatusDownloading, 50, 100),
+				blob("sha256:aaa", "layer 1/1 sha256:aaa", vmimage.BlobStatusDone, 100, 100),
+				{Message: "SHOULD_NOT_APPEAR_after_bars"}, // plain, post-blob → suppressed
+			},
+			wantSubstr: []string{"Fetching manifest", "#", "✓"},
+			notSubstr:  []string{"SHOULD_NOT_APPEAR_after_bars"},
+		},
+		{
+			// Old server that ignores ?progress=blob: only plain lines arrive,
+			// so the renderer must NOT suppress them (no blob ever starts).
+			name: "no blob events: all plain lines shown (old-server fallback)",
+			cols: 200, rows: 50,
+			events: []backend.ProgressEvent{
+				{Message: "Fetching manifest ghcr.io/x:v1..."},
+				{Message: "Pulling layer 1/2 sha256:aaa"},
+				{Message: "Pulling layer 2/2 sha256:bbb"},
+			},
+			wantSubstr: []string{"Fetching manifest", "Pulling layer 1/2", "Pulling layer 2/2"},
+		},
+		{
+			name: "all-cached pull settles with cached markers",
+			cols: 200, rows: 50,
+			events: []backend.ProgressEvent{
+				blob("sha256:aaa", "layer 1/2 sha256:aaa", vmimage.BlobStatusExists, 10, 10),
+				blob("sha256:bbb", "layer 2/2 sha256:bbb", vmimage.BlobStatusExists, 20, 20),
+			},
+			wantSubstr: []string{"✓", "(cached)", "layer 1/2", "layer 2/2"},
+		},
+		{
+			name: "narrow terminal does not panic and clamps content",
+			cols: 12, rows: 50,
+			events: []backend.ProgressEvent{
+				blob("sha256:ccc", "layer 1/1 sha256:cccccccccccc", vmimage.BlobStatusDownloading, 5, 100),
+			},
+		},
+		{
+			// More blobs than rows: block must stay bounded with a "… N more"
+			// line so erase/redraw never exceeds the viewport.
+			name: "short terminal caps the block height",
+			cols: 200, rows: 4,
+			events: []backend.ProgressEvent{
+				blob("sha256:a", "layer 1/6 sha256:a", vmimage.BlobStatusExists, 1, 1),
+				blob("sha256:b", "layer 2/6 sha256:b", vmimage.BlobStatusExists, 1, 1),
+				blob("sha256:c", "layer 3/6 sha256:c", vmimage.BlobStatusExists, 1, 1),
+				blob("sha256:d", "layer 4/6 sha256:d", vmimage.BlobStatusExists, 1, 1),
+				blob("sha256:e", "layer 5/6 sha256:e", vmimage.BlobStatusExists, 1, 1),
+				blob("sha256:f", "layer 6/6 sha256:f", vmimage.BlobStatusExists, 1, 1),
+			},
+			wantSubstr: []string{"more"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			r := newLiveRenderer(&buf, func() (int, int) { return tc.cols, tc.rows })
+			for _, ev := range tc.events {
+				r.handle(ev)
+			}
+			r.finish()
+			out := buf.String()
+			for _, want := range tc.wantSubstr {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q\n---\n%s", want, out)
+				}
+			}
+			for _, no := range tc.notSubstr {
+				if strings.Contains(out, no) {
+					t.Errorf("output unexpectedly contains %q\n---\n%s", no, out)
+				}
+			}
+			// The final block must never claim more rows than the viewport.
+			if r.drawn > tc.rows {
+				t.Errorf("drawn=%d exceeds rows=%d (would corrupt scrollback)", r.drawn, tc.rows)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require github.com/charliek/shed/sdk v0.0.0
 
 require (
+	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
 	github.com/creack/pty v1.1.21
 	github.com/distribution/reference v0.6.0
 	github.com/firecracker-microvm/firecracker-go-sdk v1.0.1-0.20251224190957-6fb280e993d4
@@ -18,11 +19,11 @@ require (
 	github.com/vishvananda/netlink v1.3.1
 	golang.org/x/crypto v0.50.0
 	golang.org/x/sys v0.43.0
+	golang.org/x/term v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
-	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.18.2 // indirect

--- a/internal/vmimage/progress.go
+++ b/internal/vmimage/progress.go
@@ -137,6 +137,9 @@ func (p *progressReader) emit(status string) {
 // byte ticks, and a terminal "done" (Current==Total). human is the message
 // carried on each event for line-mode fallback. write performs the actual
 // hash-verified write (writeBlobFromReader-shaped).
+// The caller emits the 0-byte "downloading" start (so the renderer learns
+// Total up front and, for layers, so the start precedes the verbose line);
+// this function emits the throttled byte ticks and the terminal "done".
 func streamBlobWithProgress(digest, human string, total int64, progress ProgressFunc, rc io.Reader, write func(io.Reader) error) error {
 	pr := &progressReader{
 		r:        rc,
@@ -146,7 +149,6 @@ func streamBlobWithProgress(digest, human string, total int64, progress Progress
 		progress: progress,
 		throttle: blobThrottle{interval: defaultBlobTickInterval},
 	}
-	pr.emit(BlobStatusDownloading) // 0-byte start so the renderer learns Total up front
 	if err := write(pr); err != nil {
 		return err
 	}

--- a/internal/vmimage/progress_test.go
+++ b/internal/vmimage/progress_test.go
@@ -90,10 +90,10 @@ func TestProgressReaderByteTicks(t *testing.T) {
 	}
 }
 
-func TestStreamBlobWithProgressStartAndDone(t *testing.T) {
+func TestStreamBlobWithProgressEmitsDone(t *testing.T) {
 	var events []ProgressEvent
 	var written bytes.Buffer
-	err := streamBlobWithProgress("sha256:x", "Pulling x", 500,
+	err := streamBlobWithProgress("sha256:x", "x", 500,
 		func(ev ProgressEvent) { events = append(events, ev) },
 		bytes.NewReader(make([]byte, 500)),
 		func(r io.Reader) error { _, e := io.Copy(&written, r); return e },
@@ -104,13 +104,16 @@ func TestStreamBlobWithProgressStartAndDone(t *testing.T) {
 	if written.Len() != 500 {
 		t.Fatalf("wrote %d bytes, want 500", written.Len())
 	}
-	if len(events) < 2 {
-		t.Fatalf("want at least a start and a done event, got %d", len(events))
+	if len(events) == 0 {
+		t.Fatal("want at least a done event")
 	}
-	if first := events[0]; first.Status != BlobStatusDownloading || first.Current != 0 || first.Total != 500 || first.ID != "sha256:x" {
-		t.Errorf("first event = %+v, want downloading 0/500 id sha256:x", first)
+	// The caller emits the 0-byte start; this function emits ticks + done.
+	for i, ev := range events {
+		if !ev.IsBlob() || ev.ID != "sha256:x" || ev.Total != 500 {
+			t.Errorf("event %d = %+v, want a blob event for sha256:x total 500", i, ev)
+		}
 	}
-	if last := events[len(events)-1]; last.Status != BlobStatusDone || last.Current != 500 || last.Total != 500 {
+	if last := events[len(events)-1]; last.Status != BlobStatusDone || last.Current != 500 {
 		t.Errorf("last event = %+v, want done 500/500", last)
 	}
 }

--- a/internal/vmimage/registry.go
+++ b/internal/vmimage/registry.go
@@ -375,20 +375,27 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 			// this, the i+1/N counter leaves gaps (e.g. "1/7 … 4/7") for
 			// layers already on disk, which reads as "missing layers".
 			// Mirrors Docker's "Already exists".
-			human := fmt.Sprintf("Layer %d/%d %s already present", i+1, len(layers), ShortDigest(digest))
-			emitStatus(opts.Progress, "image", human)
+			// Emit the blob event BEFORE the verbose line: a renderer client
+			// suppresses per-layer plain lines once it has seen a blob event,
+			// so this ordering keeps the bar without a redundant header.
+			// Line-mode clients never receive the blob event (it's gated
+			// server-side), so they still get the verbose line.
+			label := fmt.Sprintf("layer %d/%d %s", i+1, len(layers), ShortDigest(digest))
 			size, _ := layer.Size()
-			emitBlob(opts.Progress, digest, human, BlobStatusExists, size, size)
+			emitBlob(opts.Progress, digest, label, BlobStatusExists, size, size)
+			emitStatus(opts.Progress, "image", fmt.Sprintf("Layer %d/%d %s already present", i+1, len(layers), ShortDigest(digest)))
 			continue
 		}
-		human := fmt.Sprintf("Pulling layer %d/%d %s", i+1, len(layers), ShortDigest(digest))
-		emitStatus(opts.Progress, "image", human)
+		label := fmt.Sprintf("layer %d/%d %s", i+1, len(layers), ShortDigest(digest))
 		size, _ := layer.Size()
 		rc, err := layer.Compressed()
 		if err != nil {
 			return nil, fmt.Errorf("opening layer %s: %w", digest, err)
 		}
-		err = streamBlobWithProgress(digest, human, size, opts.Progress, rc, func(r io.Reader) error {
+		// Blob start before the verbose line (see the cached branch above).
+		emitBlob(opts.Progress, digest, label, BlobStatusDownloading, 0, size)
+		emitStatus(opts.Progress, "image", fmt.Sprintf("Pulling layer %d/%d %s", i+1, len(layers), ShortDigest(digest)))
+		err = streamBlobWithProgress(digest, label, size, opts.Progress, rc, func(r io.Reader) error {
 			return writeBlobFromReader(opts.ImagesDir, digest, r)
 		})
 		rc.Close()
@@ -408,7 +415,7 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		// Kernel is a sibling blob in the registry — fetch it as a
 		// loose blob (the registry doesn't surface it via Image()
 		// because it isn't a layer).
-		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts, opts.Progress, "Pulling kernel "+ShortDigest(d)); err != nil {
+		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts, opts.Progress, "kernel "+ShortDigest(d)); err != nil {
 			return nil, fmt.Errorf("pulling kernel blob %s: %w", d, err)
 		}
 		kernelDigest = d
@@ -420,7 +427,7 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		kernelDigest = d
 	}
 	if d := annotationFromManifest(manifestDesc, AnnotationInitrdDigest); d != "" {
-		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts, opts.Progress, "Pulling initrd "+ShortDigest(d)); err != nil {
+		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts, opts.Progress, "initrd "+ShortDigest(d)); err != nil {
 			return nil, fmt.Errorf("pulling initrd blob %s: %w", d, err)
 		}
 		initrdDigest = d
@@ -438,7 +445,7 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 	// against v0.5.2+ tooling" error so the user knows the upgrade
 	// path. See internal/vmimage/manager.go.
 	if d := annotationFromManifest(manifestDesc, AnnotationRootfsErofsDigest); d != "" {
-		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts, opts.Progress, "Pulling rootfs "+ShortDigest(d)); err != nil {
+		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts, opts.Progress, "rootfs "+ShortDigest(d)); err != nil {
 			return nil, fmt.Errorf("pulling rootfs erofs blob %s: %w", d, err)
 		}
 	}
@@ -562,7 +569,7 @@ func pullLooseBlob(ctx context.Context, ref name.Reference, digest, imagesDir st
 		// renderer shows a full bar and can tell a real zero-byte blob from
 		// "size unknown".
 		size := BlobSize(imagesDir, digest)
-		emitBlob(progress, digest, human+" (already present)", BlobStatusExists, size, size)
+		emitBlob(progress, digest, human, BlobStatusExists, size, size)
 		return nil
 	}
 	blobRef, err := name.NewDigest(ref.Context().Name()+"@"+digest, nameOptsForInsecure(insecure)...)
@@ -589,6 +596,7 @@ func pullLooseBlob(ctx context.Context, ref name.Reference, digest, imagesDir st
 		defer rc.Close()
 		// New progressReader per attempt: a retry restarts the byte count
 		// from 0 (the renderer shows the restart), which is correct.
+		emitBlob(progress, digest, human, BlobStatusDownloading, 0, size)
 		return streamBlobWithProgress(digest, human, size, progress, rc, func(r io.Reader) error {
 			return writeBlobFromReader(imagesDir, digest, r)
 		})


### PR DESCRIPTION
## Summary

On an interactive terminal, `shed image pull` now draws a **live block of per-blob progress bars** (layers + kernel/initrd/rootfs erofs) that redraw in place — size, percentage, and a ✓ on completion. Piped output, `--json`, and older servers fall back to the existing plain line stream **byte-for-byte**. Third of a phased series (`docs/discovery/pull-parallelism-and-progress-ui.md`).

```
  Fetching manifest ghcr.io/charliek/shed-vz-full:v0.5.9...
  layer 3/6 sha256:1054c0c94fa1  [##############----------]  58%  2.4 MB/4.0 MB
  ✓ layer 1/6 sha256:818154cda96d  (cached)
  kernel sha256:e012fa86396a  [########################]  ✓ 9.8 MB
```

## Client (`cmd/shed`)

- `runImagePull` builds the renderer only when stdout is a TTY and not `--json`, opting into structured events via `?progress=blob`.
- The renderer (`progress_render.go`) is a small **hand-rolled ANSI** block writer (no terminal-owning dependency, so it can be shared with the `create` path later). It: keys blobs by full digest; **re-reads terminal size each frame** (follows a resize); **caps the block to the viewport height** with a `… N more` line so erase/redraw never clears scrollback above it; truncates to width-1 to avoid autowrap; and routes warnings to stderr around an erase/redraw.
- Adds `golang.org/x/term` as a direct dependency.

## Server (`internal/vmimage`)

- Blob events are emitted **just before** the verbose per-layer line, so a renderer client suppresses the redundant line only **after** a blob has started. Consequence: an older server that streams only plain lines (no blob events) is never suppressed and still shows full progress (the version-skew fallback).
- Loose-blob/layer labels are clean nouns (`layer 1/6 …`, `kernel …`) for the bars; **line-mode wording is unchanged**.

## Review fixes (from a Codex pass)

- **Block taller than the terminal** could clear scrollback → height cap with `… N more`.
- **New client + old SSE server** would lose progress (first plain line shown, rest suppressed) → suppress only after a blob event; added a plain-only fallback test.
- **Resize mid-pull** used a stale width → per-frame size re-read + width-1 truncate.

## Verification

- `make check` — lint clean, full unit suite green (renderBar/truncate pure fns; renderer scripts: header→bars, old-server fallback, all-cached settle, narrow width, height cap).
- `make test-integration-dev` (VZ dev) — **51 passed**, 3 expected skips.
- Manual (pty): cached re-pull + fresh busybox/alpine downloads showing live bars; piped + `--json` output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live terminal progress rendering with visual bars, checkmarks, and percentage indicators for image downloads and blob operations.
  * Per-blob progress tracking displays current activity and completion status in interactive terminals; falls back to plain text in non-interactive mode.

* **Tests**
  * Added comprehensive test coverage for progress rendering utilities and live renderer behavior across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->