### PR TITLE
feat(images): parallel image-blob download with bounded concurrency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/vishvananda/netlink v1.3.1
 	golang.org/x/crypto v0.50.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0
 	golang.org/x/term v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -63,7 +64,6 @@ require (
 	github.com/vishvananda/netns v0.0.5 // indirect
 	go.mongodb.org/mongo-driver v1.14.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gotest.tools/v3 v3.5.2 // indirect

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -167,6 +167,11 @@ type FirecrackerConfig struct {
 	// or "never" (error if not cached). Ignored for local-path images.
 	PullPolicy string `yaml:"pull_policy,omitempty"`
 
+	// PullConcurrency caps how many image blobs (layers + kernel/initrd/
+	// erofs) download in parallel during a registry pull. Defaults to
+	// DefaultPullConcurrency; must be >= 1 (1 == serial).
+	PullConcurrency int `yaml:"pull_concurrency,omitempty"`
+
 	// ImagesDir is the directory for the content-addressed image store.
 	ImagesDir string `yaml:"images_dir,omitempty"`
 
@@ -247,6 +252,11 @@ type VZConfig struct {
 	// or "never" (error if not cached). Ignored for local-path images.
 	PullPolicy string `yaml:"pull_policy,omitempty"`
 
+	// PullConcurrency caps how many image blobs (layers + kernel/initrd/
+	// erofs) download in parallel during a registry pull. Defaults to
+	// DefaultPullConcurrency; must be >= 1 (1 == serial).
+	PullConcurrency int `yaml:"pull_concurrency,omitempty"`
+
 	// ImagesDir is the directory for the content-addressed image store.
 	ImagesDir string `yaml:"images_dir,omitempty"`
 
@@ -314,6 +324,9 @@ func (c *VZConfig) GetExtractKernel() bool { return true }
 
 // GetNeedsInitrd implements vmimage.ImageConfig.
 func (c *VZConfig) GetNeedsInitrd() bool { return true }
+
+// GetPullConcurrency implements vmimage.ImageConfig.
+func (c *VZConfig) GetPullConcurrency() int { return c.PullConcurrency }
 
 // DefaultVZConfig returns a VZConfig with default values.
 //
@@ -400,6 +413,9 @@ func (c *VZConfig) applyDefaults() {
 
 	if c.PullPolicy == "" {
 		c.PullPolicy = string(vmimage.PullMissing)
+	}
+	if c.PullConcurrency < 1 {
+		c.PullConcurrency = DefaultPullConcurrency
 	}
 
 	// Default ImagesDir if not set
@@ -688,6 +704,11 @@ const (
 )
 
 // DefaultVZImagesDir is the default directory for VZ rootfs images.
+// DefaultPullConcurrency is the default number of image blobs downloaded in
+// parallel per registry pull (Docker's default). Bounded to avoid tripping
+// registry connection/rate limits.
+const DefaultPullConcurrency = 3
+
 const DefaultVZImagesDir = "~/Library/Application Support/shed/vz"
 
 // VZ validation upper bounds (decoupled from Firecracker).
@@ -753,6 +774,9 @@ func (c *FirecrackerConfig) GetExtractKernel() bool { return true }
 // (it owns overlayfs assembly + pivot_root), so an initrd blob must
 // be installed alongside every shed image regardless of backend.
 func (c *FirecrackerConfig) GetNeedsInitrd() bool { return true }
+
+// GetPullConcurrency implements vmimage.ImageConfig.
+func (c *FirecrackerConfig) GetPullConcurrency() int { return c.PullConcurrency }
 
 // ResolveImage resolves an image selector to a local path or Docker ref.
 func (c *FirecrackerConfig) ResolveImage(image string) (ResolvedImage, error) {
@@ -1325,6 +1349,9 @@ func (c *FirecrackerConfig) applyDefaults() {
 	}
 	if c.PullPolicy == "" {
 		c.PullPolicy = string(vmimage.PullMissing)
+	}
+	if c.PullConcurrency < 1 {
+		c.PullConcurrency = DefaultPullConcurrency
 	}
 
 	// Expand ~ in alias paths (only for filesystem paths, not Docker refs)

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -39,9 +39,10 @@ type ImageConfig interface {
 	GetImageAliases() map[string]string // alias -> ref convenience map
 	GetPullPolicy() string              // "missing" (default) | "always" | "never"
 	GetImagesDir() string
-	GetPlatform() string    // "linux/arm64" or "linux/amd64"
-	GetExtractKernel() bool // true for both VZ and Firecracker
-	GetNeedsInitrd() bool   // true for VZ, false for Firecracker
+	GetPlatform() string     // "linux/arm64" or "linux/amd64"
+	GetExtractKernel() bool  // true for both VZ and Firecracker
+	GetNeedsInitrd() bool    // true for VZ, false for Firecracker
+	GetPullConcurrency() int // max concurrent blob downloads per pull (>=1)
 }
 
 // ImageInfo describes an image known to the blob store, addressed by tag.
@@ -176,6 +177,7 @@ func (m *Manager) EnsureImage(ctx context.Context, ref ResolvedRef, progress Pro
 		ExtractKernel: m.cfg.GetExtractKernel(),
 		NeedsInitrd:   m.cfg.GetNeedsInitrd(),
 		Progress:      progress,
+		Concurrency:   m.cfg.GetPullConcurrency(),
 	})
 	if err != nil {
 		return EnsureResult{}, fmt.Errorf("pulling %s from registry: %w", ref.DockerRef, err)
@@ -252,6 +254,7 @@ func (m *Manager) PullImage(ctx context.Context, dockerRef, tag, platform string
 		ExtractKernel: m.cfg.GetExtractKernel(),
 		NeedsInitrd:   m.cfg.GetNeedsInitrd(),
 		Progress:      progress,
+		Concurrency:   m.cfg.GetPullConcurrency(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("pulling %s from registry: %w", dockerRef, err)

--- a/internal/vmimage/manager_test.go
+++ b/internal/vmimage/manager_test.go
@@ -25,6 +25,7 @@ func (c *testConfig) GetImagesDir() string               { return c.imagesDir }
 func (c *testConfig) GetPlatform() string                { return c.platform }
 func (c *testConfig) GetExtractKernel() bool             { return c.extractKernel }
 func (c *testConfig) GetNeedsInitrd() bool               { return c.needsInitrd }
+func (c *testConfig) GetPullConcurrency() int            { return 0 }
 
 // fakeScanner is a static RefScanner used by tests.
 type fakeScanner struct {

--- a/internal/vmimage/registry.go
+++ b/internal/vmimage/registry.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -26,6 +27,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 )
 
 // PullOptions configures a registry-direct image pull.
@@ -66,6 +69,10 @@ type PullOptions struct {
 
 	// Progress receives stage messages during the pull.
 	Progress ProgressFunc
+
+	// Concurrency caps how many blobs download in parallel. <=1 means
+	// serial. Callers should pass cfg.GetPullConcurrency().
+	Concurrency int
 }
 
 // PullResult mirrors ConvertResult so callers can use either flow.
@@ -282,6 +289,20 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		return nil, err
 	}
 
+	// The progress callback is invoked from parallel download goroutines
+	// below, so serialize it: direct callers (tests, the bulk pull-images
+	// command) may pass a non-thread-safe sink. The server's SSE sink is
+	// already channel-safe; the mutex is cheap because progress is throttled.
+	if opts.Progress != nil {
+		orig := opts.Progress
+		var progMu sync.Mutex
+		opts.Progress = func(ev ProgressEvent) {
+			progMu.Lock()
+			defer progMu.Unlock()
+			orig(ev)
+		}
+	}
+
 	keychain := opts.AuthKeychain
 	if keychain == nil {
 		keychain = authn.DefaultKeychain
@@ -362,46 +383,77 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		return nil, fmt.Errorf("image has %d layers (max %d). This image was probably built with the pre-v0.5.0 build pipeline. Pull a v0.5.0 or later tag from ghcr.io, or build locally with the consolidated Dockerfile under {vz,firecracker}/Dockerfile", len(layers), MaxLayers)
 	}
 
-	layerDigests := make([]string, 0, len(layers))
-	for i, layer := range layers {
-		ld, err := layer.Digest()
+	// Resolve every layer digest up front (cheap, from the manifest) so
+	// layerDigests keeps manifest order and the parallel workers below
+	// address it by index without racing on append.
+	layerDigests := make([]string, len(layers))
+	for i := range layers {
+		ld, err := layers[i].Digest()
 		if err != nil {
 			return nil, fmt.Errorf("layer %d digest: %w", i, err)
 		}
-		digest := ld.String()
-		layerDigests = append(layerDigests, digest)
-		if BlobExists(opts.ImagesDir, digest) {
-			// Report cached layers instead of skipping silently. Without
-			// this, the i+1/N counter leaves gaps (e.g. "1/7 … 4/7") for
-			// layers already on disk, which reads as "missing layers".
-			// Mirrors Docker's "Already exists".
-			// Emit the blob event BEFORE the verbose line: a renderer client
-			// suppresses per-layer plain lines once it has seen a blob event,
-			// so this ordering keeps the bar without a redundant header.
-			// Line-mode clients never receive the blob event (it's gated
-			// server-side), so they still get the verbose line.
-			label := fmt.Sprintf("layer %d/%d %s", i+1, len(layers), ShortDigest(digest))
-			size, _ := layer.Size()
-			emitBlob(opts.Progress, digest, label, BlobStatusExists, size, size)
-			emitStatus(opts.Progress, "image", fmt.Sprintf("Layer %d/%d %s already present", i+1, len(layers), ShortDigest(digest)))
+		layerDigests[i] = ld.String()
+	}
+
+	// Download layers + annotated loose blobs concurrently, bounded by
+	// opts.Concurrency. Per-blob writes are already atomic (file lock +
+	// content-verified rename); a singleflight keyed by digest dedups
+	// concurrent fetches of the SAME digest, so a duplicate layer never
+	// opens two network streams (and distinct digests never contend on the
+	// same blob lock). The first error cancels the group, and the manifest /
+	// index / tag are written only after a clean Wait, so a partial pull can
+	// never advance a tag.
+	//
+	// Note on cancellation: gctx cancels *scheduling* (queued goroutines
+	// don't start once a sibling fails), but the HTTP reads themselves are
+	// bound to the original ctx via remoteOpts, so an already-streaming blob
+	// finishes rather than being killed mid-read. That's acceptable — the
+	// reads are wrapped in withRetry which bails on ctx cancellation, and a
+	// few extra in-flight bytes on the error path don't matter.
+	concurrency := opts.Concurrency
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	var sf singleflight.Group
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
+
+	for i := range layers {
+		i, layer, digest := i, layers[i], layerDigests[i]
+		g.Go(func() error {
+			return pullLayerBlob(gctx, &sf, opts, i, len(layers), digest, layer)
+		})
+	}
+
+	// Annotated loose blobs (kernel/initrd/erofs) are independent of the
+	// layers, so they download in the same group. The extract-from-layers
+	// fallbacks (no annotation) need the layers present and so run after
+	// Wait below — they must not race a still-downloading layer.
+	kernelAnn := annotationFromManifest(manifestDesc, AnnotationKernelDigest)
+	initrdAnn := annotationFromManifest(manifestDesc, AnnotationInitrdDigest)
+	erofsAnn := annotationFromManifest(manifestDesc, AnnotationRootfsErofsDigest)
+	for _, lb := range []struct{ digest, label, kind string }{
+		{kernelAnn, "kernel " + ShortDigest(kernelAnn), "kernel"},
+		{initrdAnn, "initrd " + ShortDigest(initrdAnn), "initrd"},
+		{erofsAnn, "rootfs " + ShortDigest(erofsAnn), "rootfs erofs"},
+	} {
+		if lb.digest == "" {
 			continue
 		}
-		label := fmt.Sprintf("layer %d/%d %s", i+1, len(layers), ShortDigest(digest))
-		size, _ := layer.Size()
-		rc, err := layer.Compressed()
-		if err != nil {
-			return nil, fmt.Errorf("opening layer %s: %w", digest, err)
-		}
-		// Blob start before the verbose line (see the cached branch above).
-		emitBlob(opts.Progress, digest, label, BlobStatusDownloading, 0, size)
-		emitStatus(opts.Progress, "image", fmt.Sprintf("Pulling layer %d/%d %s", i+1, len(layers), ShortDigest(digest)))
-		err = streamBlobWithProgress(digest, label, size, opts.Progress, rc, func(r io.Reader) error {
-			return writeBlobFromReader(opts.ImagesDir, digest, r)
+		lb := lb
+		g.Go(func() error {
+			_, err, _ := sf.Do(lb.digest, func() (any, error) {
+				return nil, pullLooseBlob(gctx, ref, lb.digest, opts.ImagesDir, opts.Insecure, remoteOpts, opts.Progress, lb.label)
+			})
+			if err != nil {
+				return fmt.Errorf("pulling %s blob %s: %w", lb.kind, lb.digest, err)
+			}
+			return nil
 		})
-		rc.Close()
-		if err != nil {
-			return nil, fmt.Errorf("streaming layer %s: %w", digest, err)
-		}
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	// Write the manifest verbatim (preserves the registry digest).
@@ -409,16 +461,13 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		return nil, fmt.Errorf("writing manifest blob: %w", err)
 	}
 
-	// Fetch or extract kernel / initrd.
+	// Resolve kernel / initrd digests: an annotation means the blob was
+	// already pulled above; otherwise extract it from the now-present layers
+	// (the legacy pre-v0.5.2 fallback). This MUST stay after g.Wait() — the
+	// extraction reads layer blobs and must not race a still-downloading one.
 	var kernelDigest, initrdDigest string
-	if d := annotationFromManifest(manifestDesc, AnnotationKernelDigest); d != "" {
-		// Kernel is a sibling blob in the registry — fetch it as a
-		// loose blob (the registry doesn't surface it via Image()
-		// because it isn't a layer).
-		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts, opts.Progress, "kernel "+ShortDigest(d)); err != nil {
-			return nil, fmt.Errorf("pulling kernel blob %s: %w", d, err)
-		}
-		kernelDigest = d
+	if kernelAnn != "" {
+		kernelDigest = kernelAnn
 	} else if opts.ExtractKernel {
 		d, err := extractKernelFromLayers(opts.ImagesDir, layerDigests)
 		if err != nil {
@@ -426,28 +475,14 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		}
 		kernelDigest = d
 	}
-	if d := annotationFromManifest(manifestDesc, AnnotationInitrdDigest); d != "" {
-		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts, opts.Progress, "initrd "+ShortDigest(d)); err != nil {
-			return nil, fmt.Errorf("pulling initrd blob %s: %w", d, err)
-		}
-		initrdDigest = d
+	if initrdAnn != "" {
+		initrdDigest = initrdAnn
 	} else if opts.NeedsInitrd && opts.ExtractKernel {
 		d, err := extractInitrdFromLayers(opts.ImagesDir, layerDigests)
 		if err != nil {
 			return nil, fmt.Errorf("extracting initrd from layer tar: %w", err)
 		}
 		initrdDigest = d
-	}
-
-	// Pull the prebuilt rootfs erofs blob (v0.5.2+). Same loose-blob
-	// shape as kernel/initrd. When absent (older image), don't fail
-	// here — the host's EnsureImage rejects with a clearer "rebuild
-	// against v0.5.2+ tooling" error so the user knows the upgrade
-	// path. See internal/vmimage/manager.go.
-	if d := annotationFromManifest(manifestDesc, AnnotationRootfsErofsDigest); d != "" {
-		if err := pullLooseBlob(ctx, ref, d, opts.ImagesDir, opts.Insecure, remoteOpts, opts.Progress, "rootfs "+ShortDigest(d)); err != nil {
-			return nil, fmt.Errorf("pulling rootfs erofs blob %s: %w", d, err)
-		}
 	}
 
 	// Record the manifest in the top-level OCI index.
@@ -479,6 +514,45 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		KernelDigest:   kernelDigest,
 		InitrdDigest:   initrdDigest,
 	}, nil
+}
+
+// pullLayerBlob downloads (or reports cached) a single layer. It emits the
+// blob event before the verbose line so a renderer client suppresses the
+// redundant per-layer line, then runs the fetch under a singleflight keyed by
+// digest so a duplicate layer is fetched exactly once.
+func pullLayerBlob(ctx context.Context, sf *singleflight.Group, opts PullOptions, i, n int, digest string, layer v1.Layer) error {
+	if err := ctx.Err(); err != nil {
+		return err // the group already failed; don't start another download
+	}
+	label := fmt.Sprintf("layer %d/%d %s", i+1, n, ShortDigest(digest))
+	if BlobExists(opts.ImagesDir, digest) {
+		size, _ := layer.Size()
+		emitBlob(opts.Progress, digest, label, BlobStatusExists, size, size)
+		emitStatus(opts.Progress, "image", fmt.Sprintf("Layer %d/%d %s already present", i+1, n, ShortDigest(digest)))
+		return nil
+	}
+	size, _ := layer.Size()
+	emitBlob(opts.Progress, digest, label, BlobStatusDownloading, 0, size)
+	emitStatus(opts.Progress, "image", fmt.Sprintf("Pulling layer %d/%d %s", i+1, n, ShortDigest(digest)))
+	_, err, _ := sf.Do(digest, func() (any, error) {
+		// Re-check under the singleflight: a duplicate layer may have just
+		// written this blob.
+		if BlobExists(opts.ImagesDir, digest) {
+			return nil, nil
+		}
+		rc, err := layer.Compressed()
+		if err != nil {
+			return nil, fmt.Errorf("opening layer %s: %w", digest, err)
+		}
+		defer rc.Close()
+		return nil, streamBlobWithProgress(digest, label, size, opts.Progress, rc, func(r io.Reader) error {
+			return writeBlobFromReader(opts.ImagesDir, digest, r)
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("streaming layer %s: %w", digest, err)
+	}
+	return nil
 }
 
 // writeBlobFromReader streams a reader through sha256 verification into

--- a/internal/vmimage/registry_parallel_test.go
+++ b/internal/vmimage/registry_parallel_test.go
@@ -1,0 +1,135 @@
+package vmimage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/registry"
+)
+
+// TestPullToOCILayout_Parallel pulls a multi-layer image with concurrency > 1
+// and asserts every blob lands. Run under `-race` it also guards the parallel
+// progress emission and layerDigests indexing against data races.
+func TestPullToOCILayout_Parallel(t *testing.T) {
+	host := startTestRegistry(t)
+	const layers = 6
+	ref := pushRandomImage(t, fmt.Sprintf("%s/test/parallel:v1", host), layers)
+	dir := t.TempDir()
+
+	// A deliberately non-thread-safe sink (unguarded slice append): under
+	// -race this proves PullToOCILayout serializes the callback across its
+	// parallel workers.
+	var events []ProgressEvent
+	res, err := PullToOCILayout(context.Background(), PullOptions{
+		Ref:         ref,
+		ImagesDir:   dir,
+		Insecure:    true,
+		Concurrency: 4,
+		Progress:    func(ev ProgressEvent) { events = append(events, ev) },
+	})
+	if err != nil {
+		t.Fatalf("parallel pull: %v", err)
+	}
+	if len(events) == 0 {
+		t.Error("expected progress events from the parallel pull")
+	}
+	if len(res.LayerDigests) != layers {
+		t.Fatalf("got %d layer digests, want %d", len(res.LayerDigests), layers)
+	}
+	for i, d := range res.LayerDigests {
+		if !BlobExists(dir, d) {
+			t.Errorf("layer %d blob %s missing after parallel pull", i, d)
+		}
+	}
+	if !BlobExists(dir, res.ConfigDigest) {
+		t.Error("config blob missing after parallel pull")
+	}
+}
+
+// countingRegistry wraps the in-memory registry and tracks the peak number of
+// concurrent blob GETs so a test can assert the concurrency cap is honored.
+func countingRegistry(t testing.TB, hold time.Duration) (handler http.Handler, peak *int32) {
+	base := registry.New(registry.Logger(log.New(io.Discard, "", 0)))
+	var inFlight, max int32
+	peak = &max
+	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/blobs/") {
+			cur := atomic.AddInt32(&inFlight, 1)
+			for {
+				m := atomic.LoadInt32(&max)
+				if cur <= m || atomic.CompareAndSwapInt32(&max, m, cur) {
+					break
+				}
+			}
+			time.Sleep(hold) // widen the window so concurrency is observable
+			atomic.AddInt32(&inFlight, -1)
+		}
+		base.ServeHTTP(w, r)
+	})
+	return handler, peak
+}
+
+func TestPullConcurrencyLimit(t *testing.T) {
+	const limit = 2
+	handler, peak := countingRegistry(t, 40*time.Millisecond)
+	host := startTestRegistryHandler(t, handler)
+	ref := pushRandomImage(t, fmt.Sprintf("%s/test/limit:v1", host), 6)
+
+	_, err := PullToOCILayout(context.Background(), PullOptions{
+		Ref:         ref,
+		ImagesDir:   t.TempDir(),
+		Insecure:    true,
+		Concurrency: limit,
+		Progress:    func(ProgressEvent) {},
+	})
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if got := atomic.LoadInt32(peak); got > limit {
+		t.Errorf("peak concurrent blob GETs = %d, want <= %d", got, limit)
+	}
+	if got := atomic.LoadInt32(peak); got < 2 {
+		t.Errorf("peak concurrent blob GETs = %d, expected the pull to actually parallelize", got)
+	}
+}
+
+// TestPullConcurrencyOne reproduces serial behavior with Concurrency == 1.
+func TestPullConcurrencyOne(t *testing.T) {
+	handler, peak := countingRegistry(t, 15*time.Millisecond)
+	host := startTestRegistryHandler(t, handler)
+	ref := pushRandomImage(t, fmt.Sprintf("%s/test/serial:v1", host), 4)
+
+	if _, err := PullToOCILayout(context.Background(), PullOptions{
+		Ref: ref, ImagesDir: t.TempDir(), Insecure: true, Concurrency: 1,
+		Progress: func(ProgressEvent) {},
+	}); err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if got := atomic.LoadInt32(peak); got != 1 {
+		t.Errorf("Concurrency=1 peak concurrent blob GETs = %d, want exactly 1", got)
+	}
+}
+
+func BenchmarkPullToOCILayout(b *testing.B) {
+	host := startTestRegistry(b)
+	ref := pushRandomImage(b, fmt.Sprintf("%s/test/bench:v1", host), 6)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		dir := b.TempDir()
+		b.StartTimer()
+		if _, err := PullToOCILayout(context.Background(), PullOptions{
+			Ref: ref, ImagesDir: dir, Insecure: true, Concurrency: 4,
+			Progress: func(ProgressEvent) {},
+		}); err != nil {
+			b.Fatalf("pull: %v", err)
+		}
+	}
+}

--- a/internal/vmimage/registry_pull_test.go
+++ b/internal/vmimage/registry_pull_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"slices"
@@ -21,9 +22,16 @@ import (
 // HTTP on loopback and returns its host:port. Reusable across pull tests
 // (cached-layer reporting, byte counting, parallel/dedup) — pulls target it
 // with PullOptions{Insecure: true}.
-func startTestRegistry(t *testing.T) string {
+func startTestRegistry(t testing.TB) string {
 	t.Helper()
-	srv := httptest.NewServer(registry.New(registry.Logger(log.New(io.Discard, "", 0))))
+	return startTestRegistryHandler(t, registry.New(registry.Logger(log.New(io.Discard, "", 0))))
+}
+
+// startTestRegistryHandler serves the given handler (typically a wrapped
+// registry that counts in-flight requests) and returns its host:port.
+func startTestRegistryHandler(t testing.TB, h http.Handler) string {
+	t.Helper()
+	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
 	return strings.TrimPrefix(srv.URL, "http://")
 }
@@ -31,7 +39,7 @@ func startTestRegistry(t *testing.T) string {
 // pushRandomImage builds a random image with the given number of layers and
 // pushes it to refStr (e.g. "<host>/test/img:v1") on the test registry,
 // returning the full reference string for PullToOCILayout.
-func pushRandomImage(t *testing.T, refStr string, layers int) string {
+func pushRandomImage(t testing.TB, refStr string, layers int) string {
 	t.Helper()
 	img, err := random.Image(1024, int64(layers))
 	if err != nil {


### PR DESCRIPTION
## Summary

`PullToOCILayout` now downloads layers **and** the annotated kernel/initrd/erofs blobs **concurrently** (bounded `errgroup`) instead of one at a time. Fourth of a phased series (`docs/discovery/pull-parallelism-and-progress-ui.md`).

## Perf

Controlled measurement through a local registry with 50 ms/blob injected latency (isolates the parallelism effect from WAN noise; same binary, only the concurrency knob varies), 8 blobs, best-of-3:

| concurrency | wall time | speedup |
|---|---|---|
| 1 (serial) | 529 ms | 1.0× |
| **3 (default)** | **246 ms** | **2.15×** |
| 8 | 135 ms | 3.9× |

The gain scales with blob count and link latency. Real ghcr.io cold pulls benefit proportionally; the cached create hot-path (the `test_create_agent_p50` gate) is unaffected — it has no cold download.

*Note: this is shared, backend-agnostic `internal/vmimage` code — the pull machinery is identical Go for VZ and FC (no build tags), so one measurement is representative. Validated end-to-end on the VZ dev server.*

## Change

- **`pull_concurrency`** server config (default 3, validated ≥1, `1` == serial) on both backends → `ImageConfig.GetPullConcurrency` → `PullOptions.Concurrency`. `SetLimit(0)` guarded by a clamp + the Validate default.
- **singleflight** keyed by digest dedups concurrent fetches of the same digest (a duplicate layer never opens two streams); per-blob writes stay atomic (file lock + content-verified rename), so distinct digests never contend on a lock.
- Annotated loose blobs download in the same group; the legacy **extract-from-layers** kernel/initrd fallbacks run only **after `g.Wait()`** (they read layer blobs and must not race a still-downloading layer).
- First error cancels the group; **manifest/index/tag are written only after a clean Wait**, so a partial pull never advances a tag.
- The **progress callback is serialized** under a mutex (now invoked from parallel workers; the server SSE sink is already channel-safe, this protects other direct callers).
- Promotes `golang.org/x/sync` to a direct dependency.

## Review (Codex pass)

Confirmed safe: `layerDigests` race-free (preallocated, index-assigned), SSE sink concurrent-safe, singleflight+file-lock prevents double-write, tag-advancement invariant holds, `SetLimit(0)` guarded, loose-blobs-racing-layers safe. Applied: the progress-callback mutex. Documented as accepted trade-offs (bounded, not hangs): in-flight reads use the original ctx (a sibling error cancels *scheduling*, in-flight blobs finish — ≤concurrency of them); `acquireFileLock` is a blocking flock (pre-existing; no intra-pull contention thanks to singleflight + distinct digests).

## Verification

- `make check` + `go test -race ./internal/vmimage/...` — green. New tests: parallel correctness with a non-thread-safe sink (proves serialization under `-race`), concurrency cap (peak in-flight blob GETs ≤ limit), serial-at-1, `BenchmarkPullToOCILayout`.
- `make test-integration-dev` (VZ dev) — **51 passed**, 3 expected skips. `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Parallel blob downloads for image pulls: container image layers are now fetched concurrently with a default limit of 3 parallel downloads for improved performance
  * New `pull_concurrency` configuration option to customize concurrent download behavior

* **Tests**
  * Added comprehensive test coverage for concurrent pull operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->