### PR TITLE
feat(create): live progress bars for the image-pull leg of create

### DIFF
--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -206,7 +206,7 @@ func (c *APIClient) CreateShed(req *config.CreateShedRequest) (*config.Shed, err
 }
 
 // CreateShedWithProgress creates a new shed and streams progress events via SSE.
-func (c *APIClient) CreateShedWithProgress(req *config.CreateShedRequest, onProgress func(backend.ProgressEvent)) (*config.Shed, error) {
+func (c *APIClient) CreateShedWithProgress(req *config.CreateShedRequest, wantBlobProgress bool, onProgress func(backend.ProgressEvent)) (*config.Shed, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.createTimeout)
 	defer cancel()
 
@@ -215,7 +215,13 @@ func (c *APIClient) CreateShedWithProgress(req *config.CreateShedRequest, onProg
 		return nil, fmt.Errorf("failed to encode request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/sheds", bytes.NewReader(bodyData))
+	// Opt into structured per-blob byte events (the image-pull leg) only when
+	// the caller can render them; older servers ignore the param.
+	url := c.baseURL + "/api/sheds"
+	if wantBlobProgress {
+		url += "?progress=blob"
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyData))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/version"
 	"github.com/charliek/shed/internal/vmimage"
@@ -703,36 +702,11 @@ func runImagePull(cmd *cobra.Command, args []string) error {
 	}
 	client := NewAPIClientFromEntry(entry, DefaultTimeout)
 
-	// On an interactive terminal, opt into structured byte progress and draw
-	// a live block of per-blob bars. Otherwise (pipe, --json, redirected, or
-	// an old server) fall back to the plain line stream.
-	useLive := !jsonFlag && isProgressTTY(os.Stdout)
-	var renderer *liveRenderer
-	if useLive {
-		renderer = newLiveRenderer(os.Stdout, func() (int, int) { return terminalSize(os.Stdout) })
-	}
-	resp, err := client.PullImageWithProgress(dockerRef, tag, imagePullPlatform, useLive, func(event backend.ProgressEvent) {
-		switch {
-		case jsonFlag:
-			// --json suppresses progress; only the final response is printed.
-		case event.Warning:
-			// Warnings go to stderr; when a live block is up, erase and
-			// redraw around the write so the block isn't corrupted.
-			warn := func() { fmt.Fprintf(os.Stderr, "  Warning: %s\n", event.Message) }
-			if renderer != nil {
-				renderer.printAbove(warn)
-			} else {
-				warn()
-			}
-		case renderer != nil:
-			renderer.handle(event)
-		default:
-			fmt.Printf("  %s\n", event.Message)
-		}
-	})
-	if renderer != nil {
-		renderer.finish()
-	}
+	// On an interactive terminal, draw a live block of per-blob bars; pipe,
+	// --json, redirected, or an old server fall back to the plain line stream.
+	onProgress, finish, wantBlob := progressSink(jsonFlag)
+	resp, err := client.PullImageWithProgress(dockerRef, tag, imagePullPlatform, wantBlob, onProgress)
+	finish()
 	if err != nil {
 		return fmt.Errorf("failed to pull image: %w", err)
 	}

--- a/cmd/shed/progress_render.go
+++ b/cmd/shed/progress_render.go
@@ -4,12 +4,23 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/vmimage"
 	"golang.org/x/term"
 )
+
+// layerProgressLineRe matches the per-layer pull lines the server emits
+// (internal/vmimage/registry.go): "Pulling layer N/M …" and
+// "Layer N/M … already present". A renderer client suppresses these once bars
+// are live because the per-blob bar conveys the same thing; every other plain
+// line still shows — the manifest header for `image pull`, and the boot-phase
+// lines for `create`, which arrive after the pull bars.
+var layerProgressLineRe = regexp.MustCompile(`^(Pulling layer|Layer) \d+/\d+\b`)
+
+func isLayerProgressLine(msg string) bool { return layerProgressLineRe.MatchString(msg) }
 
 // isProgressTTY reports whether f is an interactive terminal we can draw a
 // live progress block on.
@@ -81,6 +92,9 @@ type blobState struct {
 // liveRenderer draws a Docker-style block of per-blob progress bars that
 // redraw in place. It is fed backend.ProgressEvent values and owns a
 // contiguous block of lines at the bottom of the terminal.
+//
+// Not safe for concurrent use: it is driven serially by the single SSE
+// reader goroutine (readSSEStream), which delivers one event at a time.
 type liveRenderer struct {
 	w       io.Writer
 	size    func() (cols, rows int) // re-read per frame so a resize is honored
@@ -115,13 +129,14 @@ func (r *liveRenderer) handle(ev backend.ProgressEvent) {
 		r.redraw()
 		return
 	}
-	// Plain (non-blob) event. Show it until bars take over: the pre-blob
-	// "Fetching manifest..." header shows, and once blob events start the
-	// per-layer plain lines ("Pulling layer 2/6") are redundant with the
-	// bars, so suppress them. Crucially, if NO blob events ever arrive (an
-	// older server that ignores ?progress=blob and streams only plain
-	// lines), nothing is suppressed and the user still sees full progress.
-	if ev.Message == "" || r.sawBlob {
+	// Plain (non-blob) event. Suppress only the redundant per-layer pull
+	// lines once bars are live (their bar conveys the same thing). Everything
+	// else shows: the "Fetching manifest..." header for `image pull`, and the
+	// boot-phase lines for `create` (which arrive after the pull bars — so a
+	// blanket "suppress after first blob" would wrongly hide them). If NO blob
+	// event ever arrives (an older server that ignores ?progress=blob and
+	// streams only plain lines), nothing is suppressed.
+	if ev.Message == "" || (r.sawBlob && isLayerProgressLine(ev.Message)) {
 		return
 	}
 	r.printAbove(func() { fmt.Fprintf(r.w, "  %s\n", ev.Message) })
@@ -201,4 +216,41 @@ func (r *liveRenderer) line(id string, b *blobState, width int) string {
 // finish redraws the final state and leaves the block in the scrollback.
 func (r *liveRenderer) finish() {
 	r.redraw()
+}
+
+// progressSink wires a backend.ProgressEvent stream (from `image pull` or
+// `create`) to either a live TTY renderer or the plain line printer. It
+// returns the onProgress callback, a finish func to call when the stream
+// ends, and wantBlob — whether the caller should request ?progress=blob
+// (true only on an interactive, non-JSON terminal). Warnings always go to
+// stderr, erased/redrawn around so they don't corrupt the live block.
+func progressSink(jsonOutput bool) (onProgress func(backend.ProgressEvent), finish func(), wantBlob bool) {
+	useLive := !jsonOutput && isProgressTTY(os.Stdout)
+	var renderer *liveRenderer
+	if useLive {
+		renderer = newLiveRenderer(os.Stdout, func() (int, int) { return terminalSize(os.Stdout) })
+	}
+	onProgress = func(event backend.ProgressEvent) {
+		switch {
+		case jsonOutput:
+			// --json suppresses progress; only the final response prints.
+		case event.Warning:
+			warn := func() { fmt.Fprintf(os.Stderr, "  Warning: %s\n", event.Message) }
+			if renderer != nil {
+				renderer.printAbove(warn)
+			} else {
+				warn()
+			}
+		case renderer != nil:
+			renderer.handle(event)
+		default:
+			fmt.Printf("  %s\n", event.Message)
+		}
+	}
+	finish = func() {
+		if renderer != nil {
+			renderer.finish()
+		}
+	}
+	return onProgress, finish, useLive
 }

--- a/cmd/shed/progress_render_test.go
+++ b/cmd/shed/progress_render_test.go
@@ -68,17 +68,35 @@ func TestLiveRenderer(t *testing.T) {
 		notSubstr  []string
 	}{
 		{
-			name: "header shows, then per-layer plain lines suppressed once bars start",
+			name: "header shows; redundant per-layer plain line suppressed once bars start",
 			cols: 200, rows: 50,
 			events: []backend.ProgressEvent{
 				{Message: "Fetching manifest ghcr.io/x:v1..."}, // header (pre-blob)
 				blob("sha256:aaa", "layer 1/1 sha256:aaa", vmimage.BlobStatusDownloading, 0, 100),
 				blob("sha256:aaa", "layer 1/1 sha256:aaa", vmimage.BlobStatusDownloading, 50, 100),
 				blob("sha256:aaa", "layer 1/1 sha256:aaa", vmimage.BlobStatusDone, 100, 100),
-				{Message: "SHOULD_NOT_APPEAR_after_bars"}, // plain, post-blob → suppressed
+				{Message: "Pulling layer 1/1 sha256:aaa"}, // per-layer plain → suppressed (bar covers it)
 			},
-			wantSubstr: []string{"Fetching manifest", "#", "✓"},
-			notSubstr:  []string{"SHOULD_NOT_APPEAR_after_bars"},
+			wantSubstr: []string{"Fetching manifest", "#", "✓", "layer 1/1"},
+			notSubstr:  []string{"Pulling layer 1/1"}, // the verbose per-layer line, not the bar label
+		},
+		{
+			// `shed create`: boot-phase plain lines arrive both before AND
+			// after the pull bars. Only the per-layer pull line is suppressed;
+			// every boot phase shows.
+			name: "create: boot phases before and after bars all show",
+			cols: 200, rows: 50,
+			events: []backend.ProgressEvent{
+				{Message: "Resolving image..."},   // pre-pull phase
+				{Message: "Pulling ghcr.io/x:v1"}, // not a per-layer line → shows
+				blob("sha256:aaa", "layer 1/1 sha256:aaa", vmimage.BlobStatusDownloading, 0, 100),
+				{Message: "Pulling layer 1/1 sha256:aaa"}, // per-layer → suppressed
+				blob("sha256:aaa", "layer 1/1 sha256:aaa", vmimage.BlobStatusDone, 100, 100),
+				{Message: "Booting VM..."},        // post-pull phase → must show
+				{Message: "Waiting for agent..."}, // post-pull phase → must show
+			},
+			wantSubstr: []string{"Resolving image", "Pulling ghcr.io/x:v1", "Booting VM", "Waiting for agent"},
+			notSubstr:  []string{"Pulling layer 1/1"},
 		},
 		{
 			// Old server that ignores ?progress=blob: only plain lines arrive,

--- a/cmd/shed/shed.go
+++ b/cmd/shed/shed.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/sync"
 	"github.com/charliek/shed/internal/tunnels"
@@ -221,16 +220,12 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		UpperSizeBytes: upperSizeBytes,
 	}
 
-	shed, err := client.CreateShedWithProgress(req, func(event backend.ProgressEvent) {
-		if jsonFlag {
-			return
-		}
-		if event.Warning {
-			fmt.Fprintf(os.Stderr, "  Warning: %s\n", event.Message)
-		} else {
-			fmt.Printf("  %s\n", event.Message)
-		}
-	})
+	// On an interactive terminal, the image-pull leg renders as live per-blob
+	// bars interleaved with the boot-phase lines; pipe/--json/old server fall
+	// back to the plain line stream.
+	onProgress, finish, wantBlob := progressSink(jsonFlag)
+	shed, err := client.CreateShedWithProgress(req, wantBlob, onProgress)
+	finish()
 	if err != nil {
 		return fmt.Errorf("failed to create shed: %w", err)
 	}


### PR DESCRIPTION
## Summary

`shed create` now renders the image-pull leg as the same Docker-style **live per-blob bars** as `shed image pull`, interleaved with the boot-phase lines. Pipe / `--json` / older servers fall back to the plain line stream **unchanged**. Fifth of a phased series (`docs/discovery/pull-parallelism-and-progress-ui.md`).

## Change

- The renderer is shared via a new **`progressSink(jsonOutput)`** helper (returns the `onProgress` callback, a `finish` func, and whether to request `?progress=blob`) used by **both** `runImagePull` and `runCreate` — this also removes the duplicated inline callback from image pull.
- `CreateShedWithProgress` opts into `?progress=blob` on an interactive, non-JSON terminal, mirroring `PullImageWithProgress`.
- The renderer's plain-line suppression changed from *"suppress every plain line after the first blob"* to *"suppress only the redundant per-layer pull line (matched by a small regex `^(Pulling layer|Layer) \d+/\d+\b`) once a blob is seen."* `create` emits boot-phase lines **both before and after** the pull, so the old blanket rule would have hidden the post-pull boot phases; the new rule shows all of them while still hiding the per-layer lines the bars already convey, and preserves the no-blob **old-server fallback**.

## Verification

- Pty: a **cached** create shows the boot phases (no bars); a **re-pulling** create (`pull_policy=always`) shows the bars completing **out of order** (parallel from PR 4) then the boot phases, then success.
- `make test-integration-dev` (VZ dev) — **51 passed**, 3 expected skips (covers line-mode create). `golangci-lint` 0 issues; `cmd/shed` unit tests green (new cases: create boot-phases-before-and-after-bars, old-server plain fallback, per-layer suppression).

## Review (Codex)

All correct (suppression rule, regex against real create messages, old-server fallback, JSON/line-mode, finish ordering). One Low/theoretical note — the client renderer isn't concurrency-safe *if* invoked from multiple goroutines; it's always driven serially by the single SSE reader loop (documented), unlike the server-side callback which is genuinely concurrent and got a mutex in PR 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Progress reporting during shed creation and image pulls now suppresses redundant per-layer progress messages when detailed progress bars are actively displayed, providing cleaner output.

* **Refactor**
  * Progress handling refactored to unify event streaming and intelligently adapt output formatting based on output mode (JSON or interactive) and terminal capabilities.

* **Tests**
  * Updated progress rendering tests to verify improved suppression behavior and output formatting across different contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->