### PR TITLE
feat(images): boot-only image pulls (skip layer tarballs)

### DIFF
--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -451,9 +451,10 @@ func (c *APIClient) TagImage(src, dst string) error {
 }
 
 // PullImage pulls a Docker reference into the blob store under the named tag.
-// platform is an optional override (e.g. "linux/arm64").
-func (c *APIClient) PullImage(dockerRef, tag, platform string) (*config.ImagePullResponse, error) {
-	body := config.ImagePullRequest{DockerRef: dockerRef, Tag: tag, Platform: platform}
+// platform is an optional override (e.g. "linux/arm64"); withLayers pulls the
+// full image (false = boot-only, the default).
+func (c *APIClient) PullImage(dockerRef, tag, platform string, withLayers bool) (*config.ImagePullResponse, error) {
+	body := config.ImagePullRequest{DockerRef: dockerRef, Tag: tag, Platform: platform, WithLayers: withLayers}
 	var resp config.ImagePullResponse
 	if err := c.doRequestWithTimeout(http.MethodPost, "/api/images/pull", body, &resp, 30*time.Minute); err != nil {
 		return nil, err
@@ -464,11 +465,11 @@ func (c *APIClient) PullImage(dockerRef, tag, platform string) (*config.ImagePul
 // PullImageWithProgress pulls a Docker reference and streams per-stage
 // progress via SSE (mirrors CreateShedWithProgress). Falls back to the
 // non-streaming PullImage path only if the server rejects the stream.
-func (c *APIClient) PullImageWithProgress(dockerRef, tag, platform string, wantBlobProgress bool, onProgress func(backend.ProgressEvent)) (*config.ImagePullResponse, error) {
+func (c *APIClient) PullImageWithProgress(dockerRef, tag, platform string, withLayers, wantBlobProgress bool, onProgress func(backend.ProgressEvent)) (*config.ImagePullResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
-	bodyData, err := json.Marshal(config.ImagePullRequest{DockerRef: dockerRef, Tag: tag, Platform: platform})
+	bodyData, err := json.Marshal(config.ImagePullRequest{DockerRef: dockerRef, Tag: tag, Platform: platform, WithLayers: withLayers})
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode request: %w", err)
 	}

--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -171,8 +171,9 @@ suffix (e.g. ghcr.io/charliek/shed-vz-experimental:v0.4.0 → 'experimental').`,
 }
 
 var (
-	imagePullTag      string
-	imagePullPlatform string
+	imagePullTag        string
+	imagePullPlatform   string
+	imagePullWithLayers bool
 )
 
 var imagePruneCmd = &cobra.Command{
@@ -216,6 +217,7 @@ func init() {
 	imagePruneCmd.Flags().BoolVarP(&imagePruneVerbose, "verbose", "v", false, "Show individual blob digests, not just per-image rows")
 	imagePullCmd.Flags().StringVarP(&imagePullTag, "tag", "t", "", "Tag name (default: derived from docker ref)")
 	imagePullCmd.Flags().StringVar(&imagePullPlatform, "platform", "", "Platform override for multi-arch images (e.g. linux/arm64). Empty means the backend's native platform.")
+	imagePullCmd.Flags().BoolVar(&imagePullWithLayers, "with-layers", false, "Pull the full image including layer tarballs. The default is boot-only (skip layers — the host boots from the erofs blob). Required before 'shed image push' of a pulled image.")
 	imagePushCmd.Flags().BoolVar(&imagePushLocal, "local", false, "Push from the local OCI store (no shed-server required). Implied when -c is set without -s.")
 
 	imageCmd.AddCommand(imageBuildCmd)
@@ -528,7 +530,7 @@ func runImageList(_ *cobra.Command, _ []string) error {
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	// IMAGE is the Docker ref (the identity); SOURCE is config|user|dangling.
-	fmt.Fprintln(w, "IMAGE\tDIGEST\tSOURCE\tSIZE\tIN USE")
+	fmt.Fprintln(w, "IMAGE\tDIGEST\tSOURCE\tSIZE\tLAYERS\tIN USE")
 	for _, img := range resp.Images {
 		size := "-"
 		if img.SizeBytes > 0 {
@@ -542,7 +544,11 @@ func runImageList(_ *cobra.Command, _ []string) error {
 		if img.InUse {
 			inUse = "yes"
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", img.Name, digest, img.Source, size, inUse)
+		layers := "full"
+		if img.BootOnly {
+			layers = "boot-only"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", img.Name, digest, img.Source, size, layers, inUse)
 	}
 	w.Flush()
 	if !jsonFlag && len(resp.Images) > 0 {
@@ -656,6 +662,9 @@ func runImageInspect(_ *cobra.Command, args []string) error {
 	if resp.Image.SizeBytes > 0 {
 		fmt.Fprintf(w, "Size:\t%s\n", formatSize(resp.Image.SizeBytes))
 	}
+	if resp.Image.BootOnly {
+		fmt.Fprintf(w, "Boot-only:\tyes (layer tarballs not present; re-pull --with-layers to push)\n")
+	}
 	fmt.Fprintf(w, "In use:\t%v\n", resp.Image.InUse)
 	if resp.Manifest.Variant != "" {
 		fmt.Fprintf(w, "Variant:\t%s\n", resp.Manifest.Variant)
@@ -705,7 +714,7 @@ func runImagePull(cmd *cobra.Command, args []string) error {
 	// On an interactive terminal, draw a live block of per-blob bars; pipe,
 	// --json, redirected, or an old server fall back to the plain line stream.
 	onProgress, finish, wantBlob := progressSink(jsonFlag)
-	resp, err := client.PullImageWithProgress(dockerRef, tag, imagePullPlatform, wantBlob, onProgress)
+	resp, err := client.PullImageWithProgress(dockerRef, tag, imagePullPlatform, imagePullWithLayers, wantBlob, onProgress)
 	finish()
 	if err != nil {
 		return fmt.Errorf("failed to pull image: %w", err)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -412,22 +412,46 @@ Pulls an OCI reference registry-direct (no Docker daemon needed),
 installs every blob into the local store, and advances a tag.
 
 ```bash
-shed image pull <ref> [-t <tag>] [--platform <os/arch>]
+shed image pull <ref> [-t <tag>] [--platform <os/arch>] [--with-layers]
 ```
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--tag` | `-t` | derived from the ref | Tag to advance |
 | `--platform` | | host (`linux/arm64` on VZ, `linux/amd64` on Firecracker) | Override the manifest selection for multi-arch indexes (e.g. `linux/amd64`, `linux/arm64`) |
+| `--with-layers` | | off | Pull the full image including layer tarballs (see below) |
 
 If `--tag` is omitted, the tag is derived from the last path segment of
 the ref minus the `shed-{vz,fc}-` prefix and the version suffix (e.g.
 `ghcr.io/charliek/shed-vz-extensions:v0.5.1` → `extensions`).
 
-`pull` writes the image's blobs into `blobs/sha256/` — including the
-pre-built rootfs erofs blob (built at publish time since v0.5.2, mounted
-as-is with no host-side `mkfs.erofs`) — and records the ref→digest
-mapping in the ref-index.
+#### Boot-only by default
+
+A shed host **boots from the prebuilt rootfs erofs blob and never reads
+the OCI layer tarballs**. So `pull` (and the implicit pull during
+`shed create`) is **boot-only** by default: it fetches the config,
+kernel, initrd, erofs, and manifest, but **skips the layer tarballs** —
+roughly half the bytes of a typical image. The image boots normally;
+`shed image ls` shows it under `LAYERS` as `boot-only`.
+
+The layers are only needed to **re-push a *pulled* image** byte-perfect
+(`shed image push`). That's rare — building and pushing your *own* image
+is unaffected, because `shed image build` produces its layers locally
+(see [Build Your Own Image](../tutorials/build-your-own-image.md)). When
+you do need to push a pulled image:
+
+```bash
+shed image pull <ref> --with-layers   # full pull (or hydrate a boot-only image)
+shed image push <ref> <dst>
+```
+
+`--with-layers` on an already-boot-only image fetches just the missing
+layer blobs (everything already present is a content-addressed no-op).
+Pre-v0.5.2 images (no erofs annotation) can't be pulled boot-only and
+require `--with-layers`.
+
+`pull` writes the image's blobs into `blobs/sha256/` and records the
+ref→digest mapping in the ref-index.
 
 ### shed image push
 
@@ -456,6 +480,13 @@ shed image push full ghcr.io/myorg/shed-vz-full:v0.5.1
 shed image push --local --output-dir ./store full ghcr.io/myorg/shed-vz-full:v0.5.1
 shed -c ./publish-server.yaml image push full ghcr.io/myorg/shed-vz-full:v0.5.1
 ```
+
+A byte-perfect push streams the layer tarballs from disk, so they must
+be present. An image that was **pulled boot-only** has none — push fails
+the layer preflight with an actionable error; re-pull it with
+`shed image pull <ref> --with-layers` first. Images you **built**
+locally (`shed image build`) already have their layers, so building and
+pushing your own image needs no extra step.
 
 Authentication uses the standard Docker credential resolution chain
 (`~/.docker/config.json` and any installed credential helpers — `docker

--- a/docs/reference/storage-model.md
+++ b/docs/reference/storage-model.md
@@ -129,6 +129,16 @@ alone for typical Ubuntu-rootfs content. The trade-off:
 - `shed image inspect` matches `docker manifest inspect` for the same
   reference.
 
+**Boot-only pulls.** A host boots from the erofs and never reads the
+layer tarballs, so `shed image pull` (and `shed create`) is **boot-only**
+by default — it stores the erofs + kernel + initrd but *not* the layer
+blobs, cutting on-disk cost to roughly the erofs alone (~0.5–0.7× the
+ext4). The layers are re-fetchable via `shed image pull <ref>
+--with-layers`, which is required before re-pushing a *pulled* image
+(`shed image push`). Images built locally with `shed image build` keep
+their layers, so building and pushing your own image is unaffected.
+`shed image ls` shows a boot-only image under `LAYERS` as `boot-only`.
+
 See [Layer storage optimization](../discovery/layer-storage-optimization.md)
 for design notes on reducing this further (composefs, blob-level shared
 content, cache eviction).

--- a/docs/tutorials/build-your-own-image.md
+++ b/docs/tutorials/build-your-own-image.md
@@ -24,9 +24,9 @@ The three published variants are:
   and Docker registry auth work without further setup.
 - No coding agents are pinned, so you choose versions yourself without
   fighting `full`'s defaults.
-- You get layer sharing with `extensions` and `full` for free: anyone
-  who's already pulled either variant only fetches the top layer of
-  your derived image.
+- Building on a published variant means the shed-overlay boot setup,
+  kernel/initrd, and credential brokering are already in place — you only
+  add your own top layers.
 
 ## Prerequisites
 
@@ -229,19 +229,25 @@ the shed server. Authentication uses
 the shed-extensions Docker credential proxy when an `extensions`-based
 shed is running).
 
-Verify the layer stack:
+The pull is **boot-only** by default: the host boots from the prebuilt
+erofs blob, so the layer tarballs aren't downloaded (roughly half the
+bytes — see [boot-only pulls](../reference/cli.md#boot-only-by-default)).
+That's the right default for a host that just *boots* your image. The
+layers are only needed to byte-perfect **re-push a pulled image**; if you
+ever need that on this host, re-pull with `--with-layers`.
+
+Verify the manifest:
 
 ```bash
-shed image history my-image
+shed image inspect my-image
 ```
 
-You should see roughly 9–11 layers: your `RUN curl … uv …`,
+You should see roughly 9–11 layers in the manifest: your `RUN curl … uv …`,
 `RUN curl … opencode …`, the `LABEL` and any other top-of-Dockerfile
 instructions you added, then the 7-or-so layers from the parent
-`extensions` variant. The big shared layers (`ubuntu:24.04`,
-`apt-get install …`) appear with the same digest the parent uses, so on
-disk you only pay for the bytes your top-of-Dockerfile additions
-brought in.
+`extensions` variant. `shed image ls` shows the image under `LAYERS` as
+`boot-only` (the layer *blobs* weren't downloaded) and its `SIZE` is the
+on-disk footprint (erofs + kernel + initrd), not the full layer set.
 
 ## 5. Boot a shed from it
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -475,6 +475,11 @@ func mapBackendError(err error) (int, string, string) {
 	if errors.Is(err, config.ErrImageInUseSentinel) {
 		return http.StatusConflict, config.ErrImageInUse, err.Error()
 	}
+	if errors.Is(err, vmimage.ErrLayersMissing) {
+		// Pushing a boot-only image: client-recoverable (re-pull
+		// --with-layers). Preserve the actionable message.
+		return http.StatusConflict, config.ErrBackendError, err.Error()
+	}
 	if errors.Is(err, config.ErrNotSupportedSentinel) {
 		return http.StatusNotImplemented, config.ErrBackendError, err.Error()
 	}
@@ -672,7 +677,7 @@ func (s *Server) handlePullImage(w http.ResponseWriter, r *http.Request) {
 		s.handlePullImageSSE(w, r, req)
 		return
 	}
-	digest, err := s.backend.PullImage(r.Context(), req.DockerRef, req.Tag, req.Platform)
+	digest, err := s.backend.PullImage(r.Context(), req.DockerRef, req.Tag, req.Platform, req.WithLayers)
 	if err != nil {
 		code, errCode, msg := mapBackendError(err)
 		writeError(w, code, errCode, msg)
@@ -707,7 +712,7 @@ func (s *Server) handlePullImageSSE(w http.ResponseWriter, r *http.Request, req 
 	}
 	done := make(chan pullResult, 1)
 	go func() {
-		digest, err := s.backend.PullImage(ctx, req.DockerRef, req.Tag, req.Platform)
+		digest, err := s.backend.PullImage(ctx, req.DockerRef, req.Tag, req.Platform, req.WithLayers)
 		done <- pullResult{digest, err}
 	}()
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -232,7 +232,7 @@ func (f *createShedFakeBackend) InspectImage(_ context.Context, _ string) (confi
 func (f *createShedFakeBackend) TagImage(_ context.Context, _, _ string) error {
 	panic("unexpected")
 }
-func (f *createShedFakeBackend) PullImage(_ context.Context, _, _, _ string) (string, error) {
+func (f *createShedFakeBackend) PullImage(_ context.Context, _, _, _ string, _ bool) (string, error) {
 	panic("unexpected")
 }
 func (f *createShedFakeBackend) PushImage(_ context.Context, _, _ string) error {

--- a/internal/api/routes_test.go
+++ b/internal/api/routes_test.go
@@ -55,10 +55,12 @@ func (routesFakeBackend) ListImages(_ context.Context) ([]config.ImageInfo, erro
 func (routesFakeBackend) InspectImage(_ context.Context, _ string) (config.ImageInspectResponse, error) {
 	return config.ImageInspectResponse{}, config.ErrImageNotFoundSentinel
 }
-func (routesFakeBackend) TagImage(_ context.Context, _, _ string) error               { return nil }
-func (routesFakeBackend) PullImage(_ context.Context, _, _, _ string) (string, error) { return "", nil }
-func (routesFakeBackend) PushImage(_ context.Context, _, _ string) error              { return nil }
-func (routesFakeBackend) DeleteImage(_ context.Context, _ string) error               { return nil }
+func (routesFakeBackend) TagImage(_ context.Context, _, _ string) error { return nil }
+func (routesFakeBackend) PullImage(_ context.Context, _, _, _ string, _ bool) (string, error) {
+	return "", nil
+}
+func (routesFakeBackend) PushImage(_ context.Context, _, _ string) error { return nil }
+func (routesFakeBackend) DeleteImage(_ context.Context, _ string) error  { return nil }
 func (routesFakeBackend) PruneImages(_ context.Context, _ bool) ([]config.ImageInfo, error) {
 	return nil, nil
 }

--- a/internal/api/snapshot_handlers_test.go
+++ b/internal/api/snapshot_handlers_test.go
@@ -76,7 +76,7 @@ func (f *snapshotFakeBackend) InspectImage(_ context.Context, _ string) (config.
 	panic("unexpected")
 }
 func (f *snapshotFakeBackend) TagImage(_ context.Context, _, _ string) error { panic("unexpected") }
-func (f *snapshotFakeBackend) PullImage(_ context.Context, _, _, _ string) (string, error) {
+func (f *snapshotFakeBackend) PullImage(_ context.Context, _, _, _ string, _ bool) (string, error) {
 	panic("unexpected")
 }
 func (f *snapshotFakeBackend) PushImage(_ context.Context, _, _ string) error {

--- a/internal/api/system_handlers_test.go
+++ b/internal/api/system_handlers_test.go
@@ -66,7 +66,7 @@ func (f *fakeBackend) InspectImage(ctx context.Context, _ string) (config.ImageI
 	panic("unexpected")
 }
 func (f *fakeBackend) TagImage(ctx context.Context, _, _ string) error { panic("unexpected") }
-func (f *fakeBackend) PullImage(ctx context.Context, _, _, _ string) (string, error) {
+func (f *fakeBackend) PullImage(ctx context.Context, _, _, _ string, _ bool) (string, error) {
 	panic("unexpected")
 }
 func (f *fakeBackend) PushImage(ctx context.Context, _, _ string) error   { panic("unexpected") }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -92,8 +92,9 @@ type Backend interface {
 	// PullImage pulls a registry reference into the blob store and
 	// advances the named tag. platform is an optional override
 	// (e.g. "linux/arm64"); empty means the backend's native platform.
-	// Returns the manifest digest.
-	PullImage(ctx context.Context, dockerRef, tag, platform string) (string, error)
+	// withLayers pulls the full image (layer tarballs included); false
+	// pulls boot-only (no layers). Returns the manifest digest.
+	PullImage(ctx context.Context, dockerRef, tag, platform string, withLayers bool) (string, error)
 
 	// PushImage uploads the manifest currently held by tagOrDigest to
 	// the destination registry ref. Byte-perfect — original layer

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -244,6 +244,9 @@ type ImageInfo struct {
 	Alias string `json:"alias,omitempty"`
 	// IsDefault is true for the config image whose ref is default_image.
 	IsDefault bool `json:"is_default,omitempty"`
+	// BootOnly is true when the image was pulled without layer tarballs
+	// (boots fine; `shed image push` needs a `--with-layers` re-pull first).
+	BootOnly bool `json:"boot_only,omitempty"`
 }
 
 // ImageInspectResponse is returned by GET /api/images/{tag-or-digest}.
@@ -293,6 +296,11 @@ type ImagePullRequest struct {
 	// Platform is an optional override (e.g. "linux/arm64"). Empty
 	// means the server-side backend's native platform.
 	Platform string `json:"platform,omitempty"`
+	// WithLayers pulls the full image (layer tarballs included). Default
+	// (false) pulls boot-only — config + kernel + initrd + erofs only —
+	// which the host boots from without the layers. Set true (the CLI's
+	// --with-layers) when the image will be re-pushed.
+	WithLayers bool `json:"with_layers,omitempty"`
 }
 
 // ImagePushRequest is the body of POST /api/images/push.

--- a/internal/firecracker/backend.go
+++ b/internal/firecracker/backend.go
@@ -210,8 +210,8 @@ func (b *FirecrackerBackend) TagImage(_ context.Context, src, dst string) error 
 }
 
 // PullImage pulls a Docker reference into the blob store under the named tag.
-func (b *FirecrackerBackend) PullImage(ctx context.Context, dockerRef, tag, platform string) (string, error) {
-	return b.client.PullImage(ctx, dockerRef, tag, platform)
+func (b *FirecrackerBackend) PullImage(ctx context.Context, dockerRef, tag, platform string, withLayers bool) (string, error) {
+	return b.client.PullImage(ctx, dockerRef, tag, platform, withLayers)
 }
 
 // PushImage uploads the manifest held by tagOrDigest to dstRef.

--- a/internal/firecracker/image.go
+++ b/internal/firecracker/image.go
@@ -47,9 +47,9 @@ func (c *Client) TagImage(srcTagOrDigest, newTag string) error {
 // PullImage pulls a Docker ref, installs into the blob store, and tags.
 // platform is an optional override (e.g. "linux/arm64"); empty means
 // the backend's native platform.
-func (c *Client) PullImage(ctx context.Context, dockerRef, tag, platform string) (string, error) {
+func (c *Client) PullImage(ctx context.Context, dockerRef, tag, platform string, withLayers bool) (string, error) {
 	mgr := vmimage.NewManager(c.cfg, c.refScanner())
-	return mgr.PullImage(ctx, dockerRef, tag, platform, progressBridge(ctx))
+	return mgr.PullImage(ctx, dockerRef, tag, platform, withLayers, progressBridge(ctx))
 }
 
 // progressBridge translates vmimage progress events into backend SSE events.
@@ -213,6 +213,7 @@ func toConfigImageInfo(img vmimage.ImageInfo) config.ImageInfo {
 		InUse:     img.InUse,
 		Alias:     img.Alias,
 		IsDefault: img.IsDefault,
+		BootOnly:  img.BootOnly,
 	}
 }
 

--- a/internal/firecracker/stub_nonlinux.go
+++ b/internal/firecracker/stub_nonlinux.go
@@ -122,7 +122,7 @@ func (b *FirecrackerBackend) TagImage(_ context.Context, _, _ string) error {
 }
 
 // PullImage returns an error on non-linux platforms.
-func (b *FirecrackerBackend) PullImage(_ context.Context, _, _, _ string) (string, error) {
+func (b *FirecrackerBackend) PullImage(_ context.Context, _, _, _ string, _ bool) (string, error) {
 	return "", fmt.Errorf("pull image: %w", config.ErrNotSupportedSentinel)
 }
 

--- a/internal/vmimage/boot_only_test.go
+++ b/internal/vmimage/boot_only_test.go
@@ -83,62 +83,89 @@ func bootOnlyOpts(ref, dir string, skipLayers bool) PullOptions {
 	}
 }
 
-// TestPullBootOnlySkipsLayers: a boot-only pull writes the erofs/kernel/initrd
-// (and manifest/config) but NONE of the layer tarballs.
-func TestPullBootOnlySkipsLayers(t *testing.T) {
+// TestBootOnlyPull covers the boot-only pull of an annotated (v0.5.2+) image:
+// each case shares the pushed image but pulls into its own store, then varies
+// what it does next (verify skip / hydrate / push preflight).
+func TestBootOnlyPull(t *testing.T) {
 	host := startTestRegistry(t)
 	si := pushShedImage(t, fmt.Sprintf("%s/test/bootonly:v1", host), 4)
-	dir := t.TempDir()
 
-	res, err := PullToOCILayout(context.Background(), bootOnlyOpts(si.ref, dir, true))
-	if err != nil {
-		t.Fatalf("boot-only pull: %v", err)
+	cases := []struct {
+		name  string
+		check func(t *testing.T, dir string, res *PullResult)
+	}{
+		{
+			// A boot-only pull writes erofs/kernel/initrd (+manifest/config)
+			// but NONE of the layer tarballs.
+			name: "skips layer tarballs",
+			check: func(t *testing.T, dir string, res *PullResult) {
+				for i, d := range res.LayerDigests {
+					if BlobExists(dir, d) {
+						t.Errorf("layer %d (%s) present after boot-only pull — should be skipped", i, ShortDigest(d))
+					}
+				}
+				for name, d := range map[string]string{"erofs": si.erofsDigest, "kernel": si.kernelDigest, "initrd": si.initrdDigest} {
+					if !BlobExists(dir, d) {
+						t.Errorf("%s blob %s missing after boot-only pull", name, ShortDigest(d))
+					}
+				}
+				if !BlobExists(dir, res.ConfigDigest) {
+					t.Error("config blob missing after boot-only pull")
+				}
+			},
+		},
+		{
+			// --with-layers (SkipLayers=false) re-pulls and fetches the
+			// previously-skipped layer blobs.
+			name: "with-layers hydrates the missing layers",
+			check: func(t *testing.T, dir string, res *PullResult) {
+				if _, err := PullToOCILayout(context.Background(), bootOnlyOpts(si.ref, dir, false)); err != nil {
+					t.Fatalf("--with-layers hydration pull: %v", err)
+				}
+				for i, d := range res.LayerDigests {
+					if !BlobExists(dir, d) {
+						t.Errorf("layer %d (%s) still missing after --with-layers hydration", i, ShortDigest(d))
+					}
+				}
+			},
+		},
+		{
+			// Pushing a boot-only image fails the layer preflight with the
+			// actionable ErrLayersMissing.
+			name: "push preflight errors on missing layers",
+			check: func(t *testing.T, dir string, res *PullResult) {
+				err := PushFromOCILayout(context.Background(), PushOptions{
+					Ref:            fmt.Sprintf("%s/test/push-dest:v1", host),
+					ImagesDir:      dir,
+					ManifestDigest: res.ManifestDigest,
+					Insecure:       true,
+					Progress:       func(ProgressEvent) {},
+				})
+				if !errors.Is(err, ErrLayersMissing) {
+					t.Fatalf("push of a boot-only image: got %v, want ErrLayersMissing", err)
+				}
+				if !strings.Contains(err.Error(), "--with-layers") {
+					t.Errorf("push error %q should point at --with-layers", err)
+				}
+			},
+		},
 	}
-	for i, d := range res.LayerDigests {
-		if BlobExists(dir, d) {
-			t.Errorf("layer %d (%s) present after a boot-only pull — should be skipped", i, ShortDigest(d))
-		}
-	}
-	for name, d := range map[string]string{"erofs": si.erofsDigest, "kernel": si.kernelDigest, "initrd": si.initrdDigest} {
-		if !BlobExists(dir, d) {
-			t.Errorf("%s blob %s missing after boot-only pull", name, ShortDigest(d))
-		}
-	}
-	if !BlobExists(dir, res.ConfigDigest) {
-		t.Error("config blob missing after boot-only pull")
-	}
-}
-
-// TestPullWithLayersHydrates: after a boot-only pull, a --with-layers pull
-// (SkipLayers=false) fetches the previously-skipped layer blobs.
-func TestPullWithLayersHydrates(t *testing.T) {
-	host := startTestRegistry(t)
-	si := pushShedImage(t, fmt.Sprintf("%s/test/hydrate:v1", host), 4)
-	dir := t.TempDir()
-
-	res, err := PullToOCILayout(context.Background(), bootOnlyOpts(si.ref, dir, true))
-	if err != nil {
-		t.Fatalf("boot-only pull: %v", err)
-	}
-	for _, d := range res.LayerDigests {
-		if BlobExists(dir, d) {
-			t.Fatalf("layer present before hydration")
-		}
-	}
-	// Hydrate.
-	if _, err := PullToOCILayout(context.Background(), bootOnlyOpts(si.ref, dir, false)); err != nil {
-		t.Fatalf("--with-layers hydration pull: %v", err)
-	}
-	for i, d := range res.LayerDigests {
-		if !BlobExists(dir, d) {
-			t.Errorf("layer %d (%s) still missing after --with-layers hydration", i, ShortDigest(d))
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			res, err := PullToOCILayout(context.Background(), bootOnlyOpts(si.ref, dir, true))
+			if err != nil {
+				t.Fatalf("boot-only pull: %v", err)
+			}
+			tc.check(t, dir, res)
+		})
 	}
 }
 
 // TestPullBootOnlyRejectsUnannotated: an image without the erofs annotation
 // (pre-v0.5.2 shape) can't be pulled boot-only — it would need layer
-// extraction. random.Image has no shed annotations.
+// extraction. random.Image has no shed annotations. (Kept separate from the
+// matrix above because it uses a different, un-annotated image.)
 func TestPullBootOnlyRejectsUnannotated(t *testing.T) {
 	host := startTestRegistry(t)
 	ref := pushRandomImage(t, fmt.Sprintf("%s/test/preerofs:v1", host), 2)
@@ -149,31 +176,5 @@ func TestPullBootOnlyRejectsUnannotated(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "boot-only") || !strings.Contains(err.Error(), "--with-layers") {
 		t.Errorf("error %q should mention boot-only and --with-layers", err)
-	}
-}
-
-// TestPushPreflightMissingLayers: pushing a boot-only image fails the layer
-// preflight with the actionable ErrLayersMissing.
-func TestPushPreflightMissingLayers(t *testing.T) {
-	host := startTestRegistry(t)
-	si := pushShedImage(t, fmt.Sprintf("%s/test/push:v1", host), 3)
-	dir := t.TempDir()
-
-	res, err := PullToOCILayout(context.Background(), bootOnlyOpts(si.ref, dir, true))
-	if err != nil {
-		t.Fatalf("boot-only pull: %v", err)
-	}
-	err = PushFromOCILayout(context.Background(), PushOptions{
-		Ref:            fmt.Sprintf("%s/test/push-dest:v1", host),
-		ImagesDir:      dir,
-		ManifestDigest: res.ManifestDigest,
-		Insecure:       true,
-		Progress:       func(ProgressEvent) {},
-	})
-	if !errors.Is(err, ErrLayersMissing) {
-		t.Fatalf("push of a boot-only image: got %v, want ErrLayersMissing", err)
-	}
-	if !strings.Contains(err.Error(), "--with-layers") {
-		t.Errorf("push error %q should point at --with-layers", err)
 	}
 }

--- a/internal/vmimage/boot_only_test.go
+++ b/internal/vmimage/boot_only_test.go
@@ -1,0 +1,179 @@
+package vmimage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+// shedImage is the result of pushing a v0.5.2-shaped image: a layered image
+// plus loose kernel/initrd/erofs blobs referenced by manifest annotations.
+type shedImage struct {
+	ref          string
+	erofsDigest  string
+	kernelDigest string
+	initrdDigest string
+}
+
+// pushShedImage pushes a layered image AND the loose kernel/initrd/erofs
+// sibling blobs, wired up via the io.shed.* manifest annotations — i.e. a
+// boot-only-pullable image. Each loose blob is small random content.
+func pushShedImage(t testing.TB, refStr string, layers int) shedImage {
+	t.Helper()
+	ref, err := name.ParseReference(refStr, name.Insecure)
+	if err != nil {
+		t.Fatalf("parse ref %q: %v", refStr, err)
+	}
+	img, err := random.Image(2048, int64(layers))
+	if err != nil {
+		t.Fatalf("random.Image: %v", err)
+	}
+	// Push three loose sibling blobs (distinct content → distinct digests).
+	loose := func(seed string, n int) string {
+		t.Helper()
+		layer := static.NewLayer([]byte(strings.Repeat(seed, n)), types.MediaType("application/octet-stream"))
+		if err := remote.WriteLayer(ref.Context(), layer); err != nil {
+			t.Fatalf("push loose blob %q: %v", seed, err)
+		}
+		d, err := layer.Digest()
+		if err != nil {
+			t.Fatalf("loose digest: %v", err)
+		}
+		return d.String()
+	}
+	si := shedImage{
+		ref:          refStr,
+		erofsDigest:  loose("erofs", 4096),
+		kernelDigest: loose("kernel", 512),
+		initrdDigest: loose("initrd", 256),
+	}
+	annotated, ok := mutate.Annotations(img, map[string]string{
+		AnnotationRootfsErofsDigest: si.erofsDigest,
+		AnnotationKernelDigest:      si.kernelDigest,
+		AnnotationInitrdDigest:      si.initrdDigest,
+	}).(v1.Image)
+	if !ok {
+		t.Fatal("mutate.Annotations did not return a v1.Image")
+	}
+	if err := remote.Write(ref, annotated); err != nil {
+		t.Fatalf("push annotated image: %v", err)
+	}
+	return si
+}
+
+func bootOnlyOpts(ref, dir string, skipLayers bool) PullOptions {
+	return PullOptions{
+		Ref:           ref,
+		ImagesDir:     dir,
+		Insecure:      true,
+		ExtractKernel: true,
+		NeedsInitrd:   true,
+		SkipLayers:    skipLayers,
+		Progress:      func(ProgressEvent) {},
+	}
+}
+
+// TestPullBootOnlySkipsLayers: a boot-only pull writes the erofs/kernel/initrd
+// (and manifest/config) but NONE of the layer tarballs.
+func TestPullBootOnlySkipsLayers(t *testing.T) {
+	host := startTestRegistry(t)
+	si := pushShedImage(t, fmt.Sprintf("%s/test/bootonly:v1", host), 4)
+	dir := t.TempDir()
+
+	res, err := PullToOCILayout(context.Background(), bootOnlyOpts(si.ref, dir, true))
+	if err != nil {
+		t.Fatalf("boot-only pull: %v", err)
+	}
+	for i, d := range res.LayerDigests {
+		if BlobExists(dir, d) {
+			t.Errorf("layer %d (%s) present after a boot-only pull — should be skipped", i, ShortDigest(d))
+		}
+	}
+	for name, d := range map[string]string{"erofs": si.erofsDigest, "kernel": si.kernelDigest, "initrd": si.initrdDigest} {
+		if !BlobExists(dir, d) {
+			t.Errorf("%s blob %s missing after boot-only pull", name, ShortDigest(d))
+		}
+	}
+	if !BlobExists(dir, res.ConfigDigest) {
+		t.Error("config blob missing after boot-only pull")
+	}
+}
+
+// TestPullWithLayersHydrates: after a boot-only pull, a --with-layers pull
+// (SkipLayers=false) fetches the previously-skipped layer blobs.
+func TestPullWithLayersHydrates(t *testing.T) {
+	host := startTestRegistry(t)
+	si := pushShedImage(t, fmt.Sprintf("%s/test/hydrate:v1", host), 4)
+	dir := t.TempDir()
+
+	res, err := PullToOCILayout(context.Background(), bootOnlyOpts(si.ref, dir, true))
+	if err != nil {
+		t.Fatalf("boot-only pull: %v", err)
+	}
+	for _, d := range res.LayerDigests {
+		if BlobExists(dir, d) {
+			t.Fatalf("layer present before hydration")
+		}
+	}
+	// Hydrate.
+	if _, err := PullToOCILayout(context.Background(), bootOnlyOpts(si.ref, dir, false)); err != nil {
+		t.Fatalf("--with-layers hydration pull: %v", err)
+	}
+	for i, d := range res.LayerDigests {
+		if !BlobExists(dir, d) {
+			t.Errorf("layer %d (%s) still missing after --with-layers hydration", i, ShortDigest(d))
+		}
+	}
+}
+
+// TestPullBootOnlyRejectsUnannotated: an image without the erofs annotation
+// (pre-v0.5.2 shape) can't be pulled boot-only — it would need layer
+// extraction. random.Image has no shed annotations.
+func TestPullBootOnlyRejectsUnannotated(t *testing.T) {
+	host := startTestRegistry(t)
+	ref := pushRandomImage(t, fmt.Sprintf("%s/test/preerofs:v1", host), 2)
+
+	_, err := PullToOCILayout(context.Background(), bootOnlyOpts(ref, t.TempDir(), true))
+	if err == nil {
+		t.Fatal("expected boot-only pull of an un-annotated image to be rejected")
+	}
+	if !strings.Contains(err.Error(), "boot-only") || !strings.Contains(err.Error(), "--with-layers") {
+		t.Errorf("error %q should mention boot-only and --with-layers", err)
+	}
+}
+
+// TestPushPreflightMissingLayers: pushing a boot-only image fails the layer
+// preflight with the actionable ErrLayersMissing.
+func TestPushPreflightMissingLayers(t *testing.T) {
+	host := startTestRegistry(t)
+	si := pushShedImage(t, fmt.Sprintf("%s/test/push:v1", host), 3)
+	dir := t.TempDir()
+
+	res, err := PullToOCILayout(context.Background(), bootOnlyOpts(si.ref, dir, true))
+	if err != nil {
+		t.Fatalf("boot-only pull: %v", err)
+	}
+	err = PushFromOCILayout(context.Background(), PushOptions{
+		Ref:            fmt.Sprintf("%s/test/push-dest:v1", host),
+		ImagesDir:      dir,
+		ManifestDigest: res.ManifestDigest,
+		Insecure:       true,
+		Progress:       func(ProgressEvent) {},
+	})
+	if !errors.Is(err, ErrLayersMissing) {
+		t.Fatalf("push of a boot-only image: got %v, want ErrLayersMissing", err)
+	}
+	if !strings.Contains(err.Error(), "--with-layers") {
+		t.Errorf("push error %q should point at --with-layers", err)
+	}
+}

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -1047,10 +1047,9 @@ func (m *Manager) PruneImages(dryRun bool) ([]ImageInfo, error) {
 			if info.DockerRef != "" {
 				info.Name = info.DockerRef
 			}
-			for _, layer := range m.Layers {
-				info.SizeBytes += layer.Size
-			}
-			info.SizeBytes += CacheLowerSize(imagesDir, b)
+			// Same on-disk accounting as ls/inspect: count present layers +
+			// erofs, skip absent (boot-only) layers, flag BootOnly.
+			accumulateBlobSizes(&info, imagesDir, b, m, nil)
 		}
 		candidates = append(candidates, info)
 	}

--- a/internal/vmimage/manager.go
+++ b/internal/vmimage/manager.go
@@ -30,6 +30,11 @@ var (
 	// ErrImageInUse is returned when trying to delete an image referenced
 	// by config or an existing shed.
 	ErrImageInUse = errors.New("image is in use")
+
+	// ErrLayersMissing is returned when an operation needs layer blobs that
+	// aren't present locally — e.g. pushing an image that was pulled
+	// boot-only. Re-pull with --with-layers to recover.
+	ErrLayersMissing = errors.New("image layers not present locally")
 )
 
 // ImageConfig provides the configuration data needed by image management operations.
@@ -61,6 +66,7 @@ type ImageInfo struct {
 	InUse       bool   // protected by a shed or snapshot reference
 	Alias       string // friendly image_aliases key (empty for user/dangling)
 	IsDefault   bool   // this image's ref is the configured default_image
+	BootOnly    bool   // pulled without layer tarballs (boots, can't push without --with-layers)
 }
 
 // Manager handles image lifecycle: ensure, list, delete, prune.
@@ -178,6 +184,10 @@ func (m *Manager) EnsureImage(ctx context.Context, ref ResolvedRef, progress Pro
 		NeedsInitrd:   m.cfg.GetNeedsInitrd(),
 		Progress:      progress,
 		Concurrency:   m.cfg.GetPullConcurrency(),
+		// create only boots the image; it never re-pushes it, so the layer
+		// tarballs are dead weight. Pull boot-only (re-fetchable later via
+		// `shed image pull <ref> --with-layers` if a push is ever needed).
+		SkipLayers: true,
 	})
 	if err != nil {
 		return EnsureResult{}, fmt.Errorf("pulling %s from registry: %w", ref.DockerRef, err)
@@ -222,7 +232,7 @@ func (m *Manager) resolveCachedRef(ctx context.Context, imagesDir, ref string) (
 // PullImage pulls a registry reference straight to the OCI layout (no
 // Docker daemon required) and advances the named tag. Defaults to the
 // backend's native platform when platform is empty.
-func (m *Manager) PullImage(ctx context.Context, dockerRef, tag, platform string, progress ProgressFunc) (string, error) {
+func (m *Manager) PullImage(ctx context.Context, dockerRef, tag, platform string, withLayers bool, progress ProgressFunc) (string, error) {
 	if err := ValidateImageName(tag); err != nil {
 		return "", err
 	}
@@ -255,6 +265,10 @@ func (m *Manager) PullImage(ctx context.Context, dockerRef, tag, platform string
 		NeedsInitrd:   m.cfg.GetNeedsInitrd(),
 		Progress:      progress,
 		Concurrency:   m.cfg.GetPullConcurrency(),
+		// Boot-only by default; --with-layers (withLayers=true) pulls the
+		// full image and, on an already-boot-only image, hydrates the missing
+		// layer blobs (present blobs are content-addressed no-ops).
+		SkipLayers: !withLayers,
 	})
 	if err != nil {
 		return "", fmt.Errorf("pulling %s from registry: %w", dockerRef, err)
@@ -388,6 +402,40 @@ func (m *Manager) resolveManifestLower(_ context.Context, imagesDir, manifestDig
 		Path:   path,
 		Digest: manifestDigest,
 	}, nil
+}
+
+// accumulateBlobSizes fills info's size fields from the on-disk blobs the
+// manifest references: present layers, the prebuilt erofs (referenced by
+// annotation, not as a layer), and the legacy ext4 cache. Absent layers
+// (a boot-only pull) are not counted and flag info.BootOnly, so SIZE always
+// reflects real on-disk usage. layerRefs (digest -> cross-manifest refcount)
+// drives the unique/shared attribution; pass nil to compute SizeBytes only.
+func accumulateBlobSizes(info *ImageInfo, imagesDir, digest string, manifest *OCIManifest, layerRefs map[string]int) {
+	for _, layer := range manifest.Layers {
+		if !BlobExists(imagesDir, layer.Digest) {
+			info.BootOnly = true
+			continue
+		}
+		info.SizeBytes += layer.Size
+		if layerRefs != nil {
+			if layerRefs[layer.Digest] <= 1 {
+				info.UniqueBytes += layer.Size
+			} else {
+				info.SharedBytes += layer.Size
+			}
+		}
+	}
+	if d := manifest.ShedRootfsErofsDigest(); d != "" && BlobExists(imagesDir, d) {
+		sz := BlobSize(imagesDir, d)
+		info.SizeBytes += sz
+		if layerRefs != nil {
+			info.UniqueBytes += sz
+		}
+	}
+	info.SizeBytes += CacheLowerSize(imagesDir, digest)
+	if layerRefs != nil {
+		info.UniqueBytes += CacheLowerSize(imagesDir, digest)
+	}
 }
 
 // ListImages returns ImageInfo entries for every known tag plus dangling
@@ -568,19 +616,7 @@ func (m *Manager) ListImages() ([]ImageInfo, error) {
 			info.Source = "dangling"
 		}
 		if mi.manifest != nil {
-			for _, layer := range mi.manifest.Layers {
-				info.SizeBytes += layer.Size
-				if layerRefs[layer.Digest] <= 1 {
-					info.UniqueBytes += layer.Size
-				} else {
-					info.SharedBytes += layer.Size
-				}
-			}
-			// The flattened lower is keyed by manifest digest and
-			// unique-per-manifest (no cross-manifest sharing for the
-			// erofs file, only for layer blobs above).
-			info.SizeBytes += CacheLowerSize(imagesDir, mi.digest)
-			info.UniqueBytes += CacheLowerSize(imagesDir, mi.digest)
+			accumulateBlobSizes(&info, imagesDir, mi.digest, mi.manifest, layerRefs)
 			if path, err := CacheLowerPath(imagesDir, mi.digest); err == nil {
 				info.Path = path
 			}
@@ -671,10 +707,7 @@ func (m *Manager) InspectImage(tagOrDigest string) (*ImageInfo, *OCIManifest, er
 		}
 		info.Source = "dangling"
 	}
-	for _, layer := range manifest.Layers {
-		info.SizeBytes += layer.Size
-	}
-	info.SizeBytes += CacheLowerSize(imagesDir, digest)
+	accumulateBlobSizes(info, imagesDir, digest, manifest, nil)
 	if path, err := CacheLowerPath(imagesDir, digest); err == nil {
 		info.Path = path
 	}

--- a/internal/vmimage/registry.go
+++ b/internal/vmimage/registry.go
@@ -73,6 +73,14 @@ type PullOptions struct {
 	// Concurrency caps how many blobs download in parallel. <=1 means
 	// serial. Callers should pass cfg.GetPullConcurrency().
 	Concurrency int
+
+	// SkipLayers pulls "boot-only": config + kernel + initrd + erofs +
+	// manifest, but NOT the layer tarballs (the host boots from the erofs
+	// and never reads layers). Requires a v0.5.2+ image whose kernel/initrd/
+	// erofs come from manifest annotations; rejected otherwise. The skipped
+	// layers are re-fetchable later via a full pull (`--with-layers`), which
+	// is required before `shed image push` of a boot-only image.
+	SkipLayers bool
 }
 
 // PullResult mirrors ConvertResult so callers can use either flow.
@@ -108,6 +116,18 @@ type PushOptions struct {
 	Progress ProgressFunc
 }
 
+// missingLayers returns the manifest layer digests whose blobs are absent
+// from the local store (the boot-only case). Empty for a full image.
+func missingLayers(imagesDir string, manifest *OCIManifest) []string {
+	var missing []string
+	for _, l := range manifest.Layers {
+		if !BlobExists(imagesDir, l.Digest) {
+			missing = append(missing, l.Digest)
+		}
+	}
+	return missing
+}
+
 // PushFromOCILayout uploads the on-disk manifest + config + layers to
 // the destination registry. Layer bytes are streamed straight from the
 // OCI store so the registry digests are preserved end-to-end (the
@@ -133,6 +153,15 @@ func PushFromOCILayout(ctx context.Context, opts PushOptions) error {
 	manifest, err := ParseManifest(manifestBytes)
 	if err != nil {
 		return fmt.Errorf("parsing manifest: %w", err)
+	}
+
+	// Preflight: a byte-perfect push streams every layer blob from disk, so
+	// they must all be present. An image pulled boot-only has none — fail
+	// here with an actionable message instead of an opaque "no such file"
+	// from deep inside go-containerregistry's remote.Write.
+	if missing := missingLayers(opts.ImagesDir, manifest); len(missing) > 0 {
+		return fmt.Errorf("%w: %d of %d layer blob(s) absent (e.g. %s). The image was pulled boot-only; run `shed image pull <ref> --with-layers` to fetch the layers, then push",
+			ErrLayersMissing, len(missing), len(manifest.Layers), ShortDigest(missing[0]))
 	}
 
 	keychain := opts.AuthKeychain
@@ -395,14 +424,35 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		layerDigests[i] = ld.String()
 	}
 
-	// Download layers + annotated loose blobs concurrently, bounded by
-	// opts.Concurrency. Per-blob writes are already atomic (file lock +
-	// content-verified rename); a singleflight keyed by digest dedups
-	// concurrent fetches of the SAME digest, so a duplicate layer never
-	// opens two network streams (and distinct digests never contend on the
-	// same blob lock). The first error cancels the group, and the manifest /
-	// index / tag are written only after a clean Wait, so a partial pull can
-	// never advance a tag.
+	kernelAnn := annotationFromManifest(manifestDesc, AnnotationKernelDigest)
+	initrdAnn := annotationFromManifest(manifestDesc, AnnotationInitrdDigest)
+	erofsAnn := annotationFromManifest(manifestDesc, AnnotationRootfsErofsDigest)
+
+	// Boot-only pull: skip the layer tarballs entirely. The host boots from
+	// the erofs blob and never reads layers, so they are dead weight for any
+	// host that doesn't re-push this pulled image. Only safe when the boot
+	// blobs all come from manifest annotations — without layers we can't run
+	// the legacy extract-from-layers kernel/initrd fallback — so reject
+	// pre-v0.5.2 images that lack the annotations, pointing at --with-layers.
+	if opts.SkipLayers {
+		switch {
+		case erofsAnn == "":
+			return nil, fmt.Errorf("cannot pull %q boot-only: image has no %s annotation (built with pre-v0.5.2 tooling); re-pull with --with-layers", opts.Ref, AnnotationRootfsErofsDigest)
+		case opts.ExtractKernel && kernelAnn == "":
+			return nil, fmt.Errorf("cannot pull %q boot-only: image has no kernel annotation (the kernel would need layer extraction); re-pull with --with-layers", opts.Ref)
+		case opts.NeedsInitrd && initrdAnn == "":
+			return nil, fmt.Errorf("cannot pull %q boot-only: image has no initrd annotation (the initrd would need layer extraction); re-pull with --with-layers", opts.Ref)
+		}
+	}
+
+	// Download layers (unless boot-only) + annotated loose blobs
+	// concurrently, bounded by opts.Concurrency. Per-blob writes are already
+	// atomic (file lock + content-verified rename); a singleflight keyed by
+	// digest dedups concurrent fetches of the SAME digest, so a duplicate
+	// layer never opens two network streams (and distinct digests never
+	// contend on the same blob lock). The first error cancels the group, and
+	// the manifest / index / tag are written only after a clean Wait, so a
+	// partial pull can never advance a tag.
 	//
 	// Note on cancellation: gctx cancels *scheduling* (queued goroutines
 	// don't start once a sibling fails), but the HTTP reads themselves are
@@ -418,20 +468,21 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(concurrency)
 
-	for i := range layers {
-		i, layer, digest := i, layers[i], layerDigests[i]
-		g.Go(func() error {
-			return pullLayerBlob(gctx, &sf, opts, i, len(layers), digest, layer)
-		})
+	if !opts.SkipLayers {
+		for i := range layers {
+			i, layer, digest := i, layers[i], layerDigests[i]
+			g.Go(func() error {
+				return pullLayerBlob(gctx, &sf, opts, i, len(layers), digest, layer)
+			})
+		}
 	}
 
 	// Annotated loose blobs (kernel/initrd/erofs) are independent of the
 	// layers, so they download in the same group. The extract-from-layers
 	// fallbacks (no annotation) need the layers present and so run after
-	// Wait below — they must not race a still-downloading layer.
-	kernelAnn := annotationFromManifest(manifestDesc, AnnotationKernelDigest)
-	initrdAnn := annotationFromManifest(manifestDesc, AnnotationInitrdDigest)
-	erofsAnn := annotationFromManifest(manifestDesc, AnnotationRootfsErofsDigest)
+	// Wait below — they must not race a still-downloading layer (and are
+	// unreachable in boot-only mode, which the precondition above guarantees
+	// has all three annotations).
 	for _, lb := range []struct{ digest, label, kind string }{
 		{kernelAnn, "kernel " + ShortDigest(kernelAnn), "kernel"},
 		{initrdAnn, "initrd " + ShortDigest(initrdAnn), "initrd"},

--- a/internal/vmimage/registry.go
+++ b/internal/vmimage/registry.go
@@ -390,6 +390,24 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		return nil, fmt.Errorf("manifest digest: %w", err)
 	}
 
+	// Read the boot-blob annotations and, for a boot-only pull, validate
+	// them BEFORE writing anything to the store — so a rejected pull (a
+	// pre-v0.5.2 image that would need layer extraction for kernel/initrd)
+	// doesn't leave an orphan config blob behind.
+	kernelAnn := annotationFromManifest(manifestDesc, AnnotationKernelDigest)
+	initrdAnn := annotationFromManifest(manifestDesc, AnnotationInitrdDigest)
+	erofsAnn := annotationFromManifest(manifestDesc, AnnotationRootfsErofsDigest)
+	if opts.SkipLayers {
+		switch {
+		case erofsAnn == "":
+			return nil, fmt.Errorf("cannot pull %q boot-only: image has no %s annotation (built with pre-v0.5.2 tooling); re-pull with --with-layers", opts.Ref, AnnotationRootfsErofsDigest)
+		case opts.ExtractKernel && kernelAnn == "":
+			return nil, fmt.Errorf("cannot pull %q boot-only: image has no kernel annotation (the kernel would need layer extraction); re-pull with --with-layers", opts.Ref)
+		case opts.NeedsInitrd && initrdAnn == "":
+			return nil, fmt.Errorf("cannot pull %q boot-only: image has no initrd annotation (the initrd would need layer extraction); re-pull with --with-layers", opts.Ref)
+		}
+	}
+
 	// Config bytes.
 	configBytes, err := img.RawConfigFile()
 	if err != nil {
@@ -424,28 +442,8 @@ func PullToOCILayout(ctx context.Context, opts PullOptions) (*PullResult, error)
 		layerDigests[i] = ld.String()
 	}
 
-	kernelAnn := annotationFromManifest(manifestDesc, AnnotationKernelDigest)
-	initrdAnn := annotationFromManifest(manifestDesc, AnnotationInitrdDigest)
-	erofsAnn := annotationFromManifest(manifestDesc, AnnotationRootfsErofsDigest)
-
-	// Boot-only pull: skip the layer tarballs entirely. The host boots from
-	// the erofs blob and never reads layers, so they are dead weight for any
-	// host that doesn't re-push this pulled image. Only safe when the boot
-	// blobs all come from manifest annotations — without layers we can't run
-	// the legacy extract-from-layers kernel/initrd fallback — so reject
-	// pre-v0.5.2 images that lack the annotations, pointing at --with-layers.
-	if opts.SkipLayers {
-		switch {
-		case erofsAnn == "":
-			return nil, fmt.Errorf("cannot pull %q boot-only: image has no %s annotation (built with pre-v0.5.2 tooling); re-pull with --with-layers", opts.Ref, AnnotationRootfsErofsDigest)
-		case opts.ExtractKernel && kernelAnn == "":
-			return nil, fmt.Errorf("cannot pull %q boot-only: image has no kernel annotation (the kernel would need layer extraction); re-pull with --with-layers", opts.Ref)
-		case opts.NeedsInitrd && initrdAnn == "":
-			return nil, fmt.Errorf("cannot pull %q boot-only: image has no initrd annotation (the initrd would need layer extraction); re-pull with --with-layers", opts.Ref)
-		}
-	}
-
-	// Download layers (unless boot-only) + annotated loose blobs
+	// Download layers (unless boot-only — see the precondition above) +
+	// annotated loose blobs
 	// concurrently, bounded by opts.Concurrency. Per-blob writes are already
 	// atomic (file lock + content-verified rename); a singleflight keyed by
 	// digest dedups concurrent fetches of the SAME digest, so a duplicate

--- a/internal/vz/backend.go
+++ b/internal/vz/backend.go
@@ -214,8 +214,8 @@ func (b *VZBackend) TagImage(_ context.Context, src, dst string) error {
 }
 
 // PullImage pulls a Docker reference into the blob store under the named tag.
-func (b *VZBackend) PullImage(ctx context.Context, dockerRef, tag, platform string) (string, error) {
-	return b.client.PullImage(ctx, dockerRef, tag, platform)
+func (b *VZBackend) PullImage(ctx context.Context, dockerRef, tag, platform string, withLayers bool) (string, error) {
+	return b.client.PullImage(ctx, dockerRef, tag, platform, withLayers)
 }
 
 // PushImage uploads the manifest held by tagOrDigest to dstRef.

--- a/internal/vz/image.go
+++ b/internal/vz/image.go
@@ -87,9 +87,9 @@ func (c *Client) TagImage(srcTagOrDigest, newTag string) error {
 // PullImage pulls a Docker ref, installs into the blob store, and tags.
 // platform is an optional override (e.g. "linux/arm64"); empty means
 // the backend's native platform.
-func (c *Client) PullImage(ctx context.Context, dockerRef, tag, platform string) (string, error) {
+func (c *Client) PullImage(ctx context.Context, dockerRef, tag, platform string, withLayers bool) (string, error) {
 	mgr := vmimage.NewManager(c.cfg, c.refScanner())
-	return mgr.PullImage(ctx, dockerRef, tag, platform, progressBridge(ctx))
+	return mgr.PullImage(ctx, dockerRef, tag, platform, withLayers, progressBridge(ctx))
 }
 
 // PushImage uploads the manifest currently held by tagOrDigest to the
@@ -233,6 +233,7 @@ func toConfigImageInfo(img vmimage.ImageInfo) config.ImageInfo {
 		InUse:     img.InUse,
 		Alias:     img.Alias,
 		IsDefault: img.IsDefault,
+		BootOnly:  img.BootOnly,
 	}
 }
 

--- a/internal/vz/stub_nondarwin.go
+++ b/internal/vz/stub_nondarwin.go
@@ -120,7 +120,7 @@ func (b *VZBackend) TagImage(_ context.Context, _, _ string) error {
 }
 
 // PullImage returns an error on non-darwin platforms.
-func (b *VZBackend) PullImage(_ context.Context, _, _, _ string) (string, error) {
+func (b *VZBackend) PullImage(_ context.Context, _, _, _ string, _ bool) (string, error) {
 	return "", fmt.Errorf("pull image: %w", config.ErrNotSupportedSentinel)
 }
 


### PR DESCRIPTION
## Summary

A shed host **boots from the prebuilt erofs blob and never reads the OCI layer tarballs**, so pulling them wastes ~half the bytes of a typical image. `shed image pull` and the implicit pull in `shed create` now pull **boot-only** by default — config + kernel + initrd + erofs + manifest, but not the layer tarballs. Final PR of the pull-parallelism/progress series.

## Measured savings (real ghcr pull, base image)

| Backend | Full | Boot-only | Saved |
|---|---|---|---|
| VZ `shed-vz-base:v0.5.9` | 945 MB | **540 MB** | 405 MB (**43%**) |
| FC `shed-fc-base:v0.5.9` | 539 MB | **333 MB** | 206 MB (**38%**) |

Orthogonal to PR 4 — parallel download made the same bytes *faster*; this downloads *fewer* bytes (and saves disk).

## Behavior

- **Default boot-only.** `shed image ls` shows a new `LAYERS` column (`full` / `boot-only`); `SIZE` now reflects real on-disk footprint (skips absent layers, counts the erofs).
- **`--with-layers`** pulls the full image, and on an already-boot-only image **hydrates** the missing layer blobs (an explicit pull re-runs the pull; present blobs are content-addressed no-ops). It's the sole override — flag-only, no server config (a config knob can be added later if a mirror host needs it).
- **`shed image push`** of a boot-only image fails a layer preflight (`ErrLayersMissing` → 409) pointing at `--with-layers`.
- **Building is unaffected** — `shed image build` produces its layers locally (docker buildx → ingest), so build→push of your own image works as before. Boot-only only ever touches the rare pull-then-repush (mirror) path.
- Pre-v0.5.2 images (no erofs annotation) can't be pulled boot-only (would need layer extraction) — rejected with a clear message.

## Plumbing

`PullOptions.SkipLayers` gates the layer errgroup loop; `withLayers` threads through the `PullImage` interface/backends/CLI; `EnsureImage` hardcodes boot-only (create only boots); `ImageInfo.BootOnly` is derived from layer-blob presence (content-addressed, self-healing); `accumulateBlobSizes` shares on-disk sizing between `ls`/`inspect`. Prune already tolerates absent layers (the walk keys off the manifest, deletes only present blobs).

## Validation (all live, before merge)

- **VZ + FC sheds BOOT from boot-only images** (Ubuntu 24.04, kernels 6.8 / 6.1) — the core proof it works without layers.
- `--with-layers` hydration round-trips (540 → 945 MB).
- A custom image **built `FROM shed-vz-extensions`** ingests as **full** (10 layers) and boots with its derived layer present — verifying the build flow + tutorial.
- Unit tests (`-race`): boot-only writes no layer blobs, `--with-layers` hydrates, push preflight errors, pre-v0.5.2 rejection, prune tolerance.
- `make test-integration-dev` (VZ): **50 passed**, 3 expected skips (one FC test flaked on resource contention from a second FC server I'd brought up for the boot test — re-ran green). `golangci-lint` 0 issues.
- Docs updated: `cli.md` (pull/push), `storage-model.md`, `build-your-own-image.md`.

## Review (Codex) — approve with notes (both applied)

Non-streaming `APIClient.PullImage` gained `withLayers` for consistency; `ErrLayersMissing` now maps to 409 (was generic 500; message was already preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `shed image pull` now defaults to boot-only (fetches boot artifacts, skips layer tarballs) and gains a `--with-layers` option to fetch full layers.
  * Pull progress (including SSE progress) can opt into pulling layers.
  * `shed image ls` shows a `LAYERS` column ("full" / "boot-only"); `shed image inspect` shows boot-only status.
  * Pushing will fail preflight for boot-only images until re-pulled with `--with-layers`.

* **Documentation**
  * CLI reference, storage model, and tutorials updated to explain boot-only pulls and `--with-layers`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->