### PR TITLE
docs(upgrade): v0.6.1 → v0.6.2 boot-only pulls note

### DIFF
--- a/docs/upgrades/v0.6.1-to-v0.6.2.md
+++ b/docs/upgrades/v0.6.1-to-v0.6.2.md
@@ -1,0 +1,91 @@
+# Upgrade Guide: v0.6.1 to v0.6.2
+
+v0.6.2 is a **non-breaking** release — no config changes, no data
+migration, existing images and sheds keep working. The one behavior
+change worth knowing about is that image pulls are now **boot-only by
+default**. Upgrade is just "install the new binary, restart".
+
+## What changed
+
+### Pulls are boot-only by default
+
+A shed host boots from the prebuilt rootfs erofs blob and never reads the
+OCI layer tarballs, so they were ~half the bytes of a pull for no boot
+benefit. `shed image pull` and the implicit pull during `shed create`
+now pull **boot-only**: config + kernel + initrd + erofs + manifest, but
+not the layer tarballs.
+
+- **No action needed for the common case.** Boot-only images boot
+  normally. New pulls are smaller and faster (≈40% less disk and
+  download for a typical image). `shed image ls` shows a new `LAYERS`
+  column (`full` / `boot-only`), and `SIZE` now reflects real on-disk
+  usage.
+- **Existing images are untouched.** Images already pulled with their
+  layers stay `full`; this only affects *new* pulls.
+
+The only thing that needs layers is **byte-perfect re-pushing a *pulled*
+image** (`shed image push`). If you do that (a mirror/relay workflow),
+pull with the new `--with-layers` flag first:
+
+```bash
+shed image pull <ref> --with-layers   # full pull, or hydrate a boot-only image
+shed image push <ref> <dst>
+```
+
+Pushing a boot-only image without its layers fails fast with an
+actionable error (HTTP 409) pointing at `--with-layers` — nothing is
+silently broken.
+
+**Building your own image is unaffected.** `shed image build` produces
+its layers locally (docker buildx → ingest), so the
+build → push workflow needs no extra step. See
+[Build Your Own Image](../tutorials/build-your-own-image.md) and
+[Images → Pulling, building, pushing](../reference/images.md#pulling-building-pushing).
+
+### Faster, clearer pull progress
+
+Also in this release, with no action required:
+
+- **Parallel downloads** — image blobs download concurrently (bounded;
+  ~2× faster on a high-latency link).
+- **Live progress bars** — `shed image pull` and `shed create` render
+  Docker-style per-blob progress on an interactive terminal; piped or
+  `--json` output is unchanged.
+
+## Operator upgrade steps
+
+### macOS (Homebrew)
+
+```bash
+brew update && brew upgrade shed
+brew services restart shed
+shed -s <name> version   # expect v0.6.2
+```
+
+### Linux (.deb)
+
+```bash
+curl -fsSL -o /tmp/shed-server.deb \
+  https://github.com/charliek/shed/releases/download/v0.6.2/shed-server_0.6.2_amd64.deb
+sudo dpkg -i /tmp/shed-server.deb
+sudo systemctl restart shed-server
+```
+
+## Verify after upgrade
+
+```bash
+shed -s <name> image ls      # note the new LAYERS column (full / boot-only)
+shed -s <name> create smoke  # boot-only pull on a cache miss; boots normally
+```
+
+## Rollback
+
+No data-format change, so rollback is just reinstalling the previous
+version — boot-only and full images are both valid on v0.6.1 (it simply
+ignores the absence of layer blobs unless you `shed image push`).
+
+```bash
+# Linux
+sudo apt install --reinstall shed-server=0.6.1
+# macOS: reinstall the 0.6.1 formula
+```


### PR DESCRIPTION
Upgrade guide for the v0.6.2 patch release. Non-breaking — the one behavior change is **boot-only pulls by default** (no action for the common case; `--with-layers` is needed only to re-push a *pulled* image; building/pushing your own image is unaffected). Also notes the parallel-download + live-progress improvements. Matches the existing `docs/upgrades/` format; upgrade docs are standalone (not in nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parallel blob downloads for faster operations
  * Live per-blob progress bars during image operations

* **Changes**
  * Image pulls now default to boot-only mode
  * Image listing displays new LAYERS column and on-disk SIZE information
  * Pushing boot-only images requires `--with-layers` flag

* **Documentation**
  * Added upgrade guide from v0.6.1 to v0.6.2 with migration steps and rollback information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->