### PR TITLE
fix(firecracker): IP-conflict detection, netlink retry, TAP cleanup

### DIFF
--- a/docs/discovery/runtime-optimization-backlog.md
+++ b/docs/discovery/runtime-optimization-backlog.md
@@ -41,22 +41,24 @@ see [healthPoll](#per-backend-timing-floors-and-the-healthpoll)). The
 existing notify port instead of being polled. The poll shipped as the
 pragmatic interim; the push design did not.
 
-### Stop/reap correctness (latent bug)
+### Firecracker IP-conflict: residual (active probe)
 
-`StopShed` can mark a shed `status=stopped` even when the VM process was
-not actually reaped. A subsequent `StartShed` can then spawn a second
-process over a zombie. Fix direction: verify the PID is reaped before
-recording `stopped`, and surface reap errors rather than swallowing them.
-**This is a correctness bug, not an optimization** — a candidate to
-elevate to a tracked issue.
+Most of the original FC-network gap is now closed: allocation skips an
+index whose IP is already claimed on the host (passive `AddrList` + bridge
+`NeighList` check), TAP setup retries transient netlink errors, and the
+create path tears down partial state via the LIFO cleanup stack.
 
-### Firecracker network hardening
+The **residual** is the one case the passive check can't see: an IP held by
+a *silent* host that has never been ARP'd and isn't a host interface.
+Catching that needs an **active ARP probe**, deliberately *not* done — it
+would add a fixed wait to the create hot path (the `agent_p50` gate).
+Revisit only if duplicate-IP incidents actually occur on a shared-bridge
+deployment.
 
-FC IP allocation is offset-based (`gateway + instance_index + 1`) with
-**no conflict detection** against external services already on the
-bridge/subnet, no bounded retry on transient netlink failures, and
-unclear teardown on partial-failure paths. Linux/FC only. Real
-robustness gap.
+> The earlier "stop/reap correctness" item was removed: verification
+> against current code + a live VZ stop/start showed it is already fixed
+> (verify-before-flip on stop, `ErrZombiePresent` guard on start; PRs
+> #151/#156).
 
 ### Blob & lower cache eviction
 

--- a/internal/firecracker/network.go
+++ b/internal/firecracker/network.go
@@ -245,7 +245,7 @@ func (nm *NetworkManager) ipInUseNetlink(ip string) bool {
 	// (1) Already assigned to some host interface?
 	if addrs, err := netlink.AddrList(nil, netlink.FAMILY_V4); err == nil {
 		for _, a := range addrs {
-			if a.IPNet != nil && a.IPNet.IP.Equal(target) {
+			if a.IPNet != nil && a.IP.Equal(target) {
 				return true
 			}
 		}

--- a/internal/firecracker/network.go
+++ b/internal/firecracker/network.go
@@ -4,12 +4,16 @@
 package firecracker
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
 	"net"
 	"os/exec"
+	"syscall"
+	"time"
 
+	"github.com/charliek/shed/internal/retry"
 	"github.com/vishvananda/netlink"
 )
 
@@ -20,6 +24,13 @@ type NetworkManager struct {
 	tapPrefix  string
 	gateway    net.IP
 	network    *net.IPNet
+
+	// ipInUse reports whether an IP is already claimed on the host by
+	// something outside shed's own bookkeeping (a host interface holding
+	// it, or a live neighbor on the bridge). It is a passive, best-effort
+	// check used to skip a colliding index during allocation. Defaults to
+	// ipInUseNetlink; overridable in tests.
+	ipInUse func(string) bool
 }
 
 // NewNetworkManager creates a new NetworkManager.
@@ -32,13 +43,15 @@ func NewNetworkManager(bridgeName, bridgeCIDR, tapPrefix string) (*NetworkManage
 		return nil, fmt.Errorf("bridge CIDR %q must be IPv4", bridgeCIDR)
 	}
 
-	return &NetworkManager{
+	nm := &NetworkManager{
 		bridgeName: bridgeName,
 		bridgeCIDR: bridgeCIDR,
 		tapPrefix:  tapPrefix,
 		gateway:    ip,
 		network:    network,
-	}, nil
+	}
+	nm.ipInUse = nm.ipInUseNetlink
+	return nm, nil
 }
 
 // TAPDeviceName returns the TAP device name for an instance index.
@@ -90,48 +103,105 @@ func (nm *NetworkManager) Gateway() string {
 	return nm.gateway.String()
 }
 
-// CreateTAPDevice creates a TAP device and attaches it to the bridge.
+// tapRetryBackoffs bounds the retry of TAP setup on transient netlink
+// failures (EAGAIN/EBUSY/EINTR). Two short retries — netlink against a
+// local, pre-created bridge rarely stutters, so this adds latency only on
+// the rare transient and never on the happy path.
+var tapRetryBackoffs = []time.Duration{50 * time.Millisecond, 150 * time.Millisecond}
+
+// CreateTAPDevice creates a TAP device and attaches it to the bridge,
+// retrying the whole sequence on transient netlink errors.
 func (nm *NetworkManager) CreateTAPDevice(name string) error {
-	// Create TAP device using netlink
+	// context.Background: the retry waits are tiny and bounded
+	// (tapRetryBackoffs), so honoring a caller cancel mid-setup buys
+	// nothing, and keeping the signature stable avoids churning every
+	// caller for a sub-second robustness retry.
+	attempt := 0
+	return retry.Do(context.Background(), "create-tap "+name, tapRetryBackoffs, isRetryableNetlink, func() error {
+		attempt++
+		// Clean up a leftover device only on a RETRY — it can only be one
+		// our own previous attempt created. Pre-deleting on the first
+		// attempt would clobber a same-name TAP owned by someone else
+		// (e.g. a peer shed-server on a shared bridge) that LinkAdd should
+		// instead surface as an EEXIST error.
+		return nm.createTAPDeviceOnce(name, attempt > 1)
+	})
+}
+
+// createTAPDeviceOnce performs a single TAP create + attach + up attempt.
+// On any failure it best-effort-removes the partially-created device so a
+// retry (or the caller) starts from a clean slate.
+func (nm *NetworkManager) createTAPDeviceOnce(name string, cleanLeftover bool) error {
+	// On a retry, remove a leftover device from our own previous failed
+	// attempt (whose rollback LinkDel may itself have failed) so LinkAdd
+	// doesn't fail with EEXIST. Never on the first attempt: a pre-existing
+	// device there means another process owns the name, which LinkAdd
+	// should surface as an error rather than have us delete it.
+	if cleanLeftover && nm.TAPExists(name) {
+		if err := nm.DeleteTAPDevice(name); err != nil {
+			log.Printf("Warning: failed to remove leftover TAP %s before retry: %v", name, err)
+		}
+	}
+
 	tap := &netlink.Tuntap{
-		LinkAttrs: netlink.LinkAttrs{
-			Name: name,
-		},
-		Mode: netlink.TUNTAP_MODE_TAP,
+		LinkAttrs: netlink.LinkAttrs{Name: name},
+		Mode:      netlink.TUNTAP_MODE_TAP,
 	}
 
 	if err := netlink.LinkAdd(tap); err != nil {
 		return fmt.Errorf("failed to create TAP device %s: %w", name, err)
 	}
 
+	// cleanup removes the device created above on any later failure and —
+	// unlike the previous code — surfaces a cleanup failure instead of
+	// silently dropping it (a leaked TAP otherwise has no recorded owner).
+	cleanup := func() {
+		if delErr := netlink.LinkDel(tap); delErr != nil {
+			log.Printf("Warning: failed to clean up TAP %s after setup failure: %v", name, delErr)
+		}
+	}
+
 	// Get the bridge
 	bridge, err := netlink.LinkByName(nm.bridgeName)
 	if err != nil {
-		// Clean up TAP device on failure
-		_ = netlink.LinkDel(tap)
+		cleanup()
 		return fmt.Errorf("failed to find bridge %s: %w", nm.bridgeName, err)
 	}
 
 	// Get the TAP link (need to re-fetch after creation)
 	tapLink, err := netlink.LinkByName(name)
 	if err != nil {
-		_ = netlink.LinkDel(tap)
+		cleanup()
 		return fmt.Errorf("failed to find created TAP device %s: %w", name, err)
 	}
 
 	// Attach TAP to bridge
 	if err := netlink.LinkSetMaster(tapLink, bridge); err != nil {
-		_ = netlink.LinkDel(tap)
+		cleanup()
 		return fmt.Errorf("failed to attach TAP %s to bridge %s: %w", name, nm.bridgeName, err)
 	}
 
 	// Bring up TAP device
 	if err := netlink.LinkSetUp(tapLink); err != nil {
-		_ = netlink.LinkDel(tap)
+		cleanup()
 		return fmt.Errorf("failed to bring up TAP device %s: %w", name, err)
 	}
 
 	return nil
+}
+
+// isRetryableNetlink reports whether a netlink error is a transient kernel
+// condition worth retrying (resource temporarily unavailable / busy /
+// interrupted). Permanent errors (bad args, ENODEV, EEXIST) are not retried.
+func isRetryableNetlink(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == syscall.EAGAIN || errno == syscall.EBUSY || errno == syscall.EINTR
+	}
+	return false
 }
 
 // DeleteTAPDevice removes a TAP device.
@@ -157,6 +227,58 @@ func (nm *NetworkManager) DeleteTAPDevice(name string) error {
 func (nm *NetworkManager) TAPExists(name string) bool {
 	_, err := netlink.LinkByName(name)
 	return err == nil
+}
+
+// ipInUseNetlink is the default conflict check for an AllocateIP result. It
+// is passive and best-effort: it never sends an ARP probe (which would add
+// latency to the create hot path), so it cannot detect a silent host that
+// has never been ARP'd and isn't a host interface. It catches the realistic
+// cases — an IP already assigned to a host interface, or a live neighbor on
+// the bridge — and fails OPEN (any netlink error returns false) so an
+// inability to check never blocks allocation.
+func (nm *NetworkManager) ipInUseNetlink(ip string) bool {
+	target := net.ParseIP(ip).To4()
+	if target == nil {
+		return false
+	}
+
+	// (1) Already assigned to some host interface?
+	if addrs, err := netlink.AddrList(nil, netlink.FAMILY_V4); err == nil {
+		for _, a := range addrs {
+			if a.IPNet != nil && a.IPNet.IP.Equal(target) {
+				return true
+			}
+		}
+	}
+
+	// (2) A live neighbor on the bridge? neighStateInUse filters out
+	// entries that aren't evidence of an actually-claimed address
+	// (FAILED/INCOMPLETE/NONE, and STALE — which can linger for an IP we
+	// ourselves just freed).
+	if bridge, err := netlink.LinkByName(nm.bridgeName); err == nil {
+		if neighs, err := netlink.NeighList(bridge.Attrs().Index, netlink.FAMILY_V4); err == nil {
+			for _, n := range neighs {
+				if n.IP != nil && n.IP.Equal(target) && neighStateInUse(n.State) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// neighStateInUse reports whether a neighbor-cache state is evidence that an
+// IP is actually claimed. STALE is excluded deliberately: a stale entry can
+// linger for an IP a just-deleted shed freed, and treating it as in-use
+// would make the allocator skip an address its own bookkeeping knows is free.
+func neighStateInUse(state int) bool {
+	switch state {
+	case netlink.NUD_NONE, netlink.NUD_INCOMPLETE, netlink.NUD_FAILED, netlink.NUD_STALE:
+		return false
+	default:
+		return true
+	}
 }
 
 // EnsureBridgeExists checks if the bridge exists and creates it if needed.
@@ -250,13 +372,28 @@ func (nm *NetworkManager) SetupNAT() error {
 // maxTAPIndex is the upper bound on TAP device indices to prevent unbounded iteration.
 const maxTAPIndex = 1024
 
-// FindAvailableTAPIndex finds the next available TAP device index.
-// Returns an error if no index is available below maxTAPIndex.
+// FindAvailableTAPIndex finds the next available TAP device index whose
+// derived IP is free. It skips an index when the index is reserved
+// (usedIndices), a TAP device with that name already exists, or the derived
+// IP is already claimed on the host (ipInUse — a passive cross-process /
+// external-consumer check). Returns an error if no index is available below
+// maxTAPIndex or the subnet is exhausted.
 func (nm *NetworkManager) FindAvailableTAPIndex(usedIndices map[int]bool) (int, error) {
 	for i := 0; i < maxTAPIndex; i++ {
-		if !usedIndices[i] && !nm.TAPExists(nm.TAPDeviceName(i)) {
-			return i, nil
+		if usedIndices[i] || nm.TAPExists(nm.TAPDeviceName(i)) {
+			continue
 		}
+		ip, err := nm.AllocateIP(i)
+		if err != nil {
+			// AllocateIP only fails once the index runs past the subnet;
+			// no higher index will fit either, so stop here.
+			return 0, fmt.Errorf("no available TAP index with a free IP in %s: %w", nm.network, err)
+		}
+		if nm.ipInUse != nil && nm.ipInUse(ip) {
+			log.Printf("Warning: skipping IP %s (TAP index %d): already in use on host", ip, i)
+			continue
+		}
+		return i, nil
 	}
 	return 0, fmt.Errorf("no available TAP index found (checked %d indices)", maxTAPIndex)
 }

--- a/internal/firecracker/network_test.go
+++ b/internal/firecracker/network_test.go
@@ -5,8 +5,12 @@ package firecracker
 
 import (
 	"errors"
+	"fmt"
 	"net"
+	"syscall"
 	"testing"
+
+	"github.com/vishvananda/netlink"
 )
 
 func TestNewNetworkManager_Valid(t *testing.T) {
@@ -251,6 +255,8 @@ func TestFindAvailableTAPIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewNetworkManager() error = %v", err)
 	}
+	// Hermetic: don't let host IP assignments influence index selection.
+	nm.ipInUse = func(string) bool { return false }
 
 	tests := []struct {
 		name        string
@@ -287,6 +293,69 @@ func TestFindAvailableTAPIndex(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("FindAvailableTAPIndex() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFindAvailableTAPIndex_SkipsInUseIP verifies the passive IP-conflict
+// check (the (a) fix): an index whose derived IP is already claimed on the
+// host is skipped, even when the index itself is free.
+func TestFindAvailableTAPIndex_SkipsInUseIP(t *testing.T) {
+	nm, err := NewNetworkManager("fc-br0", "172.30.0.1/24", "fc-tap")
+	if err != nil {
+		t.Fatalf("NewNetworkManager() error = %v", err)
+	}
+	// Pretend index 0's IP (172.30.0.2) is already claimed elsewhere on the
+	// host; the allocator must skip it and pick index 1 (172.30.0.3).
+	nm.ipInUse = func(ip string) bool { return ip == "172.30.0.2" }
+
+	got, err := nm.FindAvailableTAPIndex(map[int]bool{})
+	if err != nil {
+		t.Fatalf("FindAvailableTAPIndex() unexpected error = %v", err)
+	}
+	if got != 1 {
+		t.Errorf("FindAvailableTAPIndex() = %d, want 1 (index 0's IP is in use)", got)
+	}
+}
+
+func TestNeighStateInUse(t *testing.T) {
+	inUse := []int{netlink.NUD_REACHABLE, netlink.NUD_DELAY, netlink.NUD_PROBE, netlink.NUD_PERMANENT}
+	for _, s := range inUse {
+		if !neighStateInUse(s) {
+			t.Errorf("neighStateInUse(%d) = false, want true", s)
+		}
+	}
+	// STALE in particular must be treated as free: it lingers for an IP a
+	// just-deleted shed released, and skipping it would fight our own maps.
+	notInUse := []int{netlink.NUD_NONE, netlink.NUD_INCOMPLETE, netlink.NUD_FAILED, netlink.NUD_STALE}
+	for _, s := range notInUse {
+		if neighStateInUse(s) {
+			t.Errorf("neighStateInUse(%d) = true, want false", s)
+		}
+	}
+}
+
+func TestIsRetryableNetlink(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"eagain", syscall.EAGAIN, true},
+		{"ebusy", syscall.EBUSY, true},
+		{"eintr", syscall.EINTR, true},
+		{"wrapped eagain", fmt.Errorf("create tap: %w", syscall.EAGAIN), true},
+		{"einval permanent", syscall.EINVAL, false},
+		{"enodev permanent", syscall.ENODEV, false},
+		{"eexist permanent", syscall.EEXIST, false},
+		{"non-errno", errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryableNetlink(tt.err); got != tt.want {
+				t.Errorf("isRetryableNetlink(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Hardens the Firecracker network allocation path — the one genuine bug surfaced by the runtime-optimization backlog audit. (The other "latent" item, the stop/reap race, was verified already fixed by PRs #151/#156 + a live VZ stop/start, so it's only a doc correction here.)

## Changes (`internal/firecracker/network.go`, Linux-only)
- **(a) IP-conflict detection.** `AllocateIP` results were purely index-derived (`gateway+index+1`) with no check against IPs already on the host. Added a passive, best-effort `ipInUseNetlink` (`netlink.AddrList` + bridge `NeighList`) wired into `FindAvailableTAPIndex`, so a colliding index is skipped. **No active ARP probe** — it would add a fixed wait to the create hot path; this uses only local netlink dumps. Fails **open** (any netlink error → not-in-use) so it can never block allocation. Documented residual: a silent host that's never been ARP'd and isn't a host interface still isn't detected (would need an active probe).
- **(b) Bounded netlink retry.** `CreateTAPDevice` now runs through `retry.Do` with a transient-errno classifier (`EAGAIN`/`EBUSY`/`EINTR`) and two short backoffs; split into `createTAPDeviceOnce`.
- **(c) TAP cleanup.** Rollback `LinkDel` failures are logged instead of silently discarded, so a leaked device is visible.
- **docs:** `runtime-optimization-backlog.md` — dropped the already-fixed stop/reap item; replaced the FC-network open item with the active-probe residual.

## Review (codex:rescue, applied)
- **Major:** start-of-attempt TAP delete could clobber a *peer's* same-name TAP on a shared bridge on the **first** attempt → now gated to retries only (first attempt lets `LinkAdd` EEXIST surface, as before).
- **Minor:** `NUD_STALE` lingers for a just-freed shed IP → extracted a pure `neighStateInUse` helper that excludes `STALE` (and unit-tested it).

## Validation
- **Cross-compile:** `GOOS=linux go build/vet/test -c` clean; `gofmt` clean.
- **VZ integration (dev server):** 50 passed; 1 flake (`test_ssh_exec_command_substitution[vz]`, passed on isolated re-run) — and the change isn't in the darwin binary, so VZ can't regress.
- **FC integration (dev server on mini3, this code):** **35 passed, 19 skipped** (skips are VZ-only tests). Every FC create exercised the new allocation path; `test_create_agent_p50[fc]` and the extensions/exec smokes passed.
- **Per-backend perf vet (FC, vs released deb v0.6.2):** the `network` create phase — the only phase this touches — is **~1ms baseline (793/869 samples at 1ms) vs 1–2ms with this change**: no measurable regression. `agent_p50` ≈ 1600ms, within the gate.

## Tests added
`network_test.go`: skip-on-conflict (injectable `ipInUse`), retry-classifier table, `neighStateInUse` state table; existing `FindAvailableTAPIndex` test made hermetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)