### PR TITLE
feat(sdk): dedup reconnect logs + expose connection state (#182)

### DIFF
--- a/sdk/hostclient.go
+++ b/sdk/hostclient.go
@@ -10,7 +10,9 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -20,12 +22,32 @@ const (
 	initialBackoff      = 1 * time.Second
 )
 
+// Subscription connection states reported by HostClient.Status.
+const (
+	ConnConnected    = "connected"
+	ConnReconnecting = "reconnecting"
+	ConnStopped      = "stopped"
+)
+
+// SubStatus is a snapshot of one namespace subscription's connection state, so
+// callers can report health (e.g. `shed-host-agent status --live`) without
+// scraping logs.
+type SubStatus struct {
+	Namespace string
+	State     string    // ConnConnected | ConnReconnecting | ConnStopped
+	LastError string    // last connection error (empty while connected)
+	Since     time.Time // when the current state began
+}
+
 // HostClient connects to shed-server's plugin API to receive and respond to messages.
 // Used by host-side extension binaries.
 type HostClient struct {
 	serverURL  string
 	httpClient *http.Client
 	logger     *slog.Logger
+
+	mu     sync.Mutex
+	states map[string]SubStatus
 }
 
 // HostClientOption configures a HostClient.
@@ -60,6 +82,7 @@ func NewHostClient(opts ...HostClientOption) *HostClient {
 		serverURL:  defaultServerURL,
 		httpClient: &http.Client{},
 		logger:     slog.Default(),
+		states:     make(map[string]SubStatus),
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -77,27 +100,74 @@ func (c *HostClient) Subscribe(ctx context.Context, namespace string) <-chan *En
 	return ch
 }
 
+// Status returns a snapshot of each namespace subscription's connection state,
+// sorted by namespace. Safe for concurrent use.
+func (c *HostClient) Status() []SubStatus {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]SubStatus, 0, len(c.states))
+	for _, s := range c.states {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Namespace < out[j].Namespace })
+	return out
+}
+
+// setState records a namespace's connection state, stamping Since only when the
+// state actually changes (so a snapshot shows how long it's been in that state).
+func (c *HostClient) setState(namespace, state string, cause error) {
+	es := ""
+	if cause != nil {
+		es = cause.Error()
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if prev, ok := c.states[namespace]; ok && prev.State == state {
+		prev.LastError = es
+		c.states[namespace] = prev
+		return
+	}
+	c.states[namespace] = SubStatus{Namespace: namespace, State: state, LastError: es, Since: time.Now()}
+}
+
 func (c *HostClient) subscribeLoop(ctx context.Context, namespace string, ch chan<- *Envelope) {
 	defer close(ch)
+	defer c.setState(namespace, ConnStopped, nil)
+	c.setState(namespace, ConnReconnecting, nil) // "connecting" until the first attempt resolves
 
 	backoff := initialBackoff
+	downLogged := false
 	for {
 		start := time.Now()
-		err := c.streamMessages(ctx, namespace, ch)
+		connected := false
+		err := c.streamMessages(ctx, namespace, ch, func() {
+			connected = true
+			downLogged = false
+			c.setState(namespace, ConnConnected, nil)
+			c.logger.Info("SSE connected", "namespace", namespace)
+		})
 		if ctx.Err() != nil {
 			return
 		}
+		c.setState(namespace, ConnReconnecting, err)
 
-		// Reset backoff if the connection was stable for a while
-		if time.Since(start) > 60*time.Second {
+		// Reset backoff only after a connection that held for a while, so a
+		// flapping server doesn't keep resetting it.
+		if connected && time.Since(start) > 60*time.Second {
 			backoff = initialBackoff
 		}
 
-		c.logger.Warn("SSE connection lost, reconnecting",
-			"namespace", namespace,
-			"error", err,
-			"backoff", backoff,
-		)
+		// Log loudly on a down-transition / first failure, then quietly while it
+		// stays down — a persistently-unreachable server must not flood the log
+		// with an identical WARN every backoff cycle.
+		if !downLogged {
+			c.logger.Warn("SSE connection lost, reconnecting",
+				"namespace", namespace, "error", err, "backoff", backoff)
+			downLogged = true
+		} else {
+			c.logger.Debug("SSE still down, retrying",
+				"namespace", namespace, "error", err, "backoff", backoff)
+		}
 		select {
 		case <-ctx.Done():
 			return
@@ -107,7 +177,7 @@ func (c *HostClient) subscribeLoop(ctx context.Context, namespace string, ch cha
 	}
 }
 
-func (c *HostClient) streamMessages(ctx context.Context, namespace string, ch chan<- *Envelope) error {
+func (c *HostClient) streamMessages(ctx context.Context, namespace string, ch chan<- *Envelope, onConnect func()) error {
 	url := fmt.Sprintf("%s/api/plugins/listeners/%s/messages", c.serverURL, namespace)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -126,7 +196,7 @@ func (c *HostClient) streamMessages(ctx context.Context, namespace string, ch ch
 		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
 	}
 
-	c.logger.Info("SSE connected", "namespace", namespace)
+	onConnect()
 
 	scanner := bufio.NewScanner(resp.Body)
 	const maxSSEEventSize = 1 << 20 // 1 MiB — envelopes can carry large payloads

--- a/sdk/hostclient_test.go
+++ b/sdk/hostclient_test.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,9 +9,32 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
+
+// waitFor polls pred until true or the deadline, failing the test otherwise.
+func waitFor(t *testing.T, what string, pred func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if pred() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func nsState(client *HostClient, ns string) (SubStatus, bool) {
+	for _, s := range client.Status() {
+		if s.Namespace == ns {
+			return s, true
+		}
+	}
+	return SubStatus{}, false
+}
 
 func TestSubscribeReceivesEnvelopes(t *testing.T) {
 	env1 := NewEnvelope("test-ns", MessageTypeRequest, json.RawMessage(`{"cmd":"read"}`))
@@ -162,6 +186,69 @@ func TestNewHostClientDefaults(t *testing.T) {
 	}
 	if client.logger == nil {
 		t.Fatal("expected non-nil logger")
+	}
+}
+
+func TestStatusReportsConnected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-r.Context().Done() // hold the stream open
+	}))
+	defer srv.Close()
+
+	client := NewHostClient(WithServerURL(srv.URL), WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = client.Subscribe(ctx, "ns1")
+
+	waitFor(t, "ns1 connected", func() bool {
+		s, ok := nsState(client, "ns1")
+		return ok && s.State == ConnConnected && s.LastError == ""
+	})
+}
+
+func TestStatusReportsReconnectingWithError(t *testing.T) {
+	// A server that's been shut down → connections refused → reconnecting + error.
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := dead.URL
+	dead.Close()
+
+	client := NewHostClient(WithServerURL(deadURL), WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = client.Subscribe(ctx, "ns1")
+
+	waitFor(t, "ns1 reconnecting with error", func() bool {
+		s, ok := nsState(client, "ns1")
+		return ok && s.State == ConnReconnecting && s.LastError != ""
+	})
+}
+
+func TestReconnectLogDedup(t *testing.T) {
+	// At WARN level the per-retry DEBUG lines are dropped, so a persistently
+	// down server logs the "connection lost" WARN exactly once — not once per
+	// backoff cycle (the 21 MB-log regression).
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := dead.URL
+	dead.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	client := NewHostClient(WithServerURL(deadURL), WithLogger(logger))
+
+	// Long enough for several retries (initialBackoff is 1s), short enough to
+	// keep the test quick.
+	ctx, cancel := context.WithTimeout(context.Background(), 2500*time.Millisecond)
+	defer cancel()
+	for range client.Subscribe(ctx, "ns1") {
+	}
+
+	if n := strings.Count(buf.String(), "SSE connection lost"); n != 1 {
+		t.Fatalf("expected exactly 1 'connection lost' WARN after dedup, got %d:\n%s", n, buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Two related improvements to the host-side plugin client (`sdk/hostclient.go`):

1. **Dedup reconnect logs (closes #182).** `subscribeLoop` logged a `WARN` on *every* reconnect
   attempt, so a persistently-unreachable (or 409-conflicting) server flooded the operational log —
   a 21 MB log was observed downstream in `shed-host-agent`. It now logs:
   - `WARN "SSE connection lost, reconnecting"` **once** on the down-transition / first failure,
   - `DEBUG "SSE still down, retrying"` while it stays down,
   - `INFO "SSE connected"` once per (re)connect (via an `onConnect` callback that replaced the
     inline connect log).

   The 60s flap-guard on backoff reset is preserved.

2. **Expose connection state.** New `HostClient.Status() []SubStatus` returns a per-namespace
   snapshot — `connected` / `reconnecting` / `stopped`, last error, and `Since` (when the state
   began) — so callers can report health without scraping logs. This is the foundation for
   `shed-host-agent status --live`.

## Compatibility

Additive and backward-compatible: `Subscribe` / `Respond` / `NewHostClient` are unchanged;
`streamMessages` is private (signature change is internal); `Status()` is new. The main shed module
(which uses the SDK via `replace => ./sdk`) builds + tests clean.

## Testing

- New tests: `Status()` reports `connected` (live SSE) and `reconnecting` + last error (dead
  server); **log-dedup** — a persistently-down server at `WARN` level emits exactly **one**
  "connection lost" line, not one per cycle.
- Full SDK suite + `golangci-lint`: clean.

Reviewed via `/simplify` + `/codex:rescue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Per-namespace SSE connection state tracking with detailed diagnostics
* New `Status()` method to monitor connection health, including current state, last error, and connection timestamp
* Three connection states: Connected, Reconnecting, Stopped

## Improvements
* Reduced log verbosity during reconnection attempts with intelligent deduplication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->