### PR TITLE
feat(config): resolve image refs from the server version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -173,11 +173,9 @@ brews:
               vfkit_path: vfkit
               kernel_path: ~/Library/Application Support/shed/vz/vmlinux
               initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-              default_image: ghcr.io/charliek/shed-vz-full:v{{ .Version }}
-              image_aliases:
-                base: ghcr.io/charliek/shed-vz-base:v{{ .Version }}
-                extensions: ghcr.io/charliek/shed-vz-extensions:v{{ .Version }}
-                full: ghcr.io/charliek/shed-vz-full:v{{ .Version }}
+              # default_image / image_aliases resolve from the server version
+              # when unset: ghcr.io/charliek/shed-vz-{base,extensions,full}:vX.Y.Z.
+              # Pin explicitly to override the registry or variant.
               pull_policy: missing
               instance_dir: ~/Library/Application Support/shed/vz/instances
               socket_dir: ~/.shed/vz/sockets
@@ -234,11 +232,9 @@ brews:
 
             firecracker:
               kernel_path: /var/lib/shed/firecracker/images/vmlinux
-              default_image: ghcr.io/charliek/shed-fc-full:v{{ .Version }}
-              image_aliases:
-                base: ghcr.io/charliek/shed-fc-base:v{{ .Version }}
-                extensions: ghcr.io/charliek/shed-fc-extensions:v{{ .Version }}
-                full: ghcr.io/charliek/shed-fc-full:v{{ .Version }}
+              # default_image / image_aliases resolve from the server version
+              # when unset: ghcr.io/charliek/shed-fc-{base,extensions,full}:vX.Y.Z.
+              # Pin explicitly to override the registry or variant.
               pull_policy: missing
               instance_dir: /var/lib/shed/firecracker/instances
               socket_dir: /var/run/shed/firecracker

--- a/cmd/shed-server/config_validate.go
+++ b/cmd/shed-server/config_validate.go
@@ -25,6 +25,13 @@ here with a pointer to the upgrade guide.`,
 			return err
 		}
 		fmt.Println("config OK")
+		fmt.Printf("backend: %s\n", cfg.DefaultBackend)
+		if img := cfg.ActiveDefaultImage(); img != "" {
+			// Surface the resolved default_image — it may be synthesized
+			// from the server version or expanded from ${shed.version}, in
+			// which case it never appears literally in the config file.
+			fmt.Printf("default_image: %s\n", img)
+		}
 		return nil
 	},
 }

--- a/cmd/shed-server/serve.go
+++ b/cmd/shed-server/serve.go
@@ -70,7 +70,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to create firecracker client: %w", err)
 		}
-		log.Printf("Initialized Firecracker backend")
+		log.Printf("Initialized Firecracker backend (default_image=%q, pull_policy=%s)", fcCfg.DefaultImage, fcCfg.PullPolicy)
 		be = firecracker.NewBackend(fcClient)
 
 	case config.BackendVZ:
@@ -82,7 +82,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to create vz client: %w", err)
 		}
-		log.Printf("Initialized VZ backend")
+		log.Printf("Initialized VZ backend (default_image=%q, pull_policy=%s)", vzCfg.DefaultImage, vzCfg.PullPolicy)
 		be = vz.NewBackend(vzClient)
 
 	default:

--- a/configs/server.example.yaml
+++ b/configs/server.example.yaml
@@ -70,16 +70,29 @@ log_level: info
 #   extra_known_hosts:
 #     - "gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf"
 
+# --- Images and the server version ---
+# When default_image / image_aliases are omitted, a released shed-server
+# pulls the rootfs images published in lockstep with its own version —
+# ghcr.io/charliek/shed-<backend>-{base,extensions,full}:vX.Y.Z. Upgrading
+# the server is all it takes to move to the new images; no config edit.
+#
+# To pin a custom or mirrored ref while still tracking the server version,
+# use the ${shed.version} token — it expands to the running server's tag
+# (e.g. v0.6.2) at load:
+#
+#   default_image: myregistry.example.com/shed-vz-full:${shed.version}
+#
+# (A dev/dirty build has no matching published image, so on a source build
+# the token is rejected and an unset default errors — pin an explicit ref.)
+
 # --- VZ Backend (macOS Apple Silicon) ---
 # vz:
 #   vfkit_path: vfkit
 #   kernel_path: ~/Library/Application Support/shed/vz/vmlinux
 #   initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-#   default_image: ghcr.io/charliek/shed-vz-full:{version}
-#   image_aliases:
-#     base: ghcr.io/charliek/shed-vz-base:{version}
-#     extensions: ghcr.io/charliek/shed-vz-extensions:{version}
-#     full: ghcr.io/charliek/shed-vz-full:{version}
+#   # default_image / image_aliases omitted -> synthesized from the server
+#   # version (see "Images and the server version" above). Set them only to
+#   # override the registry/variant.
 #   pull_policy: missing   # missing (default) | always | never
 #   images_dir: ~/Library/Application Support/shed/vz/
 #   instance_dir: ~/Library/Application Support/shed/vz/instances
@@ -88,10 +101,7 @@ log_level: info
 # --- Firecracker Backend (Linux with KVM) ---
 # firecracker:
 #   kernel_path: /var/lib/shed/firecracker/vmlinux
-#   default_image: ghcr.io/charliek/shed-fc-full:{version}
-#   image_aliases:
-#     base: ghcr.io/charliek/shed-fc-base:{version}
-#     extensions: ghcr.io/charliek/shed-fc-extensions:{version}
-#     full: ghcr.io/charliek/shed-fc-full:{version}
+#   # default_image / image_aliases omitted -> synthesized from the server
+#   # version (see "Images and the server version" above).
 #   pull_policy: missing   # missing (default) | always | never
 #   images_dir: /var/lib/shed/firecracker/images

--- a/docs/getting-started/fc-setup.md
+++ b/docs/getting-started/fc-setup.md
@@ -132,11 +132,11 @@ env_file: /root/.shed/env
 #     - docker-credentials
 
 firecracker:
-  default_image: ghcr.io/charliek/shed-fc-full:v0.5.1
-  image_aliases:
-    base: ghcr.io/charliek/shed-fc-base:v0.5.1
-    extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.1
-    full: ghcr.io/charliek/shed-fc-full:v0.5.1
+  # default_image / image_aliases omitted -> resolved from the server
+  # version: ghcr.io/charliek/shed-fc-{base,extensions,full}:vX.Y.Z. A
+  # released (deb) shed-server fills these in automatically; pin them
+  # explicitly only on an ahead-of-tag/dirty source build or to use a
+  # custom registry (see "Set Up Images" below).
   pull_policy: missing
   instance_dir: /var/lib/shed/firecracker/instances
   socket_dir: /var/run/shed/firecracker
@@ -158,14 +158,21 @@ firecracker:
   tap_prefix: shed-tap
 ```
 
-Pin a concrete version that matches your `shed-server`. v0.5.1
-published images are live now — check
-<https://github.com/charliek/shed/pkgs/container/shed-fc-full> for tags.
-Pre-v0.5.0 published images use the legacy flattened layout and will
-not work with v0.5.0+ `shed-server`; v0.5.0 cached images use the
-per-layer cache layout and need a one-time
-`rm -rf {images_dir}/cache` on upgrade to v0.5.1 (see the
-[changelog](../CHANGELOG.md)).
+You usually don't need to name the images: a released `shed-server`
+resolves `default_image` and `image_aliases` from its **own version**, so
+the config carries no tag to bump on upgrade. Pin an explicit ref only on
+an ahead-of-tag/dirty source build (which has no matching published
+image), or to use a custom registry. To pin a mirror while still tracking
+the server version, use the `${shed.version}` token:
+
+```yaml
+firecracker:
+  default_image: myregistry.example.com/shed-fc-full:${shed.version}
+```
+
+Check <https://github.com/charliek/shed/pkgs/container/shed-fc-full> for
+tags. Pre-v0.5.0 published images use the legacy flattened layout and will
+not work with v0.5.0+ `shed-server`.
 
 The deb package generates this config with a matching version
 automatically.
@@ -284,28 +291,37 @@ This installs `/usr/local/bin/firecracker` (v1.14.1). When using published image
 
 #### Option A: Use published images (recommended)
 
-Configure your server to use published OCI references. Shed pulls them
-registry-direct (no Docker daemon needed) and stacks the layers as
-overlayfs lowers on first boot. Published images include a custom
-Firecracker kernel with Docker, 9P, and BPF support — no separate kernel
-build needed.
+Shed pulls published OCI references registry-direct (no Docker daemon
+needed) and stacks the layers as overlayfs lowers on first boot. Published
+images include a custom Firecracker kernel with Docker, 9P, and BPF
+support — no separate kernel build needed.
+
+A released `shed-server` resolves the images from its own version, so the
+common config names none of them:
 
 ```yaml
 firecracker:
-  default_image: ghcr.io/charliek/shed-fc-full:v0.5.1
+  pull_policy: missing
+  images_dir: /var/lib/shed/firecracker/images
+  # default_image / image_aliases omitted -> resolved from the server version
+```
+
+Pin an explicit ref only on an ahead-of-tag/dirty source build, or to use
+a different release/registry:
+
+```yaml
+firecracker:
+  default_image: ghcr.io/charliek/shed-fc-full:v0.6.2
   image_aliases:
-    base: ghcr.io/charliek/shed-fc-base:v0.5.1
-    extensions: ghcr.io/charliek/shed-fc-extensions:v0.5.1
-    full: ghcr.io/charliek/shed-fc-full:v0.5.1
+    base: ghcr.io/charliek/shed-fc-base:v0.6.2
+    extensions: ghcr.io/charliek/shed-fc-extensions:v0.6.2
+    full: ghcr.io/charliek/shed-fc-full:v0.6.2
   pull_policy: missing
   images_dir: /var/lib/shed/firecracker/images
 ```
 
-Pin a concrete version. Once `v0.5.1` is tagged the corresponding
-images become available — check
-<https://github.com/charliek/shed/pkgs/container/shed-fc-full> for tags.
-
-See [Images](../reference/images.md) for available images and
+Check <https://github.com/charliek/shed/pkgs/container/shed-fc-full> for
+tags. See [Images](../reference/images.md) for available images and
 configuration details.
 
 #### Option B: Build from source

--- a/docs/getting-started/vz-setup.md
+++ b/docs/getting-started/vz-setup.md
@@ -19,7 +19,7 @@ The fastest way to get started. Homebrew handles vfkit, code signing, config gen
 brew install charliek/tap/shed
 ```
 
-This installs `shed` (CLI) and `shed-server`, installs the vfkit dependency, generates a default server config with version-pinned VZ images, and codesigns the server binary.
+This installs `shed` (CLI) and `shed-server`, installs the vfkit dependency, generates a default server config (image refs resolve from the server version — no pinned tags to bump on upgrade), and codesigns the server binary.
 
 For credential brokering (SSH agent forwarding, AWS credentials, Docker registry auth):
 
@@ -115,27 +115,48 @@ make build
 
 #### Published images (recommended)
 
-Configure your server to use published OCI references. Shed pulls them
-registry-direct (no Docker daemon needed) and stacks the layers as
-overlayfs lowers on first boot.
+Shed pulls published OCI references registry-direct (no Docker daemon
+needed) and stacks the layers as overlayfs lowers on first boot.
+
+You usually don't need to name them. When `default_image` and
+`image_aliases` are omitted, the server resolves them from its **own
+version** — `ghcr.io/charliek/shed-vz-{base,extensions,full}:vX.Y.Z` — so
+the config never carries a version to bump. A `make build` from a clean
+release tag (`git describe` yields `vX.Y.Z`) is release-shaped and gets
+this automatically:
 
 ```yaml
 vz:
-  default_image: ghcr.io/charliek/shed-vz-full:v0.5.1
+  pull_policy: missing
+  # default_image / image_aliases omitted -> resolved from the server version
+```
+
+If your tree is ahead of a tag or dirty (a typical contributor build),
+there is no matching published image, so pin an explicit ref to the
+release whose images you want to pull:
+
+```yaml
+vz:
+  default_image: ghcr.io/charliek/shed-vz-full:v0.6.2
   image_aliases:
-    base: ghcr.io/charliek/shed-vz-base:v0.5.1
-    extensions: ghcr.io/charliek/shed-vz-extensions:v0.5.1
-    full: ghcr.io/charliek/shed-vz-full:v0.5.1
+    base: ghcr.io/charliek/shed-vz-base:v0.6.2
+    extensions: ghcr.io/charliek/shed-vz-extensions:v0.6.2
+    full: ghcr.io/charliek/shed-vz-full:v0.6.2
   pull_policy: missing
 ```
 
-Pin a concrete version that matches the `shed-server` you built.
-v0.5.1 published images are live now — check
-<https://github.com/charliek/shed/pkgs/container/shed-vz-full> for tags.
-Pre-v0.5.0 published images use the legacy flattened layout and will
-not work with v0.5.0+ `shed-server`; v0.5.0 cached images use the
-per-layer cache layout and need a one-time
-`rm -rf {images_dir}/cache` on upgrade to v0.5.1.
+To pin a custom or mirrored registry while still tracking the server
+version, use the `${shed.version}` token (expands to the running server's
+tag on release builds):
+
+```yaml
+vz:
+  default_image: myregistry.example.com/shed-vz-full:${shed.version}
+```
+
+Check <https://github.com/charliek/shed/pkgs/container/shed-vz-full> for
+published tags. Pre-v0.5.0 published images use the legacy flattened
+layout and will not work with v0.5.0+ `shed-server`.
 
 The first `shed create` pulls the layer blobs plus the pre-built rootfs
 erofs blob (built at publish time, not on the host since v0.5.2) and
@@ -215,11 +236,9 @@ vz:
   # you're booting a legacy raw-rootfs image (rare).
   # kernel_path: ~/Library/Application Support/shed/vz/vmlinux
   # initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-  default_image: ghcr.io/charliek/shed-vz-full:v0.5.1
-  image_aliases:
-    base: ghcr.io/charliek/shed-vz-base:v0.5.1
-    extensions: ghcr.io/charliek/shed-vz-extensions:v0.5.1
-    full: ghcr.io/charliek/shed-vz-full:v0.5.1
+  # default_image / image_aliases omitted -> resolved from the server
+  # version (see "Published images" above). On an ahead-of-tag or dirty
+  # build, pin them explicitly instead.
   pull_policy: missing
   instance_dir: ~/Library/Application Support/shed/vz/instances
   socket_dir: ~/.shed/vz/sockets

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -350,34 +350,57 @@ Panic messages from the initramfs are numbered for triage:
 
 ### Using published images (recommended)
 
-Point your config at OCI references. Shed pulls them registry-direct on
-first `shed create` (no Docker daemon needed for pull):
+Shed pulls published OCI references registry-direct on first `shed create`
+(no Docker daemon needed for pull). The rootfs images are published in
+lockstep with each release — `ghcr.io/charliek/shed-<backend>-{base,
+extensions,full}:vX.Y.Z`.
+
+A released `shed-server` resolves them from **its own version**, so the
+common config names no image at all and never carries a tag to bump:
 
 === "VZ (macOS)"
 
     ```yaml
     vz:
-      default_image: ghcr.io/charliek/shed-vz-full:v{version}
-      image_aliases:
-        base: ghcr.io/charliek/shed-vz-base:v{version}
-        extensions: ghcr.io/charliek/shed-vz-extensions:v{version}
-        full: ghcr.io/charliek/shed-vz-full:v{version}
       pull_policy: missing
       images_dir: ~/Library/Application Support/shed/vz/
+      # default_image / image_aliases omitted -> resolved from the server version
     ```
 
 === "Firecracker (Linux)"
 
     ```yaml
     firecracker:
-      default_image: ghcr.io/charliek/shed-fc-full:v{version}
-      image_aliases:
-        base: ghcr.io/charliek/shed-fc-base:v{version}
-        extensions: ghcr.io/charliek/shed-fc-extensions:v{version}
-        full: ghcr.io/charliek/shed-fc-full:v{version}
       pull_policy: missing
       images_dir: /var/lib/shed/firecracker/images
+      # default_image / image_aliases omitted -> resolved from the server version
     ```
+
+Upgrading the server (brew/deb) is all it takes to move to the new images;
+`pull_policy: missing` means the new tag is a cache miss and pulls on the
+next `shed create`. `shed server <name> /info` and the server's startup log
+report the resolved `default_image`.
+
+### Resolving images from the server version
+
+When `default_image` (or `image_aliases`) is unset, a release build fills
+it with the lockstep ref for its version. To keep an explicit ref — a
+specific release, a private mirror — while still tracking the server
+version, use the **`${shed.version}`** token. It expands to the running
+server's tag (e.g. `v0.6.2`) when the config loads:
+
+```yaml
+vz:
+  default_image: myregistry.example.com/shed-vz-full:${shed.version}
+  image_aliases:
+    base: myregistry.example.com/shed-vz-base:${shed.version}
+```
+
+The token and version-synthesis only apply to **release builds**. A
+dev/dirty/ahead-of-tag `shed-server` has no matching published image, so it
+does not synthesize a default, and a `${shed.version}` token is rejected at
+load with an actionable error — pin an explicit ref on such builds (see
+[Using local images](#using-local-images)).
 
 ### Using local images
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -23,11 +23,12 @@ import (
 // GET /api/info
 func (s *Server) handleGetInfo(w http.ResponseWriter, r *http.Request) {
 	info := config.ServerInfo{
-		Name:     s.cfg.Name,
-		Version:  version.Info(),
-		SSHPort:  s.cfg.SSHPort,
-		HTTPPort: s.cfg.HTTPPort,
-		Backend:  s.cfg.DefaultBackend,
+		Name:         s.cfg.Name,
+		Version:      version.Info(),
+		SSHPort:      s.cfg.SSHPort,
+		HTTPPort:     s.cfg.HTTPPort,
+		Backend:      s.cfg.DefaultBackend,
+		DefaultImage: s.cfg.ActiveDefaultImage(),
 	}
 
 	writeJSON(w, http.StatusOK, info)

--- a/internal/config/config_version_image_test.go
+++ b/internal/config/config_version_image_test.go
@@ -1,0 +1,181 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charliek/shed/internal/version"
+	"github.com/charliek/shed/internal/vmimage"
+)
+
+// setVersion swaps the package-global build version for the duration of a
+// test, restoring it on cleanup. Tests in this package run sequentially, so a
+// global swap is safe.
+func setVersion(t *testing.T, v string) {
+	t.Helper()
+	orig := version.Version
+	t.Cleanup(func() { version.Version = orig })
+	version.Version = v
+}
+
+func TestExpandImageVersion(t *testing.T) {
+	t.Run("no token is identity", func(t *testing.T) {
+		setVersion(t, "0.6.2")
+		const in = "ghcr.io/charliek/shed-vz-full:v0.5.1"
+		if got := expandImageVersion(in); got != in {
+			t.Errorf("expandImageVersion(%q) = %q, want unchanged", in, got)
+		}
+	})
+
+	t.Run("release build expands token", func(t *testing.T) {
+		setVersion(t, "0.6.2")
+		got := expandImageVersion("ghcr.io/charliek/shed-vz-full:${shed.version}")
+		if want := "ghcr.io/charliek/shed-vz-full:v0.6.2"; got != want {
+			t.Errorf("expandImageVersion = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("dev build leaves token in place", func(t *testing.T) {
+		setVersion(t, "dev")
+		const in = "ghcr.io/charliek/shed-vz-full:${shed.version}"
+		if got := expandImageVersion(in); got != in {
+			t.Errorf("expandImageVersion(%q) = %q, want token left for Validate to reject", in, got)
+		}
+	})
+}
+
+func TestApplyDefaultsTokenExpansion(t *testing.T) {
+	setVersion(t, "0.6.2")
+	cfg := &VZConfig{
+		DefaultImage: "ghcr.io/charliek/shed-vz-full:${shed.version}",
+		ImageAliases: map[string]string{
+			"base": "ghcr.io/charliek/shed-vz-base:${shed.version}",
+		},
+	}
+	cfg.applyDefaults()
+
+	if want := "ghcr.io/charliek/shed-vz-full:v0.6.2"; cfg.DefaultImage != want {
+		t.Errorf("DefaultImage = %q, want %q", cfg.DefaultImage, want)
+	}
+	if want := "ghcr.io/charliek/shed-vz-base:v0.6.2"; cfg.ImageAliases["base"] != want {
+		t.Errorf("ImageAliases[base] = %q, want %q", cfg.ImageAliases["base"], want)
+	}
+	if err := cfg.Validate(); err != nil {
+		// Validate touches more than images; only assert no token error.
+		if got := err.Error(); containsToken(got) {
+			t.Errorf("Validate() reported an unexpanded token after expansion: %v", err)
+		}
+	}
+}
+
+func TestApplyDefaultsSynthesizesDefaultOnReleaseBuild(t *testing.T) {
+	setVersion(t, "0.6.2")
+
+	t.Run("vz", func(t *testing.T) {
+		cfg := &VZConfig{} // no image refs configured at all
+		cfg.applyDefaults()
+		if want := "ghcr.io/charliek/shed-vz-full:v0.6.2"; cfg.DefaultImage != want {
+			t.Errorf("synthesized DefaultImage = %q, want %q", cfg.DefaultImage, want)
+		}
+		assertAliasTrio(t, cfg.ImageAliases, "vz")
+	})
+
+	t.Run("firecracker", func(t *testing.T) {
+		cfg := &FirecrackerConfig{}
+		cfg.applyDefaults()
+		if want := "ghcr.io/charliek/shed-fc-full:v0.6.2"; cfg.DefaultImage != want {
+			t.Errorf("synthesized DefaultImage = %q, want %q", cfg.DefaultImage, want)
+		}
+		assertAliasTrio(t, cfg.ImageAliases, "fc")
+	})
+}
+
+func TestApplyDefaultsNoSynthesisOnDevBuild(t *testing.T) {
+	setVersion(t, "dev")
+	cfg := &VZConfig{}
+	cfg.applyDefaults()
+	if cfg.DefaultImage != "" {
+		t.Errorf("dev build should not synthesize a default_image, got %q", cfg.DefaultImage)
+	}
+	if len(cfg.ImageAliases) != 0 {
+		t.Errorf("dev build should not synthesize aliases, got %v", cfg.ImageAliases)
+	}
+}
+
+// An explicitly-set default_image is never overwritten by synthesis.
+func TestApplyDefaultsKeepsExplicitDefault(t *testing.T) {
+	setVersion(t, "0.6.2")
+	cfg := &VZConfig{DefaultImage: "ghcr.io/charliek/shed-vz-full:v0.5.1"}
+	cfg.applyDefaults()
+	if want := "ghcr.io/charliek/shed-vz-full:v0.5.1"; cfg.DefaultImage != want {
+		t.Errorf("DefaultImage = %q, want the explicit ref untouched", cfg.DefaultImage)
+	}
+}
+
+func TestValidateRejectsUnexpandedToken(t *testing.T) {
+	setVersion(t, "dev")
+	cfg := &VZConfig{
+		VfkitPath:    "vfkit", // set so Validate reaches the token check
+		DefaultImage: "ghcr.io/charliek/shed-vz-full:${shed.version}",
+	}
+	cfg.applyDefaults() // token survives on a dev build
+	err := cfg.Validate()
+	if err == nil || !containsToken(err.Error()) {
+		t.Fatalf("Validate() = %v, want an error naming the unexpanded token", err)
+	}
+
+	fc := &FirecrackerConfig{
+		ImageAliases: map[string]string{"base": "ghcr.io/charliek/shed-fc-base:${shed.version}"},
+		// fill required fields so we reach the token check / fail only on it
+		InstanceDir: "/tmp/i", SnapshotsDir: "/tmp/s", SocketDir: "/tmp/k",
+		DefaultCPUs: 2, DefaultMemoryMB: 1024, DefaultDiskGB: 10,
+		ConsolePort: 1024, NotifyPort: 1026, VsockBaseCID: 100,
+	}
+	fc.applyDefaults()
+	if err := fc.Validate(); err == nil || !containsToken(err.Error()) {
+		t.Fatalf("FC Validate() = %v, want an error naming the unexpanded token", err)
+	}
+}
+
+// Regression for prune protection: after load, the resolved default and
+// aliases must be concrete Docker refs so vmimage's reachability walk
+// (configuredRefs -> IsDockerRef) protects their blobs. A synthesized or
+// token-expanded ref that didn't satisfy IsDockerRef would be silently
+// dropped from prune protection and GC'd out from under a fresh create.
+func TestSynthesizedRefsAreProtectableDockerRefs(t *testing.T) {
+	setVersion(t, "0.6.2")
+	cfg := &VZConfig{
+		DefaultImage: "ghcr.io/charliek/shed-vz-full:${shed.version}",
+	}
+	cfg.applyDefaults()
+
+	if !vmimage.IsDockerRef(cfg.GetDefaultImage()) {
+		t.Errorf("GetDefaultImage() = %q is not a Docker ref; prune would not protect it", cfg.GetDefaultImage())
+	}
+	for name, ref := range cfg.GetImageAliases() {
+		if !vmimage.IsDockerRef(ref) {
+			t.Errorf("alias %q = %q is not a Docker ref; prune would not protect it", name, ref)
+		}
+	}
+}
+
+func assertAliasTrio(t *testing.T, aliases map[string]string, backend string) {
+	t.Helper()
+	want := map[string]string{
+		"base":       "ghcr.io/charliek/shed-" + backend + "-base:v0.6.2",
+		"extensions": "ghcr.io/charliek/shed-" + backend + "-extensions:v0.6.2",
+		"full":       "ghcr.io/charliek/shed-" + backend + "-full:v0.6.2",
+	}
+	if len(aliases) != len(want) {
+		t.Fatalf("aliases = %v, want %v", aliases, want)
+	}
+	for k, v := range want {
+		if aliases[k] != v {
+			t.Errorf("alias %q = %q, want %q", k, aliases[k], v)
+		}
+	}
+}
+
+func containsToken(s string) bool {
+	return strings.Contains(s, shedVersionToken)
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/charliek/shed/internal/terminal"
+	"github.com/charliek/shed/internal/version"
 	"github.com/charliek/shed/internal/vmimage"
 )
 
@@ -391,6 +392,81 @@ func DefaultVZConfig() *VZConfig {
 	}
 }
 
+// shedVersionToken is the config token expanded to the running binary's
+// release tag (vX.Y.Z) at load time. It lets a config pin image refs to the
+// server version without hand-editing on every upgrade, e.g.
+//
+//	default_image: ghcr.io/charliek/shed-vz-full:${shed.version}
+const shedVersionToken = "${shed.version}"
+
+// expandImageVersion replaces ${shed.version} in an image ref with the
+// running binary's release tag. On a dev/dirty/ahead-of-tag build (which has
+// no matching published image) the token is left in place; Validate then
+// rejects it with an actionable message rather than silently resolving to a
+// tag that does not exist.
+func expandImageVersion(s string) string {
+	if !strings.Contains(s, shedVersionToken) {
+		return s
+	}
+	tag, ok := version.CurrentReleaseTag()
+	if !ok {
+		return s
+	}
+	return strings.ReplaceAll(s, shedVersionToken, tag)
+}
+
+// applyImageVersionDefaults expands the ${shed.version} token in the default
+// image and aliases, then synthesizes the lockstep release refs for any that
+// are still unset — so a release binary needs no image refs in its config at
+// all. backend is "vz" or "fc". On a non-release build nothing is synthesized
+// (blank fields stay blank, preserving the historical "no default_image
+// configured" error surfaced at create time).
+func applyImageVersionDefaults(backend, defaultImage string, aliases map[string]string) (string, map[string]string) {
+	defaultImage = expandImageVersion(defaultImage)
+	for name, val := range aliases {
+		aliases[name] = expandImageVersion(val)
+	}
+
+	// Synthesize the lockstep release refs for anything still unset. Resolve
+	// the tag once; a dev/dirty/ahead-of-tag build has no published images, so
+	// leave blanks blank (the create path / "no default_image" error stands).
+	tag, ok := version.CurrentReleaseTag()
+	if !ok {
+		return defaultImage, aliases
+	}
+	if defaultImage == "" {
+		defaultImage = version.RootfsRef(backend, "full", tag)
+	}
+	if len(aliases) == 0 {
+		aliases = map[string]string{
+			"base":       version.RootfsRef(backend, "base", tag),
+			"extensions": version.RootfsRef(backend, "extensions", tag),
+			"full":       version.RootfsRef(backend, "full", tag),
+		}
+	}
+	return defaultImage, aliases
+}
+
+// validateImageVersionTokens rejects an unexpanded ${shed.version} token,
+// which only survives expansion on a non-release build (dev/dirty/ahead-of-
+// tag), where there is no matching published image to resolve it to.
+func validateImageVersionTokens(backend, defaultImage string, aliases map[string]string) error {
+	reject := func(field string) error {
+		return fmt.Errorf("%s.%s uses %s but this is not a release build (version %q); "+
+			"pin an explicit image ref/tag or run a released shed-server",
+			backend, field, shedVersionToken, version.Version)
+	}
+	if strings.Contains(defaultImage, shedVersionToken) {
+		return reject("default_image")
+	}
+	for name, val := range aliases {
+		if strings.Contains(val, shedVersionToken) {
+			return reject("image_aliases." + name)
+		}
+	}
+	return nil
+}
+
 // applyDefaults fills in zero-valued fields with defaults and expands ~ in paths.
 func (c *VZConfig) applyDefaults() {
 	if c.NotifyPort == 0 {
@@ -399,6 +475,12 @@ func (c *VZConfig) applyDefaults() {
 	if c.TCPProxyPort == 0 {
 		c.TCPProxyPort = 1028
 	}
+
+	// Resolve version-aware image refs before path handling: expand the
+	// ${shed.version} token and synthesize the lockstep release default /
+	// aliases when unset (release builds only). Runs first so a synthesized
+	// or expanded Docker ref isn't mistaken for a path below.
+	c.DefaultImage, c.ImageAliases = applyImageVersionDefaults("vz", c.DefaultImage, c.ImageAliases)
 
 	// Expand ~ in paths
 	c.KernelPath = ExpandPath(c.KernelPath)
@@ -450,6 +532,9 @@ func (c *VZConfig) applyDefaults() {
 func (c *VZConfig) Validate() error {
 	if c.VfkitPath == "" {
 		return fmt.Errorf("vfkit_path is required")
+	}
+	if err := validateImageVersionTokens("vz", c.DefaultImage, c.ImageAliases); err != nil {
+		return err
 	}
 	// kernel_path is optional under Phase B: vm.Start prefers the
 	// kernel inside the blob (blobs/<digest>/kernel, written by
@@ -1204,6 +1289,23 @@ func (c *ServerConfig) ValidateNoHostCoupling() error {
 	return nil
 }
 
+// ActiveDefaultImage returns the resolved default_image for the configured
+// default_backend (after ${shed.version} expansion / version synthesis at
+// load), or "" if the active backend block is absent or has no default.
+func (c *ServerConfig) ActiveDefaultImage() string {
+	switch c.DefaultBackend {
+	case BackendFirecracker:
+		if c.Firecracker != nil {
+			return c.Firecracker.DefaultImage
+		}
+	case BackendVZ:
+		if c.VZ != nil {
+			return c.VZ.DefaultImage
+		}
+	}
+	return ""
+}
+
 // Validate checks that the configuration is valid.
 func (c *ServerConfig) Validate() error {
 	if c.Name == "" {
@@ -1320,6 +1422,13 @@ func (c *FirecrackerConfig) applyDefaults() {
 		c.NotifyPort = 1026
 	}
 
+	// Resolve version-aware image refs before path handling: expand the
+	// ${shed.version} token and synthesize the lockstep release default /
+	// aliases when unset (release builds only). Runs before the IsDockerRef
+	// path-expansion below so a synthesized/expanded ref isn't treated as a
+	// path.
+	c.DefaultImage, c.ImageAliases = applyImageVersionDefaults("fc", c.DefaultImage, c.ImageAliases)
+
 	// Default ImagesDir if not set
 	if c.ImagesDir == "" {
 		c.ImagesDir = DefaultFirecrackerImagesDir
@@ -1370,6 +1479,9 @@ func (c *FirecrackerConfig) Validate() error {
 	// runs without --image (handled separately by CreateShed). The
 	// legacy path-based fields remain as fallbacks; an empty value
 	// means "rely on the blob."
+	if err := validateImageVersionTokens("firecracker", c.DefaultImage, c.ImageAliases); err != nil {
+		return err
+	}
 	if c.InstanceDir == "" {
 		return fmt.Errorf("instance_dir is required")
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -206,6 +206,11 @@ type ServerInfo struct {
 	SSHPort  int    `json:"ssh_port"`
 	HTTPPort int    `json:"http_port"`
 	Backend  string `json:"backend"`
+	// DefaultImage is the resolved default_image for the active backend
+	// (after ${shed.version} expansion / version synthesis at load). Exposed
+	// so clients can see which image a `shed create` without --image will
+	// use — useful when the ref is synthesized and never written in config.
+	DefaultImage string `json:"default_image,omitempty"`
 }
 
 // SSHHostKeyResponse is returned by GET /api/ssh-host-key.

--- a/internal/version/buildtools.go
+++ b/internal/version/buildtools.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -11,31 +12,55 @@ import (
 // are v-prefixed (vX.Y.Z), versioned in lockstep with shed-server.
 const BuildToolsImageBase = "ghcr.io/charliek/shed-build-tools"
 
+// RootfsImageBase is the registry/namespace under which the per-backend
+// rootfs images (shed-vz-{base,extensions,full}, shed-fc-{...}) are
+// published, in lockstep with each shed release. Used to synthesize the
+// default image ref from the running server's version when default_image
+// is unset, and to expand the ${shed.version} config token.
+const RootfsImageBase = "ghcr.io/charliek"
+
 // releaseVersionRE matches a clean semver tag with or without the leading
 // "v" — release binaries embed "X.Y.Z" (no v), `git describe` yields
 // "vX.Y.Z" (with v).
 var releaseVersionRE = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
 
-// BuildToolsRefForTag returns the canonical shed-build-tools image ref
-// (BuildToolsImageBase:vX.Y.Z, ALWAYS v-prefixed) for a release-shaped
-// version/tag string, or "" if s is not release-shaped (dev, dirty,
-// ahead-of-tag, or a custom name).
+// ReleaseTag normalizes a version/tag string to a v-prefixed release tag.
+// It returns ("vX.Y.Z", true) for a release-shaped input (the v-prefix is
+// added when absent), or ("", false) when s is not release-shaped (dev,
+// dirty, ahead-of-tag, or a custom name).
 //
-// The v-prefix is added when absent. This is the whole point of having
-// one shared implementation: published build-tools tags are v-prefixed,
-// so concatenating a bare "0.5.4" version yields ":0.5.4" — a tag that
-// does not exist, which silently disabled the upper-template fast path in
-// v0.5.4 (it fell back to slow in-guest mkfs). Resolve every build-tools
-// ref through here so the prefix can't drift between call sites.
-func BuildToolsRefForTag(s string) string {
+// Published shed artifacts — build-tools and rootfs images alike — are
+// v-prefixed, so concatenating a bare "0.5.4" version yields ":0.5.4", a
+// tag that does not exist (this silently disabled the upper-template fast
+// path in v0.5.4). Resolve every release tag through here so the prefix
+// can't drift between call sites.
+func ReleaseTag(s string) (string, bool) {
 	s = strings.TrimSpace(s)
 	if !releaseVersionRE.MatchString(s) {
-		return ""
+		return "", false
 	}
 	if !strings.HasPrefix(s, "v") {
 		s = "v" + s
 	}
-	return BuildToolsImageBase + ":" + s
+	return s, true
+}
+
+// CurrentReleaseTag returns the v-prefixed release tag for this binary's
+// Version, or ("", false) for dev/dirty/ahead-of-tag builds.
+func CurrentReleaseTag() (string, bool) {
+	return ReleaseTag(Version)
+}
+
+// BuildToolsRefForTag returns the canonical shed-build-tools image ref
+// (BuildToolsImageBase:vX.Y.Z, ALWAYS v-prefixed) for a release-shaped
+// version/tag string, or "" if s is not release-shaped (dev, dirty,
+// ahead-of-tag, or a custom name).
+func BuildToolsRefForTag(s string) string {
+	tag, ok := ReleaseTag(s)
+	if !ok {
+		return ""
+	}
+	return BuildToolsImageBase + ":" + tag
 }
 
 // ReleaseBuildToolsRef returns the canonical shed-build-tools ref for the
@@ -44,4 +69,13 @@ func BuildToolsRefForTag(s string) string {
 // skipping the build-tools step entirely).
 func ReleaseBuildToolsRef() string {
 	return BuildToolsRefForTag(Version)
+}
+
+// RootfsRef returns the canonical rootfs image ref for the given backend
+// ("vz" or "fc") and variant ("base", "extensions", or "full") at the
+// given v-prefixed tag — e.g. RootfsRef("vz", "full", "v0.6.2") yields
+// "ghcr.io/charliek/shed-vz-full:v0.6.2". Pair with CurrentReleaseTag to
+// build the ref for the running binary's version.
+func RootfsRef(backend, variant, tag string) string {
+	return fmt.Sprintf("%s/shed-%s-%s:%s", RootfsImageBase, backend, variant, tag)
 }

--- a/internal/version/buildtools_test.go
+++ b/internal/version/buildtools_test.go
@@ -27,6 +27,40 @@ func TestBuildToolsRefForTag(t *testing.T) {
 	}
 }
 
+func TestReleaseTag(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantTag string
+		wantOK  bool
+	}{
+		{name: "release no v-prefix", in: "0.6.2", wantTag: "v0.6.2", wantOK: true},
+		{name: "release with v-prefix", in: "v0.6.2", wantTag: "v0.6.2", wantOK: true},
+		{name: "whitespace tolerated", in: "  0.6.2 ", wantTag: "v0.6.2", wantOK: true},
+		{name: "dev", in: "dev", wantTag: "", wantOK: false},
+		{name: "empty", in: "", wantTag: "", wantOK: false},
+		{name: "ahead-of-tag/dirty", in: "v0.6.2-2-g493976f", wantTag: "", wantOK: false},
+		{name: "dirty suffix", in: "0.6.2-dirty", wantTag: "", wantOK: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTag, gotOK := ReleaseTag(tc.in)
+			if gotTag != tc.wantTag || gotOK != tc.wantOK {
+				t.Errorf("ReleaseTag(%q) = (%q, %v), want (%q, %v)", tc.in, gotTag, gotOK, tc.wantTag, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestRootfsRef(t *testing.T) {
+	if got := RootfsRef("vz", "full", "v0.6.2"); got != "ghcr.io/charliek/shed-vz-full:v0.6.2" {
+		t.Errorf("RootfsRef(vz, full, v0.6.2) = %q", got)
+	}
+	if got := RootfsRef("fc", "base", "v0.6.2"); got != "ghcr.io/charliek/shed-fc-base:v0.6.2" {
+		t.Errorf("RootfsRef(fc, base, v0.6.2) = %q", got)
+	}
+}
+
 func TestReleaseBuildToolsRefUsesVersion(t *testing.T) {
 	orig := Version
 	t.Cleanup(func() { Version = orig })

--- a/packaging/server.yaml.tmpl
+++ b/packaging/server.yaml.tmpl
@@ -40,12 +40,9 @@ vz:
   vfkit_path: vfkit
   kernel_path: ~/Library/Application Support/shed/vz/vmlinux
   initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-  default_image: ghcr.io/charliek/shed-vz-full:v{{VERSION}}
-  # Optional convenience aliases for `shed create --image <alias>`.
-  image_aliases:
-    base: ghcr.io/charliek/shed-vz-base:v{{VERSION}}
-    extensions: ghcr.io/charliek/shed-vz-extensions:v{{VERSION}}
-    full: ghcr.io/charliek/shed-vz-full:v{{VERSION}}
+  # default_image / image_aliases resolve from the server version when unset:
+  # ghcr.io/charliek/shed-vz-{base,extensions,full}:vX.Y.Z. Pin explicitly to
+  # override the registry or variant — see the full reference above.
   # missing (default) | always | never
   pull_policy: missing
   instance_dir: ~/Library/Application Support/shed/vz/instances
@@ -61,12 +58,9 @@ vz:
 
 firecracker:
   kernel_path: /var/lib/shed/firecracker/images/vmlinux
-  default_image: ghcr.io/charliek/shed-fc-full:v{{VERSION}}
-  # Optional convenience aliases for `shed create --image <alias>`.
-  image_aliases:
-    base: ghcr.io/charliek/shed-fc-base:v{{VERSION}}
-    extensions: ghcr.io/charliek/shed-fc-extensions:v{{VERSION}}
-    full: ghcr.io/charliek/shed-fc-full:v{{VERSION}}
+  # default_image / image_aliases resolve from the server version when unset:
+  # ghcr.io/charliek/shed-fc-{base,extensions,full}:vX.Y.Z. Pin explicitly to
+  # override the registry or variant — see the full reference above.
   # missing (default) | always | never
   pull_policy: missing
   instance_dir: /var/lib/shed/firecracker/instances


### PR DESCRIPTION
## Problem

Every release, the image tags pinned in `default_image` / `image_aliases` — in the repo's example configs, the docs, and **most importantly the configs on users' machines** — have to be bumped to pull the new release's images. That hand-edit-on-every-upgrade is the churn this removes.

## What changed

Two complementary mechanisms, both resolved **once at config load** so `create`, `image prune` reachability, and `/info` all see concrete refs:

1. **Synthesized default** — when `default_image`/`image_aliases` are unset, a *release* `shed-server` resolves them from its own version: `ghcr.io/charliek/shed-<backend>-{base,extensions,full}:vX.Y.Z`. Upgrade the binary → it pulls the matching images. The version never appears in the config.
2. **`${shed.version}` token** — for custom/mirrored refs that should still track the server version: `myregistry.example.com/shed-vz-full:${shed.version}` expands to the running release tag.

**Dev policy:** a dev/dirty/ahead-of-tag build has no matching published image, so it does not synthesize, and a `${shed.version}` token is rejected at load with an actionable error. Pin an explicit ref on such builds (unchanged from today).

**Shipped configs are now version-free.** The deb (`packaging/server.yaml.tmpl`) and brew (`.goreleaser.yaml` heredocs) default configs drop their pinned tags and rely on synthesis — so a packaged install never carries a tag to bump.

## Why this altitude

Expanding at load (in `applyDefaults`) keeps the token out of every downstream consumer. It's also what keeps `shed image prune` correct: it protects the configured `default_image`/alias digests, and now sees the resolved refs rather than a literal token.

## Observability

The resolved `default_image` (which may be synthesized and never written in the file) is surfaced in three places: the `/api/info` response, the server startup log, and `shed-server config-validate`.

## Files

- `internal/version/buildtools.go` — `ReleaseTag`/`CurrentReleaseTag` (factored from `BuildToolsRefForTag`), `RootfsRef`/`RootfsImageBase`
- `internal/config/server.go` — token expansion + synthesis at load, token validation, `ActiveDefaultImage()`
- `internal/api/handlers.go`, `internal/config/types.go` — `default_image` in `/info`
- `cmd/shed-server/{serve,config_validate}.go` — resolved default in log + preflight
- `packaging/server.yaml.tmpl`, `.goreleaser.yaml`, `configs/server.example.yaml`, `docs/**` — lead with the omit-it form; document the token
- tests: `internal/version/buildtools_test.go`, `internal/config/config_version_image_test.go`

## Validation

- `make lint` (0 issues), full `go test ./...` green, `gofmt` clean.
- **Live matrix through the real binary** (`config-validate`, release-ldflag vs dev-ldflag): release+omit → synthesized `:v0.6.2`; release+token → expanded; dev+omit → no synthesis; dev+token → rejected. The edited deb template validates and synthesizes through a release-built binary.
- Off the hot path — expansion runs once at server start; the per-create `resolveImageRef` is untouched.

### Reviews
- `/simplify`: one refactor applied (collapsed the alias-synthesis loop into `applyImageVersionDefaults`, resolving the release tag once; removed unused `CurrentRootfsRef`).
- `/codex:rescue`: the run stalled before emitting a final report, but its investigation trail surfaced one real thread — whether the shipped/packaged config actually exercises the new path. It didn't (the deb/brew templates still pinned tags); this PR fixes that. The `/info` exposure it was probing adds nothing new — `/api/images` already returns configured refs on the same unauthenticated management API, and refs carry no secret material.

### Security note
`/info` now returns `default_image`. The API is the (unauthenticated) management plane and already exposes configured refs via `/api/images`; an image ref contains no credentials (registry auth lives in docker config), so this is consistent with the existing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * VM images now automatically resolve based on the running server version when not explicitly configured.
  * API endpoints now expose the default image that will be used for new VMs.

* **Improvements**
  * Configuration validation command now displays resolved backend and image details.
  * Server logs include more detailed backend initialization information.
  * Support for `${shed.version}` token in custom image registries to track server versions.

* **Documentation**
  * Updated setup guides with clearer image resolution behavior and version-pinning guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->