### PR TITLE
docs: refresh provisioning guide + language tutorials; fix image-variant claims

### DIFF
--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -40,13 +40,22 @@ steps.
 
 | Variant | Description |
 |---------|-------------|
-| `base` | Minimal OS layer: systemd, SSH, Docker CE, git, gh, build-essential, the shed-agent. No coding agents, no language runtimes. |
-| `extensions` | `base` + [shed-extensions](https://charliek.github.io/shed-extensions/) credential brokering (SSH agent forwarding, AWS STS proxy, Docker credential helper). No coding agents pinned — start here for custom images. |
-| `full` | `extensions` + Node.js LTS, Python 3.13, Claude Code, OpenCode, Codex CLI, and (VZ only) Cursor CLI. The batteries-included default. |
+| `base` | Minimal OS layer: systemd, SSH, git, gh, build-essential, jq, ripgrep, neovim, tmux, and the shed-agent. No Docker, no coding agents, no language runtimes. |
+| `extensions` | `base` + [shed-extensions](https://charliek.github.io/shed-extensions/) credential brokering (SSH agent forwarding, AWS STS proxy, Docker credential helper). No Docker daemon, no coding agents pinned — start here for custom images. |
+| `full` | `extensions` + Docker CE (with `docker compose`), [mise](https://mise.jdx.dev/), [bun](https://bun.sh/), and coding agents (Claude Code, OpenCode, Codex CLI). The batteries-included default. |
 
 Each variant inherits from the one above it as a discrete OCI layer, so
 `shed image pull shed-vz-full` reuses the `base` and `extensions` layers
 already cached locally.
+
+!!! note "Docker is only in `full`"
+    The Docker daemon ships **only** in the `full` variant. `base` and
+    `extensions` install the `docker-credential-shed` helper config but not
+    the daemon. Provisioning hooks that use `docker` / `docker compose`
+    (Testcontainers, service stacks) therefore require the `full` image.
+    `full` does **not** ship a system Node.js or Python — install language
+    runtimes per-project (e.g. `uv` provisions Python, `bun` is built in).
+    See [Provisioning](provisioning.md) for the patterns.
 
 ### `extensions` variant
 

--- a/docs/reference/provisioning.md
+++ b/docs/reference/provisioning.md
@@ -244,14 +244,13 @@ docker compose down || true
     Only the `full` variant ships the Docker daemon. With `base`/`extensions`,
     `docker` is absent and these hooks will warn and continue.
 
-### Docker quirks inside a shed
+### Docker networking inside a shed
 
 The `full` image's Docker is tuned for the nested-VM environment, which affects
-two common workflows. Handle them in your install hook:
+one common workflow — handle it in your install hook:
 
 | Behavior | Effect | Fix in the install hook |
 |----------|--------|-------------------------|
-| `credsStore=shed` in `~/.docker/config.json` | Anonymous Docker Hub pulls fail when the host doesn't broker the registry. | Drop just that key so public images pull while keeping any `auths`/`credHelpers`: `jq 'del(.credsStore)' ~/.docker/config.json` written back in place. |
 | `bridge: none` in `daemon.json` | The default `docker0` bridge is absent, so containers started on the **default** network get no published ports. `docker compose` is unaffected (it creates its own user-defined network), but [Testcontainers](https://testcontainers.com/) is not. | Re-enable it for Testcontainers: `jq 'del(.bridge)' /etc/docker/daemon.json` → write back → `sudo systemctl restart docker`. |
 
 ## Example: PostgreSQL via Docker Compose

--- a/docs/reference/provisioning.md
+++ b/docs/reference/provisioning.md
@@ -158,7 +158,107 @@ All shed hooks run as login shells (`bash --login -c`), which source `~/.bash_pr
 
 The base images also include `/etc/profile.d/shed-path.sh` which ensures [mise](https://mise.jdx.dev/) shims and `~/.local/bin` are in PATH for login shells.
 
-## Example: PostgreSQL Setup
+## Installing Language Toolchains
+
+The `full` image ships [mise](https://mise.jdx.dev/) and [bun](https://bun.sh/),
+but **not** `uv`, a JDK, or a system Node/Python. Install what your project needs
+in the install hook. Write each step to be idempotent (check first, install if
+missing) so it is a no-op when a tool is already present and re-running the hook
+is safe:
+
+```bash
+ensure_uv()  { command -v uv  >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh; }
+ensure_bun() { command -v bun >/dev/null 2>&1 || curl -fsSL https://bun.com/install | bash; }
+```
+
+| Language | Recommended tool | Notes |
+|----------|------------------|-------|
+| Python | [uv](https://docs.astral.sh/uv/) | `uv sync` auto-downloads the interpreter pinned in `.python-version`; no system Python needed. |
+| TypeScript / JS | [bun](https://bun.sh/) | Built into the `full` image. `bun install`, `bun test`, `bun run build`. |
+| Java / Kotlin | [SDKMAN](https://sdkman.io/) | `sdk env install` installs the JDK pinned in `.sdkmanrc`. Wrap `sdk` calls in `set +u` — SDKMAN's scripts reference unset variables. |
+
+These tools install into the shed user's home (`~/.local/bin`, `~/.bun/bin`,
+`~/.sdkman`), which survives stop/start on the rootfs upper layer.
+
+!!! warning "Login PATH for `shed exec`"
+    `shed exec` and `shed console` run a **non-interactive** login shell. Tools
+    that only add themselves to `~/.bashrc` (e.g. SDKMAN's snippet) won't be on
+    `PATH` there. To expose a tool to every session, write an
+    `/etc/profile.d/*.sh` snippet from your install hook — login shells source
+    it regardless of interactivity:
+
+    ```bash
+    sudo tee /etc/profile.d/zz-java.sh >/dev/null <<'EOF'
+    if [ -d "$HOME/.sdkman/candidates/java/current/bin" ]; then
+      export JAVA_HOME="$HOME/.sdkman/candidates/java/current"
+      export PATH="$JAVA_HOME/bin:$PATH"
+    fi
+    EOF
+    ```
+
+## Running Services with Docker Compose
+
+The `full` image ships the Docker daemon (started automatically) and `docker
+compose`. Provisioning a service stack is now as simple as bringing up your
+project's own `compose.yaml` — no need to apt-install and hand-manage databases.
+
+**`.shed/provision.yaml`:**
+
+```yaml
+hooks:
+  install: .shed/scripts/install.sh
+  startup: .shed/scripts/startup.sh
+  shutdown: .shed/scripts/shutdown.sh
+```
+
+**`startup.sh`** brings the stack up every boot and waits for health:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+cd "${SHED_WORKSPACE:-$PWD}"
+
+# Daemon auto-starts, but may not be ready the instant the hook fires.
+for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 1; done
+
+docker compose up -d
+# Wait until every service with a healthcheck reports healthy.
+for i in $(seq 1 30); do
+  pending="$(docker compose ps --format '{{.Name}} {{.Health}}' \
+    | awk '$2 != "" && $2 != "healthy" {print $1}')"
+  [ -z "$pending" ] && break
+  sleep 2
+done
+```
+
+**`shutdown.sh`** stops it gracefully (named volumes persist):
+
+```bash
+#!/bin/bash
+set -euo pipefail
+cd "${SHED_WORKSPACE:-$PWD}"
+docker compose down || true
+```
+
+!!! warning "Docker requires the `full` image"
+    Only the `full` variant ships the Docker daemon. With `base`/`extensions`,
+    `docker` is absent and these hooks will warn and continue.
+
+### Docker quirks inside a shed
+
+The `full` image's Docker is tuned for the nested-VM environment, which affects
+two common workflows. Handle them in your install hook:
+
+| Behavior | Effect | Fix in the install hook |
+|----------|--------|-------------------------|
+| `credsStore=shed` in `~/.docker/config.json` | Anonymous Docker Hub pulls fail when the host doesn't broker the registry. | Reset it so public images pull: `echo '{}' > ~/.docker/config.json` (back up first if you use a private registry via the host). |
+| `bridge: none` in `daemon.json` | The default `docker0` bridge is absent, so containers started on the **default** network get no published ports. `docker compose` is unaffected (it creates its own user-defined network), but [Testcontainers](https://testcontainers.com/) is not. | Re-enable it for Testcontainers: `jq 'del(.bridge)' /etc/docker/daemon.json` → write back → `sudo systemctl restart docker`. |
+
+## Example: PostgreSQL via Docker Compose
+
+For most projects, run Postgres from your `compose.yaml` (above) rather than
+installing it into the image. The example below is the **no-Docker alternative**
+— installing the service directly — kept for `base`/`extensions` images.
 
 **`.shed/provision.yaml`:**
 
@@ -297,6 +397,20 @@ env:
   DATABASE_URL: "postgresql://localhost/myapp"
   NODE_ENV: "development"
 ```
+
+!!! warning "`provision.yaml` `env:` reaches hooks only"
+    Variables in the `env:` map are injected into the **provisioning hooks**,
+    not into later `shed exec` / `shed console` sessions or the app. To make a
+    variable available everywhere, write it to `/etc/environment.d/*.conf` from
+    your install hook (it is read per-exec):
+
+    ```bash
+    # In the install hook — available to every session afterward.
+    sudo tee /etc/environment.d/90-myapp.conf >/dev/null <<'EOF'
+    DATABASE_URL=postgresql://localhost/myapp
+    TESTCONTAINERS_RYUK_DISABLED=true
+    EOF
+    ```
 
 ## Skipping Provisioning
 

--- a/docs/reference/provisioning.md
+++ b/docs/reference/provisioning.md
@@ -251,7 +251,7 @@ two common workflows. Handle them in your install hook:
 
 | Behavior | Effect | Fix in the install hook |
 |----------|--------|-------------------------|
-| `credsStore=shed` in `~/.docker/config.json` | Anonymous Docker Hub pulls fail when the host doesn't broker the registry. | Reset it so public images pull: `echo '{}' > ~/.docker/config.json` (back up first if you use a private registry via the host). |
+| `credsStore=shed` in `~/.docker/config.json` | Anonymous Docker Hub pulls fail when the host doesn't broker the registry. | Drop just that key so public images pull while keeping any `auths`/`credHelpers`: `jq 'del(.credsStore)' ~/.docker/config.json` written back in place. |
 | `bridge: none` in `daemon.json` | The default `docker0` bridge is absent, so containers started on the **default** network get no published ports. `docker compose` is unaffected (it creates its own user-defined network), but [Testcontainers](https://testcontainers.com/) is not. | Re-enable it for Testcontainers: `jq 'del(.bridge)' /etc/docker/daemon.json` → write back → `sudo systemctl restart docker`. |
 
 ## Example: PostgreSQL via Docker Compose

--- a/docs/tutorials/build-your-own-image.md
+++ b/docs/tutorials/build-your-own-image.md
@@ -14,9 +14,9 @@ The three published variants are:
 
 | Variant | Contents | Recommended use |
 |---|---|---|
-| `base` | OS layer only. systemd, SSH, Docker, the shed-agent. | Tiny images. You'll wire up coding agents and credentials yourself. |
-| `extensions` | `base` + [shed-extensions](https://charliek.github.io/shed-extensions/) credential brokering. No coding agents pinned. | **Custom images.** Credentials work out of the box; you choose the runtime/agent set. |
-| `full` | `extensions` + Node.js LTS, Python 3.13, Claude Code, OpenCode, Codex CLI. | Default for `shed create`. |
+| `base` | OS layer only. systemd, SSH, git, build tools, the shed-agent. No Docker. | Tiny images. You'll wire up coding agents and credentials yourself. |
+| `extensions` | `base` + [shed-extensions](https://charliek.github.io/shed-extensions/) credential brokering. No Docker daemon, no coding agents pinned. | **Custom images.** Credentials work out of the box; you choose the runtime/agent set. |
+| `full` | `extensions` + Docker CE (with `docker compose`), mise, bun, and coding agents (Claude Code, OpenCode, Codex CLI). | Default for `shed create`. |
 
 `extensions` is the right starting point because:
 

--- a/docs/tutorials/gradle-provisioning.md
+++ b/docs/tutorials/gradle-provisioning.md
@@ -55,10 +55,12 @@ wait_for_docker() {
   docker info >/dev/null 2>&1 || log "WARN: docker not ready (needs the 'full' image)"
 }
 
-# Public Docker Hub pulls fail under the image's credsStore=shed; reset it.
+# Public Docker Hub pulls fail under the image's credsStore=shed; drop only that
+# key (keeping any auths/credHelpers).
 enable_public_image_pulls() {
   local cfg="$HOME/.docker/config.json"
-  grep -q '"credsStore"' "$cfg" 2>/dev/null && { cp "$cfg" "$cfg.bak"; echo '{}' >"$cfg"; }
+  grep -q '"credsStore"' "$cfg" 2>/dev/null || return
+  cp "$cfg" "$cfg.bak"; jq 'del(.credsStore)' "$cfg" >"$cfg.tmp" && mv "$cfg.tmp" "$cfg"
 }
 
 # Testcontainers launches containers on docker's DEFAULT bridge, which the image

--- a/docs/tutorials/gradle-provisioning.md
+++ b/docs/tutorials/gradle-provisioning.md
@@ -1,0 +1,145 @@
+# Provisioning a Gradle (JVM) Project
+
+This tutorial sets up `.shed/` provisioning for a Gradle project — Java or
+Kotlin — that builds with the Gradle wrapper and runs
+[Testcontainers](https://testcontainers.com/) integration tests. Java is
+installed with [SDKMAN](https://sdkman.io/), pinned to the project's
+`.sdkmanrc`.
+
+It assumes the [`full` image](../reference/images.md) (the default), which ships
+the Docker daemon that Testcontainers needs.
+
+## Layout
+
+```
+.shed/
+├── provision.yaml
+└── scripts/
+    ├── lib.sh
+    ├── install.sh
+    ├── startup.sh
+    └── shutdown.sh
+```
+
+## `provision.yaml`
+
+```yaml
+hooks:
+  install: .shed/scripts/install.sh
+  startup: .shed/scripts/startup.sh
+  shutdown: .shed/scripts/shutdown.sh
+
+# JDK download + first build can be slow under the vfs storage driver.
+timeout: 30m
+```
+
+## `scripts/lib.sh`
+
+Shared helpers, sourced by each hook. Every step is idempotent so re-running a
+hook is safe.
+
+```bash
+#!/bin/bash
+log() { echo "[provision $(date +%H:%M:%S)] $*"; }
+
+# Source SDKMAN (installing it first if missing). Disable nounset around it —
+# SDKMAN's scripts reference unset variables.
+ensure_sdkman() {
+  [ -s "$HOME/.sdkman/bin/sdkman-init.sh" ] || curl -fsSL "https://get.sdkman.io" | bash
+  export sdkman_auto_answer=true sdkman_selfupdate_feature=false
+  set +u; source "$HOME/.sdkman/bin/sdkman-init.sh"; set -u
+}
+
+wait_for_docker() {
+  for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 1; done
+  docker info >/dev/null 2>&1 || log "WARN: docker not ready (needs the 'full' image)"
+}
+
+# Public Docker Hub pulls fail under the image's credsStore=shed; reset it.
+enable_public_image_pulls() {
+  local cfg="$HOME/.docker/config.json"
+  grep -q '"credsStore"' "$cfg" 2>/dev/null && { cp "$cfg" "$cfg.bak"; echo '{}' >"$cfg"; }
+}
+
+# Testcontainers launches containers on docker's DEFAULT bridge, which the image
+# disables (bridge: none). Re-enable it (compose is unaffected; it uses its own).
+enable_docker_default_bridge() {
+  docker network inspect bridge >/dev/null 2>&1 && return
+  local cfg=/etc/docker/daemon.json tmp; tmp="$(mktemp)"
+  jq 'del(.bridge) | del(.iptables)' "$cfg" >"$tmp" && sudo install -m 0644 "$tmp" "$cfg"; rm -f "$tmp"
+  sudo systemctl restart docker
+  for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 1; done
+}
+```
+
+## `scripts/install.sh`
+
+```bash
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+wait_for_docker
+enable_docker_default_bridge
+enable_public_image_pulls
+ensure_sdkman
+
+# Install the JDK pinned in .sdkmanrc (e.g. java=21.0.5-tem). Disable nounset
+# around every sdk call.
+set +u
+sdk env install || sdk install java "$(awk -F= '/^java=/{print $2}' .sdkmanrc)"
+sdk env use
+set -u
+java -version
+
+# Expose the JDK to every login shell (shed exec/console), not just this hook.
+sudo tee /etc/profile.d/zz-java.sh >/dev/null <<'EOF'
+if [ -d "$HOME/.sdkman/candidates/java/current/bin" ]; then
+  export JAVA_HOME="$HOME/.sdkman/candidates/java/current"
+  export PATH="$JAVA_HOME/bin:$PATH"
+fi
+EOF
+
+# Ryuk (Testcontainers' reaper) is flaky under the nested docker config; the
+# test JVM reaps its own containers. Persist for all test sessions.
+sudo mkdir -p /etc/environment.d
+echo 'TESTCONTAINERS_RYUK_DISABLED=true' | sudo tee /etc/environment.d/90-gradle.conf >/dev/null
+
+./gradlew --no-daemon help >/dev/null   # warm the wrapper + dependency cache
+```
+
+## `scripts/startup.sh` and `scripts/shutdown.sh`
+
+Testcontainers manages its own ephemeral containers, so there are no long-running
+services to start or stop:
+
+```bash
+#!/bin/bash
+# startup.sh
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+wait_for_docker
+enable_docker_default_bridge   # no-op after first create (config persists)
+```
+
+```bash
+#!/bin/bash
+# shutdown.sh — nothing to stop; Testcontainers are torn down by the test JVM.
+echo "no managed services"
+```
+
+## Build and test
+
+```bash
+shed create myproj --local-dir .
+shed exec myproj -- bash -lc 'cd ~/myproj && ./gradlew build'
+```
+
+`./gradlew build` compiles and runs the unit + Testcontainers integration suite
+against the shed's Docker daemon.
+
+!!! tip "Iterating on the install hook"
+    The install hook runs once. While developing it, re-run the script directly
+    — it's idempotent: `shed exec myproj -- bash '$SHED_WORKSPACE/.shed/scripts/install.sh'`.
+    Then do a clean `shed delete` + `shed create` to validate the real hook path.

--- a/docs/tutorials/gradle-provisioning.md
+++ b/docs/tutorials/gradle-provisioning.md
@@ -55,14 +55,6 @@ wait_for_docker() {
   docker info >/dev/null 2>&1 || log "WARN: docker not ready (needs the 'full' image)"
 }
 
-# Public Docker Hub pulls fail under the image's credsStore=shed; drop only that
-# key (keeping any auths/credHelpers).
-enable_public_image_pulls() {
-  local cfg="$HOME/.docker/config.json"
-  grep -q '"credsStore"' "$cfg" 2>/dev/null || return
-  cp "$cfg" "$cfg.bak"; jq 'del(.credsStore)' "$cfg" >"$cfg.tmp" && mv "$cfg.tmp" "$cfg"
-}
-
 # Testcontainers launches containers on docker's DEFAULT bridge, which the image
 # disables (bridge: none). Re-enable it (compose is unaffected; it uses its own).
 enable_docker_default_bridge() {
@@ -84,7 +76,6 @@ cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
 wait_for_docker
 enable_docker_default_bridge
-enable_public_image_pulls
 ensure_sdkman
 
 # Install the JDK pinned in .sdkmanrc (e.g. java=21.0.5-tem). Disable nounset

--- a/docs/tutorials/python-provisioning.md
+++ b/docs/tutorials/python-provisioning.md
@@ -1,0 +1,144 @@
+# Provisioning a Python (uv) Project
+
+This tutorial sets up `.shed/` provisioning for a Python project managed with
+[uv](https://docs.astral.sh/uv/). `uv` provisions the interpreter itself from
+`.python-version`, so no system Python is required. Postgres and Redis come from
+the project's `compose.yaml`, and integration tests use
+[Testcontainers](https://testcontainers.com/).
+
+It assumes the [`full` image](../reference/images.md) (the default), which ships
+the Docker daemon Testcontainers needs.
+
+## Layout
+
+```
+.shed/
+├── provision.yaml
+└── scripts/
+    ├── lib.sh
+    ├── install.sh
+    ├── startup.sh
+    └── shutdown.sh
+```
+
+## `provision.yaml`
+
+```yaml
+hooks:
+  install: .shed/scripts/install.sh
+  startup: .shed/scripts/startup.sh
+  shutdown: .shed/scripts/shutdown.sh
+
+# First uv sync (downloads the interpreter + deps) can be slow under vfs.
+timeout: 30m
+```
+
+## `scripts/lib.sh`
+
+```bash
+#!/bin/bash
+log() { echo "[provision $(date +%H:%M:%S)] $*"; }
+
+# uv is not in any image; it installs to ~/.local/bin (already on the login PATH).
+ensure_uv() { command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh; }
+
+wait_for_docker() {
+  for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 1; done
+  docker info >/dev/null 2>&1 || log "WARN: docker not ready (needs the 'full' image)"
+}
+
+enable_public_image_pulls() {
+  local cfg="$HOME/.docker/config.json"
+  grep -q '"credsStore"' "$cfg" 2>/dev/null && { cp "$cfg" "$cfg.bak"; echo '{}' >"$cfg"; }
+}
+
+# Testcontainers uses docker's DEFAULT bridge, which the image disables.
+enable_docker_default_bridge() {
+  docker network inspect bridge >/dev/null 2>&1 && return
+  local cfg=/etc/docker/daemon.json tmp; tmp="$(mktemp)"
+  jq 'del(.bridge) | del(.iptables)' "$cfg" >"$tmp" && sudo install -m 0644 "$tmp" "$cfg"; rm -f "$tmp"
+  sudo systemctl restart docker
+  for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 1; done
+}
+
+wait_for_compose_healthy() {
+  for i in $(seq 1 30); do
+    pending="$(docker compose ps --format '{{.Name}} {{.Health}}' \
+      | awk '$2 != "" && $2 != "healthy" {print $1}')"
+    [ -z "$pending" ] && return 0
+    sleep 2
+  done
+}
+
+persist_session_env() {
+  local name="$1"; shift
+  sudo mkdir -p /etc/environment.d
+  printf '%s\n' "$@" | sudo tee "/etc/environment.d/90-${name}.conf" >/dev/null
+}
+```
+
+## `scripts/install.sh`
+
+```bash
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+ensure_uv
+wait_for_docker
+enable_docker_default_bridge   # for Testcontainers integration tests
+enable_public_image_pulls
+
+# UV_LINK_MODE=copy avoids a hardlink warning on the VirtioFS-mounted project.
+# RYUK is reaped by the test process; the reaper is flaky under nested docker.
+persist_session_env myapp \
+  UV_LINK_MODE=copy \
+  DATABASE_URL=postgresql://dev:dev@localhost:5432/myapp \
+  TESTCONTAINERS_RYUK_DISABLED=true
+
+# uv reads .python-version, downloads CPython if absent, builds .venv, installs
+# the locked deps + the dev group.
+uv sync
+
+docker pull postgres:16-alpine || true   # warm the Testcontainers image
+```
+
+## `scripts/startup.sh`
+
+```bash
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+wait_for_docker
+enable_docker_default_bridge   # no-op after first create
+enable_public_image_pulls
+docker compose up -d
+wait_for_compose_healthy
+uv run alembic upgrade head || log "WARN: migrations failed"
+```
+
+## `scripts/shutdown.sh`
+
+```bash
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
+docker compose down || true
+```
+
+## Build and test
+
+```bash
+shed create myproj --local-dir .
+shed exec myproj -- bash -lc 'cd ~/myproj && uv run pytest -m unit'
+shed exec myproj -- bash -lc 'cd ~/myproj && uv run pytest -m integration'   # Testcontainers
+```
+
+!!! tip "uv provisions Python for you"
+    There is no system Python in the `full` image. `uv sync` (or
+    `uv python install`) downloads the interpreter pinned in `.python-version`
+    into uv's own toolchain dir — nothing to apt-install.

--- a/docs/tutorials/python-provisioning.md
+++ b/docs/tutorials/python-provisioning.md
@@ -49,7 +49,8 @@ wait_for_docker() {
 
 enable_public_image_pulls() {
   local cfg="$HOME/.docker/config.json"
-  grep -q '"credsStore"' "$cfg" 2>/dev/null && { cp "$cfg" "$cfg.bak"; echo '{}' >"$cfg"; }
+  grep -q '"credsStore"' "$cfg" 2>/dev/null || return
+  cp "$cfg" "$cfg.bak"; jq 'del(.credsStore)' "$cfg" >"$cfg.tmp" && mv "$cfg.tmp" "$cfg"
 }
 
 # Testcontainers uses docker's DEFAULT bridge, which the image disables.

--- a/docs/tutorials/python-provisioning.md
+++ b/docs/tutorials/python-provisioning.md
@@ -47,12 +47,6 @@ wait_for_docker() {
   docker info >/dev/null 2>&1 || log "WARN: docker not ready (needs the 'full' image)"
 }
 
-enable_public_image_pulls() {
-  local cfg="$HOME/.docker/config.json"
-  grep -q '"credsStore"' "$cfg" 2>/dev/null || return
-  cp "$cfg" "$cfg.bak"; jq 'del(.credsStore)' "$cfg" >"$cfg.tmp" && mv "$cfg.tmp" "$cfg"
-}
-
 # Testcontainers uses docker's DEFAULT bridge, which the image disables.
 enable_docker_default_bridge() {
   docker network inspect bridge >/dev/null 2>&1 && return
@@ -89,7 +83,6 @@ cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
 ensure_uv
 wait_for_docker
 enable_docker_default_bridge   # for Testcontainers integration tests
-enable_public_image_pulls
 
 # UV_LINK_MODE=copy avoids a hardlink warning on the VirtioFS-mounted project.
 # RYUK is reaped by the test process; the reaper is flaky under nested docker.
@@ -115,7 +108,6 @@ cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
 wait_for_docker
 enable_docker_default_bridge   # no-op after first create
-enable_public_image_pulls
 docker compose up -d
 wait_for_compose_healthy
 uv run alembic upgrade head || log "WARN: migrations failed"

--- a/docs/tutorials/typescript-provisioning.md
+++ b/docs/tutorials/typescript-provisioning.md
@@ -1,0 +1,133 @@
+# Provisioning a TypeScript (bun) Project
+
+This tutorial sets up `.shed/` provisioning for a TypeScript project that uses
+[bun](https://bun.sh/) as its runtime and package manager, with Postgres and
+Redis supplied by the project's `compose.yaml`.
+
+It assumes the [`full` image](../reference/images.md) (the default), which ships
+bun and the Docker daemon.
+
+## Layout
+
+```
+.shed/
+├── provision.yaml
+└── scripts/
+    ├── lib.sh
+    ├── install.sh
+    ├── startup.sh
+    └── shutdown.sh
+```
+
+## `provision.yaml`
+
+```yaml
+hooks:
+  install: .shed/scripts/install.sh
+  startup: .shed/scripts/startup.sh
+  shutdown: .shed/scripts/shutdown.sh
+
+# First bun install + image pulls can be slow under the vfs storage driver.
+timeout: 30m
+```
+
+## `scripts/lib.sh`
+
+```bash
+#!/bin/bash
+log() { echo "[provision $(date +%H:%M:%S)] $*"; }
+
+# bun ships in the `full` image; the guard installs it on leaner images.
+ensure_bun() { command -v bun >/dev/null 2>&1 || curl -fsSL https://bun.com/install | bash; }
+
+wait_for_docker() {
+  for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 1; done
+  docker info >/dev/null 2>&1 || log "WARN: docker not ready (needs the 'full' image)"
+}
+
+# Public Docker Hub pulls fail under the image's credsStore=shed; reset it.
+enable_public_image_pulls() {
+  local cfg="$HOME/.docker/config.json"
+  grep -q '"credsStore"' "$cfg" 2>/dev/null && { cp "$cfg" "$cfg.bak"; echo '{}' >"$cfg"; }
+}
+
+# Wait until every compose service with a healthcheck reports healthy.
+wait_for_compose_healthy() {
+  for i in $(seq 1 30); do
+    pending="$(docker compose ps --format '{{.Name}} {{.Health}}' \
+      | awk '$2 != "" && $2 != "healthy" {print $1}')"
+    [ -z "$pending" ] && return 0
+    sleep 2
+  done
+}
+
+# Persist KEY=VALUE env to every exec/console session (read per-exec).
+persist_session_env() {
+  local name="$1"; shift
+  sudo mkdir -p /etc/environment.d
+  printf '%s\n' "$@" | sudo tee "/etc/environment.d/90-${name}.conf" >/dev/null
+}
+```
+
+## `scripts/install.sh`
+
+```bash
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+ensure_bun
+wait_for_docker
+enable_public_image_pulls
+
+# App/session env (used by the dev server, migrations, and `shed exec`). Tests
+# usually load their own .env.test, so this just mirrors compose.yaml.
+persist_session_env myapp \
+  DATABASE_URL=postgres://dev:dev@localhost:5432/myapp \
+  REDIS_URL=redis://localhost:6379
+
+bun install                                  # workspace deps
+docker pull postgres:16-alpine redis:7-alpine || true   # warm the compose images
+```
+
+## `scripts/startup.sh`
+
+```bash
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+wait_for_docker
+enable_public_image_pulls
+docker compose up -d
+wait_for_compose_healthy
+
+# Apply schema/migrations the tests rely on (adjust to your tool).
+bun run db:push || log "WARN: db:push failed"
+```
+
+## `scripts/shutdown.sh`
+
+```bash
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
+docker compose down || true
+```
+
+## Build and test
+
+```bash
+shed create myproj --local-dir .
+shed exec myproj -- bash -lc 'cd ~/myproj && bun run test'
+shed exec myproj -- bash -lc 'cd ~/myproj && bun run build'
+shed exec myproj -- bash -lc 'cd ~/myproj && bun run lint'
+```
+
+!!! note "Compose networking just works"
+    `docker compose` creates its own user-defined network, which publishes ports
+    normally in a shed. (Only Testcontainers, which uses docker's *default*
+    bridge, needs the extra step in the [Gradle tutorial](gradle-provisioning.md).)

--- a/docs/tutorials/typescript-provisioning.md
+++ b/docs/tutorials/typescript-provisioning.md
@@ -45,14 +45,6 @@ wait_for_docker() {
   docker info >/dev/null 2>&1 || log "WARN: docker not ready (needs the 'full' image)"
 }
 
-# Public Docker Hub pulls fail under the image's credsStore=shed; drop only that
-# key (keeping any auths/credHelpers).
-enable_public_image_pulls() {
-  local cfg="$HOME/.docker/config.json"
-  grep -q '"credsStore"' "$cfg" 2>/dev/null || return
-  cp "$cfg" "$cfg.bak"; jq 'del(.credsStore)' "$cfg" >"$cfg.tmp" && mv "$cfg.tmp" "$cfg"
-}
-
 # Wait until every compose service with a healthcheck reports healthy.
 wait_for_compose_healthy() {
   for i in $(seq 1 30); do
@@ -81,7 +73,6 @@ cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
 ensure_bun
 wait_for_docker
-enable_public_image_pulls
 
 # App/session env (used by the dev server, migrations, and `shed exec`). Tests
 # usually load their own .env.test, so this just mirrors compose.yaml.
@@ -102,7 +93,6 @@ source "$(dirname "$0")/lib.sh"
 cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
 wait_for_docker
-enable_public_image_pulls
 docker compose up -d
 wait_for_compose_healthy
 

--- a/docs/tutorials/typescript-provisioning.md
+++ b/docs/tutorials/typescript-provisioning.md
@@ -45,10 +45,12 @@ wait_for_docker() {
   docker info >/dev/null 2>&1 || log "WARN: docker not ready (needs the 'full' image)"
 }
 
-# Public Docker Hub pulls fail under the image's credsStore=shed; reset it.
+# Public Docker Hub pulls fail under the image's credsStore=shed; drop only that
+# key (keeping any auths/credHelpers).
 enable_public_image_pulls() {
   local cfg="$HOME/.docker/config.json"
-  grep -q '"credsStore"' "$cfg" 2>/dev/null && { cp "$cfg" "$cfg.bak"; echo '{}' >"$cfg"; }
+  grep -q '"credsStore"' "$cfg" 2>/dev/null || return
+  cp "$cfg" "$cfg.bak"; jq 'del(.credsStore)' "$cfg" >"$cfg.tmp" && mv "$cfg.tmp" "$cfg"
 }
 
 # Wait until every compose service with a healthcheck reports healthy.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,9 @@ nav:
           - v0.5.7 → v0.5.8: upgrades/v0.5.7-to-v0.5.8.md
   - Tutorials:
       - Build Your Own Image: tutorials/build-your-own-image.md
+      - Provisioning a Gradle Project: tutorials/gradle-provisioning.md
+      - Provisioning a TypeScript Project: tutorials/typescript-provisioning.md
+      - Provisioning a Python Project: tutorials/python-provisioning.md
   - Reference:
       - CLI: reference/cli.md
       - Configuration: reference/configuration.md


### PR DESCRIPTION
## Summary

Refreshes the provisioning docs for the Docker-capable `full` image and corrects stale image-variant claims found while building real provisioning setups across Gradle/TypeScript/Python projects.

### Provisioning reference (`docs/reference/provisioning.md`)
- Documents the **docker-compose** service pattern (now that `full` ships Docker) as the recommended way to run Postgres/Redis/etc., replacing the apt-install headline.
- Adds an **Installing language toolchains** section (uv / bun / SDKMAN) and the `/etc/profile.d` login-PATH gotcha for non-interactive `shed exec`.
- Clarifies that `provision.yaml` `env:` reaches **hooks only**; `/etc/environment.d` is what reaches `shed exec`/`console`/the app.
- Documents the two `full`-image Docker quirks: `credsStore=shed` blocking anonymous pulls, and `bridge: none` breaking Testcontainers' default network.

### New tutorials
- `tutorials/gradle-provisioning.md` — SDKMAN Java + Testcontainers.
- `tutorials/typescript-provisioning.md` — bun + docker-compose.
- `tutorials/python-provisioning.md` — uv (Python via `.python-version`) + docker-compose.

### Image-doc accuracy fixes (verified against `vz/Dockerfile`)
- `base`/`extensions` do **not** ship Docker CE — only `full` does (`docker-ce` is installed in the `shed-vz-full` stage).
- `full` ships Docker + mise + bun + coding agents, **not** a system Node.js/Python.

## Validation

`mkdocs build --strict` succeeds; new tutorials render in the Tutorials nav. Every snippet is derived from provisioning setups validated end-to-end in a VZ `full` shed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified image variant contents — base no longer includes Docker; full includes Docker daemon but does not ship system Node/Python; guidance added to install runtimes per-project.
  * Expanded provisioning guidance for install/startup/shutdown hooks, Docker Compose workflows, PATH/session caveats, and persisting env vars for later sessions.
  * Added tutorials for provisioning Gradle, Python, and TypeScript projects and updated site navigation to include them; added Docker networking/Testcontainers troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->