### PR TITLE
fix: retry provision-config read so --local-dir provisioning isn't silently skipped

### DIFF
--- a/internal/vmutil/provisioning.go
+++ b/internal/vmutil/provisioning.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/provision"
+	"github.com/charliek/shed/internal/retry"
 )
 
 // Provisioner runs provisioning hooks in VMs using the agent.
@@ -54,33 +55,107 @@ func (p *Provisioner) SetOutput(stdout, stderr io.Writer) {
 	p.errOut = stderr
 }
 
+// provisionReadBackoffs bounds the retry of the provision-config read. The
+// read can momentarily fail right after the --local-dir VirtioFS/9P mount: the
+// mount syscall returns before the host share is serving reads, so the first
+// `cat` of .shed/provision.yaml hits a transient I/O error. Without a retry the
+// entire provisioning step is silently skipped (RunProvisioning's caller
+// log-and-continues), so a shed comes up with no hooks run. A genuinely-absent
+// config is the common case and is NOT retried — see LoadConfig.
+var provisionReadBackoffs = []time.Duration{
+	250 * time.Millisecond,
+	500 * time.Millisecond,
+	1 * time.Second,
+	2 * time.Second,
+}
+
+// errProvisionConfigNotReady marks a read that succeeded but returned no content
+// on a project mount — treated as coherence lag and retried.
+var errProvisionConfigNotReady = errors.New("provision config not ready (empty read on project mount)")
+
+// loadConfigProbe reads .shed/provision.yaml and reports, via exit code,
+// whether a missing file looks like a genuinely-absent config or a mount that
+// is not serving yet. $1 is the config path, $2 the landing (work) dir:
+//
+//	0  → config read; its contents are on stdout
+//	66 → no config file, and the landing dir lists content (mount serving)
+//	75 → landing dir empty/unreadable (mount almost certainly not serving)
+const loadConfigProbe = `if out=$(cat "$1" 2>/dev/null); then printf '%s' "$out"; exit 0; fi; ` +
+	`if [ -n "$(ls -A "$2" 2>/dev/null)" ]; then exit 66; fi; exit 75`
+
 // LoadConfig loads provisioning configuration from within the VM.
 // It reads .shed/provision.yaml from the workspace directory.
+//
+// On a --local-dir shed the read can race the project mount: the VirtioFS/9P
+// mount syscall returns before the host share is coherent, so the landing dir
+// momentarily lists empty (probe exit 75) — or lists a partial set without
+// .shed yet (probe exit 66) — and the config read finds nothing. Without
+// resilience here, provisioning is silently skipped and the shed comes up with
+// no hooks run.
+//
+// The retry distinguishes the common no-provisioning case from the race using
+// the landing dir: a bare shed (landing == HomePath) that reports "no config"
+// is terminal, so sheds without provisioning pay no latency. A project landing
+// dir (--local-dir / --repo) keeps retrying a "no config" result, since it may
+// be a mount that hasn't settled; if it stays absent the retries drain and we
+// conclude there genuinely is no config.
 func (p *Provisioner) LoadConfig(ctx context.Context) (*provision.Config, error) {
 	configPath := filepath.Join(p.workDir, provision.ShedProvisionYAML)
+	projectDir := p.workDir != config.HomePath
 
-	// Read the config file via exec
-	var stdout, stderr strings.Builder
-	opts := backend.ExecOptions{
-		Cmd:        []string{"cat", configPath},
-		Stdout:     NopWriteCloser(&stdout),
-		Stderr:     NopWriteCloser(&stderr),
-		WorkingDir: p.workDir,
-		TTY:        false,
-	}
-
-	if err := p.agent.Exec(ctx, opts); err != nil {
-		// Check if file doesn't exist (expected case - no config file).
-		combined := stdout.String() + stderr.String()
-		if strings.Contains(combined, "No such file") {
-			return &provision.Config{
-				Env: make(map[string]string),
-			}, nil
+	var content string
+	lastCode := -1
+	readErr := retry.Do(ctx, "read provision config", provisionReadBackoffs, nil, func() error {
+		var stdout, stderr strings.Builder
+		opts := backend.ExecOptions{
+			Cmd: []string{"sh", "-c", loadConfigProbe, "sh", configPath, p.workDir},
+			// Run from "/" so the exec itself never depends on the racing mount.
+			Stdout:     NopWriteCloser(&stdout),
+			Stderr:     NopWriteCloser(&stderr),
+			WorkingDir: "/",
+			TTY:        false,
 		}
-		return nil, fmt.Errorf("failed to read provision config: %w", err)
-	}
+		err := p.agent.Exec(ctx, opts)
+		if err == nil {
+			content = stdout.String()
+			lastCode = 0
+			// A successful-but-empty read on a project mount is most likely
+			// coherence lag (the dentry appeared before the file data), so
+			// retry. A genuinely-empty provision.yaml is a no-op anyway, so
+			// retrying then concluding "no config" is harmless.
+			if projectDir && strings.TrimSpace(content) == "" {
+				return errProvisionConfigNotReady
+			}
+			return nil
+		}
+		var exitErr *ExitError
+		if errors.As(err, &exitErr) {
+			lastCode = exitErr.Code
+		} else {
+			lastCode = -1
+		}
+		// On a bare shed, "no config" (66) is terminal — the common case stays
+		// fast. On a project landing dir it may be an unsettled mount, so retry.
+		if lastCode == 66 && !projectDir {
+			return nil
+		}
+		return err
+	})
 
-	return provision.ParseConfigContent([]byte(stdout.String()))
+	switch {
+	case strings.TrimSpace(content) != "":
+		// Got config content (possibly after retries) — parse it.
+		return provision.ParseConfigContent([]byte(content))
+	case lastCode == 66 || lastCode == 0:
+		// Dir served but no config file (66), or an empty config file (0):
+		// genuinely no provisioning. Not an error.
+		return &provision.Config{Env: make(map[string]string)}, nil
+	case readErr != nil:
+		// Drained retries on a mount that never served (75) or an RPC error.
+		return nil, fmt.Errorf("failed to read provision config: %w", readErr)
+	default:
+		return &provision.Config{Env: make(map[string]string)}, nil
+	}
 }
 
 // RunProvisioning runs provisioning hooks for a VM.

--- a/internal/vmutil/provisioning_loadconfig_test.go
+++ b/internal/vmutil/provisioning_loadconfig_test.go
@@ -1,0 +1,159 @@
+package vmutil
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/charliek/shed/internal/agentproto"
+	"github.com/charliek/shed/internal/config"
+)
+
+// TestLoadConfigRetriesUnreadyMount verifies that a not-yet-serving project
+// mount (probe exit 75) is retried rather than silently skipping provisioning.
+func TestLoadConfigRetriesUnreadyMount(t *testing.T) {
+	orig := provisionReadBackoffs
+	provisionReadBackoffs = []time.Duration{time.Millisecond, time.Millisecond, time.Millisecond}
+	defer func() { provisionReadBackoffs = orig }()
+
+	const yaml = "hooks:\n  install: .shed/scripts/install.sh\n"
+	var calls int32
+	dialer := &pipeDialer{
+		handler: func(conn net.Conn) {
+			defer conn.Close()
+			agentproto.ReadMessage(conn) // exec request
+			agentproto.ReadMessage(conn) // stdin EOF
+			if atomic.AddInt32(&calls, 1) < 3 {
+				agentproto.WriteExitCode(conn, 75) // mount not serving yet
+				return
+			}
+			agentproto.WriteData(conn, []byte(yaml))
+			agentproto.WriteExitCode(conn, 0)
+		},
+	}
+
+	p := NewProvisioner(NewAgentClient(dialer, 1024, 1026), "test")
+	p.SetWorkDir("/home/shed/proj")
+
+	cfg, err := p.LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg == nil || !cfg.HasInstallHook() {
+		t.Fatalf("LoadConfig() did not parse hooks after retry: %+v", cfg)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Errorf("read attempts = %d, want 3 (2 retries then success)", got)
+	}
+}
+
+// TestLoadConfigBareShedMissingConfigNoRetry verifies that a bare shed (landing
+// dir == HomePath) reporting "no config" (probe exit 66) is terminal — the
+// common no-provisioning case must not burn the backoff schedule.
+func TestLoadConfigBareShedMissingConfigNoRetry(t *testing.T) {
+	orig := provisionReadBackoffs
+	// Long backoffs: if the bare-shed path retried, the test would hang.
+	provisionReadBackoffs = []time.Duration{time.Hour, time.Hour}
+	defer func() { provisionReadBackoffs = orig }()
+
+	var calls int32
+	dialer := &pipeDialer{
+		handler: func(conn net.Conn) {
+			defer conn.Close()
+			agentproto.ReadMessage(conn) // exec request
+			agentproto.ReadMessage(conn) // stdin EOF
+			atomic.AddInt32(&calls, 1)
+			agentproto.WriteExitCode(conn, 66) // dir serving; no config file
+		},
+	}
+
+	p := NewProvisioner(NewAgentClient(dialer, 1024, 1026), "test")
+	p.SetWorkDir(config.HomePath) // bare shed
+
+	cfg, err := p.LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg == nil || cfg.HasAnyHooks() {
+		t.Fatalf("expected empty config for missing file, got %+v", cfg)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("read attempts = %d, want 1 (bare-shed missing config is terminal)", got)
+	}
+}
+
+// TestLoadConfigProjectDirMissingConfigRetriesThenEmpty verifies that a project
+// landing dir reporting "no config" (probe exit 66, which on a --local-dir mount
+// can be a not-yet-coherent share) is retried, and once the retries drain we
+// conclude there is genuinely no config — without surfacing an error.
+func TestLoadConfigProjectDirMissingConfigRetriesThenEmpty(t *testing.T) {
+	orig := provisionReadBackoffs
+	provisionReadBackoffs = []time.Duration{time.Millisecond, time.Millisecond}
+	defer func() { provisionReadBackoffs = orig }()
+
+	var calls int32
+	dialer := &pipeDialer{
+		handler: func(conn net.Conn) {
+			defer conn.Close()
+			agentproto.ReadMessage(conn) // exec request
+			agentproto.ReadMessage(conn) // stdin EOF
+			atomic.AddInt32(&calls, 1)
+			agentproto.WriteExitCode(conn, 66)
+		},
+	}
+
+	p := NewProvisioner(NewAgentClient(dialer, 1024, 1026), "test")
+	p.SetWorkDir("/home/shed/proj") // project landing dir
+
+	cfg, err := p.LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg == nil || cfg.HasAnyHooks() {
+		t.Fatalf("expected empty config after draining retries, got %+v", cfg)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Errorf("read attempts = %d, want 3 (1 + 2 backoffs)", got)
+	}
+}
+
+// TestLoadConfigProjectDirEmptyReadRetries verifies that a successful-but-empty
+// read on a project mount (the file's dentry appeared before its data) is
+// retried, and once real content arrives it is parsed.
+func TestLoadConfigProjectDirEmptyReadRetries(t *testing.T) {
+	orig := provisionReadBackoffs
+	provisionReadBackoffs = []time.Duration{time.Millisecond, time.Millisecond, time.Millisecond}
+	defer func() { provisionReadBackoffs = orig }()
+
+	const yaml = "hooks:\n  install: .shed/scripts/install.sh\n"
+	var calls int32
+	dialer := &pipeDialer{
+		handler: func(conn net.Conn) {
+			defer conn.Close()
+			agentproto.ReadMessage(conn) // exec request
+			agentproto.ReadMessage(conn) // stdin EOF
+			if atomic.AddInt32(&calls, 1) < 3 {
+				agentproto.WriteExitCode(conn, 0) // success, but empty content
+				return
+			}
+			agentproto.WriteData(conn, []byte(yaml))
+			agentproto.WriteExitCode(conn, 0)
+		},
+	}
+
+	p := NewProvisioner(NewAgentClient(dialer, 1024, 1026), "test")
+	p.SetWorkDir("/home/shed/proj") // project landing dir
+
+	cfg, err := p.LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg == nil || !cfg.HasInstallHook() {
+		t.Fatalf("LoadConfig() did not parse hooks after empty-read retries: %+v", cfg)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Errorf("read attempts = %d, want 3 (2 empty reads then content)", got)
+	}
+}


### PR DESCRIPTION
## Problem

On a `--local-dir` shed, provisioning could be **silently skipped** — the shed boots with no install/startup hooks run. Reproduced at ~1-in-6 on a fast VZ host.

Root cause: `LoadConfig` reads `.shed/provision.yaml` immediately after the project mount, but the VirtioFS mount syscall returns before the host share is *coherent*. So the `cat` momentarily sees the file missing, the landing dir listing empty, or the file served as empty. `LoadConfig` had no retry, returned an empty config, and `RunProvisioning` skipped all hooks — with only a server-log warning, or (the empty-read case) none at all.

## Fix

`LoadConfig` now reads through a small probe that reports, by exit code, whether a missing file looks genuinely absent (landing dir lists content) or like an unsettled mount (dir empty), and retries with backoff:

- A **bare shed** (`landing == HomePath`) reporting "no config" is terminal → sheds without provisioning pay **no** latency.
- A **project landing dir** (`--local-dir`/`--repo`) keeps retrying a "no config" or empty read, since it may be a mount that hasn't settled; it concludes "no config" only once the retries drain.

## Validation (parallel dev server, VZ)

- A 15× `--local-dir` create/delete stress loop went **~12/15 → 15/15** running provisioning.
- New unit tests: unready-mount (exit 75), empty-read, bare-shed-missing (no retry), project-dir-missing (retry then empty). `go test ./internal/vmutil`, `go vet`, `golangci-lint`: clean.
- `make test-integration-dev`: **54 passed, 3 skipped, 1 failed**. The one failure — `test_exec_shell.py::test_shed_exec_with_explicit_bash_lc[vz]` (`bash -lc 'echo $HOME'` returned empty once) — is a flaky miss in the **exec login-shell path**, unrelated to this change (that test uses a `base` image with no provisioning); it passes 5/5 on direct reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved resilience of VM provisioning configuration loading by adding retry logic to handle transient mount-coherency issues, distinguishing between temporary read failures and permanent missing configurations.

* **Tests**
  * Added comprehensive test coverage for provisioning configuration loading behavior under various mount and configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->