### PR TITLE
feat(vz): enable docker0 default bridge in the full image

### DIFF
--- a/docs/development/in-shed-build-debugging.md
+++ b/docs/development/in-shed-build-debugging.md
@@ -172,10 +172,11 @@ FAIL lines come in a few flavours:
   `dial tcp 127.0.0.1:5050: connect: connection refused` during the
   `shed image build` phase - BuildKit reaches its own loopback, not
   the shed's.
-- Docker daemon in the shed ships with `"bridge": "none"` in
-  `daemon.json`, so `docker run` without `--network host` will not
-  give the container network access. The script accounts for this by
-  using `--network host` on the registry container as well.
+- The publish script runs its `registry:2` with `--network host` so the
+  in-shed BuildKit (also `network=host`) reaches it at `127.0.0.1:5050`.
+  (The `full` image now enables the default `docker0` bridge, so general
+  `docker run` works without `--network host` — but this loopback-registry
+  pattern still needs it.)
 - The 'full' image variant has docker + buildx, but it does NOT have
   Go installed. Cross-build the shed CLI on the host and `scp` it in
   rather than trying to `go build` inside the shed.

--- a/docs/reference/provisioning.md
+++ b/docs/reference/provisioning.md
@@ -244,14 +244,15 @@ docker compose down || true
     Only the `full` variant ships the Docker daemon. With `base`/`extensions`,
     `docker` is absent and these hooks will warn and continue.
 
-### Docker networking inside a shed
-
-The `full` image's Docker is tuned for the nested-VM environment, which affects
-one common workflow — handle it in your install hook:
-
-| Behavior | Effect | Fix in the install hook |
-|----------|--------|-------------------------|
-| `bridge: none` in `daemon.json` | The default `docker0` bridge is absent, so containers started on the **default** network get no published ports. `docker compose` is unaffected (it creates its own user-defined network), but [Testcontainers](https://testcontainers.com/) is not. | Re-enable it for Testcontainers: `jq 'del(.bridge)' /etc/docker/daemon.json` → write back → `sudo systemctl restart docker`. |
+!!! note "Docker networking differs by backend"
+    On **VZ**, the `full` image enables Docker's default `docker0` bridge, so
+    `docker run`, published ports, and [Testcontainers](https://testcontainers.com/)
+    work normally. On **Firecracker**, the microVM guest kernel has no
+    netfilter/iptables NAT, so Docker runs with `bridge: none` + `iptables:
+    false` and containers must use `--network host` — the default bridge,
+    published ports, and Testcontainers are unavailable there. Compose stacks
+    that need to reach published ports therefore run only on VZ (or use
+    `network_mode: host` on Firecracker).
 
 ## Example: PostgreSQL via Docker Compose
 

--- a/docs/tutorials/gradle-provisioning.md
+++ b/docs/tutorials/gradle-provisioning.md
@@ -7,7 +7,9 @@ installed with [SDKMAN](https://sdkman.io/), pinned to the project's
 `.sdkmanrc`.
 
 It assumes the [`full` image](../reference/images.md) (the default), which ships
-the Docker daemon that Testcontainers needs.
+the Docker daemon that Testcontainers needs, on the **VZ** backend.
+Testcontainers uses Docker's default bridge, which is unavailable on Firecracker
+— see the backend note in [Provisioning](../reference/provisioning.md).
 
 ## Layout
 

--- a/docs/tutorials/gradle-provisioning.md
+++ b/docs/tutorials/gradle-provisioning.md
@@ -54,16 +54,6 @@ wait_for_docker() {
   for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 1; done
   docker info >/dev/null 2>&1 || log "WARN: docker not ready (needs the 'full' image)"
 }
-
-# Testcontainers launches containers on docker's DEFAULT bridge, which the image
-# disables (bridge: none). Re-enable it (compose is unaffected; it uses its own).
-enable_docker_default_bridge() {
-  docker network inspect bridge >/dev/null 2>&1 && return
-  local cfg=/etc/docker/daemon.json tmp; tmp="$(mktemp)"
-  jq 'del(.bridge) | del(.iptables)' "$cfg" >"$tmp" && sudo install -m 0644 "$tmp" "$cfg"; rm -f "$tmp"
-  sudo systemctl restart docker
-  for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 1; done
-}
 ```
 
 ## `scripts/install.sh`
@@ -75,7 +65,6 @@ source "$(dirname "$0")/lib.sh"
 cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
 wait_for_docker
-enable_docker_default_bridge
 ensure_sdkman
 
 # Install the JDK pinned in .sdkmanrc (e.g. java=21.0.5-tem). Disable nounset
@@ -113,7 +102,6 @@ services to start or stop:
 set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 wait_for_docker
-enable_docker_default_bridge   # no-op after first create (config persists)
 ```
 
 ```bash

--- a/docs/tutorials/python-provisioning.md
+++ b/docs/tutorials/python-provisioning.md
@@ -47,15 +47,6 @@ wait_for_docker() {
   docker info >/dev/null 2>&1 || log "WARN: docker not ready (needs the 'full' image)"
 }
 
-# Testcontainers uses docker's DEFAULT bridge, which the image disables.
-enable_docker_default_bridge() {
-  docker network inspect bridge >/dev/null 2>&1 && return
-  local cfg=/etc/docker/daemon.json tmp; tmp="$(mktemp)"
-  jq 'del(.bridge) | del(.iptables)' "$cfg" >"$tmp" && sudo install -m 0644 "$tmp" "$cfg"; rm -f "$tmp"
-  sudo systemctl restart docker
-  for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 1; done
-}
-
 wait_for_compose_healthy() {
   for i in $(seq 1 30); do
     pending="$(docker compose ps --format '{{.Name}} {{.Health}}' \
@@ -82,7 +73,6 @@ cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
 ensure_uv
 wait_for_docker
-enable_docker_default_bridge   # for Testcontainers integration tests
 
 # UV_LINK_MODE=copy avoids a hardlink warning on the VirtioFS-mounted project.
 # RYUK is reaped by the test process; the reaper is flaky under nested docker.
@@ -107,7 +97,6 @@ source "$(dirname "$0")/lib.sh"
 cd "${SHED_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
 wait_for_docker
-enable_docker_default_bridge   # no-op after first create
 docker compose up -d
 wait_for_compose_healthy
 uv run alembic upgrade head || log "WARN: migrations failed"

--- a/docs/tutorials/python-provisioning.md
+++ b/docs/tutorials/python-provisioning.md
@@ -7,7 +7,9 @@ the project's `compose.yaml`, and integration tests use
 [Testcontainers](https://testcontainers.com/).
 
 It assumes the [`full` image](../reference/images.md) (the default), which ships
-the Docker daemon Testcontainers needs.
+the Docker daemon Testcontainers needs, on the **VZ** backend. Testcontainers
+uses Docker's default bridge, which is unavailable on Firecracker — see the
+backend note in [Provisioning](../reference/provisioning.md).
 
 ## Layout
 

--- a/docs/tutorials/typescript-provisioning.md
+++ b/docs/tutorials/typescript-provisioning.md
@@ -119,7 +119,9 @@ shed exec myproj -- bash -lc 'cd ~/myproj && bun run build'
 shed exec myproj -- bash -lc 'cd ~/myproj && bun run lint'
 ```
 
-!!! note "Compose networking just works"
+!!! note "Compose vs Testcontainers networking"
     `docker compose` creates its own user-defined network, which publishes ports
-    normally in a shed. (Only Testcontainers, which uses docker's *default*
-    bridge, needs the extra step in the [Gradle tutorial](gradle-provisioning.md).)
+    normally on both backends. Testcontainers uses docker's *default* bridge,
+    which the `full` image enables on **VZ** but which is unavailable on
+    Firecracker — see the backend note in
+    [Provisioning](../reference/provisioning.md).

--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -267,6 +267,12 @@ ENV CLAUDE_CONFIG_DIR="/home/shed/.claude"
 # who want nested containers pull `full`. docker-buildx-plugin is NOT
 # installed (rarely used by coding agents; users can `apt install` on
 # demand). docker-compose-plugin is kept for `docker compose`.
+#
+# daemon.json keeps "bridge": "none" + "iptables": false here (unlike vz/,
+# which enables docker0): the Firecracker microVM guest kernel has no
+# netfilter/iptables NAT, so dockerd fails to start if it tries to create
+# the bridge NAT chains. Containers on Firecracker must use `--network host`;
+# the default bridge, published ports, and Testcontainers are unavailable.
 RUN install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
     && chmod a+r /etc/apt/keyrings/docker.asc \

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -268,6 +268,11 @@ ENV CLAUDE_CONFIG_DIR="/home/shed/.claude"
 # who want nested containers pull `full`. docker-buildx-plugin is NOT
 # installed (rarely used by coding agents; users can `apt install` on
 # demand). docker-compose-plugin is kept for `docker compose`.
+#
+# daemon.json keeps the default docker0 bridge here (unlike firecracker/,
+# which disables it): the vfkit/VZ guest kernel has the netfilter/iptables
+# NAT that docker's bridge driver needs, so `docker run`, published ports,
+# and Testcontainers work out of the box.
 RUN install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
     && chmod a+r /etc/apt/keyrings/docker.asc \

--- a/vz/daemon.json
+++ b/vz/daemon.json
@@ -1,6 +1,5 @@
 {
     "storage-driver": "vfs",
-    "bridge": "none",
     "exec-opts": ["native.cgroupdriver=systemd"],
     "log-driver": "json-file",
     "log-opts": {


### PR DESCRIPTION
## Summary

The VZ `full` image shipped `daemon.json` with `"bridge": "none"`, disabling Docker's default `docker0` bridge. The consequence: plain `docker run`, published ports, and **Testcontainers** (anything on the default network) got no IP / no published ports — only `docker compose` (user-defined network) worked. This forced every Testcontainers project to carry a `enable_docker_default_bridge` workaround in its provisioning.

This drops `"bridge": "none"` from `vz/daemon.json` so the VZ guest brings up `docker0` normally. The vfkit/VZ guest kernel has the netfilter/iptables NAT Docker's bridge driver needs (and the image already sets `net.ipv4.ip_forward=1`), so `docker0`, MASQUERADE, and published-port DNAT all work out of the box.

## Firecracker is intentionally left unchanged

`firecracker/daemon.json` keeps `"bridge": "none"` + `"iptables": false`. The Firecracker microVM guest kernel has **no** nftables/iptables NAT, so dockerd fails to start with the bridge enabled — verified live:

```
failed to create NAT chain DOCKER: iptables --wait -t nat -N DOCKER:
iptables: Failed to initialize nft: Protocol not supported
```

On Firecracker, containers must use `--network host`. Both Dockerfiles now document this divergence inline.

## Also

- Removes the now-unneeded per-project bridge workaround from the provisioning docs + gradle/python tutorials, and adds a "Docker networking differs by backend" note.
- Updates the `in-shed-build-debugging` gotcha (the registry container still uses `--network host` for the loopback pattern, but general `docker run` no longer needs it).

## Validation

- **VZ (end-to-end):** built the `full` image with this change, booted a shed from it — `docker0` present, container got `172.17.0.2`, a published port (`-p 35432:5432`) was reachable at `localhost`. Earlier live validation: the gradle Testcontainers integration suite passes with the bridge enabled.
- **FC:** confirmed dockerd fails to start with the bridge enabled (guest kernel lacks nftables), and recovers with the original config; `--network host` works.
- `/codex:rescue` reviewed: confirmed dropping only `bridge: none` is correct (iptables default-on + ip_forward already set), no other VZ references to `bridge: none`, asymmetry handled cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Docker networking differences between VZ and Firecracker backends, including Testcontainers availability on VZ only.
  * Updated provisioning tutorials and reference guides with backend-specific Docker configuration guidance.
  * Removed bridge-enabling helper functions from Gradle and Python provisioning tutorials.

* **Chores**
  * Modified VZ configuration to enable Docker's default bridge by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->