### PR TITLE
feat(fc): enable docker0 bridge via custom kernel netfilter; bump shed-extensions v0.3.7

### DIFF
--- a/docs/development/in-shed-build-debugging.md
+++ b/docs/development/in-shed-build-debugging.md
@@ -94,8 +94,9 @@ preceding `FAIL:` identifies which variant tripped.
 
 3. Neutralise the docker credential helper. The shed-agent inside the
    shed installs a `credsStore` that talks to the host over vsock;
-   inside a validation shed there is no host to answer, so any
-   `docker pull` / `docker push` hangs forever waiting for creds.
+   inside a validation shed there is no host to answer, so the helper
+   fails after its ~5s bus timeout and `docker pull` / `docker push`
+   errors out (with the v0.3.7+ guest helper) instead of succeeding.
 
    ```bash
    echo '{}' > "$HOME/.docker/config.json"

--- a/docs/reference/fc-operations.md
+++ b/docs/reference/fc-operations.md
@@ -388,7 +388,7 @@ shed exec myproject -- dockerd --debug
 
 The `vfs` storage driver is slower than overlay2 but always works in VM environments where overlay filesystems may not be supported.
 
-**Note:** Docker bridge networking is disabled (kernel lacks nftables support), so containers use `--network=host` by default. This means containers share the VM's network namespace. The custom 6.1 kernel built by `build-firecracker-kernel.sh` has BPF cgroup support, so containers start correctly.
+**Note:** The custom 6.1 kernel built by `build-firecracker-kernel.sh` includes BPF cgroup support and the netfilter/NAT options Docker's default bridge needs (see `firecracker/kernel-config-docker.fragment`), so `docker0` is enabled — `docker run`, published ports (DNAT), and outbound NAT work, same as VZ.
 
 If using a minimal kernel without BPF support, containers will fail with BPF errors. Build the custom kernel for Docker support: `./scripts/build-firecracker-kernel.sh`
 

--- a/docs/reference/provisioning.md
+++ b/docs/reference/provisioning.md
@@ -244,15 +244,12 @@ docker compose down || true
     Only the `full` variant ships the Docker daemon. With `base`/`extensions`,
     `docker` is absent and these hooks will warn and continue.
 
-!!! note "Docker networking differs by backend"
-    On **VZ**, the `full` image enables Docker's default `docker0` bridge, so
-    `docker run`, published ports, and [Testcontainers](https://testcontainers.com/)
-    work normally. On **Firecracker**, the microVM guest kernel has no
-    netfilter/iptables NAT, so Docker runs with `bridge: none` + `iptables:
-    false` and containers must use `--network host` — the default bridge,
-    published ports, and Testcontainers are unavailable there. Compose stacks
-    that need to reach published ports therefore run only on VZ (or use
-    `network_mode: host` on Firecracker).
+!!! note "Docker networking"
+    The `full` image enables Docker's default `docker0` bridge on **both**
+    backends — VZ via the vfkit guest kernel, Firecracker via a custom kernel
+    built with the netfilter/NAT options docker needs. So `docker run`,
+    published ports, outbound NAT, and [Testcontainers](https://testcontainers.com/)
+    work the same on VZ and Firecracker.
 
 ## Example: PostgreSQL via Docker Compose
 

--- a/docs/tutorials/gradle-provisioning.md
+++ b/docs/tutorials/gradle-provisioning.md
@@ -7,9 +7,8 @@ installed with [SDKMAN](https://sdkman.io/), pinned to the project's
 `.sdkmanrc`.
 
 It assumes the [`full` image](../reference/images.md) (the default), which ships
-the Docker daemon that Testcontainers needs, on the **VZ** backend.
-Testcontainers uses Docker's default bridge, which is unavailable on Firecracker
-— see the backend note in [Provisioning](../reference/provisioning.md).
+the Docker daemon that Testcontainers needs. The default `docker0` bridge
+Testcontainers relies on is enabled on both the VZ and Firecracker backends.
 
 ## Layout
 

--- a/docs/tutorials/python-provisioning.md
+++ b/docs/tutorials/python-provisioning.md
@@ -7,9 +7,8 @@ the project's `compose.yaml`, and integration tests use
 [Testcontainers](https://testcontainers.com/).
 
 It assumes the [`full` image](../reference/images.md) (the default), which ships
-the Docker daemon Testcontainers needs, on the **VZ** backend. Testcontainers
-uses Docker's default bridge, which is unavailable on Firecracker — see the
-backend note in [Provisioning](../reference/provisioning.md).
+the Docker daemon Testcontainers needs. The default `docker0` bridge
+Testcontainers relies on is enabled on both the VZ and Firecracker backends.
 
 ## Layout
 

--- a/docs/tutorials/typescript-provisioning.md
+++ b/docs/tutorials/typescript-provisioning.md
@@ -119,9 +119,8 @@ shed exec myproj -- bash -lc 'cd ~/myproj && bun run build'
 shed exec myproj -- bash -lc 'cd ~/myproj && bun run lint'
 ```
 
-!!! note "Compose vs Testcontainers networking"
-    `docker compose` creates its own user-defined network, which publishes ports
-    normally on both backends. Testcontainers uses docker's *default* bridge,
-    which the `full` image enables on **VZ** but which is unavailable on
-    Firecracker — see the backend note in
-    [Provisioning](../reference/provisioning.md).
+!!! note "Compose and Testcontainers networking"
+    `docker compose` creates its own user-defined network, and the `full` image
+    enables Docker's default `docker0` bridge — both work on the VZ and
+    Firecracker backends, so published ports and Testcontainers behave the same
+    on each.

--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -24,7 +24,7 @@
 
 # Bump this when shed-extensions releases a new version.
 # The extensions and full variants pull binaries from this tag.
-ARG SHED_EXT_VERSION=v0.3.2
+ARG SHED_EXT_VERSION=v0.3.7
 FROM ghcr.io/charliek/shed-extensions:${SHED_EXT_VERSION} AS shed-extensions
 
 # Note: the shed initramfs (overlay-on-the-guest init) is built from
@@ -268,11 +268,10 @@ ENV CLAUDE_CONFIG_DIR="/home/shed/.claude"
 # installed (rarely used by coding agents; users can `apt install` on
 # demand). docker-compose-plugin is kept for `docker compose`.
 #
-# daemon.json keeps "bridge": "none" + "iptables": false here (unlike vz/,
-# which enables docker0): the Firecracker microVM guest kernel has no
-# netfilter/iptables NAT, so dockerd fails to start if it tries to create
-# the bridge NAT chains. Containers on Firecracker must use `--network host`;
-# the default bridge, published ports, and Testcontainers are unavailable.
+# daemon.json enables docker's default docker0 bridge (no "bridge": "none").
+# The custom Firecracker guest kernel is built with the netfilter/NAT options
+# docker's bridge driver needs (see kernel-config-docker.fragment), so docker0,
+# published ports (DNAT), and outbound MASQUERADE work — same as VZ.
 RUN install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
     && chmod a+r /etc/apt/keyrings/docker.asc \
@@ -284,6 +283,7 @@ RUN install -m 0755 -d /etc/apt/keyrings \
        docker-ce docker-ce-cli containerd.io docker-compose-plugin \
     && rm -rf /var/lib/apt/lists/* \
     && install -m 0644 /usr/local/share/shed-docker-daemon.json /etc/docker/daemon.json \
+    && printf 'net.ipv4.ip_forward=1\n' > /etc/sysctl.d/99-docker-forward.conf \
     && SYSTEMD_OFFLINE=1 systemctl enable docker
 
 # Layer: install all language runtimes + coding agents as the shed user,

--- a/firecracker/daemon.json
+++ b/firecracker/daemon.json
@@ -1,7 +1,5 @@
 {
     "storage-driver": "vfs",
-    "iptables": false,
-    "bridge": "none",
     "exec-opts": ["native.cgroupdriver=cgroupfs"],
     "log-driver": "json-file",
     "log-opts": {

--- a/firecracker/kernel-config-docker.fragment
+++ b/firecracker/kernel-config-docker.fragment
@@ -22,7 +22,9 @@
 # explicitly. Everything is =y — a Firecracker microVM has no loadable modules.
 # This enables `docker run`, published ports (DNAT), outbound MASQUERADE, and
 # Testcontainers, on top of the compose/docker-proxy path that already worked.
-# nf_tables path (Docker 29's default iptables-nft backend):
+# Core netfilter/conntrack/NAT framework. Several of these are already =y in the
+# CI base config; re-asserted defensively so a future base change can't silently
+# drop a dependency the nf_tables path below relies on.
 CONFIG_NETFILTER=y
 CONFIG_NETFILTER_ADVANCED=y
 CONFIG_NETFILTER_NETLINK=y
@@ -31,6 +33,8 @@ CONFIG_NF_NAT=y
 CONFIG_NF_NAT_MASQUERADE=y
 CONFIG_NETFILTER_XTABLES=y
 CONFIG_BRIDGE_NETFILTER=y
+# nf_tables family + expressions (CI base ships NF_TABLES off — this turns it on,
+# which is what Docker 29's default iptables-nft backend needs):
 CONFIG_NF_TABLES=y
 CONFIG_NF_TABLES_INET=y
 CONFIG_NF_TABLES_IPV4=y

--- a/firecracker/kernel-config-docker.fragment
+++ b/firecracker/kernel-config-docker.fragment
@@ -1,7 +1,6 @@
 # Kernel config fragment for Docker support inside Firecracker VMs.
 #
-# The Firecracker CI 6.1 config already includes all configs needed for
-# our Docker setup (vfs driver, cgroupfs, host networking, no iptables):
+# The Firecracker CI 6.1 config already includes the base configs:
 #
 #   BPF:        CONFIG_BPF=y, CONFIG_BPF_SYSCALL=y, CONFIG_CGROUP_BPF=y
 #   Cgroups:    CONFIG_CGROUPS=y, CONFIG_MEMCG=y, CONFIG_CGROUP_PIDS=y
@@ -11,6 +10,44 @@
 #
 # This fragment is an extension point for future additions. Lines below
 # are merged into the base config before building.
+
+# ----------------------------------------------------------------------------
+# Docker default-bridge (docker0) netfilter/NAT support.
+#
+# Without these, dockerd fails to start with the default bridge enabled —
+# `iptables -t nat -N DOCKER` returns "Failed to initialize nft: Protocol not
+# supported" because the nf_tables netlink family (NETLINK_NETFILTER) isn't
+# built in. The CI config + `make olddefconfig` leave the nf_tables NAT path
+# and the x_tables extensions docker's rules use turned off, so assert them
+# explicitly. Everything is =y — a Firecracker microVM has no loadable modules.
+# This enables `docker run`, published ports (DNAT), outbound MASQUERADE, and
+# Testcontainers, on top of the compose/docker-proxy path that already worked.
+# nf_tables path (Docker 29's default iptables-nft backend):
+CONFIG_NETFILTER=y
+CONFIG_NETFILTER_ADVANCED=y
+CONFIG_NETFILTER_NETLINK=y
+CONFIG_NF_CONNTRACK=y
+CONFIG_NF_NAT=y
+CONFIG_NF_NAT_MASQUERADE=y
+CONFIG_NETFILTER_XTABLES=y
+CONFIG_BRIDGE_NETFILTER=y
+CONFIG_NF_TABLES=y
+CONFIG_NF_TABLES_INET=y
+CONFIG_NF_TABLES_IPV4=y
+CONFIG_NF_TABLES_IPV6=y
+CONFIG_NFT_COMPAT=y
+CONFIG_NFT_NAT=y
+CONFIG_NFT_MASQ=y
+CONFIG_NFT_REDIR=y
+# x_tables extensions nft_compat wraps (docker0's iptables rules use these):
+CONFIG_NETFILTER_XT_NAT=y
+CONFIG_NETFILTER_XT_TARGET_MASQUERADE=y
+CONFIG_NETFILTER_XT_TARGET_REDIRECT=y
+CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=y
+CONFIG_NETFILTER_XT_MATCH_CONNTRACK=y
+CONFIG_NETFILTER_XT_MATCH_COMMENT=y
+CONFIG_NETFILTER_XT_MATCH_MULTIPORT=y
+# ----------------------------------------------------------------------------
 
 # Uncomment if live mounts (SSHFS over vsock) are needed:
 # CONFIG_FUSE_FS=y

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -24,7 +24,7 @@
 
 # Bump this when shed-extensions releases a new version.
 # The extensions and full variants pull binaries from this tag.
-ARG SHED_EXT_VERSION=v0.3.2
+ARG SHED_EXT_VERSION=v0.3.7
 FROM ghcr.io/charliek/shed-extensions:${SHED_EXT_VERSION} AS shed-extensions
 
 # Note: the shed initramfs (overlay-on-the-guest init) is built from

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -269,10 +269,11 @@ ENV CLAUDE_CONFIG_DIR="/home/shed/.claude"
 # installed (rarely used by coding agents; users can `apt install` on
 # demand). docker-compose-plugin is kept for `docker compose`.
 #
-# daemon.json keeps the default docker0 bridge here (unlike firecracker/,
-# which disables it): the vfkit/VZ guest kernel has the netfilter/iptables
-# NAT that docker's bridge driver needs, so `docker run`, published ports,
-# and Testcontainers work out of the box.
+# daemon.json keeps the default docker0 bridge enabled: the vfkit/VZ guest
+# kernel has the netfilter/iptables NAT docker's bridge driver needs, so
+# `docker run`, published ports, and Testcontainers work out of the box.
+# (firecracker/ enables docker0 too, via a custom kernel with netfilter built
+# in — see firecracker/kernel-config-docker.fragment.)
 RUN install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
     && chmod a+r /etc/apt/keyrings/docker.asc \


### PR DESCRIPTION
## Summary

Brings **Firecracker** to parity with VZ for Docker: the default `docker0` bridge now works (so `docker run`, published ports, outbound NAT, and **Testcontainers** all work — not just `--network host` + compose/docker-proxy). Also bumps `shed-extensions` to `v0.3.7` in **both** images (the docker-credential-shed creds fix).

## Changes

- **`firecracker/kernel-config-docker.fragment`** — assert the `nf_tables` + `nft_compat` NAT path and the `x_tables` extensions Docker's rules use, all `=y` (the microVM has no loadable modules). The Firecracker CI 6.1 config ships `NF_TABLES` **off**, so dockerd couldn't create the `nat DOCKER` chain (`iptables -t nat -N DOCKER` → "Failed to initialize nft: Protocol not supported"). Verified via clean-container replication that merging the fragment + `make olddefconfig` yields `CONFIG_NF_TABLES=y`, `CONFIG_NF_NAT=y`, `CONFIG_IP_NF_NAT=y`, etc.
- **`firecracker/daemon.json`** — drop `"bridge": "none"` + `"iptables": false`.
- **`firecracker/Dockerfile`** — add `net.ipv4.ip_forward=1` (FC was missing it; VZ already had it — the other half of outbound NAT).
- **`vz/Dockerfile` + `firecracker/Dockerfile`** — bump `SHED_EXT_VERSION` `v0.3.2 → v0.3.7` (creds fix: the guest helper now emits the standard `credentials not found in native keychain` sentinel, so anonymous public pulls work with `credsStore=shed` intact).
- **Docs** — reverse the now-stale "FC can't do docker0 / Testcontainers is VZ-only" statements (provisioning.md, fc-operations.md, vz/Dockerfile comment, gradle/python/typescript tutorials).

## Validation (end-to-end on real FC hardware — mini2)

Rebuilt the `full` image (recompiling the kernel with the fragment), booted a shed, and confirmed on a **clean boot** (no manual intervention):

```
daemon.json: no bridge:none / iptables:false
nft list ruleset            → OK (nf_tables present)
dockerd up (bridge enabled) → YES
docker network ls           → bridge present (docker0)
iptables -t nat -S          → 4 DOCKER/MASQUERADE rules
sysctl net.ipv4.ip_forward  → 1
docker pull (credsStore=shed intact) → success    # v0.3.7 creds fix
docker run -p 35432:5432 …  → localhost:35432 reachable  # DNAT
docker run … ping internet  → MASQUERADE-OK            # outbound NAT
```

`/codex:rescue` reviewed: verdict merge-with-minor-fixes — addressed (stale docs reversed, fragment annotated). The FC build-script `--shed-ext-version` passthrough gap it noted is pre-existing (same as VZ) and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker's default bridge networking is enabled on both Firecracker and VZ backends, so published ports, outbound NAT, and Testcontainers behave consistently.

* **Documentation**
  * Updated reference guides and tutorials to reflect unified Docker networking across backends.
  * Clarified credential helper behavior in validation sheds (timeout causes pull/push to fail instead of hang).

* **Chores**
  * Updated build/kernel pieces to support Docker networking features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->