### PR TITLE
feat(exec): SHED_WORKSPACE/SHED_ADD_DIRS env vars; docs: version-token fix + quickstarts + README slim-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,352 +1,85 @@
 # Shed
 
-Shed is a lightweight tool for managing persistent, VM-based development environments across multiple servers. It enables developers to spin up isolated coding sessions with AI tools (Claude Code, OpenCode) pre-installed, disconnect, and reconnect later to continue work.
+Shed manages persistent, VM-based development environments across multiple
+servers. Spin up isolated coding sessions (with Claude Code / OpenCode
+pre-installed), disconnect, and reconnect later to continue — backed by
+Firecracker microVMs on Linux or Apple Virtualization VMs on macOS Apple Silicon.
+
+**📖 Full documentation: <https://charliek.github.io/shed/>**
 
 ## Features
 
-- **Simple CLI** - Create and manage dev environments with minimal commands
-- **Session Persistence** - VMs keep running after disconnect
-- **Multi-Server** - Manage sheds across home servers and cloud VPS instances
-- **IDE Integration** - Native Cursor/VS Code support via SSH Remote
-- **AI-Ready** - Pre-configured for Claude Code and OpenCode workflows
-- **VM Backends** - Firecracker microVMs (Linux) or Apple VZ virtual machines (macOS Apple Silicon)
+- **Simple CLI** — create and manage dev environments with minimal commands.
+- **Session persistence** — VMs (and your tmux sessions) keep running after you disconnect.
+- **Multi-server** — manage sheds across home servers and cloud VPS instances.
+- **IDE integration** — native Cursor / VS Code Remote-SSH support.
+- **AI-ready** — pre-configured for Claude Code and OpenCode workflows.
+- **VM backends** — Firecracker microVMs (Linux) or Apple VZ (macOS Apple Silicon).
 
-## Quick Start
+## Quick start
 
-### 1. Install
+Follow the packaged quickstart for your platform:
 
-#### Homebrew (macOS, Recommended)
+- **[macOS Quickstart](https://charliek.github.io/shed/getting-started/macos-quickstart/)** — Homebrew + the shed-desktop approval app.
+- **[Linux Quickstart](https://charliek.github.io/shed/getting-started/linux-quickstart/)** — the `shed-server` deb running Firecracker.
 
-```bash
-brew install charliek/tap/shed
-brew install charliek/tap/shed-host-agent  # optional: credential brokering
-```
+Building from source or customizing images? See
+[Developer Setup](https://charliek.github.io/shed/getting-started/quick-start/).
 
-This installs `shed` (CLI) and `shed-server`, generates a default server config, codesigns the server binary, and sets up launchd services. Pulls `vfkit` and `erofs-utils` as dependencies. See [VZ Setup](docs/getting-started/vz-setup.md) for the full macOS setup guide.
-
-#### Debian / Ubuntu (apt)
-
-```bash
-sudo install -d -m 0755 /etc/apt/keyrings
-curl -fsSL https://apt.stridelabs.ai/pubkey.gpg | \
-  sudo tee /etc/apt/keyrings/apt-charliek.gpg > /dev/null
-echo 'deb [signed-by=/etc/apt/keyrings/apt-charliek.gpg] https://apt.stridelabs.ai noble main' | \
-  sudo tee /etc/apt/sources.list.d/apt-charliek.list
-sudo apt update
-sudo apt install shed-server
-```
-
-Installs the `shed-server` binary, default config at `/etc/shed/server.yaml`, and the systemd unit. Pulls `erofs-utils` as a dependency. The `shed` CLI is built from source on Linux today (see below).
-
-#### Build from Source
-
-```bash
-git clone https://github.com/charliek/shed.git
-cd shed
-make build
-
-# Or install the CLI only
-go install github.com/charliek/shed/cmd/shed@latest
-```
-
-#### Claude Code / agent skills
-
-shed ships a skill that teaches your coding agent to drive the shed CLI (create and attach to sheds, forward ports, sync files, work across servers). Install the CLI (above) first, since the skill drives it.
-
-The general route ([`skills`](https://skills.sh)) installs into Claude Code, GitHub Copilot, OpenCode, and other agents:
-
-```bash
-npx skills add charliek/shed
-```
-
-For Claude Code, a native plugin is also available (it namespaces the skill as `shed:shed`):
-
-```text
-/plugin marketplace add charliek/shed
-/plugin install shed@shed
-```
-
-### 2. Add a Server
-
-```bash
-shed server add my-server.local --name my-server
-```
-
-### 3. Create a Shed
-
-```bash
-# Create an empty shed
-shed create my-project
-
-# Or clone a repository
-shed create my-project --repo git@github.com:user/repo.git
-
-# Or mount a local directory as the workspace
-shed create my-project --local-dir ~/projects/my-project
-
-# Pick a specific image alias or ref (base / extensions / full; default_image is used otherwise)
-shed create big-project --image full --upper-size 20G
-```
-
-### 4. Connect
-
-```bash
-# Open a terminal session
-shed console my-project
-
-# Or use VS Code/Cursor with SSH Remote
-# The shed ssh-config command generates SSH config entries
-shed ssh-config >> ~/.ssh/config
-```
-
-## Backends
-
-Both backends boot from **layered OCI images**. Each shed's rootfs is a
-stack of read-only ext4 layers (pulled registry-direct from `ghcr.io`,
-no Docker daemon needed) plus a per-shed writable upper layer, mounted
-together via overlayfs inside the guest. Three images ship per backend —
-`base`, `extensions`, and `full` — wired up as the backend's
-`default_image` and `image_aliases`. See [Images](docs/reference/images.md).
-
-### VZ (macOS)
-
-Uses Apple's Virtualization.framework for native Linux VMs on macOS. Best for:
-- Local development on macOS with full VM isolation
-- Running Docker inside the shed (no Docker Desktop needed)
-- Vsock + agent architecture for fast host-guest communication
-
-```bash
-# Create with VZ backend (default on macOS)
-shed create myproject
-
-# With custom resources
-shed create myproject --cpus=4 --memory=8192
-```
-
-See [VZ Setup](docs/getting-started/vz-setup.md) and [VZ Operations](docs/reference/vz-operations.md) for setup and usage details.
-
-### Firecracker
-
-Uses Firecracker microVMs for stronger isolation. Best for:
-- Security-sensitive workloads
-- Full VM-level isolation
-- Running Docker inside the shed
-
-```bash
-# Create with Firecracker backend (default on Linux)
-shed create myproject
-
-# With custom resources
-shed create myproject --cpus=4 --memory=8192
-
-# Clone a private repo (requires SSH credentials configured)
-shed create myproject --repo=git@github.com:user/repo.git
-```
-
-See [Firecracker Setup](docs/getting-started/fc-setup.md) and [Firecracker Operations](docs/reference/fc-operations.md) for setup and usage details.
-
-## Requirements
-
-- **Client**: macOS or Linux (Homebrew or Go 1.24+ for source builds)
-- **Server (VZ)**: macOS 13+ (Ventura) on Apple Silicon (arm64), Docker
-- **Server (Firecracker)**: Linux with KVM support, Docker
-- **Network**: Tailscale (or any private network) connecting all machines
+The CLI also ships a coding-agent skill — `npx skills add charliek/shed` (or, for
+Claude Code, `/plugin marketplace add charliek/shed` then `/plugin install shed@shed`).
 
 ## Architecture
 
-Shed consists of three binaries:
+Three binaries:
 
-- **`shed`** - CLI for developer machines
-- **`shed-server`** - Server daemon exposing HTTP API (port 8080) and SSH server (port 2222)
-- **`shed-host-agent`** - Optional host-side credential brokering daemon (from [shed-extensions](https://github.com/charliek/shed-extensions))
-
-The server supports two backends:
-- **VZ** - Uses Apple Virtualization.framework VMs via vfkit (macOS Apple Silicon only)
-- **Firecracker** - Uses microVMs with vsock communication for better isolation (Linux only)
+- **`shed`** — the CLI on your developer machine.
+- **`shed-server`** — the daemon on each host (HTTP API + SSH server) that runs VMs via the VZ (macOS) or Firecracker (Linux) backend.
+- **`shed-host-agent`** — optional host-side credential broker, from [shed-extensions](https://github.com/charliek/shed-extensions); on macOS it pairs with the [shed-desktop](https://github.com/charliek/shed-desktop) approval app.
 
 ```
-Developer Machine                    Remote Server / Local Mac
-┌─────────────────┐                 ┌──────────────────────────────────────┐
-│    shed CLI     │ ──HTTP/SSH───▶ │  shed-server                         │
-└─────────────────┘                 │  ├── HTTP API (CRUD operations)      │
-                                    │  └── SSH Server (terminal/IDE)       │
-                                    │              │                        │
-                                    │      ┌───────┴───────┐               │
-                                    │      ▼               ▼               │
-                                    │  ┌──────┐       ┌────┐              │
-                                    │  │  FC  │       │ VZ │              │
-                                    │  │┌────┐│       │┌──┐│              │
-                                    │  ││ VM ││       ││VM││              │
-                                    │  │└────┘│       │└──┘│              │
-                                    │  └──────┘       └────┘              │
-                                    └──────────────────────────────────────┘
+Developer Machine                Remote Server / Local Mac
+┌─────────────┐   HTTP/SSH    ┌──────────────────────────────┐
+│  shed CLI   │ ────────────▶ │  shed-server                 │
+└─────────────┘               │   ├── HTTP API (lifecycle)   │
+                              │   └── SSH server (shell/IDE) │
+                              │        VZ │ Firecracker VMs  │
+                              └──────────────────────────────┘
 ```
 
-## CLI Commands
+Both backends boot from layered OCI images (`base` / `extensions` / `full`)
+pulled registry-direct from `ghcr.io`. See
+[Images](https://charliek.github.io/shed/reference/images/).
 
-```bash
-# Shed Management
-shed create <name> [--repo URL]  # Create a new shed (or --local-dir PATH)
-shed list                        # List all sheds on the current server
-shed start <name>                # Start a stopped shed
-shed stop <name>                 # Stop a running shed
-shed reset <name>                # Wipe and recreate the per-shed writable upper
-shed delete <name> [--force]     # Delete a shed
+## Documentation
 
-# Connection & Execution
-shed console <name>              # Open direct terminal session
-shed attach <name>               # Attach to tmux session (persistent)
-shed attach <name> -S <session>  # Attach to named session
-shed exec <name> <cmd>           # Run command in shed
+- [Getting Started](https://charliek.github.io/shed/getting-started/quick-start/) — quickstarts + developer setup
+- [CLI Reference](https://charliek.github.io/shed/reference/cli/) — every command
+- [Configuration](https://charliek.github.io/shed/reference/configuration/) — client + server config
+- [Images](https://charliek.github.io/shed/reference/images/) · [Storage Model](https://charliek.github.io/shed/reference/storage-model/)
+- [Extensions](https://charliek.github.io/shed/reference/extensions/) — credential brokering
+- [Provisioning](https://charliek.github.io/shed/reference/provisioning/) — `.shed/` install/startup hooks + tutorials
+- Related projects: [shed-extensions](https://charliek.github.io/shed-extensions/) · [shed-desktop](https://charliek.github.io/shed-desktop/)
 
-# Image Management
-shed image build                 # Build an OCI image from a Dockerfile
-shed image ls                    # List images by ref (SOURCE: config/user/dangling; alias: list)
-shed image history <tag>         # Show the layer stack for an image
-shed image inspect <tag-or-digest>  # Show manifest + annotations + digest
-shed image pull <ref>            # Pull an OCI image registry-direct
-shed image push <src> <dst>      # Push a tag/digest to a registry (byte-perfect)
-shed image save <tag> -o <file>  # Save an image to an OCI archive
-shed image load -i <file>        # Load an OCI archive into the local store
-shed image tag <src> <new>       # Point a new tag at an existing digest
-shed image rm <ref|digest|label> # Remove an image from the ref-index (alias: delete)
-shed image prune                 # Reclaim unreferenced layer blobs
+## Requirements
 
-# Session Management
-shed sessions                    # List all sessions on default server
-shed sessions <name>             # List sessions in a specific shed
-shed sessions --all              # List sessions across all servers
-shed sessions kill <shed> <session>  # Kill a session
+- **Client**: macOS or Linux (the `shed` CLI).
+- **Server (VZ)**: macOS 13+ on Apple Silicon (arm64); macOS 14+ for shed-desktop.
+- **Server (Firecracker)**: Linux with KVM.
+- **Network**: Tailscale (or any private network) connecting the machines.
 
-# Port Forwarding
-shed tunnels start <name> -t <ports>  # Forward ports from a shed
-shed tunnels stop <name>              # Stop port forwarding
-shed tunnels list                     # List active tunnels
+## Security model
 
-# Server & IDE
-shed server add <name>           # Add a server to client config
-shed server list                 # List configured servers
-shed server remove <name>        # Remove a server from client config
-shed ssh-config                  # Generate SSH config for IDE integration
-```
-
-## Session Persistence
-
-Shed supports persistent sessions via tmux. This allows you to:
-
-1. Start a long-running agent (Claude Code, OpenCode)
-2. Detach from the session (Ctrl-B D)
-3. Reconnect later to check on progress
-4. Run multiple named sessions per shed
-
-### Quick Example
-
-```bash
-# Create a shed and attach to a persistent session
-shed create myproj --repo user/repo
-shed attach myproj
-
-# Inside the session, start an agent
-claude
-
-# Detach with Ctrl-B D (tmux default)
-# The agent keeps running!
-
-# Later, reattach to see progress
-shed attach myproj
-
-# List all active sessions
-shed sessions --all
-```
-
-### console vs attach
-
-- `shed console` - Direct shell, no persistence (exits when you disconnect)
-- `shed attach` - tmux session, persists after disconnect
-
-## Setup
-
-See [VZ Setup (macOS)](docs/getting-started/vz-setup.md) or [Firecracker Setup (Linux)](docs/getting-started/fc-setup.md) for detailed server installation and configuration instructions.
+Shed targets single-user setups where every machine is on a private network
+(e.g. Tailscale), the developer controls all of them, and network access implies
+trust. Workloads run as a non-root `shed` user (UID 1000) with passwordless sudo.
+It is **not** built for multi-tenant use, public-internet exposure, or untrusted
+networks.
 
 ## Development
 
-See [Development Setup](docs/development/setup.md) for building from source and contributing.
-
-## Configuration
-
-### Client Configuration (`~/.shed/config.yaml`)
-
-```yaml
-default_server: my-server
-servers:
-  my-server:
-    host: my-server.local
-    http_port: 8080
-    ssh_port: 2222
-```
-
-### Server Configuration (`/etc/shed/server.yaml` or `~/.config/shed/server.yaml`)
-
-```yaml
-name: my-server
-http_port: 8080
-ssh_port: 2222
-
-# Auto-detect backend: vz on macOS, firecracker on Linux
-default_backend: detect
-
-# Host directories mounted into every shed (the deprecated key
-# "credentials" is still accepted as a fallback).
-mounts:
-  ssh:
-    source: ~/.ssh
-    target: /home/shed/.ssh
-    readonly: true
-  gh:
-    source: ~/.config/gh
-    target: /home/shed/.config/gh
-    readonly: true
-env_file: ~/.shed/env
-
-# VZ backend (macOS Apple Silicon)
-vz:
-  default_image: ghcr.io/charliek/shed-vz-full:v{version}
-  image_aliases:
-    base: ghcr.io/charliek/shed-vz-base:v{version}
-    extensions: ghcr.io/charliek/shed-vz-extensions:v{version}
-    full: ghcr.io/charliek/shed-vz-full:v{version}
-  pull_policy: missing
-  images_dir: ~/Library/Application Support/shed/vz/
-  default_cpus: 2
-  default_memory_mb: 4096
-
-# Firecracker backend (Linux with KVM)
-# firecracker:
-#   default_image: ghcr.io/charliek/shed-fc-full:v{version}
-#   image_aliases:
-#     base: ghcr.io/charliek/shed-fc-base:v{version}
-#     extensions: ghcr.io/charliek/shed-fc-extensions:v{version}
-#     full: ghcr.io/charliek/shed-fc-full:v{version}
-#   pull_policy: missing
-#   images_dir: /var/lib/shed/firecracker/images
-#   default_cpus: 2
-#   default_memory_mb: 4096
-```
-
-Replace `{version}` with the version matching your `shed` binary — run `shed version` to check. See [Configuration](docs/reference/configuration.md) for all options.
-
-## Security Model
-
-Shed is designed for single-user scenarios where:
-- All machines are connected via Tailscale (or similar private network)
-- The developer owns/controls all machines
-- Network access implies trust
-- Workloads run as a non-root `shed` user (UID 1000) with passwordless sudo
-
-**Not suitable for:**
-- Multi-tenant environments
-- Public internet exposure
-- Untrusted network access
+See [Development Setup](docs/development/setup.md) for building from source and
+contributing.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Three binaries:
 - **`shed-server`** — the daemon on each host (HTTP API + SSH server) that runs VMs via the VZ (macOS) or Firecracker (Linux) backend.
 - **`shed-host-agent`** — optional host-side credential broker, from [shed-extensions](https://github.com/charliek/shed-extensions); on macOS it pairs with the [shed-desktop](https://github.com/charliek/shed-desktop) approval app.
 
-```
+```text
 Developer Machine                Remote Server / Local Mac
 ┌─────────────┐   HTTP/SSH    ┌──────────────────────────────┐
 │  shed CLI   │ ────────────▶ │  shed-server                 │

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -106,7 +106,7 @@ The suite picks up FC tests automatically once the remote server emits PhaseTime
    SHED_FC_HOST=<your-host> make test-integration
    ```
 
-   FC tests now run live against the installed binary. To validate against your source tree instead, see [Validating server-side changes](#validating-server-side-changes-required-for-server-side-prs) below.
+   FC tests now run live against the installed binary. To validate against your source tree instead, see [Validating server-side changes](#validating-server-side-changes-parallel-dev-server) below.
 
 #### Environment overrides
 

--- a/docs/getting-started/fc-setup.md
+++ b/docs/getting-started/fc-setup.md
@@ -1,10 +1,14 @@
-# Firecracker Setup
+# Firecracker Developer Setup
 
-This guide covers the installation and setup of the Firecracker backend
-for shed. Firecracker is Linux-only and requires KVM. The remote-Linux-host
-workflow is the common case: you run `shed` on your laptop and `shed-server`
-on a separate Linux box you SSH into (e.g.,
-`ssh charliek@your.linux.host.example.com`).
+This is the in-depth Firecracker guide: the full manual setup, **building from
+source**, and custom kernels/images. Firecracker is Linux-only and requires KVM.
+The remote-Linux-host workflow is the common case: you run `shed` on your laptop
+and `shed-server` on a separate Linux box you SSH into.
+
+!!! tip "Just want a server running?"
+    Use the **[Linux Quickstart](linux-quickstart.md)** — the `shed-server` deb
+    plus `sudo shed-server setup`. This page is for the manual/from-source setup,
+    custom kernels, and operations detail.
 
 ## Prerequisites
 

--- a/docs/getting-started/linux-quickstart.md
+++ b/docs/getting-started/linux-quickstart.md
@@ -39,15 +39,14 @@ sudo apt install shed-server
 This installs `shed` + `shed-server`, generates a default Firecracker config at
 `/etc/shed/server.yaml`, and registers a systemd service.
 
-??? note "Alternative: install the `.deb` directly"
-    Without the apt repo, grab the `.deb` from the
-    [releases page](https://github.com/charliek/shed/releases):
+**Alternative — without the apt repo**, grab the `.deb` from the
+[releases page](https://github.com/charliek/shed/releases):
 
-    ```bash
-    VERSION=$(gh release view --repo charliek/shed --json tagName -q .tagName | sed 's/^v//')
-    wget https://github.com/charliek/shed/releases/download/v${VERSION}/shed-server_${VERSION}_amd64.deb
-    sudo dpkg -i shed-server_${VERSION}_amd64.deb
-    ```
+```bash
+VERSION=$(gh release view --repo charliek/shed --json tagName -q .tagName | sed 's/^v//')
+wget https://github.com/charliek/shed/releases/download/v${VERSION}/shed-server_${VERSION}_amd64.deb
+sudo dpkg -i shed-server_${VERSION}_amd64.deb
+```
 
 ## 2. Set up Firecracker infrastructure
 

--- a/docs/getting-started/linux-quickstart.md
+++ b/docs/getting-started/linux-quickstart.md
@@ -1,0 +1,118 @@
+# Linux Quickstart
+
+The opinionated, packaged path to a working `shed-server` on Linux, where it runs
+[Firecracker](https://firecracker-microvm.github.io/) microVMs. This is the path
+shed's Linux testing focuses on: a remote host you reach from a Mac (or another
+Linux box) with the `shed` CLI.
+
+Building from source, custom kernels/images, or the full manual setup? See
+[Firecracker Developer Setup](fc-setup.md).
+
+!!! note "Scope on Linux today"
+    Linux currently runs the **server** (`shed-server`). Host-side credential
+    brokering (`shed-host-agent`) and a desktop GUI are roadmap items — a headless
+    Linux host-agent is planned first, once the macOS pieces are established. For
+    now, credential brokering and the shed-desktop approval UI are macOS-only (see
+    the [macOS Quickstart](macos-quickstart.md)).
+
+## Prerequisites
+
+- Linux with **KVM** (`/dev/kvm` present; bare metal or a nested-virt VM).
+- root / sudo.
+- A private network (Tailscale or LAN) if you'll reach it from another machine.
+
+## 1. Install the server (apt)
+
+Add the apt repository and install `shed-server` — this gives you `apt`-managed
+upgrades:
+
+```bash
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://apt.stridelabs.ai/pubkey.gpg | \
+  sudo tee /etc/apt/keyrings/apt-charliek.gpg > /dev/null
+echo 'deb [signed-by=/etc/apt/keyrings/apt-charliek.gpg] https://apt.stridelabs.ai noble main' | \
+  sudo tee /etc/apt/sources.list.d/apt-charliek.list
+sudo apt update
+sudo apt install shed-server
+```
+
+This installs `shed` + `shed-server`, generates a default Firecracker config at
+`/etc/shed/server.yaml`, and registers a systemd service.
+
+??? note "Alternative: install the `.deb` directly"
+    Without the apt repo, grab the `.deb` from the
+    [releases page](https://github.com/charliek/shed/releases):
+
+    ```bash
+    VERSION=$(gh release view --repo charliek/shed --json tagName -q .tagName | sed 's/^v//')
+    wget https://github.com/charliek/shed/releases/download/v${VERSION}/shed-server_${VERSION}_amd64.deb
+    sudo dpkg -i shed-server_${VERSION}_amd64.deb
+    ```
+
+## 2. Set up Firecracker infrastructure
+
+One command provisions everything the Firecracker backend needs — KVM access, the
+bridge network, IP forwarding + NAT, and capabilities:
+
+```bash
+sudo shed-server setup
+```
+
+## 3. Configure the server (optional)
+
+The default config at `/etc/shed/server.yaml` works out of the box. A minimal
+config looks like:
+
+```yaml
+# /etc/shed/server.yaml
+# Full reference: https://charliek.github.io/shed/reference/configuration/
+name: my-linux-host
+http_port: 8080
+ssh_port: 2222
+default_backend: firecracker
+
+firecracker:
+  pull_policy: missing
+  # default_image / image_aliases omitted -> synthesized from the server version.
+```
+
+See [Configuration](../reference/configuration.md) for the Firecracker-specific
+fields (bridge name/CIDR, vsock, resource defaults).
+
+## 4. Start it
+
+```bash
+sudo systemctl start shed-server
+systemctl status shed-server            # should be active (running)
+curl -s http://localhost:8080/api/info  # name, version, backend: firecracker
+```
+
+The first `shed create` pulls the matching `shed-fc-full` image automatically
+(`pull_policy: missing`). To pre-cache it, run `sudo shed-server pull-images`.
+
+## 5. Connect from your workstation
+
+From the Mac/Linux box that has the `shed` CLI (over Tailscale/LAN):
+
+```bash
+shed server add my-linux-host.tailnet.ts.net --name my-linux-host
+shed create demo --repo charliek/your-repo
+shed attach demo
+```
+
+## Upgrading
+
+```bash
+sudo apt update && sudo apt install --only-upgrade shed-server
+sudo systemctl restart shed-server
+```
+
+Image refs synthesize from the server version, so a fresh shed pulls the matching
+image with no config edit — see
+[Configuration → Image references](../reference/configuration.md#image-references-and-shedversion).
+
+## Next steps
+
+- [Firecracker Developer Setup](fc-setup.md) — manual setup, custom kernels/images, from source.
+- [Firecracker Operations](../reference/fc-operations.md) — running and debugging the FC backend.
+- [Configuration](../reference/configuration.md) — all server-config fields.

--- a/docs/getting-started/macos-quickstart.md
+++ b/docs/getting-started/macos-quickstart.md
@@ -1,0 +1,182 @@
+# macOS Quickstart
+
+The opinionated, packaged path to a working shed on macOS, with the
+[shed-desktop](https://charliek.github.io/shed-desktop/) menu-bar app handling
+credential approvals. Everything installs from Homebrew plus one DMG.
+
+Building from source, custom images, or hacking on shed itself? See
+[macOS Developer Setup](vz-setup.md) instead.
+
+## What you get
+
+- A local `shed-server` running VMs through Apple's Virtualization.framework (via
+  `vfkit`, installed by Homebrew).
+- `shed-host-agent` brokering your real credentials (SSH agent, Docker registry
+  auth, optionally AWS) into sheds — keys never leave the host.
+- **shed-desktop**: a menu-bar app that lists/creates sheds and shows a Touch ID
+  approval prompt whenever a shed asks to use a credential.
+
+## Prerequisites
+
+- macOS 14 (Sonoma) or newer, Apple Silicon (arm64).
+- [Homebrew](https://brew.sh).
+- No host Docker needed — the `full` shed image ships its own Docker daemon.
+
+## 1. Install the CLI, server, and host agent
+
+```bash
+brew install charliek/tap/shed             # shed CLI + shed-server (+ vfkit)
+brew install charliek/tap/shed-host-agent  # credential broker
+brew services start shed
+brew services start shed-host-agent
+```
+
+`brew install charliek/tap/shed` installs the `shed` CLI and `shed-server`, pulls
+`vfkit` (the Apple Virtualization bridge), generates a default VZ server config,
+codesigns the server binary, and registers a launchd service.
+
+## 2. Configure the server
+
+The server config lives at `/opt/homebrew/etc/shed/server.yaml`. A minimal setup
+shares a couple of host credential directories and enables the credential
+extensions:
+
+```yaml
+# /opt/homebrew/etc/shed/server.yaml
+# Full reference: https://charliek.github.io/shed/reference/configuration/
+name: my-mac
+http_port: 8080
+ssh_port: 2222
+default_backend: vz
+
+# Host directories shared into every shed (VirtioFS). Add only what you need.
+mounts:
+  claude:
+    source: ~/.claude
+    target: /home/shed/.claude
+    readonly: false
+  gh:
+    source: ~/.config/gh
+    target: /home/shed/.config/gh
+    readonly: false
+
+# Credential brokering via shed-host-agent (configured in step 3).
+extensions:
+  enabled:
+    - ssh-agent
+    - docker-credentials
+    # - aws-credentials
+
+# default_image / image_aliases are omitted, so they're synthesized from the
+# server version — upgrades move to the matching images with no config edit.
+```
+
+Restart after editing: `brew services restart shed`.
+
+## 3. Configure credential brokering (shed-host-agent)
+
+The host agent holds your real keys and decides each request; its config is at
+`/opt/homebrew/etc/shed/extensions.yaml`. To route approvals to shed-desktop, set
+each provider's policy to `shed-desktop` and turn on the desktop channel:
+
+```yaml
+# /opt/homebrew/etc/shed/extensions.yaml
+# Full reference: https://charliek.github.io/shed-extensions/reference/configuration/
+discovery:
+  servers: all            # broker for every server in ~/.shed/config.yaml
+  watch: fsnotify         # pick up `shed server add/remove` live
+
+desktop:
+  enabled: true           # serve the local socket shed-desktop connects to
+  # socket_path: ~/Library/Application Support/shed/host-agent.sock
+  # timeout_ms: 25000     # fail-closed (deny) if the app doesn't answer in time
+
+ssh:
+  approval:
+    policy: shed-desktop  # SSH sign approvals decided in shed-desktop
+                          # no-GUI alternative: biometrics-or-password (native Touch ID)
+
+docker:
+  approval:
+    policy: shed-desktop  # live Allow/Deny toggle in shed-desktop
+  registries:             # registries the agent brokers creds for
+    - ghcr.io
+    - docker.io
+    # - registry.example.com   # add your private/org registries here
+  allow_all: false        # set true to broker for ANY registry (ignores the list)
+
+# AWS credential vending (inactive until you set a role)
+aws:
+  approval:
+    policy: shed-desktop  # or deny-all until a role is configured
+  source_profile: default
+  default_role: ""        # set an IAM role ARN to enable AWS vending
+  session_duration: 1h
+  cache_refresh_before: 5m
+  # Per-shed role overrides:
+  # sheds:
+  #   my-shed:
+  #     role: arn:aws:iam::123456789012:role/ShedRole
+
+logging:
+  enabled: true
+  path: ~/.local/share/shed/extensions-audit.log
+```
+
+Restart and verify — point `status` at the Homebrew config (bare `status` reads
+`~/.config/shed/extensions.yaml`, which the brew service doesn't use):
+
+```bash
+brew services restart shed-host-agent
+shed-host-agent -config /opt/homebrew/etc/shed/extensions.yaml status
+```
+
+Each delegated provider should read `shed-desktop` and the desktop channel
+`state: listening`. Policies, roles, and registries are off by default — see the
+[full reference](https://charliek.github.io/shed-extensions/reference/configuration/).
+
+## 4. Install shed-desktop
+
+Download the latest `ShedDesktop-<version>.dmg` from the
+[releases page](https://github.com/charliek/shed-desktop/releases), open it, and
+drag **ShedDesktop.app** to Applications. Builds are signed ad-hoc (not yet
+notarized), so clear the quarantine flag once:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/ShedDesktop.app
+```
+
+Launch it (it lives in the menu bar, no Dock icon). It reads your
+`~/.shed/config.yaml` host list and connects to the host-agent socket. Open
+**Preferences** from the menu-bar dropdown to set approval behavior:
+
+| Section | What |
+|---|---|
+| **SSH approvals** | Method (Touch ID or password / Touch ID / Prompt), default decision (Time Based Allow, etc.), and duration. |
+| **AWS / Docker credentials** | A live **Allow / Deny** toggle (default Deny). |
+| **Per-shed overrides** | Always-allow / always-deny rules keyed by `(server, shed)`. |
+
+Credentials **fail closed**: when shed-desktop isn't running, delegated requests
+are denied. See the shed-desktop
+[installation](https://charliek.github.io/shed-desktop/getting-started/installation/)
+and [approvals](https://charliek.github.io/shed-desktop/reference/approvals/)
+docs for the full policy model.
+
+## 5. Register the server and create your first shed
+
+```bash
+shed server add localhost --name my-mac      # registers the local server
+shed create demo --repo charliek/your-repo   # or --local-dir ~/projects/app
+shed attach demo
+```
+
+The first SSH credential use inside the shed (e.g. a `git push`) raises a Touch
+ID approval in shed-desktop; once approved per your policy, it's seamless.
+
+## Next steps
+
+- [Configuration](../reference/configuration.md) — every server-config field.
+- [Extensions](../reference/extensions.md) · [shed-extensions docs](https://charliek.github.io/shed-extensions/) — the credential bus in full.
+- [shed-desktop docs](https://charliek.github.io/shed-desktop/) — the menu-bar app in full.
+- [macOS Developer Setup](vz-setup.md) — build from source, custom images.
+- Provisioning a project: [Gradle](../tutorials/gradle-provisioning.md) · [TypeScript](../tutorials/typescript-provisioning.md) · [Python](../tutorials/python-provisioning.md).

--- a/docs/getting-started/macos-quickstart.md
+++ b/docs/getting-started/macos-quickstart.md
@@ -162,16 +162,46 @@ are denied. See the shed-desktop
 and [approvals](https://charliek.github.io/shed-desktop/reference/approvals/)
 docs for the full policy model.
 
-## 5. Register the server and create your first shed
+## 5. Register the server and create a shed
 
 ```bash
-shed server add localhost --name my-mac      # registers the local server
-shed create demo --repo charliek/your-repo   # or --local-dir ~/projects/app
-shed attach demo
+shed server add localhost --name my-mac   # registers the local server
+shed create hello-world                   # a small shed to verify with
+shed console hello-world                  # drop into a shell inside it
 ```
 
-The first SSH credential use inside the shed (e.g. a `git push`) raises a Touch
-ID approval in shed-desktop; once approved per your policy, it's seamless.
+(You can also create from a repo or a local directory:
+`shed create demo --repo charliek/your-repo`, or
+`shed create demo --local-dir ~/projects/app`.)
+
+## 6. Verify credential brokering
+
+Run these **inside the shed** — the `shed console hello-world` shell from step 5.
+The first SSH or Docker credential use raises a Touch ID approval in shed-desktop;
+approve it (pick a policy like *Time Based Allow* so you aren't asked again for a
+while).
+
+```bash
+# SSH — signs with your host key via the forwarded agent (-> approval in shed-desktop).
+# Success prints: Hi <you>! You've successfully authenticated...
+ssh -T git@github.com
+
+# Docker — pull a small public image (anonymous pulls work with credsStore=shed):
+docker pull postgres:16-alpine
+# ...and a private registry to exercise credential brokering (-> approval):
+# docker pull ghcr.io/your-org/your-image:tag
+
+# AWS — only if you set default_role + aws.approval.policy in step 3:
+aws sts get-caller-identity
+```
+
+Back on the **host**, check each shed's extension health and connection state:
+
+```bash
+shed list -vv
+```
+
+Remove the test shed when you're done: `shed delete hello-world`.
 
 ## Next steps
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,99 +1,26 @@
-# Quick Start
+# Getting Started
 
-Get up and running with Shed in a few minutes.
+Shed runs persistent, VM-based dev environments you reach over SSH. Start with
+the packaged quickstart for your platform, then use the reference below for the
+day-to-day commands.
 
-## Prerequisites
+## Choose your path
 
-- **macOS Apple Silicon** — Homebrew (recommended) or Go 1.24+ for source builds
-- **Linux with KVM** — deb package (recommended) or Go 1.24+ for source builds
-- Docker (for VM image management)
-- Tailscale (or other private network) if connecting to remote servers
+**Quickstarts (packaged, recommended)** — install from a package manager, copy a
+config, create a shed:
 
-## Install
+- **[macOS Quickstart](macos-quickstart.md)** — Homebrew + the shed-desktop
+  approval app; runs VMs via Apple's Virtualization.framework (VZ backend).
+- **[Linux Quickstart](linux-quickstart.md)** — the `shed-server` deb running
+  Firecracker microVMs (the tested remote-host path).
 
-Shed has two install paths:
+**Developer setup** — build from source, custom images, or the full manual setup:
 
-- **Published packages (Homebrew on macOS, deb on Linux)** are the
-  easiest path. They install pre-built binaries and pull pre-built VM
-  images from `ghcr.io`. Pick this if you want shed running quickly and
-  don't need to modify the rootfs / kernel / initramfs.
-- **Build from source** is for contributors and bleeding-edge use. It
-  builds binaries locally from the repo and (optionally) builds the VM
-  rootfs images from the local `vz/` and `firecracker/` Dockerfiles.
-  Pick this if you're hacking on shed itself or want to run an unreleased
-  commit.
+- **[macOS Developer Setup](vz-setup.md)** (VZ backend)
+- **[Firecracker Developer Setup](fc-setup.md)** (Linux / KVM backend)
 
-Upgrading from v0.4.x? See the [v0.4 → v0.5 Upgrade Guide](../upgrades/v0.4-to-v0.5.md) —
-the v0.5.0 image store is not backwards-compatible.
-
-### Homebrew (macOS, Recommended)
-
-```bash
-brew install charliek/tap/shed
-```
-
-This installs both `shed` (CLI) and `shed-server`, generates a default server config with the VZ backend, codesigns the server binary, and sets up a launchd service.
-
-For credential brokering (SSH agent forwarding, AWS credentials, Docker registry auth), also install the host agent:
-
-```bash
-brew install charliek/tap/shed-host-agent
-```
-
-Edit the server config at `$(brew --prefix)/etc/shed/server.yaml` to configure credentials and extensions, then start the services:
-
-```bash
-brew services start shed
-brew services start shed-host-agent  # if installed
-```
-
-See [VZ Setup](vz-setup.md) for the full macOS setup guide.
-
-### deb Package (Linux, Recommended)
-
-Download and install the `.deb` from the [latest release](https://github.com/charliek/shed/releases):
-
-```bash
-# Find the latest version at https://github.com/charliek/shed/releases
-# or, with the gh CLI:
-VERSION=$(gh release view --repo charliek/shed --json tagName -q .tagName | sed 's/^v//')
-
-wget https://github.com/charliek/shed/releases/download/v${VERSION}/shed-server_${VERSION}_amd64.deb
-sudo dpkg -i shed-server_${VERSION}_amd64.deb
-```
-
-This installs `shed` (CLI) and `shed-server`, generates a default Firecracker server config, and sets up a systemd service.
-
-Complete the Firecracker infrastructure setup:
-
-```bash
-sudo shed-server setup
-sudo shed-server pull-images
-sudo systemctl start shed-server
-```
-
-See [Firecracker Setup](fc-setup.md) for the full Linux setup guide.
-
-### Build from Source
-
-```bash
-git clone https://github.com/charliek/shed.git
-cd shed
-make build
-
-# Or install the CLI only
-go install github.com/charliek/shed/cmd/shed@latest
-```
-
-`make build` produces `bin/shed`, `bin/shed-server`, and `bin/shed-agent`.
-That's only step one of a source install — `shed-server` still needs a
-server config, VM images, and (on Linux) bridge networking before it can
-launch a VM.
-
-Continue with the backend-specific setup guide:
-
-- macOS Apple Silicon: [VZ Setup — Build from Source](vz-setup.md#build-from-source-alternative)
-- Linux with KVM: [Firecracker Setup — Build from Source](fc-setup.md#build-from-source-alternative)
+The rest of this page is the platform-agnostic command reference once a server is
+running.
 
 ## Add a Server
 
@@ -111,7 +38,7 @@ This connects to the server, retrieves its SSH host key, and saves the configura
 # Create an empty shed — you land in /home/shed
 shed create my-project
 
-# Or clone a repository — cloned into ~/repo, login lands there
+# Or clone a repository — cloned into ~/<reponame>, login lands there
 shed create my-project --repo git@github.com:user/repo.git
 
 # Or mount a local directory — mounted at ~/<basename>, login lands there
@@ -122,13 +49,14 @@ shed create my-project --local-dir ~/projects/my-project
 shed create app --local-dir ~/projects/app --add-dir ~/projects/shared-lib
 ```
 
-Interactive logins (`shed console`, `shed attach`, raw `ssh`, VS Code
-Remote-SSH) land in the shed's project directory: `~/<reponame>` with
-`--repo`, `~/<basename>` with `--local-dir`, otherwise `/home/shed`.
-`shed exec <name> -- <cmd>` runs there too. `--repo` and
-`--local-dir`/`--add-dir` are mutually exclusive.
+Interactive logins (`shed console`, `shed attach`, raw `ssh`, VS Code Remote-SSH)
+land in the shed's project directory: `~/<reponame>` with `--repo`, `~/<basename>`
+with `--local-dir`, otherwise `/home/shed`. `shed exec <name> -- <cmd>` runs there
+too, with `$SHED_WORKSPACE` (the project dir) and `$SHED_ADD_DIRS` (any `--add-dir`
+mounts) set. `--repo` and `--local-dir`/`--add-dir` are mutually exclusive.
 
-Once you have a few sheds, `shed system df` shows what's on disk and `shed system prune` reclaims unused space. See [Disk Management](../reference/disk-management.md).
+Once you have a few sheds, `shed system df` shows what's on disk and
+`shed system prune` reclaims unused space. See [Disk Management](../reference/disk-management.md).
 
 ## Connect
 
@@ -146,7 +74,8 @@ Opens a bash shell in the VM. Exits when you disconnect.
 shed attach my-project
 ```
 
-Opens a tmux session that persists after you disconnect. Detach with `Ctrl-B D` and reconnect later with the same command.
+Opens a tmux session that persists after you disconnect. Detach with `Ctrl-B D`
+and reconnect later with the same command.
 
 ## IDE Integration
 
@@ -174,36 +103,21 @@ shed attach myproj
 # Inside the session, start Claude Code
 claude
 
-# Detach with Ctrl-B D - the agent keeps running
-# Later, reattach to see progress
+# Detach with Ctrl-B D - the agent keeps running; reattach later
 shed attach myproj
-```
-
-### Multiple sessions
-
-```bash
-# Attach to a named session
-shed attach myproj --session debug
-
-# List all sessions
-shed sessions --all
 ```
 
 ### Port forwarding
 
 ```bash
-# Start tunnels for web development
-shed tunnels start myproj -t 3000:3000
-
-# Run in background
+# Start tunnels for web development (-d runs in background)
 shed tunnels start myproj -t 3000:3000 -d
 ```
 
 ## Next Steps
 
-- [VZ Setup (macOS)](vz-setup.md) - Set up the VZ backend on Apple Silicon
-- [Firecracker Setup (Linux)](fc-setup.md) - Set up the Firecracker backend
-- [CLI Reference](../reference/cli.md) - All available commands
-- [Configuration](../reference/configuration.md) - Client and server config options
-- [Extensions](../reference/extensions.md) - Credential brokering with the `extensions` image
-- [Tunnels](../reference/tunnels.md) - Port forwarding configuration
+- [CLI Reference](../reference/cli.md) — all available commands
+- [Configuration](../reference/configuration.md) — client and server config options
+- [Extensions](../reference/extensions.md) — credential brokering with the host agent
+- [Tunnels](../reference/tunnels.md) — port forwarding configuration
+- [Provisioning](../reference/provisioning.md) — `.shed/` install/startup hooks

--- a/docs/getting-started/vz-setup.md
+++ b/docs/getting-started/vz-setup.md
@@ -1,6 +1,13 @@
-# VZ Setup (macOS Apple Silicon)
+# macOS Developer Setup (VZ)
 
-This guide covers setting up the VZ backend, which uses Apple's Virtualization.framework to run Linux VMs on macOS via [vfkit](https://github.com/crc-org/vfkit).
+This is the in-depth VZ guide: the full setup, including **building from source**
+and custom images. The VZ backend uses Apple's Virtualization.framework to run
+Linux VMs on macOS via [vfkit](https://github.com/crc-org/vfkit).
+
+!!! tip "Just want shed running?"
+    Use the **[macOS Quickstart](macos-quickstart.md)** — Homebrew + shed-desktop,
+    no source build. This page is for contributors, custom images, or running an
+    unreleased commit.
 
 ## Prerequisites
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -702,6 +702,8 @@ shed exec <name> <command...>
 
 **Working directory.** Commands run in the shed's landing directory — the shed user's home (`/home/shed`) by default, or the project directory when the shed was created with `--repo` (`~/<reponame>`) or `--local-dir` (`~/<basename>`).
 
+**Environment.** Sessions (`shed exec` and interactive logins) export `SHED_NAME` (the shed name), `SHED_WORKSPACE` (the landing/project directory), and — when the shed was created with `--add-dir` — `SHED_ADD_DIRS` (a colon-separated list of the additional mount paths, e.g. `/home/shed/lib-a:/home/shed/lib-b`). These mirror the variables provisioning hooks receive.
+
 **Execution model.** `shed exec` ships argv literally. The CLI single-quote-wraps each argv element before transmission so nested quotes, spaces, and shell metacharacters in *your* data survive the SSH wire intact and reach the guest as argv, not as shell code. The server-side SSH command channel does run those quoted tokens through `bash -lc` (so login PATH adjustments — `/etc/profile.d/*.sh`, `~/.profile`, mise, nvm, rustup — are in effect), but bash treats single-quoted text as literal data, so argv stays argv. End result: `shed exec name -- mytool` just works for tools installed via login-shell PATH managers, and `shed exec name -- echo '$HOME'` still prints the literal `$HOME` — no expansion, no command splitting.
 
 This is the same model Docker, devcontainers, Codespaces, and Coder follow on their `exec` path. Pipes, redirects, semicolons, `$VAR` expansion, command substitution, and other shell metacharacters only take effect when *you* explicitly invoke a shell as part of the command (e.g. `bash -c '...'`).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -197,6 +197,35 @@ The `git.extra_known_hosts` list is *additive* — it extends the built-in defau
 
 **Key rotation:** If GitHub or another host rotates its keys, you can extend the trust list via `extra_known_hosts` immediately without waiting for a shed release. The default GitHub keys ship with the server binary and are updated in releases.
 
+## Image references and `${shed.version}`
+
+`default_image` and `image_aliases` are **optional**. On a release build of
+`shed-server`, when they are unset they are **synthesized from the server's own
+version**: `default_image` becomes `ghcr.io/charliek/shed-<backend>-full:vX.Y.Z`
+and the `base` / `extensions` / `full` aliases resolve to the matching tags. So
+upgrading `shed-server` moves new sheds to the new images with **no config edit**.
+
+Set them explicitly only to pin a custom or mirrored registry. To track the
+server version without hand-editing the tag on every upgrade, use the
+`${shed.version}` token — it expands to the running server's release tag
+(`vX.Y.Z`) at config load:
+
+```yaml
+vz:
+  default_image: myregistry.example.com/shed-vz-full:${shed.version}
+```
+
+**Why this is version-coupled:** the base images bundle the in-VM `shed-agent`
+and the shed-extensions guest binaries, which are versioned in lockstep with
+`shed`. Pinning the image to the server version — via the default synthesis or
+the `${shed.version}` token — keeps the guest components compatible with the
+server instead of drifting on upgrade.
+
+!!! note "`${shed.version}` is the only accepted token"
+    A literal `{version}` or `v{version}` is **not** expanded. On a dev/unreleased
+    build the token has nothing to resolve to, so set concrete refs (or leave them
+    unset and pass `--image` on each `create`).
+
 ## Firecracker Configuration
 
 When enabling Firecracker, configure the Firecracker-specific settings:
@@ -205,11 +234,11 @@ When enabling Firecracker, configure the Firecracker-specific settings:
 default_backend: firecracker
 
 firecracker:
-  default_image: ghcr.io/charliek/shed-fc-full:v{version}
+  default_image: ghcr.io/charliek/shed-fc-full:${shed.version}
   image_aliases:
-    base: ghcr.io/charliek/shed-fc-base:v{version}
-    extensions: ghcr.io/charliek/shed-fc-extensions:v{version}
-    full: ghcr.io/charliek/shed-fc-full:v{version}
+    base: ghcr.io/charliek/shed-fc-base:${shed.version}
+    extensions: ghcr.io/charliek/shed-fc-extensions:${shed.version}
+    full: ghcr.io/charliek/shed-fc-full:${shed.version}
   pull_policy: missing
   images_dir: /var/lib/shed/firecracker/images
   instance_dir: /var/lib/shed/firecracker/instances
@@ -227,7 +256,10 @@ firecracker:
   tap_prefix: shed-tap
 ```
 
-Replace `{version}` with the version matching your `shed` binary — run `shed version` to check.
+The `${shed.version}` token above resolves to the running server's release tag —
+see [Image references and `${shed.version}`](#image-references-and-shedversion).
+These fields are optional; left unset on a release build they are synthesized
+from the server version.
 
 ### Firecracker Fields
 
@@ -274,11 +306,11 @@ vz:
   vfkit_path: vfkit
   kernel_path: ~/Library/Application Support/shed/vz/vmlinux
   initrd_path: ~/Library/Application Support/shed/vz/initrd.img
-  default_image: ghcr.io/charliek/shed-vz-full:v{version}
+  default_image: ghcr.io/charliek/shed-vz-full:${shed.version}
   image_aliases:
-    base: ghcr.io/charliek/shed-vz-base:v{version}
-    extensions: ghcr.io/charliek/shed-vz-extensions:v{version}
-    full: ghcr.io/charliek/shed-vz-full:v{version}
+    base: ghcr.io/charliek/shed-vz-base:${shed.version}
+    extensions: ghcr.io/charliek/shed-vz-extensions:${shed.version}
+    full: ghcr.io/charliek/shed-vz-full:${shed.version}
   pull_policy: missing
   images_dir: ~/Library/Application Support/shed/vz/
   instance_dir: ~/Library/Application Support/shed/vz/instances

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -83,15 +83,19 @@ Pre-built images for each variant are published per release to `ghcr.io`:
 
 | Image | Platform | Tag Format |
 |-------|----------|------------|
-| `ghcr.io/charliek/shed-vz-base` | linux/arm64 | `:v{version}` |
-| `ghcr.io/charliek/shed-vz-extensions` | linux/arm64 | `:v{version}` |
-| `ghcr.io/charliek/shed-vz-full` | linux/arm64 | `:v{version}` |
-| `ghcr.io/charliek/shed-fc-base` | linux/amd64 | `:v{version}` |
-| `ghcr.io/charliek/shed-fc-extensions` | linux/amd64 | `:v{version}` |
-| `ghcr.io/charliek/shed-fc-full` | linux/amd64 | `:v{version}` |
+| `ghcr.io/charliek/shed-vz-base` | linux/arm64 | `:vX.Y.Z` |
+| `ghcr.io/charliek/shed-vz-extensions` | linux/arm64 | `:vX.Y.Z` |
+| `ghcr.io/charliek/shed-vz-full` | linux/arm64 | `:vX.Y.Z` |
+| `ghcr.io/charliek/shed-fc-base` | linux/amd64 | `:vX.Y.Z` |
+| `ghcr.io/charliek/shed-fc-extensions` | linux/amd64 | `:vX.Y.Z` |
+| `ghcr.io/charliek/shed-fc-full` | linux/amd64 | `:vX.Y.Z` |
 
-Replace `{version}` with the version matching your `shed` binary — run
-`shed version` to check.
+Each release publishes a `:vX.Y.Z` tag matching the `shed` version (e.g.
+`:v0.6.5`) — run `shed version` to check. In **server config**, leave
+`default_image`/`image_aliases` unset to track the version automatically, or use
+the `${shed.version}` token — see
+[Configuration](configuration.md#image-references-and-shedversion). (That token
+is shed-config only; a Dockerfile `FROM` must pin a concrete tag.)
 
 Both VZ and Firecracker images embed the kernel needed to boot the VM. For
 VZ, the kernel and initrd are extracted from the Ubuntu
@@ -491,7 +495,7 @@ free, no coding agents are pre-pinned, and your layer sits on top of a
 stable shed-managed base.
 
 ```dockerfile
-FROM ghcr.io/charliek/shed-vz-extensions:v{version}
+FROM ghcr.io/charliek/shed-vz-extensions:vX.Y.Z
 
 USER shed
 ENV PATH="/home/shed/.local/bin:${PATH}"

--- a/docs/tutorials/build-your-own-image.md
+++ b/docs/tutorials/build-your-own-image.md
@@ -295,7 +295,7 @@ shed image pull ghcr.io/myorg/my-shed-image:v2 -t my-image
 
 Existing sheds keep booting from the digest they were created against —
 tag updates don't propagate to running sheds (see
-[Storage Model → Tag updates](../reference/storage-model.md#tag-updates-dont-propagate-to-existing-sheds)).
+[Storage Model → Re-pulling a ref doesn't propagate](../reference/storage-model.md#re-pulling-a-ref-doesnt-propagate-to-existing-sheds)).
 To roll a shed onto the new image, `shed delete devbox` and recreate.
 
 ## See also

--- a/internal/config/mounts.go
+++ b/internal/config/mounts.go
@@ -95,6 +95,21 @@ func BuildProjectMounts(localDir string, addDirs []string) ([]MountConfig, strin
 	return mounts, landing, nil
 }
 
+// ProjectAddDirTargets returns the guest target paths of a shed's --add-dir
+// mounts: every project mount except the --local-dir mount the shed lands in
+// (identified by landingDir). Order is preserved. Returns nil when there are no
+// add-dir mounts (a bare, --repo, or --local-dir-only shed). Used to expose
+// SHED_ADD_DIRS to sessions and provisioning hooks.
+func ProjectAddDirTargets(mounts []MountConfig, landingDir string) []string {
+	var out []string
+	for _, m := range mounts {
+		if m.Target != "" && m.Target != landingDir {
+			out = append(out, m.Target)
+		}
+	}
+	return out
+}
+
 // ResolveCreateLayout computes the project mounts and landing directory for a
 // (already-validated) create request. --repo lands in the cloned repository
 // directory (no project mounts); --local-dir/--add-dir mount under the home

--- a/internal/config/mounts_test.go
+++ b/internal/config/mounts_test.go
@@ -278,3 +278,43 @@ func TestServerConfigMountsCredentialsFallback(t *testing.T) {
 		}
 	})
 }
+
+func TestProjectAddDirTargets(t *testing.T) {
+	tests := []struct {
+		name    string
+		mounts  []MountConfig
+		landing string
+		want    []string
+	}{
+		{name: "nil mounts (bare or --repo)", mounts: nil, landing: HomePath, want: nil},
+		{
+			name:    "--local-dir only has no add-dirs",
+			mounts:  []MountConfig{{Target: HomePath + "/proj"}},
+			landing: HomePath + "/proj",
+			want:    nil,
+		},
+		{
+			name: "--add-dirs are every mount but the landing one, in order",
+			mounts: []MountConfig{
+				{Target: HomePath + "/proj"}, // --local-dir (landing)
+				{Target: HomePath + "/sibling"},
+				{Target: HomePath + "/other"},
+			},
+			landing: HomePath + "/proj",
+			want:    []string{HomePath + "/sibling", HomePath + "/other"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ProjectAddDirTargets(tt.mounts, tt.landing)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ProjectAddDirTargets() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("index %d: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/firecracker/orchestrator.go
+++ b/internal/firecracker/orchestrator.go
@@ -447,6 +447,7 @@ func (b *fcCreator) RunProvisioning(ctx context.Context, req config.CreateShedRe
 	agent := b.c.newAgentClient(meta.Name)
 	provisioner := vmutil.NewProvisioner(agent, req.Name)
 	provisioner.SetWorkDir(meta.LandingDir)
+	provisioner.SetAddDirs(config.ProjectAddDirTargets(meta.ProjectMounts, meta.LandingDir))
 	provisioner.SetOutput(os.Stdout, os.Stderr)
 	cfg, err := provisioner.LoadConfig(ctx)
 	if err != nil {
@@ -625,6 +626,7 @@ func (b *fcStarter) RunStartupHook(ctx context.Context, metaRaw orchestrator.Met
 	agent := b.c.newAgentClient(meta.Name)
 	provisioner := vmutil.NewProvisioner(agent, meta.Name)
 	provisioner.SetWorkDir(meta.LandingDir)
+	provisioner.SetAddDirs(config.ProjectAddDirTargets(meta.ProjectMounts, meta.LandingDir))
 	provisioner.SetOutput(os.Stdout, os.Stderr)
 	cfg, err := provisioner.LoadConfig(ctx)
 	if err != nil {

--- a/internal/provision/config.go
+++ b/internal/provision/config.go
@@ -19,6 +19,9 @@ const (
 	EnvShedContainer = "SHED_CONTAINER"
 	EnvShedName      = "SHED_NAME"
 	EnvShedWorkspace = "SHED_WORKSPACE"
+	// EnvShedAddDirs is a colon-separated list of the guest paths of any
+	// --add-dir mounts (empty/unset when there are none).
+	EnvShedAddDirs = "SHED_ADD_DIRS"
 )
 
 // Log file paths in the container/VM.

--- a/internal/sshd/session.go
+++ b/internal/sshd/session.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/gliderlabs/ssh"
 
 	"github.com/charliek/shed/internal/backend"
 	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/provision"
 	"github.com/charliek/shed/internal/vmutil"
 )
 
@@ -173,6 +175,11 @@ func (s *Server) execInContainer(ctx context.Context, sess ssh.Session, shed *co
 	// Add shed name for shell prompt customization
 	env = append(env, fmt.Sprintf("SHED_NAME=%s", shed.Name))
 
+	// Project-directory context, mirroring the provisioning-hook env so
+	// `shed exec` / interactive logins see the same SHED_WORKSPACE (the landing
+	// dir) and SHED_ADD_DIRS (any --add-dir mounts) the install/startup hooks do.
+	env = append(env, projectSessionEnv(shed)...)
+
 	// Create resize channel for window changes.
 	resizeChan := make(chan backend.TerminalSize, 10)
 	defer close(resizeChan)
@@ -211,6 +218,22 @@ func (s *Server) execInContainer(ctx context.Context, sess ssh.Session, shed *co
 	log.Printf("Executing in shed %s: tty=%v cmd=%v", shed.Name, isPTY, cmd)
 
 	return s.backend.Exec(ctx, shed.Name, opts)
+}
+
+// projectSessionEnv returns the SHED_WORKSPACE / SHED_ADD_DIRS variables for a
+// session (`shed exec` + interactive logins), mirroring the provisioning-hook
+// env. SHED_WORKSPACE is the shed's landing directory; SHED_ADD_DIRS is the
+// colon-joined list of --add-dir mount targets. Each is omitted when not
+// applicable (e.g. an older shed with no landing dir, or no add-dir mounts).
+func projectSessionEnv(shed *config.Shed) []string {
+	var env []string
+	if shed.LandingDir != "" {
+		env = append(env, fmt.Sprintf("%s=%s", provision.EnvShedWorkspace, shed.LandingDir))
+	}
+	if dirs := config.ProjectAddDirTargets(shed.ProjectMounts, shed.LandingDir); len(dirs) > 0 {
+		env = append(env, fmt.Sprintf("%s=%s", provision.EnvShedAddDirs, strings.Join(dirs, ":")))
+	}
+	return env
 }
 
 // handleWindowResize forwards window resize events from SSH to the resize channel.

--- a/internal/sshd/session_test.go
+++ b/internal/sshd/session_test.go
@@ -1,0 +1,62 @@
+package sshd
+
+import (
+	"testing"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+func TestProjectSessionEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		shed *config.Shed
+		want []string
+	}{
+		{
+			name: "older shed without a landing dir gets no project vars",
+			shed: &config.Shed{},
+			want: nil,
+		},
+		{
+			name: "bare shed lands in home",
+			shed: &config.Shed{LandingDir: config.HomePath},
+			want: []string{"SHED_WORKSPACE=" + config.HomePath},
+		},
+		{
+			name: "--local-dir / --repo sets workspace only",
+			shed: &config.Shed{
+				LandingDir:    config.HomePath + "/proj",
+				ProjectMounts: []config.MountConfig{{Target: config.HomePath + "/proj"}},
+			},
+			want: []string{"SHED_WORKSPACE=" + config.HomePath + "/proj"},
+		},
+		{
+			name: "--local-dir + --add-dir sets workspace + colon-joined add-dirs",
+			shed: &config.Shed{
+				LandingDir: config.HomePath + "/proj",
+				ProjectMounts: []config.MountConfig{
+					{Target: config.HomePath + "/proj"}, // --local-dir (landing)
+					{Target: config.HomePath + "/sibling"},
+					{Target: config.HomePath + "/ref"},
+				},
+			},
+			want: []string{
+				"SHED_WORKSPACE=" + config.HomePath + "/proj",
+				"SHED_ADD_DIRS=" + config.HomePath + "/sibling:" + config.HomePath + "/ref",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := projectSessionEnv(tt.shed)
+			if len(got) != len(tt.want) {
+				t.Fatalf("projectSessionEnv() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("index %d: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/vmutil/provisioning.go
+++ b/internal/vmutil/provisioning.go
@@ -23,6 +23,7 @@ type Provisioner struct {
 	agent    *AgentClient
 	shedName string
 	workDir  string
+	addDirs  []string
 	output   io.Writer
 	errOut   io.Writer
 }
@@ -47,6 +48,12 @@ func (p *Provisioner) SetWorkDir(dir string) {
 	if dir != "" {
 		p.workDir = dir
 	}
+}
+
+// SetAddDirs records the guest target paths of any --add-dir mounts so hooks
+// see them via SHED_ADD_DIRS (colon-separated), matching the session env.
+func (p *Provisioner) SetAddDirs(dirs []string) {
+	p.addDirs = dirs
 }
 
 // SetOutput sets the output writers for streaming hook output.
@@ -322,13 +329,16 @@ func (p *Provisioner) ensureLogDir(ctx context.Context) error {
 
 // buildEnv builds the environment variables list for hook execution.
 func (p *Provisioner) buildEnv(cfg *provision.Config) []string {
-	env := make([]string, 0, len(cfg.Env)+3)
+	env := make([]string, 0, len(cfg.Env)+4)
 
 	env = append(env,
 		fmt.Sprintf("%s=true", provision.EnvShedContainer),
 		fmt.Sprintf("%s=%s", provision.EnvShedName, p.shedName),
 		fmt.Sprintf("%s=%s", provision.EnvShedWorkspace, p.workDir),
 	)
+	if len(p.addDirs) > 0 {
+		env = append(env, fmt.Sprintf("%s=%s", provision.EnvShedAddDirs, strings.Join(p.addDirs, ":")))
+	}
 
 	for key, value := range cfg.Env {
 		env = append(env, fmt.Sprintf("%s=%s", key, value))

--- a/internal/vmutil/provisioning_env_test.go
+++ b/internal/vmutil/provisioning_env_test.go
@@ -1,0 +1,36 @@
+package vmutil
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/charliek/shed/internal/provision"
+)
+
+func TestBuildEnvProjectVars(t *testing.T) {
+	t.Run("workspace + add-dirs", func(t *testing.T) {
+		p := &Provisioner{shedName: "demo", workDir: "/home/shed/proj"}
+		p.SetAddDirs([]string{"/home/shed/sibling", "/home/shed/ref"})
+		env := p.buildEnv(&provision.Config{})
+		for _, want := range []string{
+			"SHED_CONTAINER=true",
+			"SHED_NAME=demo",
+			"SHED_WORKSPACE=/home/shed/proj",
+			"SHED_ADD_DIRS=/home/shed/sibling:/home/shed/ref",
+		} {
+			if !slices.Contains(env, want) {
+				t.Errorf("buildEnv() missing %q; got %v", want, env)
+			}
+		}
+	})
+
+	t.Run("no add-dirs omits SHED_ADD_DIRS", func(t *testing.T) {
+		p := &Provisioner{shedName: "bare", workDir: "/home/shed"}
+		for _, e := range p.buildEnv(&provision.Config{}) {
+			if strings.HasPrefix(e, "SHED_ADD_DIRS=") {
+				t.Errorf("expected no SHED_ADD_DIRS without add-dirs; got %q", e)
+			}
+		}
+	})
+}

--- a/internal/vz/orchestrator.go
+++ b/internal/vz/orchestrator.go
@@ -419,6 +419,7 @@ func (b *vzCreator) RunProvisioning(ctx context.Context, req config.CreateShedRe
 	agent := b.c.newAgentClient(meta.Name)
 	provisioner := vmutil.NewProvisioner(agent, req.Name)
 	provisioner.SetWorkDir(meta.LandingDir)
+	provisioner.SetAddDirs(config.ProjectAddDirTargets(meta.ProjectMounts, meta.LandingDir))
 	provisioner.SetOutput(os.Stdout, os.Stderr)
 	cfg, err := provisioner.LoadConfig(ctx)
 	if err != nil {
@@ -599,6 +600,7 @@ func (b *vzStarter) RunStartupHook(ctx context.Context, metaRaw orchestrator.Met
 	agent := b.c.newAgentClient(meta.Name)
 	provisioner := vmutil.NewProvisioner(agent, meta.Name)
 	provisioner.SetWorkDir(meta.LandingDir)
+	provisioner.SetAddDirs(config.ProjectAddDirTargets(meta.ProjectMounts, meta.LandingDir))
 	provisioner.SetOutput(os.Stdout, os.Stderr)
 	cfg, err := provisioner.LoadConfig(ctx)
 	if err != nil {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,9 +89,12 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started:
-      - Quick Start: getting-started/quick-start.md
-      - VZ Setup (macOS): getting-started/vz-setup.md
-      - Firecracker Setup: getting-started/fc-setup.md
+      - Overview: getting-started/quick-start.md
+      - macOS Quickstart: getting-started/macos-quickstart.md
+      - Linux Quickstart: getting-started/linux-quickstart.md
+      - Developer Setup:
+          - macOS (VZ): getting-started/vz-setup.md
+          - Firecracker (Linux): getting-started/fc-setup.md
       - Upgrades:
           - v0.4 → v0.5: upgrades/v0.4-to-v0.5.md
           - v0.5.1 → v0.5.2: upgrades/v0.5.1-to-v0.5.2.md


### PR DESCRIPTION
Three related work-streams, one PR (per request).

## WS1 — `SHED_WORKSPACE` + `SHED_ADD_DIRS` session env vars

`shed exec` and interactive logins already land in the project directory; this also **exports** it:
- `SHED_WORKSPACE` = the landing dir (`--local-dir`/`--repo` project dir, or `/home/shed`).
- `SHED_ADD_DIRS` = colon-joined guest paths of any `--add-dir` mounts.

Mirrors the provisioning-hook env (hooks now get `SHED_ADD_DIRS` too). Shared `config.ProjectAddDirTargets` helper used by both `internal/sshd` (sessions) and `internal/vmutil` (hooks, wired via `Provisioner.SetAddDirs` in the vz/fc orchestrators). Unit tests added.

**Live-validated** on a dev-build shed created with `--local-dir ~/projects/sltemplate --add-dir ~/projects/slauthclient`:
```
PWD=/home/shed/sltemplate
SHED_WORKSPACE=/home/shed/sltemplate
SHED_ADD_DIRS=/home/shed/slauthclient
```

## WS2 — `${shed.version}` docs

The only token shed expands is `${shed.version}`; the docs showed `v{version}` as if it were a literal. Fixed `configuration.md` (config context → `${shed.version}`) and `images.md` (published tags / Dockerfile `FROM` → concrete `:vX.Y.Z`; the token is shed-config only). Added an **"Image references and `${shed.version}`"** section: optional fields, synthesized-from-version default, token for custom/mirror refs, and *why* it's version-coupled (base images bundle the version-locked shed-agent + shed-extensions). README's embedded config (the other offender) is removed in WS3.

## WS3 — quickstarts, dev guides, README, nav

Two-tier getting-started — opinionated **Quickstarts** vs deeper **Developer Setup**:
- New **[macOS Quickstart]** (Homebrew `shed` + `shed-host-agent` + the shed-desktop approval app; verified `server.yaml` + `extensions.yaml` templates with config-reference links; DMG install + Preferences).
- New **[Linux Quickstart]** (apt `shed-server` + `sudo shed-server setup`; host-agent + GUI noted as roadmap, Linux-as-remote-host is the tested path).
- `vz-setup.md` / `fc-setup.md` re-scoped to **Developer Setup**; `quick-start.md` → router + platform-agnostic command reference; `mkdocs.yml` nav grouped.
- `cli.md` documents the new env vars under `shed exec`.
- **README slimmed** to overview + links (drops embedded install/config/CLI dumps).

## Validation

- `go build ./...` (darwin) + `GOOS=linux go build` (FC), `go vet`, `golangci-lint`: clean; new unit tests pass.
- `mkdocs build --strict`: passes; new pages/nav/links resolve. (Two pre-existing anchor INFO notes in `testing.md` / `build-your-own-image.md` are unrelated and left for a separate cleanup.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README condensed to a high-level overview with platform quickstart links.
  * Added comprehensive Linux and macOS quickstart guides; revised Getting Started and developer-setup pages and nav.
  * Clarified image reference/version token behavior and updated CLI environment docs and developer testing notes.

* **New Features**
  * Shell/SSH sessions now expose SHED_WORKSPACE and SHED_ADD_DIRS for project context.
  * Provisioning and startup hooks receive configured add-dir targets via an environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->