### PR TITLE
chore(deps): bump shed-extensions to v0.4.0

### DIFF
--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -24,7 +24,7 @@
 
 # Bump this when shed-extensions releases a new version.
 # The extensions and full variants pull binaries from this tag.
-ARG SHED_EXT_VERSION=v0.3.7
+ARG SHED_EXT_VERSION=v0.4.0
 FROM ghcr.io/charliek/shed-extensions:${SHED_EXT_VERSION} AS shed-extensions
 
 # Note: the shed initramfs (overlay-on-the-guest init) is built from

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -24,7 +24,7 @@
 
 # Bump this when shed-extensions releases a new version.
 # The extensions and full variants pull binaries from this tag.
-ARG SHED_EXT_VERSION=v0.3.7
+ARG SHED_EXT_VERSION=v0.4.0
 FROM ghcr.io/charliek/shed-extensions:${SHED_EXT_VERSION} AS shed-extensions
 
 # Note: the shed initramfs (overlay-on-the-guest init) is built from


### PR DESCRIPTION
## Summary

Bumps the bundled shed-extensions guest binaries from **v0.3.7 → v0.4.0** in both rootfs Dockerfiles (`vz/Dockerfile`, `firecracker/Dockerfile`, the `extensions`/`full` variants).

What v0.4.0 brings:
- Always-on, fixed-path credential sockets + **live-only `shed-host-agent status`** (it now queries the running daemon and reports the config it loaded — closes the host-agent #29 confusion).
- Opt-in **AWS passthrough mode** for SSO/SAML environments.

## Scope

Host-side change only — the guest binaries' interface (`shed-ext-ssh-agent`, `shed-ext-aws-credentials`, `docker-credential-shed`) is unchanged, so no other shed changes are required. shed-desktop also needs no change (it already connects to the fixed socket path).

The multi-arch image `ghcr.io/charliek/shed-extensions:v0.4.0` (linux/amd64 + arm64) is published and verified pullable.

This pairs with the already-merged quickstart docs update (#195), which documents the always-on approval channel and bare `shed-host-agent status`.

## Test plan

- CI builds the `extensions`/`full` rootfs images, which pull `:v0.4.0` via `COPY --from=` — green CI confirms the new image resolves and layers correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
