### PR TITLE
chore(deps): bump shed-extensions to v0.4.1

### DIFF
--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -24,7 +24,7 @@
 
 # Bump this when shed-extensions releases a new version.
 # The extensions and full variants pull binaries from this tag.
-ARG SHED_EXT_VERSION=v0.4.0
+ARG SHED_EXT_VERSION=v0.4.1
 FROM ghcr.io/charliek/shed-extensions:${SHED_EXT_VERSION} AS shed-extensions
 
 # Note: the shed initramfs (overlay-on-the-guest init) is built from

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -24,7 +24,7 @@
 
 # Bump this when shed-extensions releases a new version.
 # The extensions and full variants pull binaries from this tag.
-ARG SHED_EXT_VERSION=v0.4.0
+ARG SHED_EXT_VERSION=v0.4.1
 FROM ghcr.io/charliek/shed-extensions:${SHED_EXT_VERSION} AS shed-extensions
 
 # Note: the shed initramfs (overlay-on-the-guest init) is built from


### PR DESCRIPTION
Bumps `SHED_EXT_VERSION` v0.4.0 → v0.4.1 in both Dockerfiles so the image build pulls the released host-agent (pinned-TLS + scoped-token support). Guest binaries are unchanged from v0.4.0; this keeps shed's pinned extensions version aligned with the released host-agent ahead of the v0.7.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)