### PR TITLE
fix(net): auto-detect guest MTU for VPN/reduced-MTU paths (#196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Guest MTU auto-detection for VPNs / reduced-MTU paths (#196)
+
+Behind a VPN (or any host path with an MTU below 1500), full-size guest packets
+were silently black-holed — `docker pull` failed with a TLS handshake timeout
+even though `curl` to the same registry worked, because dockerd's larger
+ClientHello exceeded the path MTU. shed-server now **detects the host's egress
+path MTU when a shed starts** and lowers the guest's primary interface to match
+(passed via a `shed.mtu=` kernel arg). On a normal 1500 path nothing changes, so
+there is no penalty for the common no-VPN case.
+
+- **Both backends** lower the guest MTU; on VZ an MSS-clamp rule additionally
+  fixes Docker *container* egress behind a reduced-MTU path. (The Firecracker
+  container-egress clamp is a fast-follow — its custom kernel lacks the
+  `xt_TCPMSS` target.)
+- New optional `vz.guest_mtu` / `firecracker.guest_mtu` config field (`0` =
+  auto-detect; set `1280`–`1500` to pin a value when detection misses).
+- Detection runs at VM start: toggling a VPN under a running shed needs
+  `shed restart <name>` to re-detect.
+- **Requires a rebuilt rootfs image** (the guest-side change ships in the image)
+  — published with this release.
+
 ## v0.7.0 — 2026-06-13
 
 Optional, default-off authentication and transport encryption so a shed server

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -331,6 +331,7 @@ from the server version.
 | `notify_port` | int | `1026` | Vsock port for the message channel (health checks, plugins) |
 | `start_timeout` | duration | `30s` | VM startup timeout |
 | `stop_timeout` | duration | `10s` | Graceful shutdown timeout |
+| `guest_mtu` | int | `0` | Guest primary-interface MTU. `0` (default) auto-detects the host egress path MTU at VM start and lowers the guest to match a reduced path (e.g. a VPN/overlay), otherwise leaves it at 1500. Set `1280`–`1500` to pin a value when detection misses. See note below. |
 | `bridge_name` | string | `shed-br0` | Linux bridge name |
 | `bridge_cidr` | string | `172.30.0.1/24` | Bridge network CIDR |
 | `tap_prefix` | string | `shed-tap` | TAP device name prefix |
@@ -397,6 +398,20 @@ vz:
 | `tcp_proxy_port` | int | `1028` | Vsock port for TCP proxy (used by DialService for tunnels and Connect API) |
 | `start_timeout` | duration | `60s` | VM startup timeout |
 | `stop_timeout` | duration | `10s` | Graceful shutdown timeout |
+| `guest_mtu` | int | `0` | Guest primary-interface MTU. `0` (default) auto-detects the host egress path MTU at VM start and lowers the guest to match a reduced path (e.g. a VPN), otherwise leaves it at 1500. Set `1280`–`1500` to pin a value when detection misses. See note below. |
+
+### Guest MTU and VPNs
+
+Behind a VPN (or any path whose MTU is below 1500), full-size guest packets can
+be silently dropped — most visibly, `docker pull` fails with a TLS handshake
+timeout while `curl` to the same registry works. With `guest_mtu: 0` (the
+default), shed-server detects the host's egress path MTU when a shed starts and
+lowers the guest interface to match; on a normal 1500 path nothing changes.
+
+Detection runs **at VM start**, so if you connect or disconnect the VPN while a
+shed is already running, run `shed restart <name>` to re-detect. Set `guest_mtu`
+explicitly only to override detection (for example, to pin a value for a VPN
+whose tunnel interface still reports 1500).
 
 See [VZ Setup](../getting-started/vz-setup.md) for setup details.
 

--- a/firecracker/network-setup.sh
+++ b/firecracker/network-setup.sh
@@ -61,6 +61,20 @@ ip addr add "${IP_ADDR}/24" dev "$INTERFACE" 2>/dev/null || true
 ip link set "$INTERFACE" up
 ip route add default via "$GATEWAY" 2>/dev/null || true
 
+# Lower the guest MTU when shed-server detected a reduced host egress path
+# (e.g. a VPN/overlay on the FC host routing through a <1500 link). shed.mtu=
+# is emitted on the kernel cmdline ONLY in that case (see
+# vmutil.ResolveGuestMTU), so a normal 1500 path leaves the guest unchanged.
+# FC uses a static IP (no systemd-networkd to re-assert the link), so an
+# imperative set sticks. No MSS clamp here: the FC custom kernel lacks the
+# xt_TCPMSS target (tracked as a fast-follow); the MTU-lowering alone fixes
+# dockerd's own registry pulls. Bounds mirror config.MinGuestMTU/MaxGuestMTU.
+SHED_MTU=$(grep -oP 'shed\.mtu=\K[0-9]+' /proc/cmdline 2>/dev/null || true)
+if [ -n "$SHED_MTU" ] && [ "$SHED_MTU" -ge 1280 ] && [ "$SHED_MTU" -le 1500 ] && [ -n "$INTERFACE" ]; then
+    echo "Applying guest MTU $SHED_MTU to $INTERFACE (reduced host egress path)"
+    ip link set "$INTERFACE" mtu "$SHED_MTU" || true
+fi
+
 # Configure DNS
 echo "nameserver $DNS" > /etc/resolv.conf
 

--- a/internal/config/guest_mtu_test.go
+++ b/internal/config/guest_mtu_test.go
@@ -1,0 +1,57 @@
+package config
+
+import "testing"
+
+func TestVZConfigGuestMTUValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		mtu     int
+		wantErr bool
+	}{
+		{"zero is auto-detect", 0, false},
+		{"floor", MinGuestMTU, false},
+		{"in range", 1400, false},
+		{"ceiling", MaxGuestMTU, false},
+		{"below floor rejected", MinGuestMTU - 1, true},
+		{"above ceiling rejected", MaxGuestMTU + 1, true},
+		{"jumbo rejected", 9000, true},
+		{"negative rejected", -1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultVZConfig()
+			cfg.GuestMTU = tt.mtu
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("guest_mtu=%d: Validate() err = %v, wantErr = %v", tt.mtu, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFirecrackerConfigGuestMTUValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		mtu     int
+		wantErr bool
+	}{
+		{"zero is auto-detect", 0, false},
+		{"floor", MinGuestMTU, false},
+		{"in range", 1400, false},
+		{"ceiling", MaxGuestMTU, false},
+		{"below floor rejected", MinGuestMTU - 1, true},
+		{"above ceiling rejected", MaxGuestMTU + 1, true},
+		{"jumbo rejected", 9000, true},
+		{"negative rejected", -1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultFirecrackerConfig()
+			cfg.GuestMTU = tt.mtu
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("guest_mtu=%d: Validate() err = %v, wantErr = %v", tt.mtu, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -447,6 +447,14 @@ type FirecrackerConfig struct {
 	// StopTimeout is the timeout for graceful VM shutdown
 	StopTimeout Duration `yaml:"stop_timeout"`
 
+	// GuestMTU, when non-zero, forces the guest's primary interface MTU
+	// instead of auto-detecting the host's egress path MTU at VM start.
+	// 0 (the default) means auto-detect: behind a reduced-MTU path (e.g. a
+	// VPN/overlay) the guest is lowered to match; otherwise it stays at
+	// 1500. Set this only to pin a value when detection misses. Validated to
+	// [MinGuestMTU, MaxGuestMTU] when non-zero.
+	GuestMTU int `yaml:"guest_mtu,omitempty"`
+
 	// BridgeName is the name of the Linux bridge for VM networking
 	BridgeName string `yaml:"bridge_name"`
 
@@ -533,6 +541,14 @@ type VZConfig struct {
 
 	// StopTimeout is the timeout for graceful VM shutdown
 	StopTimeout Duration `yaml:"stop_timeout"`
+
+	// GuestMTU, when non-zero, forces the guest's primary interface MTU
+	// instead of auto-detecting the host's egress path MTU at VM start.
+	// 0 (the default) means auto-detect: behind a reduced-MTU path (e.g. a
+	// VPN/overlay) the guest is lowered to match; otherwise it stays at
+	// 1500. Set this only to pin a value when detection misses. Validated to
+	// [MinGuestMTU, MaxGuestMTU] when non-zero.
+	GuestMTU int `yaml:"guest_mtu,omitempty"`
 }
 
 // GetDefaultImage implements vmimage.ImageConfig.
@@ -844,6 +860,12 @@ func (c *VZConfig) Validate() error {
 		}
 	}
 
+	// guest_mtu: 0 means auto-detect; an explicit override must be a value
+	// the host vmnet path can actually carry.
+	if c.GuestMTU != 0 && (c.GuestMTU < MinGuestMTU || c.GuestMTU > MaxGuestMTU) {
+		return fmt.Errorf("vz: guest_mtu must be 0 (auto-detect) or in [%d, %d]", MinGuestMTU, MaxGuestMTU)
+	}
+
 	if c.UpperSizeDefault != "" {
 		if _, err := ParseUpperSize(c.UpperSizeDefault); err != nil {
 			return fmt.Errorf("vz: upper_size_default: %w", err)
@@ -1016,6 +1038,14 @@ const (
 	MaxVsockPort           uint32 = 65535
 	MinTimeout                    = 1 * time.Second
 	MaxTimeout                    = 30 * time.Minute
+
+	// Guest-MTU bounds, shared by the auto-detection clamp
+	// (vmutil.ClampGuestMTU) and the guest_mtu override validation on both
+	// backends. Floor is the IPv6 minimum link MTU (RFC 8200) — guaranteed
+	// routable on any path; ceiling is the host vmnet/TAP MTU, above which a
+	// guest packet would itself black-hole.
+	MinGuestMTU = 1280
+	MaxGuestMTU = 1500
 )
 
 // DefaultVZImagesDir is the default directory for VZ rootfs images.
@@ -1821,6 +1851,12 @@ func (c *FirecrackerConfig) Validate() error {
 		if stopTimeout > MaxTimeout {
 			return fmt.Errorf("stop_timeout must be at most %s", MaxTimeout)
 		}
+	}
+
+	// guest_mtu: 0 means auto-detect; an explicit override must be a value
+	// the host TAP/bridge path can actually carry.
+	if c.GuestMTU != 0 && (c.GuestMTU < MinGuestMTU || c.GuestMTU > MaxGuestMTU) {
+		return fmt.Errorf("guest_mtu must be 0 (auto-detect) or in [%d, %d]", MinGuestMTU, MaxGuestMTU)
 	}
 
 	// Defer kernel/rootfs path validation when every configured source

--- a/internal/firecracker/vm.go
+++ b/internal/firecracker/vm.go
@@ -129,6 +129,13 @@ func (vm *VM) Start(ctx context.Context) error {
 		vm.meta.IPAddress, vm.netMgr.Gateway(), netmask, vm.meta.Name,
 	)
 
+	// Pass the resolved guest MTU so network-setup lowers eth0 to match a
+	// reduced host egress path (e.g. a VPN/overlay on the FC host). Omitted
+	// entirely when detection finds no reduction and no override is set.
+	if mtu, ok := vmutil.ResolveGuestMTU(vm.cfg.GuestMTU); ok {
+		kernelArgs += fmt.Sprintf(" shed.mtu=%d", mtu)
+	}
+
 	drives := []models.Drive{
 		// Upper (writable). The initramfs runs mkfs.ext4 on first
 		// boot when no FS signature is present.

--- a/internal/vmutil/mtu.go
+++ b/internal/vmutil/mtu.go
@@ -1,0 +1,150 @@
+package vmutil
+
+import (
+	"log"
+	"net"
+	"strings"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+// mtuDetectTarget is the destination used to discover which host interface
+// (and therefore which MTU) egress traffic to the public internet would take.
+// No packet is ever sent — Dial on a UDP "connection" only triggers a kernel
+// route lookup so a local address is bound. Centralized as a single constant so
+// a future `mtu_detection_target` config knob (some corporate networks
+// special-route or block Cloudflare) is a one-line change.
+const mtuDetectTarget = "1.1.1.1:80"
+
+// ResolveGuestMTU decides the MTU to hand the guest's primary interface at VM
+// start. It returns (mtu, true) when a value should be applied via the
+// `shed.mtu=` kernel cmdline, or (0, false) to leave the guest at its default
+// (1500) and emit no cmdline arg.
+//
+// Order of precedence:
+//  1. An explicit override (already validated to [MinGuestMTU, MaxGuestMTU] by
+//     config) wins — detection is skipped.
+//  2. Otherwise auto-detect the host egress path MTU and apply it only when it
+//     is below 1500 (i.e. a reduced-MTU path such as a VPN/overlay).
+//  3. On any detection failure, or when the path is already >= 1500, return
+//     (0, false): identical to today's behavior, so there is no regression.
+//
+// The decision path is logged because VPN/MTU failures are otherwise hard to
+// diagnose from the outside.
+func ResolveGuestMTU(override int) (int, bool) {
+	return resolveGuestMTU(override, DetectEgressMTU)
+}
+
+// resolveGuestMTU is the testable core of ResolveGuestMTU with the detector
+// injected.
+func resolveGuestMTU(override int, detect func() (int, bool)) (int, bool) {
+	if override > 0 {
+		log.Printf("guest MTU: using configured override guest_mtu=%d", override)
+		return override, true
+	}
+	detected, ok := detect()
+	if !ok {
+		log.Printf("guest MTU: host egress MTU not detected; leaving guest at default (%d)", config.MaxGuestMTU)
+		return 0, false
+	}
+	if detected >= config.MaxGuestMTU {
+		log.Printf("guest MTU: host egress MTU=%d (>= %d); leaving guest at default", detected, config.MaxGuestMTU)
+		return 0, false
+	}
+	clamped := ClampGuestMTU(detected)
+	log.Printf("guest MTU: detected reduced host egress MTU=%d; lowering guest to %d", detected, clamped)
+	return clamped, true
+}
+
+// ClampGuestMTU clamps an auto-detected MTU into the supportable
+// [MinGuestMTU, MaxGuestMTU] range. The floor guards against an absurdly small
+// tunnel; the ceiling guards against ever raising the guest above the host
+// vmnet/TAP MTU.
+func ClampGuestMTU(mtu int) int {
+	return max(config.MinGuestMTU, min(config.MaxGuestMTU, mtu))
+}
+
+// ifaceInfo is the address/MTU view of one host interface. It exists so the
+// address-matching logic (egressMTUForAddr) is pure and unit-testable: the
+// real net.Interface.Addrs() is a syscall that can't be faked, so DetectEgressMTU
+// snapshots it into these structs first.
+type ifaceInfo struct {
+	name  string
+	mtu   int
+	addrs []net.IP
+}
+
+// DetectEgressMTU reports the MTU of the host interface that egress traffic to
+// the public internet would use, and whether detection succeeded. It opens a
+// connected — but never written-to — UDP socket to learn the kernel-selected
+// local address, then maps that address back to its interface. Read-only: no
+// packet is sent.
+func DetectEgressMTU() (int, bool) {
+	conn, err := net.Dial("udp", mtuDetectTarget)
+	if err != nil {
+		return 0, false
+	}
+	defer conn.Close()
+
+	udpAddr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok || udpAddr == nil {
+		return 0, false
+	}
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return 0, false
+	}
+
+	infos := make([]ifaceInfo, 0, len(ifaces))
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		ips := make([]net.IP, 0, len(addrs))
+		for _, a := range addrs {
+			switch v := a.(type) {
+			case *net.IPNet:
+				ips = append(ips, v.IP)
+			case *net.IPAddr:
+				ips = append(ips, v.IP)
+			}
+		}
+		infos = append(infos, ifaceInfo{name: iface.Name, mtu: iface.MTU, addrs: ips})
+	}
+
+	return egressMTUForAddr(udpAddr.IP, infos)
+}
+
+// egressMTUForAddr finds the interface that owns localIP and returns its MTU.
+// Pure (no syscalls) for testability. Returns (0, false) when localIP is
+// loopback/unspecified, when it belongs only to a shed-managed bridge/tap, when
+// no interface owns it, or when the owning interface reports a non-positive MTU.
+func egressMTUForAddr(localIP net.IP, ifaces []ifaceInfo) (int, bool) {
+	if localIP == nil || localIP.IsLoopback() || localIP.IsUnspecified() {
+		return 0, false
+	}
+	for _, iface := range ifaces {
+		if isShedManagedIface(iface.name) {
+			continue
+		}
+		for _, ip := range iface.addrs {
+			if ip != nil && ip.Equal(localIP) {
+				if iface.mtu <= 0 {
+					return 0, false
+				}
+				return iface.mtu, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// isShedManagedIface reports whether name is one of shed's own VM-facing
+// devices (the Firecracker bridge `shed-br0` and `shed-tap*` devices). Internet
+// egress never routes through these, so matching one means the host routing
+// table is unusual — skip it rather than read its bridge MTU.
+func isShedManagedIface(name string) bool {
+	return strings.HasPrefix(name, "shed-")
+}

--- a/internal/vmutil/mtu_test.go
+++ b/internal/vmutil/mtu_test.go
@@ -1,0 +1,102 @@
+package vmutil
+
+import (
+	"net"
+	"testing"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+func TestClampGuestMTU(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"below floor", 900, config.MinGuestMTU},
+		{"at floor", config.MinGuestMTU, config.MinGuestMTU},
+		{"in range", 1400, 1400},
+		{"at ceiling", config.MaxGuestMTU, config.MaxGuestMTU},
+		{"above ceiling", 9000, config.MaxGuestMTU},
+		{"zero", 0, config.MinGuestMTU},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClampGuestMTU(tt.in); got != tt.want {
+				t.Errorf("ClampGuestMTU(%d) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveGuestMTU(t *testing.T) {
+	detect := func(mtu int, ok bool) func() (int, bool) {
+		return func() (int, bool) { return mtu, ok }
+	}
+	tests := []struct {
+		name     string
+		override int
+		detect   func() (int, bool)
+		wantMTU  int
+		wantOK   bool
+	}{
+		{"override wins, skips detection", 1400, detect(0, false), 1400, true},
+		{"override below 1500 trusted as-is", 1300, detect(1450, true), 1300, true},
+		{"detect reduced -> clamped", 0, detect(1400, true), 1400, true},
+		{"detect tiny -> clamped to floor", 0, detect(900, true), config.MinGuestMTU, true},
+		{"detect 1500 -> none", 0, detect(1500, true), 0, false},
+		{"detect above 1500 -> none", 0, detect(9000, true), 0, false},
+		{"detection fails -> none", 0, detect(0, false), 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMTU, gotOK := resolveGuestMTU(tt.override, tt.detect)
+			if gotMTU != tt.wantMTU || gotOK != tt.wantOK {
+				t.Errorf("resolveGuestMTU(%d) = (%d, %v), want (%d, %v)",
+					tt.override, gotMTU, gotOK, tt.wantMTU, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestEgressMTUForAddr(t *testing.T) {
+	ip := func(s string) net.IP { return net.ParseIP(s) }
+	ifaces := []ifaceInfo{
+		{name: "lo0", mtu: 16384, addrs: []net.IP{ip("127.0.0.1")}},
+		{name: "en0", mtu: 1500, addrs: []net.IP{ip("192.168.1.20"), ip("fe80::1")}},
+		{name: "utun4", mtu: 1400, addrs: []net.IP{ip("10.8.0.2")}},
+		{name: "shed-br0", mtu: 1500, addrs: []net.IP{ip("172.30.0.1")}},
+	}
+
+	tests := []struct {
+		name    string
+		local   net.IP
+		wantMTU int
+		wantOK  bool
+	}{
+		{"matches en0 (no VPN)", ip("192.168.1.20"), 1500, true},
+		{"matches utun4 (VPN)", ip("10.8.0.2"), 1400, true},
+		{"matches en0 v6 alias", ip("fe80::1"), 1500, true},
+		{"loopback rejected", ip("127.0.0.1"), 0, false},
+		{"unspecified rejected", ip("0.0.0.0"), 0, false},
+		{"nil rejected", nil, 0, false},
+		{"shed-managed iface skipped", ip("172.30.0.1"), 0, false},
+		{"no owning interface", ip("203.0.113.5"), 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMTU, gotOK := egressMTUForAddr(tt.local, ifaces)
+			if gotMTU != tt.wantMTU || gotOK != tt.wantOK {
+				t.Errorf("egressMTUForAddr(%v) = (%d, %v), want (%d, %v)",
+					tt.local, gotMTU, gotOK, tt.wantMTU, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestEgressMTUForAddrNonPositiveMTU(t *testing.T) {
+	ifaces := []ifaceInfo{{name: "weird0", mtu: 0, addrs: []net.IP{net.ParseIP("192.0.2.7")}}}
+	if mtu, ok := egressMTUForAddr(net.ParseIP("192.0.2.7"), ifaces); ok || mtu != 0 {
+		t.Errorf("egressMTUForAddr with mtu=0 = (%d, %v), want (0, false)", mtu, ok)
+	}
+}

--- a/internal/vz/vm.go
+++ b/internal/vz/vm.go
@@ -178,6 +178,13 @@ func (vm *VM) buildVfkitArgs() (args []string, err error) {
 		vm.meta.Name,
 	)
 
+	// Pass the resolved guest MTU so network-setup lowers enp0s1 to match a
+	// reduced host egress path (e.g. a VPN). Omitted entirely when detection
+	// finds no reduction and no override is set — the guest stays at 1500.
+	if mtu, ok := vmutil.ResolveGuestMTU(vm.cfg.GuestMTU); ok {
+		kernelArgs += fmt.Sprintf(" shed.mtu=%d", mtu)
+	}
+
 	// Console log for debugging boot issues (writes guest console to a file)
 	consoleLogPath := filepath.Join(vm.cfg.InstanceDir, vm.meta.Name, "console.log")
 

--- a/internal/vz/vm_test.go
+++ b/internal/vz/vm_test.go
@@ -344,6 +344,36 @@ func TestBuildVfkitArgsKernelCmdline(t *testing.T) {
 	if !strings.Contains(argsStr, "shed.name=test-vm") {
 		t.Errorf("expected shed.name=test-vm in kernel cmdline (read by shed-firstboot for identity regen), got: %s", argsStr)
 	}
+	// With no guest_mtu override and auto-detection of the host egress MTU,
+	// shed.mtu= must be omitted on a normal (1500) path — never shed.mtu=0.
+	if strings.Contains(argsStr, "shed.mtu=0") {
+		t.Errorf("shed.mtu=0 must never be emitted, got: %s", argsStr)
+	}
+}
+
+// TestBuildVfkitArgsGuestMTUOverride exercises the shed.mtu= cmdline wiring
+// deterministically via the guest_mtu override (which short-circuits host
+// detection), independent of whatever MTU the test host's egress interface has.
+func TestBuildVfkitArgsGuestMTUOverride(t *testing.T) {
+	imagesDir, digest := setupBlobForTest(t)
+	meta := &Metadata{Name: "test-vm", CPUs: 2, MemoryMB: 4096, RootfsPath: "/tmp/rootfs.ext4", LowerDigest: digest}
+	cfg := &config.VZConfig{
+		ImagesDir:    imagesDir,
+		SocketDir:    "/tmp/sockets",
+		ConsolePort:  1024,
+		NotifyPort:   1026,
+		TCPProxyPort: 1028,
+		GuestMTU:     1400,
+	}
+
+	vm := &VM{meta: meta, cfg: cfg}
+	args, err := vm.buildVfkitArgs()
+	if err != nil {
+		t.Fatalf("buildVfkitArgs: %v", err)
+	}
+	if argsStr := strings.Join(args, " "); !strings.Contains(argsStr, "shed.mtu=1400") {
+		t.Errorf("expected shed.mtu=1400 in kernel cmdline with guest_mtu override, got: %s", argsStr)
+	}
 }
 
 func TestCleanupSockets(t *testing.T) {

--- a/tests/integration/test_guest_mtu.py
+++ b/tests/integration/test_guest_mtu.py
@@ -1,0 +1,64 @@
+"""Guest-MTU auto-detection tests (issue #196).
+
+Parameterized over `["vz", "fc"]` via the `shed_server` fixture. The core
+assertion is an *internal consistency* invariant that holds on any host —
+behind a VPN or not — and on both backends:
+
+    - The guest's primary-interface MTU is always within [1280, 1500].
+    - `shed.mtu=` is passed on the guest cmdline IFF shed-server detected a
+      reduced host egress path (or a `guest_mtu` override is set); when present,
+      the guest interface MTU equals that value (detection -> cmdline ->
+      guest-apply round-trips), and `shed.mtu=0` is never emitted.
+    - When absent (the common no-VPN path), the guest stays at 1500 — i.e. the
+      change is invisible on a normal path (the "worst-case == today" guarantee).
+
+Run under `make test-integration-dev` to exercise the new shed-server binary.
+The reduced-MTU behavior itself (guest lowered to match + the VZ MSS clamp) is
+validated separately by the simulated-reduced-MTU / real-VPN steps in the PR,
+which need a <1500 host path the CI host does not have.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+
+def _guest_default_iface(shed_server, name: str) -> str:
+    r = shed_server.exec(name, ["bash", "-lc", "ip route show default | awk '{print $5; exit}'"])
+    assert r.returncode == 0, f"resolving default iface failed: {r.stdout!r} {r.stderr!r}"
+    iface = r.stdout.strip()
+    assert iface, f"no default-route interface in guest: {r.stdout!r} {r.stderr!r}"
+    return iface
+
+
+def test_guest_mtu_consistency(shed_server, test_shed_name):
+    shed_server.create(test_shed_name, image="base")
+
+    iface = _guest_default_iface(shed_server, test_shed_name)
+
+    mtu_r = shed_server.exec(test_shed_name, ["cat", f"/sys/class/net/{iface}/mtu"])
+    assert mtu_r.returncode == 0, f"reading guest MTU failed: {mtu_r.stdout!r} {mtu_r.stderr!r}"
+    guest_mtu = int(mtu_r.stdout.strip())
+
+    cmdline_r = shed_server.exec(test_shed_name, ["cat", "/proc/cmdline"])
+    assert cmdline_r.returncode == 0, (
+        f"reading /proc/cmdline failed: {cmdline_r.stdout!r} {cmdline_r.stderr!r}"
+    )
+    cmdline = cmdline_r.stdout
+
+    assert "shed.mtu=0" not in cmdline, f"shed.mtu=0 must never be emitted: {cmdline!r}"
+    assert 1280 <= guest_mtu <= 1500, f"guest MTU {guest_mtu} outside [1280, 1500]"
+
+    m = re.search(r"shed\.mtu=(\d+)", cmdline)
+    if m:
+        passed = int(m.group(1))
+        assert 1280 <= passed <= 1500, f"passed shed.mtu={passed} outside [1280, 1500]"
+        assert guest_mtu == passed, (
+            f"guest MTU {guest_mtu} does not match passed shed.mtu={passed}"
+        )
+    else:
+        assert guest_mtu == 1500, (
+            f"no shed.mtu= passed (normal 1500 path) but guest MTU is {guest_mtu}, expected 1500"
+        )

--- a/vz/network-setup.sh
+++ b/vz/network-setup.sh
@@ -35,6 +35,32 @@ elif [ -z "$IP_ADDR" ]; then
     echo "WARNING: No IPv4 address assigned via DHCP on $INTERFACE"
 fi
 
+# Lower the guest MTU when shed-server detected a reduced host egress path
+# (e.g. a VPN routing the vfkit subnet through a <1500 tunnel). shed.mtu= is
+# emitted on the kernel cmdline ONLY in that case (see vmutil.ResolveGuestMTU),
+# so a normal 1500 path leaves this block dormant and the guest unchanged.
+# Bounds mirror config.MinGuestMTU/MaxGuestMTU (1280/1500).
+SHED_MTU=$(grep -oP 'shed\.mtu=\K[0-9]+' /proc/cmdline 2>/dev/null || true)
+if [ -n "$SHED_MTU" ] && [ "$SHED_MTU" -ge 1280 ] && [ "$SHED_MTU" -le 1500 ] && [ -n "$INTERFACE" ]; then
+    echo "Applying guest MTU $SHED_MTU to $INTERFACE (reduced host egress path)"
+    # Immediate effect for this boot...
+    ip link set "$INTERFACE" mtu "$SHED_MTU" || true
+    # ...plus a systemd-networkd drop-in so the value survives a DHCP renew
+    # (networkd would otherwise re-assert the link default on reconfigure).
+    mkdir -p /run/systemd/network/80-dhcp.network.d
+    printf '[Link]\nMTUBytes=%s\n' "$SHED_MTU" > /run/systemd/network/80-dhcp.network.d/10-shed-mtu.conf
+    networkctl reload 2>/dev/null || true
+    # MSS-clamp forwarded Docker container egress to the now-lowered route PMTU
+    # so container TLS handshakes don't black-hole behind the VPN. Guarded on
+    # iptables (only the `full` image ships it) and idempotent. Works with both
+    # iptables-legacy and iptables-nft.
+    if command -v iptables >/dev/null 2>&1; then
+        iptables -t mangle -C FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu 2>/dev/null \
+            || iptables -t mangle -A FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu 2>/dev/null \
+            || echo "WARNING: failed to install MSS clamp rule"
+    fi
+fi
+
 # Ensure /etc/resolv.conf points to systemd-resolved stub.
 # Docker overwrites resolv.conf during image build, so we restore the symlink.
 if [ ! -L /etc/resolv.conf ] || [ "$(readlink /etc/resolv.conf)" != "../run/systemd/resolve/stub-resolv.conf" ]; then


### PR DESCRIPTION
## Summary

Fixes #196. Behind a VPN (or any host path with MTU < 1500), full-size guest packets were silently **black-holed** — `docker pull` failed with a `TLS handshake timeout` while `curl` to the same registry worked, because dockerd's larger ClientHello exceeded the path MTU and PMTU discovery never recovered (the VPN drops the ICMP "fragmentation needed" replies).

shed-server now **detects the host's egress path MTU at VM start** and lowers the guest's primary interface to match (passed via a `shed.mtu=` kernel arg). On a normal 1500 path **nothing changes** — no `shed.mtu=` is emitted and the guest stays at 1500 — so there is **no penalty for the common no-VPN case** (worst case == today's behavior).

## Approach

- **Detection (`internal/vmutil/mtu.go`):** a connected-UDP probe to `1.1.1.1:80` (no packet sent — pure kernel route lookup) finds the egress interface and reads its MTU. Pure `egressMTUForAddr` is unit-tested; the dial shim isn't. `ResolveGuestMTU` ladder: explicit `guest_mtu` override wins → else detect and apply only if `< 1500` → else emit nothing.
- **Plumbing:** `shed.mtu=` appended to the kernel cmdline in `internal/vz/vm.go` and `internal/firecracker/vm.go` (mirrors the existing `shed.name=` convention). Never emits `shed.mtu=0`.
- **Guest apply (`*/network-setup.sh`):** parse `shed.mtu=`, lower the interface — **VZ** via a systemd-networkd `MTUBytes=` drop-in (survives DHCP renew) + immediate `ip link set`; **FC** imperative `ip link set` (static IP, no networkd). On **VZ** an idempotent `mangle FORWARD` `TCPMSS --clamp-mss-to-pmtu` rule fixes forwarded Docker **container** egress (guarded by `command -v iptables`).
- **Config:** optional `vz.guest_mtu` / `firecracker.guest_mtu` override (`0` = auto-detect; validated to `[1280, 1500]`).

**Scope note — FC container-egress clamp is deferred** (fast-follow): the FC custom kernel lacks the `xt_TCPMSS` target, so the clamp would fail at runtime there. The MTU-lowering (which fixes the reported `docker pull` symptom) ships on **both** backends; only VZ gets the clamp this PR.

## Validation

- `make test` (unit: detection ladder, clamp, egress-match, config validation, cmdline assembly), `make lint` (0 issues), `make build` + Linux-FC cross-compile — all green. `shellcheck`/`bash -n` clean.
- **Live end-to-end on VZ** against the parallel dev server (rebuilt rootfs at this branch): server emits `shed.mtu=1400` → guest `enp0s1` comes up at **1400** with the networkd `MTUBytes=1400` drop-in present; on a 1500 host no `shed.mtu=` is emitted and the guest stays 1500.
- Guest-script commands (parse → bounds → `ip link set mtu` → idempotent `TCPMSS` clamp) validated on `iptables-nft`.
- Integration test `tests/integration/test_guest_mtu.py` (vz/fc) asserts the consistency invariant; passes in both no-VPN and forced-reduced-MTU modes against the dev binary.
- Reviewed: `/simplify` (4-agent quality pass) + CodeRabbit (no Critical/Warning). *(Codex review was unavailable this session.)*
- **Not run here (recommended):** live FC parity needs a remote image rebuild on a workload host; real-VPN acceptance is the author's `shed exec t -- docker pull hello-world` behind the corporate VPN.

## Release / follow-ups

- Guest-side change ships in the rootfs image → effective once a new image is **built and published** with this release.
- Follow-up tickets to file: **FC container-egress clamp** (add `CONFIG_NETFILTER_XT_TARGET_TCPMSS` + FC kernel rebuild) and the **gvproxy / userspace-netstack** option (permanent VPN robustness + a per-shed egress-policy choke point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)