### PR TITLE
feat(auth): collapse auth surface — secure is TLS-only, https⟺secure (v0.7.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+Auth-surface simplification: the `auth.mode: open | secure` headline is
+unchanged, but the intermediate states beneath it are removed so two invariants
+always hold — **tokens ⟺ TLS ⟺ secure** and **https ⟺ secure**. **Breaking** (a
+`0.7.x` patch; the auth interface is still settling) — but most LAN / Tailscale
+deployments, and plain `auth.mode: secure` + `github_users` configs, are
+unaffected.
+
+### Changed
+
+- **Secure mode is now TLS-only.** It no longer serves a plain-HTTP listener
+  (not even on loopback) — only the pinned-TLS `https_port` listener faces
+  clients. On-box tooling uses the HTTPS endpoint; `shed server add` against a
+  secure server needs `--https-port`. A loopback credential-bus channel remains
+  available only via the explicit, opt-in `internal_http_port` (unchanged).
+
+### Removed (rejected at startup)
+
+- **`auth.http.mode`** (and the whole `auth.http` block) — HTTP token
+  enforcement now derives purely from `auth.mode: secure`.
+- **`https_port` under `auth.mode: open`** — `https_port` requires secure mode
+  (this is what lets a client treat an `https` `api_url` as proof of secure).
+- **`auth.ssh.mode: enforce` under `auth.mode: open`** — use `secure`, or `warn`
+  to stage an allowlist on a trusted network.
+- An explicit **`auth.ssh.mode: off`/`warn` under `auth.mode: secure`** — secure
+  forces `enforce`.
+
+See [Upgrading v0.7.1 → v0.7.2](docs/upgrades/v0.7.1-to-v0.7.2.md).
+
 ## v0.7.1 — 2026-06-15
 
 Secure-by-default authentication that makes a public-VPS shed server safe to

--- a/cmd/shed-server/serve.go
+++ b/cmd/shed-server/serve.go
@@ -104,7 +104,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	log.Printf("Starting shed-server...")
-	log.Printf("HTTP listen: %s", cfg.HTTPListenAddr())
+	if cfg.PlainHTTPEnabled() {
+		log.Printf("HTTP listen: %s", cfg.HTTPListenAddr())
+	}
 	log.Printf("SSH listen: %s", cfg.SSHListenAddr())
 
 	// Initialize plugin system (before backends, since backends use the bridge)
@@ -252,7 +254,14 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// the internal-listener split is enabled, it omits the credential bus +
 	// Connect tunnel.
 	publicHandler := apiServer.Router()
-	httpServer := newHTTPServer(cfg.HTTPListenAddr(), publicHandler)
+
+	// Plain-HTTP listener. In secure mode it is not started — only the pinned-TLS
+	// (https_port) listener faces clients (TLS-only). The internal loopback
+	// listener below is a separate listener and is unaffected.
+	var httpServer *http.Server
+	if cfg.PlainHTTPEnabled() {
+		httpServer = newHTTPServer(cfg.HTTPListenAddr(), publicHandler)
+	}
 
 	// Optional internal (loopback) listener carrying the credential bus +
 	// Connect tunnel, kept off the public interface.
@@ -293,13 +302,15 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// Channel to collect errors from servers (HTTP, HTTPS, SSH, internal HTTP).
 	errChan := make(chan error, 4)
 
-	// Start HTTP server in goroutine
-	go func() {
-		log.Printf("HTTP server listening on %s", httpServer.Addr)
-		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			errChan <- fmt.Errorf("HTTP server error: %w", err)
-		}
-	}()
+	// Start HTTP server in goroutine (skipped in secure mode — TLS-only)
+	if httpServer != nil {
+		go func() {
+			log.Printf("HTTP server listening on %s", httpServer.Addr)
+			if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				errChan <- fmt.Errorf("HTTP server error: %w", err)
+			}
+		}()
+	}
 
 	// Start internal HTTP server in goroutine (when split enabled)
 	if internalServer != nil {
@@ -348,10 +359,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 
-	// Shutdown HTTP server
-	log.Printf("Shutting down HTTP server...")
-	if err := httpServer.Shutdown(ctx); err != nil {
-		log.Printf("HTTP server shutdown error: %v", err)
+	// Shutdown HTTP server (when serving — skipped in secure mode)
+	if httpServer != nil {
+		log.Printf("Shutting down HTTP server...")
+		if err := httpServer.Shutdown(ctx); err != nil {
+			log.Printf("HTTP server shutdown error: %v", err)
+		}
 	}
 
 	// Shutdown internal HTTP server (when enabled)

--- a/cmd/shed/server.go
+++ b/cmd/shed/server.go
@@ -254,6 +254,12 @@ func runServerAdd(cmd *cobra.Command, args []string) error {
 	// Connect and get server info
 	info, err := client.GetInfo()
 	if err != nil {
+		// A secure server serves no plain-HTTP listener, so an unauthenticated
+		// /api/info probe over http fails. Point the operator at --https-port
+		// rather than leaving them with a bare connection error.
+		if serverAddHTTPSPort == 0 {
+			return fmt.Errorf("failed to get server info over plain HTTP: %w\n\nIf this is a secure server, it serves only HTTPS — re-run with --https-port (e.g. --https-port 8443)", err)
+		}
 		return fmt.Errorf("failed to get server info: %w", err)
 	}
 
@@ -288,12 +294,6 @@ func runServerAdd(cmd *cobra.Command, args []string) error {
 		}
 		controlToken = bundle.Token
 		controlTokenExpiresAt = bundle.ExpiresAt
-		// If the operator reached a secure server without --https-port, take the
-		// TLS pin + https port from the bundle (the server returns them).
-		if apiURL == "" && bundle.HTTPSPort > 0 {
-			apiURL = "https://" + net.JoinHostPort(host, strconv.Itoa(bundle.HTTPSPort))
-			tlsFingerprint = bundle.TLSCertFingerprint
-		}
 	}
 
 	// Determine server name

--- a/docs/guides/security-configuration.md
+++ b/docs/guides/security-configuration.md
@@ -1,0 +1,222 @@
+# Security Configuration
+
+shed's network security is two independent choices:
+
+1. **Posture** — `auth.mode: open | secure`. *Open* trusts the network (plain
+   HTTP, no tokens, no TLS). *Secure* trusts nothing (pinned TLS + bearer tokens
+   + an SSH key allowlist), and is **TLS-only** — it serves no plain-HTTP
+   listener at all.
+2. **Where listeners bind** — `http_bind` / `ssh_bind` (and the optional
+   `internal_http_port`). This decides whether the server is reachable only on
+   `127.0.0.1` (this machine) or across the network.
+
+This guide walks the common shapes those two choices produce. For the underlying
+model — the invariants, the credential bus, and the exact connection flow — see
+the [Security reference](../reference/security.md). For a full internet-facing
+walkthrough, see [Public VPS Deployment](vps-deployment.md).
+
+Server settings live in `server.yaml` (`/etc/shed/server.yaml` on Linux,
+`~/.config/shed/server.yaml` or the Homebrew `…/etc/shed/server.yaml` on macOS).
+Client settings are written per server into `~/.shed/config.yaml` by
+`shed server add`.
+
+## Choosing a posture
+
+| Question | If yes |
+|----------|--------|
+| Is everything on **one machine**, and do you want zero auth ceremony? | **Open + loopback** (Case 1) |
+| One machine, but you want TLS + key checking anyway (shared box, or mirror prod locally)? | **Secure + loopback** (Case 2) |
+| Reachable **over the network** / internet-facing? | **Secure, all interfaces** (Case 3) |
+| Network-facing **and** the credential host-agent runs on the same box? | **Secure + `internal_http_port`** (Case 4) |
+
+Two invariants hold across every secure deployment, and explain the startup
+rejections you may hit (see [Troubleshooting](#troubleshooting-startup-rejections)):
+
+- **tokens ⟺ TLS ⟺ secure** — HTTP token enforcement only exists in secure mode,
+  and secure mode is always TLS.
+- **https ⟺ secure** — `https_port` is valid only in secure mode. So a client (or
+  the host-agent) can treat an `https://` `api_url` as proof the server enforces
+  tokens.
+
+---
+
+## Case 1 — Local only, simplest (open + loopback)
+
+**For:** a developer running shed-server and the CLI on the same machine, who
+wants nothing exposed to the LAN and no SSH allowlist / token / TLS ceremony.
+
+`server.yaml`:
+
+```yaml
+auth:
+  mode: open        # the default — may be omitted
+http_bind: 127.0.0.1   # plain-HTTP API reachable only on this machine
+ssh_bind: 127.0.0.1    # SSH (shed sessions) reachable only on this machine
+```
+
+Add the server (plain HTTP — no flags):
+
+```bash
+shed server add localhost
+```
+
+**You get:** plain HTTP + SSH bound to loopback. Nothing reaches the LAN; no
+tokens, no TLS, no key allowlist. **Trade-off:** any local user on the box can
+reach the API — loopback *is* the trust boundary. Right for a single-user laptop.
+
+---
+
+## Case 2 — Local only, hardened (secure + loopback)
+
+**For:** one machine, but you want full TLS and an SSH key allowlist even locally
+— a shared/multi-user host where loopback isn't a sufficient boundary, or to
+mirror a production secure config on your laptop.
+
+`server.yaml`:
+
+```yaml
+auth:
+  mode: secure
+  ssh:
+    authorized_keys:
+      - ssh-ed25519 AAAA…your-key… you@laptop   # the key you SSH/​bootstrap with
+http_bind: 127.0.0.1   # the HTTPS listener binds here → loopback-only TLS
+ssh_bind: 127.0.0.1
+# https_port defaults to 8443 in secure mode
+```
+
+Add the server over TLS (pins the self-signed cert, mints a token over SSH):
+
+```bash
+shed server add localhost --https-port 8443
+```
+
+**You get:** TLS-only on `127.0.0.1:8443`, SSH allowlist enforced, bearer tokens
+enforced — nothing plaintext, nothing on the LAN. **Trade-off:** secure mode
+**requires** an SSH key source, so you must list your key (`authorized_keys`
+here, or `github_users: [you]`); clients pin the cert. More setup than Case 1,
+in exchange for defense-in-depth on the box itself.
+
+---
+
+## Case 3 — Remote, internet-facing (secure, all interfaces)
+
+**For:** a VPS or remote host reachable over the network — only your keys may
+connect, and all traffic is encrypted.
+
+`server.yaml`:
+
+```yaml
+auth:
+  mode: secure
+  ssh:
+    github_users: [charliek]   # only these GitHub keys may SSH in (and mint tokens)
+tls_names:
+  - shed.example.com           # your public hostname / IP (extra cert SANs)
+# http_bind empty → HTTPS binds all interfaces; https_port defaults to 8443
+```
+
+From your laptop:
+
+```bash
+shed server add shed.example.com --https-port 8443
+```
+
+This fetches the cert + SSH host key, shows both fingerprints for confirmation,
+pins them, then mints a token over the `_bootstrap` SSH channel — no token to
+paste. **You get:** HTTPS on all interfaces (`8443`), SSH allowlist, tokens; no
+plaintext anywhere. See [Public VPS Deployment](vps-deployment.md) for the full
+flow, out-of-band fingerprint verification, and rotation.
+
+---
+
+## Case 4 — Remote + co-located host-agent (secure + `internal_http_port`)
+
+**For:** a remote secure server where the credential **host-agent runs on the
+same box**. The credential bus should stay on loopback rather than ride the
+public TLS listener.
+
+`server.yaml`:
+
+```yaml
+auth:
+  mode: secure
+  ssh:
+    github_users: [charliek]
+tls_names: [shed.example.com]
+internal_http_port: 8081   # bus + Connect tunnel move to a loopback-only listener
+```
+
+Clients add the server exactly as in Case 3 (the control plane is unchanged):
+
+```bash
+shed server add shed.example.com --https-port 8443
+```
+
+The co-located host-agent reaches the bus over `http://127.0.0.1:8081` (loopback,
+on-box). **You get:** a public pinned-TLS control plane *plus* an on-box loopback
+bus. **Trade-off (important):** `internal_http_port` also moves the Connect
+tunnel to loopback, so **remote `shed forward` stops working** — use this only
+when the host-agent is on the same machine as shed-server. With it unset (Case 3),
+the bus + tunnel ride the public TLS listener, gated by the `credentials` scope,
+which is what a **remote** host-agent / `shed forward` needs.
+
+---
+
+## Staging the SSH allowlist with `warn` (avoid locking yourself out)
+
+`auth.mode: secure` forces the SSH allowlist to `enforce` — and a wrong or
+incomplete allowlist on a remote host locks you out (recovery means editing
+`server.yaml` from the provider's console). The safe rollout uses `warn` as a
+**pre-flight**, in open mode, before you commit:
+
+```yaml
+auth:
+  mode: open
+  ssh:
+    mode: warn                 # consult the allowlist, LOG would-deny, but still accept
+    github_users: [charliek]
+```
+
+Restart, then watch the log for `would-deny` lines while you (and your CI, and
+the host-agent) connect. Once nothing legitimate is denied, switch to
+`auth.mode: secure` (which forces `enforce`). This is the same pattern as
+SELinux `permissive` or CSP report-only — a dry run that proves the policy before
+it blocks. `warn` is valid only in open mode; secure always enforces.
+
+## Is anything plaintext in secure mode?
+
+No. Secure mode serves **no** plain-HTTP listener — only the pinned-TLS listener
+faces clients, and a client that holds a pin but is handed a non-`https` URL
+fails closed rather than send plaintext. The SSH channel (shed sessions and the
+token mint) is encrypted with the host key pinned in `known_hosts`. The only
+trust-on-first-use moment is `shed server add` showing you the cert fingerprint
+to confirm (or pass `--tls-fingerprint` / `--fingerprint` to verify out-of-band).
+See the [connection-flow table](../reference/security.md#connection-flow-whats-encrypted-where).
+
+The one exception is deliberate and opt-in: `internal_http_port` (Case 4) is a
+loopback-only plaintext listener for a co-located bus. There is no implicit
+plaintext channel.
+
+## Troubleshooting startup rejections
+
+Secure mode refuses to start half-configured, and the simplification removed the
+footgun states — so these configs are **rejected at startup** (the server names
+the gap and exits):
+
+| Message names… | Cause | Fix |
+|----------------|-------|-----|
+| `auth.mode: secure requires … an SSH key source` | secure with no `github_users` / `authorized_keys` / `authorized_keys_file` | Add a key source (Cases 2–4). |
+| `https_port requires auth.mode: secure` | `https_port` set under `open` | Use `secure` (it defaults `https_port` to 8443), or drop `https_port`. |
+| `auth.ssh.mode: enforce requires auth.mode: secure` | enforcing the allowlist without secure | Use `secure`, or `warn` to stage (above). |
+| `auth.mode: secure forces auth.ssh.mode: enforce` | an explicit `off`/`warn` under secure | Remove `auth.ssh.mode` — secure derives `enforce`. |
+| `config key "auth.http" was removed` | a leftover `auth.http` block | Delete it — token enforcement derives from `auth.mode: secure`. |
+
+## Quick reference
+
+| Case | `auth.mode` | `http_bind` | TLS | `shed server add` |
+|------|-------------|-------------|-----|-------------------|
+| 1 — local simple | `open` | `127.0.0.1` | none | `shed server add localhost` |
+| 2 — local hardened | `secure` | `127.0.0.1` | loopback `:8443` | `shed server add localhost --https-port 8443` |
+| 3 — remote | `secure` | (all) | all ifaces `:8443` | `shed server add <host> --https-port 8443` |
+| 4 — remote + co-located agent | `secure` + `internal_http_port` | (all) | all ifaces `:8443` | `shed server add <host> --https-port 8443` |

--- a/docs/guides/vps-deployment.md
+++ b/docs/guides/vps-deployment.md
@@ -8,9 +8,9 @@ credentials token over TLS**.
 The default shed posture is open-on-a-trusted-network (Tailscale/LAN). This
 guide is the opposite end: a hardened, internet-facing server. One switch —
 [`auth.mode: secure`](../reference/security.md#secure-mode) — derives the whole
-hardening bundle (SSH allowlist enforced + HTTP tokens enforced + TLS + loopback
-plain-HTTP) and **refuses to start** if any piece is missing. There are no tokens
-to mint or paste: clients get them automatically over SSH.
+hardening bundle (SSH allowlist enforced + HTTP tokens enforced + TLS-only, with
+no plain-HTTP listener) and **refuses to start** if any piece is missing. There
+are no tokens to mint or paste: clients get them automatically over SSH.
 
 ## 1. Server config
 

--- a/docs/guides/vps-deployment.md
+++ b/docs/guides/vps-deployment.md
@@ -27,9 +27,10 @@ tls_names:
 ```
 
 `secure` mode forces `auth.ssh.mode: enforce`, enforces HTTP bearer tokens, turns
-on pinned TLS (`https_port` defaults to `8443`), and binds the plain-HTTP
-listener to loopback — so the only network-facing API is HTTPS on `8443`, with
-the credential bus and Connect tunnel gated by the `credentials` scope.
+on pinned TLS (`https_port` defaults to `8443`), and serves **no plain-HTTP
+listener** (TLS-only) — so the only API is HTTPS on `8443`, with the credential
+bus and Connect tunnel gated by the `credentials` scope. (`shed server add`
+against a secure server therefore needs `--https-port`, as below.)
 
 Start (or restart) the server. If a required piece is missing it exits
 immediately, naming the gap:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -99,19 +99,24 @@ log_level: info
 ### Authentication mode
 
 `auth.mode` is the headline switch. The default `open` posture is unchanged —
-ideal on a tailnet or trusted LAN — with the per-layer fields below (`auth.ssh`,
-`auth.http`, TLS) staying individually opt-in. `secure` is the internet-facing
-posture: it derives the full bundle and refuses to start without an SSH key
-source. See [Security](security.md) for the model.
+ideal on a tailnet or trusted LAN (plain HTTP, no tokens, no TLS); the SSH
+allowlist (`auth.ssh`) is the one independently-tunable layer there. `secure` is
+the internet-facing posture: it derives the full bundle (SSH enforce + HTTP
+tokens + TLS-only) and refuses to start without an SSH key source. Two invariants
+hold: **tokens ⟺ TLS ⟺ secure** and **https ⟺ secure**. See [Security](security.md)
+and the [Security Configuration guide](../guides/security-configuration.md).
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `auth.mode` | string | `open` | `open` enforces nothing by default; `secure` derives SSH-allowlist enforce + HTTP-token enforce + TLS (`https_port` defaults to `8443`) + a loopback-bound plain-HTTP listener, and **fails to start without a key source**. |
+| `auth.mode` | string | `open` | `open` enforces nothing (plain HTTP only); `secure` derives SSH-allowlist enforce + HTTP-token enforce + TLS-only (`https_port` defaults to `8443`; **no plain-HTTP listener is served**), and **fails to start without a key source**. |
 | `auth.token_ttl` | duration | `24h` | Lifetime of a bootstrap-minted HTTP token. Clients refresh transparently near expiry / on a 401. |
 
 The pre-v0.7.1 `public_exposure` flag and `auth.http.tokens` list are removed and
 **rejected at startup** — set `auth.mode: secure` and let `shed server add` mint
-tokens over SSH. See [Upgrading v0.7.0 → v0.7.1](../upgrades/v0.7.0-to-v0.7.1.md).
+tokens over SSH. As of v0.7.2 the whole `auth.http` block is gone (HTTP
+enforcement derives from `auth.mode: secure`), and `https_port` /
+`auth.ssh.mode: enforce` are valid only in secure mode — see
+[Upgrading v0.7.1 → v0.7.2](../upgrades/v0.7.1-to-v0.7.2.md).
 
 ### SSH authentication
 
@@ -135,17 +140,17 @@ auth:
     github_users: [charliek]  # a key source is required in secure mode
 ```
 
-### HTTP authentication, TLS, and network surface
+### TLS and network surface
 
-These per-layer fields harden the HTTP API. In `open` mode they default to off
-(the trusted-network posture); `auth.mode: secure` turns the bundle on for you.
-See [Security](security.md) for the full model and
-[Public VPS Deployment](../guides/vps-deployment.md) for a walkthrough.
+TLS and network-surface fields. HTTP token enforcement is **not** an independent
+field — it is derived from `auth.mode: secure` (there is no `auth.http` block).
+`secure` turns on TLS for you, and `https_port` is valid only in secure mode. See
+[Security](security.md) and the
+[Security Configuration guide](../guides/security-configuration.md).
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `auth.http.mode` | string | `off` | Advanced per-layer override: `off` accepts all requests, `enforce` requires a valid bearer token (except the bootstrap endpoints `GET /api/info` and `GET /api/ssh-host-key`). `auth.mode: secure` forces `enforce`. Tokens are minted over SSH by `shed server add` — there is no static token list. |
-| `https_port` | int | - | Serve HTTPS on this port (in addition to `http_port`) with a self-signed, client-pinned cert. |
+| `https_port` | int | `8443` in secure | Serve HTTPS with a self-signed, client-pinned cert. **Requires `auth.mode: secure`** (rejected in open mode); defaults to `8443` there. In secure mode this is the *only* listener — no plain HTTP is served. |
 | `tls_names` | list | `[]` | Extra hostnames/IPs added as cert SANs. `localhost`, `127.0.0.1`, `::1` are always included. |
 | `tls_cert_file` / `tls_key_file` | string | next to host key | Override where the TLS cert + key are persisted. |
 | `http_bind` / `ssh_bind` | string | all interfaces | Restrict a listener to one interface (e.g. `127.0.0.1`, a tailnet IP). |

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -154,7 +154,7 @@ exactly the trust model SSH host keys use. `auth.mode: secure` turns this on by
 default (`https_port` defaults to `8443`).
 
 ```yaml
-https_port: 8443                 # serve HTTPS here (in addition to http_port)
+https_port: 8443                 # the pinned-TLS listener (secure mode serves HTTPS only)
 tls_names:                       # extra SANs so hostname verification passes
   - shed.example.com
   - 203.0.113.10

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -9,17 +9,19 @@ auth:
 
 - **`open`** (the default) is the right posture on a private network — a
   Tailscale tailnet or a trusted LAN — where the network is the security
-  boundary. No SSH key allowlist, no HTTP token, no TLS is required; each
-  hardening layer below is still available, opt-in and independent.
+  boundary. It serves plain HTTP only: no HTTP token, no TLS. The SSH allowlist
+  is the one independently-tunable layer here (`auth.ssh.mode: off|warn`, where
+  `warn` stages an allowlist before you commit to enforcing it).
 - **`secure`** is for an internet-facing deployment. It derives the whole
-  hardening bundle (SSH allowlist enforced + HTTP tokens enforced + TLS +
-  loopback plain-HTTP) and **refuses to start** without an SSH key source, so a
-  server is never half-hardened on a public address.
+  hardening bundle (SSH allowlist enforced + HTTP tokens enforced + TLS-only,
+  with no plain-HTTP listener) and **refuses to start** without an SSH key
+  source, so a server is never half-hardened on a public address. Two invariants
+  hold: **tokens ⟺ TLS ⟺ secure** and **https ⟺ secure**.
 
 | `auth.mode` | SSH allowlist | HTTP tokens | Plain-HTTP listener | TLS |
 |-------------|---------------|-------------|---------------------|-----|
-| `open` | as configured (`auth.ssh`, default off) | off | as configured (`http_bind`) | optional (`https_port`) |
-| `secure` | **forced `enforce`** (needs a key source) | **enforced** | **forced loopback** | **on** (`https_port` defaults to 8443) |
+| `open` | as configured (`auth.ssh`: `off`/`warn`) | off | all interfaces (`http_bind`) | none (`https_port` requires `secure`) |
+| `secure` | **forced `enforce`** (needs a key source) | **enforced** | **none — TLS-only** | **on** (`https_port` defaults to 8443) |
 
 All server settings live in the server config (`/etc/shed/server.yaml` on
 Linux, `~/.config/shed/server.yaml` on macOS). Client settings live per server
@@ -178,16 +180,16 @@ Rotating an existing pin in a non-interactive session requires
 
 ## Network surface
 
-By default both listeners bind all interfaces on a single HTTP listener. These
-knobs shape what is reachable where; `auth.mode: secure` forces the plain-HTTP
-listener to loopback regardless of `http_bind`.
+In open mode both listeners bind all interfaces on a single plain-HTTP listener.
+In `secure` mode there is **no plain-HTTP listener at all** — only the pinned-TLS
+(`https_port`) listener faces clients. These knobs shape what is reachable where:
 
 | Field | Effect |
 |-------|--------|
-| `http_bind` | Interface for the plain-HTTP listener (e.g. `127.0.0.1`, a tailnet IP). Empty = all interfaces. Forced to loopback in `secure` mode. |
+| `http_bind` | Interface for the plain-HTTP listener (e.g. `127.0.0.1`, a tailnet IP). Empty = all interfaces. **Not served in `secure` mode** (TLS-only). |
 | `ssh_bind` | Interface for the SSH listener. |
-| `https_port` | When set, an HTTPS listener (shares `http_bind`) serving the same control plane over pinned TLS. On by default in `secure` mode. |
-| `internal_http_port` | When > 0, moves the credential bus (`/api/plugins/*`) **and the Connect tunnel** to a loopback-only internal listener; the public listener omits them. |
+| `https_port` | An HTTPS listener (shares `http_bind`) serving the control plane over pinned TLS. **Requires `secure` mode**; defaults to `8443` there. |
+| `internal_http_port` | When > 0, moves the credential bus (`/api/plugins/*`) **and the Connect tunnel** to an opt-in loopback-only internal listener; the public listener omits them. This is the one loopback channel available in secure mode. |
 | `trusted_proxy` | Trust `X-Forwarded-For` (only safe behind a proxy that overwrites it). Default false uses the real TCP peer, so a source IP can't be forged to evade per-IP controls. |
 
 ### Route matrix
@@ -206,6 +208,22 @@ Where the bus and Connect tunnel are reachable depends on `internal_http_port`:
     co-located with shed-server. For remote access, leave `internal_http_port`
     unset — HTTP-enforce already gates the bus and tunnel by the `credentials`
     scope.
+
+## Connection flow — what's encrypted where
+
+| Hop | open mode | secure mode |
+|-----|-----------|-------------|
+| Control-plane / bus HTTP | plain `http://` (the network is the trust boundary) | pinned `https://` only — a client that holds a pin but is given a non-`https` URL **fails closed** rather than sending plaintext |
+| SSH (shed sessions + the `_bootstrap` token mint) | encrypted; host key pinned in `known_hosts` | same |
+| Token mint | n/a (no tokens) | over the pinned-host-key SSH `_bootstrap` channel |
+
+In secure mode **nothing plaintext faces the network**: there is no plain-HTTP
+listener at all (see [Network surface](#network-surface)), and the only
+trust-on-first-use moment is `shed server add` fetching the cert to show you its
+fingerprint for confirmation (or pass `--tls-fingerprint` / `--fingerprint` to
+verify out-of-band). After that, every byte travels over pinned TLS or
+pinned-host-key SSH — the flow never depends on an unverified or plaintext
+response.
 
 ## Credential bus
 
@@ -253,7 +271,7 @@ What `secure` derives:
 | `auth.ssh.mode: enforce` | Only allowlisted keys may SSH in — and that allowlist is what mints/revokes HTTP tokens. **Requires** a key source (`github_users`, `authorized_keys`, or `authorized_keys_file`), else startup fails. |
 | HTTP auth enforced | Every HTTP request needs a bearer token; the credential bus is gated by the `credentials` scope. |
 | `https_port: 8443` | The network-facing API is pinned TLS. |
-| plain-HTTP → loopback | The plain-HTTP listener is forced to loopback regardless of `http_bind`, so only the TLS listener (and the loopback internal bus, if configured) face the network — no public plaintext path. |
+| no plain-HTTP listener | Secure mode serves **no** plain-HTTP listener at all (not even on loopback) — only the pinned-TLS listener faces clients. On-box tooling uses the HTTPS endpoint; a loopback credential-bus channel is available only via the explicit, opt-in `internal_http_port`. |
 
 The whole flow is hands-off: enable `secure`, list your `github_users`, and a
 client runs one `shed server add` to pin TLS and mint its token. See the
@@ -273,6 +291,22 @@ exits) so an old config can't silently weaken a deployment:
 | client `credentials_token` | The host-agent mints its own `credentials` token. |
 
 See [Upgrading v0.7.0 → v0.7.1](../upgrades/v0.7.0-to-v0.7.1.md) for the migration.
+
+### Removed/changed in v0.7.2
+
+v0.7.2 collapses the intermediate states beneath `auth.mode` so that
+`tokens ⟺ TLS ⟺ secure` and `https ⟺ secure` always hold. These are **rejected
+at startup**:
+
+| Removed / invalid | Replacement |
+|-------------------|-------------|
+| `auth.http.mode` (the whole `auth.http` block) | HTTP enforcement derives from `auth.mode: secure`. |
+| `https_port` under `auth.mode: open` | Use `secure` (defaults `https_port` to 8443), or drop it. |
+| `auth.ssh.mode: enforce` under `open` | Use `secure`, or `warn` to stage. |
+| `auth.ssh.mode: off`/`warn` under `secure` | Remove it — secure forces `enforce`. |
+
+Plus a behavior change: **secure mode no longer serves a loopback plain-HTTP
+listener** (TLS-only). See [Upgrading v0.7.1 → v0.7.2](../upgrades/v0.7.1-to-v0.7.2.md).
 
 ## Deferred
 

--- a/docs/upgrades/v0.7.1-to-v0.7.2.md
+++ b/docs/upgrades/v0.7.1-to-v0.7.2.md
@@ -1,0 +1,77 @@
+# Upgrade Guide: v0.7.1 to v0.7.2
+
+v0.7.2 **simplifies** the v0.7.1 auth surface to a clean binary posture. The headline
+`auth.mode: open | secure` is unchanged; what changes is that the intermediate,
+footgun-prone states beneath it are removed so that two invariants now always hold:
+
+- **tokens ⟺ TLS ⟺ secure** — HTTP bearer-token enforcement is derived purely from
+  `auth.mode: secure` (the standalone `auth.http.mode` knob is gone).
+- **https ⟺ secure** — `https_port` is valid only in secure mode, and secure mode is
+  **TLS-only** (it no longer serves a plain-HTTP listener at all, not even on loopback).
+
+!!! note "A breaking patch"
+    Like v0.7.1, this is a `0.7.x` patch that carries **breaking config changes** — the
+    auth interface is still settling in the `0.7` line. **Most users are unaffected:** the
+    default is `auth.mode: open`, byte-for-byte the trusted-network posture, and a plain
+    `auth.mode: secure` + `github_users` config keeps working unchanged. The changes below
+    only affect configs that used the now-removed intermediate states.
+
+## What changed
+
+- **`auth.http.mode` is removed.** HTTP token enforcement is no longer an independent
+  knob — it is on iff `auth.mode: secure`. "Tokens enforced over plaintext" is no longer
+  representable.
+- **`https_port` requires `auth.mode: secure`.** An open-mode server serves plain HTTP
+  only; setting `https_port` without `secure` is rejected at startup. This is what lets a
+  client (or the host-agent) treat an `https` `api_url` as proof the server enforces
+  tokens.
+- **`auth.ssh.mode: enforce` requires `auth.mode: secure`.** Restricting SSH while leaving
+  the HTTP API open is no longer a supported posture. Use `auth.ssh.mode: warn` to stage
+  an allowlist on a trusted network (the SSH-allowlist **pre-flight**), then switch to
+  `secure` (which forces `enforce`). An explicit `auth.ssh.mode: off|warn` *under* secure
+  is rejected (secure derives `enforce` itself).
+- **Secure mode is TLS-only.** It no longer serves a loopback plain-HTTP listener. Only
+  the pinned-TLS (`https_port`, default `8443`) listener faces clients. On-box tooling and
+  health probes must use the HTTPS endpoint; `shed server add` against a secure server
+  requires `--https-port`.
+
+## Breaking: removed/invalid config now hard-fails
+
+These are **rejected at startup** in v0.7.2 — the server names the gap and exits. **Edit
+your server config before upgrading** an affected host, or it will fail to restart:
+
+| v0.7.1 (now removed / invalid) | v0.7.2 replacement |
+|---|---|
+| `auth.http.mode: enforce` (and the whole `auth.http` block) | Remove it — enforcement derives from `auth.mode: secure`. |
+| `https_port` under `auth.mode: open` | Use `auth.mode: secure` (it defaults `https_port` to `8443`), or drop `https_port`. |
+| `auth.ssh.mode: enforce` under `auth.mode: open` | Use `auth.mode: secure`, or `warn` to stage. |
+| `auth.ssh.mode: off | warn` under `auth.mode: secure` | Remove it — secure forces `enforce`. |
+
+## Migrating
+
+Most secure deployments need **no change** — a config like this is already correct:
+
+```yaml
+auth:
+  mode: secure
+  ssh:
+    github_users: [charliek]
+tls_names: [shed.example.com]
+```
+
+If you had set `auth.http.mode`, an open-mode `https_port`, or an open-mode
+`auth.ssh.mode: enforce`, delete those keys per the table above. Clients are unaffected:
+`shed server add … --https-port 8443` and the auto-minted, auto-refreshing tokens work
+exactly as in v0.7.1.
+
+### On-box access in secure mode
+
+Because secure mode is now TLS-only, anything that previously reached the API over plain
+`http://localhost:<http_port>` (health probes, scripts) must use
+`https://localhost:<https_port>` with the pinned cert. A co-located credential-bus
+listener over loopback remains available **only** via the explicit, opt-in
+`internal_http_port` (unchanged) — there is no implicit plaintext channel.
+
+See **[Security](../reference/security.md)** for the full model and the connection-flow
+breakdown, and **[Public VPS Deployment](../guides/vps-deployment.md)** for the end-to-end
+secure flow.

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -7,9 +7,9 @@ import (
 	"github.com/charliek/shed/internal/authtoken"
 )
 
-// authMiddleware enforces bearer-token auth when auth.http.mode == enforce.
-// When auth is off (the default), it is a pass-through, so existing
-// deployments are unaffected.
+// authMiddleware enforces bearer-token auth in secure mode (auth.mode: secure).
+// In open mode (the default) it is a pass-through, so existing deployments are
+// unaffected.
 //
 // Exemptions: the bootstrap endpoints GET /api/info and GET /api/ssh-host-key
 // are always reachable without a token, so `shed server add` can fetch server

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -10,10 +10,11 @@ import (
 	"github.com/charliek/shed/internal/config"
 )
 
-// authTestServer builds a server in the given http-auth mode whose token store
-// holds one control and one credentials token; it returns those plaintext
-// tokens for the table to exercise.
-func authTestServer(t *testing.T, mode string) (s *Server, control, credentials string) {
+// authTestServer builds a server whose HTTP auth enforcement matches secure
+// (secure mode enforces bearer tokens; open mode is pass-through). Its token
+// store holds one control and one credentials token, returned as plaintext for
+// the table to exercise.
+func authTestServer(t *testing.T, secure bool) (s *Server, control, credentials string) {
 	t.Helper()
 	store := authtoken.NewStore()
 	control, _, err := store.Mint("SHA256:test", authtoken.ScopeControl, authtoken.ClientCLI, time.Hour)
@@ -24,8 +25,12 @@ func authTestServer(t *testing.T, mode string) (s *Server, control, credentials 
 	if err != nil {
 		t.Fatalf("mint credentials: %v", err)
 	}
+	mode := config.AuthModeOpen
+	if secure {
+		mode = config.AuthModeSecure
+	}
 	s = &Server{
-		cfg:    &config.ServerConfig{Auth: &config.AuthConfig{HTTP: &config.HTTPAuthConfig{Mode: mode}}},
+		cfg:    &config.ServerConfig{Auth: &config.AuthConfig{Mode: mode}},
 		tokens: store,
 	}
 	return s, control, credentials
@@ -45,7 +50,7 @@ func doAuth(s *Server, method, path, token string) int {
 }
 
 func TestAuthMiddlewareEnforce(t *testing.T) {
-	s, ctl, cred := authTestServer(t, config.HTTPAuthEnforce)
+	s, ctl, cred := authTestServer(t, true)
 	tests := []struct {
 		name, method, path, token string
 		want                      int
@@ -72,7 +77,7 @@ func TestAuthMiddlewareEnforce(t *testing.T) {
 }
 
 func TestAuthMiddlewareOffIsPassthrough(t *testing.T) {
-	s, _, _ := authTestServer(t, config.HTTPAuthOff)
+	s, _, _ := authTestServer(t, false)
 	if got := doAuth(s, "GET", "/api/sheds", ""); got != 200 {
 		t.Errorf("off mode should pass through, got %d", got)
 	}
@@ -92,7 +97,7 @@ func TestAuthMiddlewareExpiredToken(t *testing.T) {
 	}
 	time.Sleep(time.Millisecond)
 	s := &Server{
-		cfg:    &config.ServerConfig{Auth: &config.AuthConfig{HTTP: &config.HTTPAuthConfig{Mode: config.HTTPAuthEnforce}}},
+		cfg:    &config.ServerConfig{Auth: &config.AuthConfig{Mode: config.AuthModeSecure}},
 		tokens: store,
 	}
 	if got := doAuth(s, "GET", "/api/sheds", tok); got != 401 {

--- a/internal/api/plugin_handlers_test.go
+++ b/internal/api/plugin_handlers_test.go
@@ -234,7 +234,7 @@ func TestHandlePluginRespondOwnershipEnforced(t *testing.T) {
 		t.Fatal(err)
 	}
 	srv.tokens = store
-	srv.cfg.Auth = &config.AuthConfig{HTTP: &config.HTTPAuthConfig{Mode: config.HTTPAuthEnforce}}
+	srv.cfg.Auth = &config.AuthConfig{Mode: config.AuthModeSecure}
 	srv.plugins.EnableOwnershipTracking() // a server with HTTP auth enforced does this
 	srv.bridge.RegisterShed("dev", &plugin.ShedConn{
 		Name: "dev",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -19,7 +19,7 @@ type Server struct {
 	plugins     *plugin.Registry
 	bridge      *plugin.Bridge
 	egressAudit *egress.AuditLog // nil when egress is disabled
-	tokens      *authtoken.Store // nil until SetTokenStore; consulted only when auth.http.mode=enforce
+	tokens      *authtoken.Store // nil until SetTokenStore; consulted only in secure mode (auth.mode: secure)
 }
 
 // SetEgressAudit attaches the durable egress audit log so `shed egress show`

--- a/internal/config/auth_mode_test.go
+++ b/internal/config/auth_mode_test.go
@@ -92,13 +92,20 @@ func TestPreflightSecure(t *testing.T) {
 func TestPlainHTTPEnabled(t *testing.T) {
 	// Secure mode is TLS-only: the plain-HTTP listener is not served (only the
 	// pinned-TLS listener faces clients). Open mode serves plain HTTP.
-	secure := &ServerConfig{HTTPPort: 8080, Auth: &AuthConfig{Mode: AuthModeSecure}}
-	if secure.PlainHTTPEnabled() {
-		t.Error("secure mode should not serve the plain-HTTP listener")
+	tests := []struct {
+		name string
+		cfg  ServerConfig
+		want bool
+	}{
+		{"open serves plain HTTP", ServerConfig{HTTPPort: 8080}, true},
+		{"secure is TLS-only", ServerConfig{HTTPPort: 8080, Auth: &AuthConfig{Mode: AuthModeSecure}}, false},
 	}
-	open := &ServerConfig{HTTPPort: 8080}
-	if !open.PlainHTTPEnabled() {
-		t.Error("open mode should serve the plain-HTTP listener")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.PlainHTTPEnabled(); got != tt.want {
+				t.Errorf("PlainHTTPEnabled() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/config/auth_mode_test.go
+++ b/internal/config/auth_mode_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -16,8 +17,6 @@ func TestSecureAndEnforcement(t *testing.T) {
 		{"open default", &AuthConfig{}, false, false},
 		{"explicit open", &AuthConfig{Mode: AuthModeOpen}, false, false},
 		{"secure", &AuthConfig{Mode: AuthModeSecure}, true, true},
-		{"open + http enforce override", &AuthConfig{HTTP: &HTTPAuthConfig{Mode: HTTPAuthEnforce}}, false, true},
-		{"open + http off", &AuthConfig{HTTP: &HTTPAuthConfig{Mode: HTTPAuthOff}}, false, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -90,16 +89,89 @@ func TestPreflightSecure(t *testing.T) {
 	}
 }
 
-func TestSecureModeLoopbackBind(t *testing.T) {
-	// Secure mode forces the plain-HTTP listener to loopback (the same property
-	// public_exposure provided), so the cleartext control plane is never
-	// reachable off-box — only the pinned-TLS listener faces the network.
+func TestPlainHTTPEnabled(t *testing.T) {
+	// Secure mode is TLS-only: the plain-HTTP listener is not served (only the
+	// pinned-TLS listener faces clients). Open mode serves plain HTTP.
 	secure := &ServerConfig{HTTPPort: 8080, Auth: &AuthConfig{Mode: AuthModeSecure}}
-	if got := secure.HTTPListenAddr(); got != "127.0.0.1:8080" {
-		t.Errorf("secure HTTPListenAddr=%q, want loopback", got)
+	if secure.PlainHTTPEnabled() {
+		t.Error("secure mode should not serve the plain-HTTP listener")
 	}
 	open := &ServerConfig{HTTPPort: 8080}
-	if got := open.HTTPListenAddr(); got != ":8080" {
-		t.Errorf("open HTTPListenAddr=%q, want all-interfaces", got)
+	if !open.PlainHTTPEnabled() {
+		t.Error("open mode should serve the plain-HTTP listener")
+	}
+}
+
+// TestCrossFieldAuthValidation exercises the secure⟺tokens⟺TLS coupling: SSH
+// enforce and https_port are secure-mode-only surfaces, and secure forbids an
+// explicit ssh off/warn override.
+func TestCrossFieldAuthValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     ServerConfig
+		wantErr string // substring the error must name; "" means expect success
+	}{
+		{
+			name:    "open + ssh enforce rejected",
+			cfg:     ServerConfig{HTTPPort: 8080, SSHPort: 2222, Auth: &AuthConfig{Mode: AuthModeOpen, SSH: &SSHAuthConfig{Mode: SSHAuthEnforce}}},
+			wantErr: "auth.ssh.mode: enforce requires auth.mode: secure",
+		},
+		{
+			name:    "open + https_port rejected",
+			cfg:     ServerConfig{HTTPPort: 8080, SSHPort: 2222, HTTPSPort: 8443, Auth: &AuthConfig{Mode: AuthModeOpen}},
+			wantErr: "https_port requires auth.mode: secure",
+		},
+		{
+			name:    "https_port with no auth block rejected",
+			cfg:     ServerConfig{HTTPPort: 8080, SSHPort: 2222, HTTPSPort: 8443},
+			wantErr: "https_port requires auth.mode: secure",
+		},
+		{
+			name:    "secure + ssh warn rejected",
+			cfg:     ServerConfig{HTTPPort: 8080, SSHPort: 2222, Auth: &AuthConfig{Mode: AuthModeSecure, SSH: &SSHAuthConfig{Mode: SSHAuthWarn}}},
+			wantErr: "auth.mode: secure forces auth.ssh.mode: enforce",
+		},
+		{
+			name:    "secure + ssh off rejected",
+			cfg:     ServerConfig{HTTPPort: 8080, SSHPort: 2222, Auth: &AuthConfig{Mode: AuthModeSecure, SSH: &SSHAuthConfig{Mode: SSHAuthOff}}},
+			wantErr: "auth.mode: secure forces auth.ssh.mode: enforce",
+		},
+		{
+			name:    "open + ssh warn ok (staging)",
+			cfg:     ServerConfig{HTTPPort: 8080, SSHPort: 2222, Auth: &AuthConfig{Mode: AuthModeOpen, SSH: &SSHAuthConfig{Mode: SSHAuthWarn}}},
+			wantErr: "",
+		},
+		{
+			name:    "secure + ssh enforce ok",
+			cfg:     ServerConfig{HTTPPort: 8080, SSHPort: 2222, Auth: &AuthConfig{Mode: AuthModeSecure, SSH: &SSHAuthConfig{Mode: SSHAuthEnforce}}},
+			wantErr: "",
+		},
+		{
+			name:    "secure + ssh unset ok (derives enforce)",
+			cfg:     ServerConfig{HTTPPort: 8080, SSHPort: 2222, Auth: &AuthConfig{Mode: AuthModeSecure, SSH: &SSHAuthConfig{GitHubUsers: []string{"charliek"}}}},
+			wantErr: "",
+		},
+		{
+			name:    "secure + https_port ok",
+			cfg:     ServerConfig{HTTPPort: 8080, SSHPort: 2222, HTTPSPort: 8443, Auth: &AuthConfig{Mode: AuthModeSecure}},
+			wantErr: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.validateAuth()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("validateAuth() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateAuth() = nil, want error naming %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("validateAuth() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/internal/config/network_surface_test.go
+++ b/internal/config/network_surface_test.go
@@ -100,7 +100,7 @@ func TestRejectRemovedAuthKeys(t *testing.T) {
 		{"no auth block ok", "name: x\n", ""},
 		{"public_exposure rejected", "name: x\npublic_exposure: true\n", "public_exposure"},
 		{"auth.http.tokens rejected", "name: x\nauth:\n  http:\n    tokens:\n      - {scope: control, token: abc}\n", "auth.http.tokens"},
-		{"auth.http without tokens ok", "name: x\nauth:\n  http:\n    mode: enforce\n", ""},
+		{"auth.http.mode rejected", "name: x\nauth:\n  http:\n    mode: enforce\n", "auth.http"},
 		{"malformed yaml deferred to typed unmarshal", "name: [unterminated", ""},
 	}
 	for _, tt := range tests {
@@ -131,15 +131,14 @@ func TestValidateAuth(t *testing.T) {
 	}{
 		{"nil auth block is allowed", nil, ""},
 		{"empty ssh mode defaults ok", &AuthConfig{SSH: &SSHAuthConfig{}}, ""},
-		{"ssh off/warn/enforce ok", &AuthConfig{SSH: &SSHAuthConfig{Mode: SSHAuthEnforce}}, ""},
+		{"ssh off ok", &AuthConfig{SSH: &SSHAuthConfig{Mode: SSHAuthOff}}, ""},
+		{"ssh warn ok", &AuthConfig{SSH: &SSHAuthConfig{Mode: SSHAuthWarn}}, ""},
+		{"secure + ssh enforce ok", &AuthConfig{Mode: AuthModeSecure, SSH: &SSHAuthConfig{Mode: SSHAuthEnforce}}, ""},
 		{"invalid ssh mode rejected", &AuthConfig{SSH: &SSHAuthConfig{Mode: "enfore"}}, "auth.ssh.mode"},
-		{"negative max_auth_tries rejected", &AuthConfig{SSH: &SSHAuthConfig{Mode: SSHAuthEnforce, MaxAuthTries: -1}}, "max_auth_tries"},
-		{"zero max_auth_tries ok", &AuthConfig{SSH: &SSHAuthConfig{Mode: SSHAuthEnforce, MaxAuthTries: 0}}, ""},
-		{"valid github user ok", &AuthConfig{SSH: &SSHAuthConfig{Mode: SSHAuthEnforce, GitHubUsers: []string{"charliek"}}}, ""},
-		{"malformed github user rejected", &AuthConfig{SSH: &SSHAuthConfig{Mode: SSHAuthEnforce, GitHubUsers: []string{"bad user!"}}}, "github_users"},
-		{"empty http mode defaults ok", &AuthConfig{HTTP: &HTTPAuthConfig{}}, ""},
-		{"http enforce ok", &AuthConfig{HTTP: &HTTPAuthConfig{Mode: HTTPAuthEnforce}}, ""},
-		{"invalid http mode rejected", &AuthConfig{HTTP: &HTTPAuthConfig{Mode: "warn"}}, "auth.http.mode"},
+		{"negative max_auth_tries rejected", &AuthConfig{Mode: AuthModeSecure, SSH: &SSHAuthConfig{Mode: SSHAuthEnforce, MaxAuthTries: -1}}, "max_auth_tries"},
+		{"zero max_auth_tries ok", &AuthConfig{Mode: AuthModeSecure, SSH: &SSHAuthConfig{Mode: SSHAuthEnforce, MaxAuthTries: 0}}, ""},
+		{"valid github user ok", &AuthConfig{Mode: AuthModeSecure, SSH: &SSHAuthConfig{Mode: SSHAuthEnforce, GitHubUsers: []string{"charliek"}}}, ""},
+		{"malformed github user rejected", &AuthConfig{Mode: AuthModeSecure, SSH: &SSHAuthConfig{Mode: SSHAuthEnforce, GitHubUsers: []string{"bad user!"}}}, "github_users"},
 		{"invalid auth.mode rejected", &AuthConfig{Mode: "secur"}, "auth.mode"},
 		{"secure auth.mode ok", &AuthConfig{Mode: AuthModeSecure}, ""},
 	}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -117,34 +117,22 @@ func (c *ServerConfig) SSHAuth() *SSHAuthConfig {
 	return c.Auth.SSH
 }
 
-// HTTPAuth returns the HTTP auth config, or nil when unset.
-func (c *ServerConfig) HTTPAuth() *HTTPAuthConfig {
-	if c.Auth == nil {
-		return nil
-	}
-	return c.Auth.HTTP
-}
-
 // DefaultTokenTTL is the lifetime of a bootstrap-minted HTTP token when
 // auth.token_ttl is unset.
 const DefaultTokenTTL = 24 * time.Hour
 
 // Secure reports whether the server runs in secure mode (auth.mode: secure):
-// SSH allowlist enforce + HTTP bearer-token enforce + TLS + a loopback-bound
-// plain HTTP listener. The default (open) preserves the legacy accept-all
+// SSH allowlist enforce + HTTP bearer-token enforce + TLS-only (no plain HTTP
+// listener faces clients). The default (open) preserves the legacy accept-all
 // tailnet/LAN posture.
 func (c *ServerConfig) Secure() bool {
 	return c.Auth != nil && c.Auth.Mode == AuthModeSecure
 }
 
-// HTTPAuthEnforced reports whether the HTTP API requires a bearer token: true in
-// secure mode, or when the advanced auth.http.mode override is set to enforce.
+// HTTPAuthEnforced reports whether the HTTP API requires a bearer token. HTTP
+// token enforcement is derived purely from secure mode: enforced iff secure.
 func (c *ServerConfig) HTTPAuthEnforced() bool {
-	if c.Secure() {
-		return true
-	}
-	h := c.HTTPAuth()
-	return h != nil && h.Mode == HTTPAuthEnforce
+	return c.Secure()
 }
 
 // EffectiveSSHAuth returns the SSH auth config to build the allowlist from. In
@@ -181,6 +169,7 @@ func (c *ServerConfig) validateAuth() error {
 			return fmt.Errorf("invalid auth.mode: %q (must be open or secure)", c.Auth.Mode)
 		}
 	}
+	secure := c.Secure()
 	if ssh := c.SSHAuth(); ssh != nil {
 		switch ssh.Mode {
 		case "", SSHAuthOff, SSHAuthWarn, SSHAuthEnforce:
@@ -195,30 +184,41 @@ func (c *ServerConfig) validateAuth() error {
 				return fmt.Errorf("invalid auth.ssh.github_users entry: %q", u)
 			}
 		}
-	}
-	if h := c.HTTPAuth(); h != nil {
-		switch h.Mode {
-		case "", HTTPAuthOff, HTTPAuthEnforce:
-		default:
-			return fmt.Errorf("invalid auth.http.mode: %q (must be off or enforce)", h.Mode)
+		// tokens ⟺ TLS ⟺ secure: SSH enforce is the secure-mode posture. An
+		// explicit enforce on an open-mode server is rejected (warn stages an
+		// allowlist on a trusted network); secure forces enforce itself, so an
+		// explicit off/warn under secure contradicts the mode. An unset ssh.Mode
+		// under secure stays valid (EffectiveSSHAuth derives enforce).
+		if ssh.Mode == SSHAuthEnforce && !secure {
+			return fmt.Errorf("auth.ssh.mode: enforce requires auth.mode: secure (use warn to stage an allowlist on a trusted network)")
 		}
+		if secure && (ssh.Mode == SSHAuthOff || ssh.Mode == SSHAuthWarn) {
+			return fmt.Errorf("auth.mode: secure forces auth.ssh.mode: enforce; remove the explicit auth.ssh.mode: %s", ssh.Mode)
+		}
+	}
+	// https_port is a secure-mode-only surface: an open-mode server serves plain
+	// http only. Checked outside the ssh block so it fires even when auth.ssh is
+	// unset.
+	if c.HTTPSPort > 0 && !secure {
+		return fmt.Errorf("https_port requires auth.mode: secure (an open-mode server serves plain http only)")
 	}
 	return nil
 }
 
-// HTTPListenAddr returns the bind address for the plain-HTTP listener. In secure
-// mode it is forced to loopback so the plaintext control-plane API is never
-// reachable off-box — only the pinned-TLS (https_port) listener faces the
-// network. Otherwise it honors http_bind (default all interfaces).
+// HTTPListenAddr returns the bind address for the plain-HTTP listener, honoring
+// http_bind (default all interfaces). The plain-HTTP listener is served only in
+// open mode (see PlainHTTPEnabled); secure mode is TLS-only and starts no
+// plain-HTTP listener, so this is not consulted there.
 func (c *ServerConfig) HTTPListenAddr() string {
-	if c.Secure() {
-		return listenAddr(loopbackBind, c.HTTPPort)
-	}
 	return listenAddr(c.HTTPBind, c.HTTPPort)
 }
 
+// PlainHTTPEnabled reports whether the main plain-HTTP listener should be
+// served. False in secure mode (TLS-only; the plain listener is not started).
+func (c *ServerConfig) PlainHTTPEnabled() bool { return !c.Secure() }
+
 // loopbackBind is the IPv4 loopback interface used for listeners that must not
-// be reachable off-box (the internal bus, and plain HTTP in secure mode).
+// be reachable off-box (the internal bus).
 const loopbackBind = "127.0.0.1"
 
 // HTTPSEnabled reports whether the HTTPS listener is configured.
@@ -1280,9 +1280,9 @@ func rejectRemovedImageKeys(data []byte) error {
 }
 
 // rejectRemovedAuthKeys fails loudly if a config still carries auth keys removed
-// in the auth-issuance-v2 redesign. yaml.Unmarshal silently ignores unknown
-// fields, so without this an upgraded operator's stale public_exposure /
-// auth.http.tokens would be accepted while the new binary ignored them — and for
+// in the secure-by-default redesign. yaml.Unmarshal silently ignores unknown
+// fields, so without this an upgraded operator's stale public_exposure / auth.http
+// block would be accepted while the new binary ignored them — and for
 // public_exposure that silent drop would un-loopback the plaintext listener on
 // an internet-facing box. Mirrors rejectRemovedImageKeys.
 func rejectRemovedAuthKeys(data []byte) error {
@@ -1298,11 +1298,19 @@ func rejectRemovedAuthKeys(data []byte) error {
 	if !ok {
 		return nil
 	}
-	if httpBlock, ok := auth["http"].(map[string]any); ok {
-		if _, present := httpBlock["tokens"]; present {
-			return fmt.Errorf("config key %q was removed; tokens are now minted over the SSH bootstrap channel under %q (see docs/upgrades/v0.7.0-to-v0.7.1.md)",
-				"auth.http.tokens", "auth.mode: secure")
+	// The entire auth.http subtree was removed: HTTP token enforcement is now
+	// derived from auth.mode: secure (the auth.http.mode knob is gone), and
+	// tokens are minted over the SSH bootstrap channel (auth.http.tokens is
+	// gone). Reject the block wholesale, with a tokens-specific hint when present.
+	if httpBlock, present := auth["http"]; present {
+		if hb, ok := httpBlock.(map[string]any); ok {
+			if _, hasTokens := hb["tokens"]; hasTokens {
+				return fmt.Errorf("config key %q was removed; tokens are now minted over the SSH bootstrap channel under %q (see docs/upgrades/v0.7.1-to-v0.7.2.md)",
+					"auth.http.tokens", "auth.mode: secure")
+			}
 		}
+		return fmt.Errorf("config key %q was removed; HTTP token enforcement is now derived from %q (see docs/upgrades/v0.7.1-to-v0.7.2.md)",
+			"auth.http", "auth.mode: secure")
 	}
 	return nil
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -690,12 +690,6 @@ const (
 	SSHAuthEnforce = "enforce" // reject keys not in the allowlist
 )
 
-// HTTP auth modes for HTTPAuthConfig.Mode.
-const (
-	HTTPAuthOff     = "off"     // accept all requests (legacy default)
-	HTTPAuthEnforce = "enforce" // require a valid bearer token (except bootstrap endpoints)
-)
-
 // Auth modes for AuthConfig.Mode — the binary secure-by-default switch.
 const (
 	AuthModeOpen   = "open"   // default: no enforcement (tailnet/LAN posture)
@@ -703,28 +697,18 @@ const (
 )
 
 // AuthConfig configures authentication. The headline control is Mode (the
-// binary open|secure switch). The SSH/HTTP sub-blocks carry key sources and
-// advanced per-layer overrides.
+// binary open|secure switch). The SSH sub-block carries key sources and the
+// advanced SSH mode override. HTTP bearer-token enforcement is derived purely
+// from secure mode — there is no HTTP sub-block.
 type AuthConfig struct {
 	// Mode is open | secure (default open). secure derives: SSH allowlist
-	// enforce, HTTP bearer-token enforce, TLS on, and a loopback-bound plain
-	// HTTP listener; it requires at least one SSH key source.
+	// enforce, HTTP bearer-token enforce, and TLS on (the server serves the
+	// TLS listener only); it requires at least one SSH key source.
 	Mode string `yaml:"mode,omitempty"`
 	// TokenTTL is the lifetime of a bootstrap-minted HTTP token (default 24h).
 	TokenTTL Duration `yaml:"token_ttl,omitempty"`
 	// SSH configures the SSH public-key allowlist (key sources + advanced mode).
 	SSH *SSHAuthConfig `yaml:"ssh,omitempty"`
-	// HTTP configures bearer-token auth on the HTTP API (advanced mode override).
-	HTTP *HTTPAuthConfig `yaml:"http,omitempty"`
-}
-
-// HTTPAuthConfig is the advanced per-layer override for HTTP bearer-token auth.
-// The headline control is auth.mode (secure enforces HTTP auth automatically);
-// tokens are minted over the SSH bootstrap channel, never configured here.
-type HTTPAuthConfig struct {
-	// Mode is off | enforce (default off). enforce requires a valid bearer token
-	// (except the bootstrap endpoints GET /api/info and GET /api/ssh-host-key).
-	Mode string `yaml:"mode,omitempty"`
 }
 
 // SSHAuthConfig configures the SSH public-key allowlist. Identity comes from

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
       - Provisioning a TypeScript Project: tutorials/typescript-provisioning.md
       - Provisioning a Python Project: tutorials/python-provisioning.md
   - Guides:
+      - Security Configuration: guides/security-configuration.md
       - Public VPS Deployment: guides/vps-deployment.md
   - Reference:
       - CLI: reference/cli.md

--- a/tests/integration/fixtures/devcontrol.py
+++ b/tests/integration/fixtures/devcontrol.py
@@ -46,6 +46,7 @@ import copy
 import json
 import os
 import signal
+import ssl
 import subprocess
 import time
 import urllib.error
@@ -220,7 +221,9 @@ def _make_restart(dev_config: Path) -> None:
         )
 
 
-def _wait_reachable(server: str, timeout: float) -> None:
+def _wait_reachable(
+    server: str, timeout: float, *, secure: bool = False, https_port: Optional[int] = None
+) -> None:
     """Poll the server's bootstrap `/api/info` endpoint until it answers.
 
     `/api/info` is unauthenticated (bootstrap-exempt), so this readiness check
@@ -228,21 +231,34 @@ def _wait_reachable(server: str, timeout: float) -> None:
     unlike a `shed list` probe, a control-plane call that would 401 under
     enforce. `make dev-server-up` returns as soon as it has launched the
     process, so the caller must wait for actual readiness here.
+
+    In secure mode the server serves NO plain-HTTP listener (TLS-only), so the
+    probe targets `https://<host>:<https_port>/api/info`. The cert is the
+    server's self-signed one; this readiness probe skips verification — it only
+    needs a 200 from a bootstrap-exempt endpoint, and the real tests pin the
+    cert for their actual assertions.
     """
     entry = resolve_server_entry(server)
     if entry is None:
         raise AssertionError(f"dev server {server!r} not registered in ~/.shed/config.yaml")
-    url = f"http://{entry.get('host', 'localhost')}:{int(entry['http_port'])}/api/info"
+    host = entry.get("host", "localhost")
+    ctx = None
+    if secure:
+        port = int(https_port or 8443)  # secure mode defaults https_port to 8443
+        url = f"https://{host}:{port}/api/info"
+        ctx = ssl._create_unverified_context()
+    else:
+        url = f"http://{host}:{int(entry['http_port'])}/api/info"
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
-            with urllib.request.urlopen(url, timeout=5) as resp:
+            with urllib.request.urlopen(url, timeout=5, context=ctx) as resp:
                 if resp.status == 200:
                     return
         except (urllib.error.URLError, OSError):
             pass
         time.sleep(0.5)
-    raise AssertionError(f"dev server {server!r} not reachable within {timeout:.0f}s")
+    raise AssertionError(f"dev server {server!r} not reachable within {timeout:.0f}s (url={url})")
 
 
 @contextmanager
@@ -267,10 +283,15 @@ def dev_config(
     assert_dev_target(server)
     merged = _merge_config(overrides)
     _assert_config_ports_safe(merged)
+    # In secure mode the server is TLS-only (no plain-HTTP listener), so the
+    # readiness probe must use https. The base config (restored in finally) is
+    # open, so its probe stays plain-http.
+    secure = (merged.get("auth") or {}).get("mode") == "secure"
+    https_port = merged.get("https_port")
     temp = _write_config(merged, DEV_CONFIG_TMP)
     try:
         _make_restart(temp)
-        _wait_reachable(server, ready_timeout)
+        _wait_reachable(server, ready_timeout, secure=secure, https_port=https_port)
         yield server
     finally:
         try:

--- a/tests/integration/fixtures/tlsclient.py
+++ b/tests/integration/fixtures/tlsclient.py
@@ -1,0 +1,89 @@
+"""Pinned-TLS client helpers for the secure-mode integration tests.
+
+Secure mode is TLS-only: the server serves no plain-HTTP listener, only the
+pinned-TLS (`https_port`) listener faces clients. The tests therefore drive
+their assertions over HTTPS against the server's self-signed cert, trusting it
+by the fingerprint the client computes (the pin) rather than a CA chain.
+
+These three helpers were originally local to `test_tls.py`; they are promoted
+here so `test_tls.py` and the five secure-mode HTTP tests
+(`test_http_auth`, `test_token_ttl`, `test_bootstrap`, `test_cred_bus`) share
+one implementation. Public behavior is identical to the prior `test_tls.py`
+locals.
+
+  - `server_cert_pem(host, port)` — fetch the presented cert WITHOUT trusting
+    it, exactly as `shed server add` does before pinning. The returned PEM is
+    the pin material passed back as `ca_pem` to the request helpers.
+  - `fingerprint(pem)` — the stable `sha256:<hex>` pin a client computes from
+    the cert (used to assert pin stability / rotation).
+  - `https_status(port, path, ca_pem, ...)` — issue a pinned-HTTPS request
+    (GET, or POST with a JSON body) and return the HTTP status code. When
+    `ca_pem` is set it trusts EXACTLY that cert (the pin); when None it uses the
+    system CA bundle (which must NOT trust the self-signed cert, so an
+    unpinned client cannot connect at all — surfaced as a URLError).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import ssl
+import urllib.error
+import urllib.request
+from typing import Optional
+
+
+def server_cert_pem(host: str, port: int) -> str:
+    """Retrieve the presented cert without trusting it (the pre-pin fetch
+    `shed server add` does)."""
+    return ssl.get_server_certificate((host, port))
+
+
+def fingerprint(pem: str) -> str:
+    """The stable `sha256:<hex>` pin a client computes from a cert PEM."""
+    der = ssl.PEM_cert_to_DER_cert(pem)
+    return "sha256:" + hashlib.sha256(der).hexdigest()
+
+
+def _ctx(ca_pem: Optional[str]) -> ssl.SSLContext:
+    # ca_pem trusts exactly the server's cert (the pin); None uses the system
+    # CA bundle (which must NOT trust the self-signed cert).
+    if ca_pem:
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.load_verify_locations(cadata=ca_pem)
+        return ctx
+    return ssl.create_default_context()
+
+
+def https_status(
+    port: int,
+    path: str,
+    ca_pem: Optional[str],
+    token: Optional[str] = None,
+    *,
+    host: str = "localhost",
+    method: str = "GET",
+    body: Optional[dict] = None,
+) -> Optional[int]:
+    """Issue a pinned-HTTPS request and return the HTTP status code.
+
+    `ca_pem` is the pin (the server's cert PEM from `server_cert_pem`); pass
+    None to use the system CA bundle, which won't trust the self-signed cert
+    (the caller asserts the resulting URLError). `token`, when set, is sent as
+    a Bearer header. For POSTs, set `method="POST"` and pass `body` (encoded as
+    JSON with a Content-Type header).
+    """
+    data = None
+    req = urllib.request.Request(f"https://{host}:{port}{path}", method=method)
+    if body is not None:
+        data = json.dumps(body).encode()
+        req.data = data
+        req.add_header("Content-Type", "application/json")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=10, context=_ctx(ca_pem)) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        e.close()  # warnings-as-errors: don't leak the response body
+        return e.code

--- a/tests/integration/test_bootstrap.py
+++ b/tests/integration/test_bootstrap.py
@@ -22,14 +22,31 @@ from fixtures.server import resolve_server_entry
 
 KNOWN_HOSTS = Path.home() / ".shed" / "known_hosts"
 
+# Secure mode is TLS-only (no plain-HTTP listener), so the dev_config readiness
+# probe targets https. Pin the explicitly-set https_port (the port-safety guard
+# allows 18443) so the probe hits the actual listener rather than the 8443
+# default. The mint itself is over SSH, unaffected by the HTTP transport.
+HTTPS_PORT = 18443
+
 
 def _bootstrap_with_key(ssh_port: int, key_path: Path, scope: str = "control") -> subprocess.CompletedProcess:
-    """Attempt a `_bootstrap` exchange offering ONLY `key_path` (IdentitiesOnly).
-    A non-zero returncode means the mint was refused at SSH auth."""
+    """Attempt a `_bootstrap` exchange offering ONLY `key_path`.
+    A non-zero returncode means the mint was refused at SSH auth.
+
+    `IdentitiesOnly=yes` alone is NOT enough to isolate `key_path`: a user
+    `~/.ssh/config` with `Host * IdentityFile ~/.ssh/id_ed25519` (the macOS
+    default) makes that key an explicit identity, and a key loaded in the agent
+    that matches a configured IdentityFile is then offered too — so an
+    allowlisted local key would be tried first and authenticate, masking the
+    off-list rejection this probe exists to assert. `-F /dev/null` ignores the
+    user/system ssh_config and `IdentityAgent=none` ignores the agent, so the
+    only key offered is `key_path`."""
     args = [
         "ssh", "-T", "-p", str(ssh_port),
+        "-F", "/dev/null",
         "-i", str(key_path),
         "-o", "IdentitiesOnly=yes",
+        "-o", "IdentityAgent=none",
         "-o", "BatchMode=yes",
         "-o", f"UserKnownHostsFile={KNOWN_HOSTS}",
         "-o", "StrictHostKeyChecking=yes",
@@ -44,7 +61,10 @@ def test_bootstrap_mint_is_allowlist_gated(vz_server_dev):
     server = vz_server_dev.name
     ssh_port = int(resolve_server_entry(server)["ssh_port"])
     pubkey = (Path.home() / ".ssh" / "id_ed25519.pub").read_text().strip()
-    overrides = {"auth": {"mode": "secure", "ssh": {"authorized_keys": [pubkey]}}}
+    overrides = {
+        "https_port": HTTPS_PORT,
+        "auth": {"mode": "secure", "ssh": {"authorized_keys": [pubkey]}},
+    }
     with dev_config(overrides, server):
         # Positive control: the allowlisted local key mints a control token.
         assert bootstrap_mint(server, "control").startswith("shed_control_")

--- a/tests/integration/test_cred_bus.py
+++ b/tests/integration/test_cred_bus.py
@@ -9,46 +9,37 @@ this is the below-the-handler ownership defense (response-injection /
 listener-squat). A second test asserts the removed `public_exposure` /
 `auth.http.tokens` keys hard-fail at startup.
 
-VZ-only (config mutation restarts the local dev server); the ownership logic is
-backend-agnostic Go covered by internal/plugin + internal/api unit tests.
+Secure mode is TLS-only (no plain-HTTP listener), so the forged-`/respond` POST
+goes over the pinned HTTPS listener. VZ-only (config mutation restarts the local
+dev server); the ownership logic is backend-agnostic Go covered by
+internal/plugin + internal/api unit tests.
 """
 
 from __future__ import annotations
 
-import json
-import urllib.error
-import urllib.request
 from pathlib import Path
 
 import pytest
 
 from fixtures.devcontrol import bootstrap_mint, dev_config, run_preflight
-from fixtures.server import resolve_server_entry
+from fixtures.tlsclient import https_status, server_cert_pem
 
-
-def _post(port: int, path: str, body: dict, token: str | None) -> int | None:
-    req = urllib.request.Request(
-        f"http://localhost:{port}{path}", data=json.dumps(body).encode(), method="POST"
-    )
-    req.add_header("Content-Type", "application/json")
-    if token:
-        req.add_header("Authorization", f"Bearer {token}")
-    try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            return resp.status
-    except urllib.error.HTTPError as e:
-        e.close()  # warnings-as-errors: don't leak the response body
-        return e.code
+# Secure mode is TLS-only; pin the explicitly-set https_port (the port-safety
+# guard allows 18443) so the POST reaches the only listener facing clients.
+HTTPS_PORT = 18443
 
 
 @pytest.mark.vz
 @pytest.mark.slow
 def test_cred_bus_forged_respond_dropped(vz_server_dev):
     server = vz_server_dev.name
-    port = int(resolve_server_entry(server)["http_port"])
     pubkey = (Path.home() / ".ssh" / "id_ed25519.pub").read_text().strip()
-    overrides = {"auth": {"mode": "secure", "ssh": {"authorized_keys": [pubkey]}}}
+    overrides = {
+        "https_port": HTTPS_PORT,
+        "auth": {"mode": "secure", "ssh": {"authorized_keys": [pubkey]}},
+    }
     with dev_config(overrides, server):
+        pin = server_cert_pem("localhost", HTTPS_PORT)
         creds = bootstrap_mint(server, "credentials")
         # A /respond that names no pending request is dropped (403) even with a
         # valid credentials token: the requestID was never dispatched to any
@@ -60,7 +51,10 @@ def test_cred_bus_forged_respond_dropped(vz_server_dev):
             "final": True,
             "shed": {"name": "itest-shed"},
         }
-        assert _post(port, "/api/plugins/listeners/itest-ns/respond", body, creds) == 403
+        assert https_status(
+            HTTPS_PORT, "/api/plugins/listeners/itest-ns/respond", pin, creds,
+            method="POST", body=body,
+        ) == 403
 
 
 @pytest.mark.vz

--- a/tests/integration/test_http_auth.py
+++ b/tests/integration/test_http_auth.py
@@ -4,48 +4,45 @@ Puts the VZ dev server in `auth.mode: secure` with the local SSH key allowlisted
 mints scoped tokens over the `_bootstrap` SSH channel (no static token list — that
 was removed), and verifies live: bootstrap endpoints stay open, the control plane
 and bus require a token, and the credentials vs control scopes are enforced per
-route. VZ-only (config mutation restarts the local dev server); the middleware
-logic itself is backend-agnostic Go covered by unit tests.
+route. Secure mode is TLS-only (no plain-HTTP listener), so the requests go over
+the pinned HTTPS listener. VZ-only (config mutation restarts the local dev
+server); the middleware logic itself is backend-agnostic Go covered by unit
+tests.
 """
 
 from __future__ import annotations
 
-import urllib.error
-import urllib.request
 from pathlib import Path
 
 import pytest
 
 from fixtures.devcontrol import bootstrap_mint, dev_config
-from fixtures.server import resolve_server_entry
+from fixtures.tlsclient import https_status as _status
+from fixtures.tlsclient import server_cert_pem
 
-
-def _status(port: int, path: str, token: str | None = None) -> int | None:
-    req = urllib.request.Request(f"http://localhost:{port}{path}")
-    if token:
-        req.add_header("Authorization", f"Bearer {token}")
-    try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            return resp.status
-    except urllib.error.HTTPError as e:
-        e.close()  # warnings-as-errors: don't leak the response body
-        return e.code
-    except urllib.error.URLError:
-        return None
+# Secure mode is TLS-only; pin the explicitly-set https_port (the port-safety
+# guard allows 18443) so requests reach the only listener facing clients.
+HTTPS_PORT = 18443
 
 
 @pytest.mark.vz
 @pytest.mark.slow
 def test_secure_mode_enforces_scoped_tokens(vz_server_dev):
     server = vz_server_dev.name
-    port = int(resolve_server_entry(server)["http_port"])
     # Allowlist the local SSH key so the bootstrap channel mints for it.
     pubkey = (Path.home() / ".ssh" / "id_ed25519.pub").read_text().strip()
-    overrides = {"auth": {"mode": "secure", "ssh": {"authorized_keys": [pubkey]}}}
+    overrides = {
+        "https_port": HTTPS_PORT,
+        "auth": {"mode": "secure", "ssh": {"authorized_keys": [pubkey]}},
+    }
     with dev_config(overrides, server):
+        # Fetch the server's self-signed cert and pin it for every request
+        # (the TLS-only listener presents no CA-chain trust).
+        pin = server_cert_pem("localhost", HTTPS_PORT)
+
         # Bootstrap endpoints stay reachable without a token (shed server add).
-        assert _status(port, "/api/info") == 200
-        assert _status(port, "/api/ssh-host-key") == 200
+        assert _status(HTTPS_PORT, "/api/info", pin) == 200
+        assert _status(HTTPS_PORT, "/api/ssh-host-key", pin) == 200
 
         # Mint scoped tokens over the _bootstrap SSH channel — no static list.
         control = bootstrap_mint(server, "control")
@@ -54,12 +51,12 @@ def test_secure_mode_enforces_scoped_tokens(vz_server_dev):
         assert creds.startswith("shed_credentials_")
 
         # Control plane requires a control token.
-        assert _status(port, "/api/sheds") == 401
-        assert _status(port, "/api/sheds", token="shed_control_bogus") == 401
-        assert _status(port, "/api/sheds", token=control) == 200
-        assert _status(port, "/api/sheds", token=creds) == 403  # wrong scope
+        assert _status(HTTPS_PORT, "/api/sheds", pin) == 401
+        assert _status(HTTPS_PORT, "/api/sheds", pin, token="shed_control_bogus") == 401
+        assert _status(HTTPS_PORT, "/api/sheds", pin, token=control) == 200
+        assert _status(HTTPS_PORT, "/api/sheds", pin, token=creds) == 403  # wrong scope
 
         # The credential bus requires the credentials scope.
-        assert _status(port, "/api/plugins/listeners") == 401
-        assert _status(port, "/api/plugins/listeners", token=creds) == 200
-        assert _status(port, "/api/plugins/listeners", token=control) == 403
+        assert _status(HTTPS_PORT, "/api/plugins/listeners", pin) == 401
+        assert _status(HTTPS_PORT, "/api/plugins/listeners", pin, token=creds) == 200
+        assert _status(HTTPS_PORT, "/api/plugins/listeners", pin, token=control) == 403

--- a/tests/integration/test_ssh_auth.py
+++ b/tests/integration/test_ssh_auth.py
@@ -9,6 +9,13 @@ The auth decision happens during the SSH handshake, before any shed session,
 so these probes don't need a real shed — `ssh -v` reports `Authenticated to`
 on success and `Permission denied (publickey)` on rejection. VZ-only (config
 mutation via the Phase 0.5 harness restarts the local VZ dev server).
+
+SSH enforce is now a secure-mode-only posture: `auth.ssh.mode: enforce` on an
+open-mode server is rejected at startup, so the enforce test drives secure mode
+(which itself forces SSH enforce). Secure mode is TLS-only, so it carries an
+explicitly-set `https_port` for the dev_config readiness probe — the SSH probes
+themselves hit the SSH port and are unaffected by the HTTP transport. The warn
+test stays open-mode (secure forbids an explicit warn override).
 """
 
 from __future__ import annotations
@@ -20,6 +27,11 @@ import pytest
 
 from fixtures.devcontrol import dev_config
 from fixtures.server import resolve_server_entry
+
+# Secure mode is TLS-only; the enforce test pins this explicitly-set https_port
+# (the port-safety guard allows 18443) so dev_config's readiness probe hits the
+# actual listener rather than the 8443 default.
+HTTPS_PORT = 18443
 
 
 def _keygen(dir_: pathlib.Path, name: str) -> tuple[str, str]:
@@ -63,8 +75,15 @@ def test_enforce_denies_offlist_admits_onlist(vz_server_dev, tmp_path):
     on_key, on_pub = _keygen(tmp_path, "onlist")
     off_key, _ = _keygen(tmp_path, "offlist")
 
+    # SSH enforce is a secure-mode-only posture; secure forces auth.ssh.mode to
+    # enforce, so this exercises the same allowlist gate (off-list denied,
+    # on-list admitted) the explicit enforce mode used to.
     with dev_config(
-        {"auth": {"ssh": {"mode": "enforce", "authorized_keys": [on_pub]}}}, server
+        {
+            "https_port": HTTPS_PORT,
+            "auth": {"mode": "secure", "ssh": {"authorized_keys": [on_pub]}},
+        },
+        server,
     ):
         off = _ssh_auth_stderr(ssh_port, off_key)
         assert "Permission denied" in off, f"off-list key should be denied; stderr={off!r}"

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -11,7 +11,9 @@ Configures the VZ dev server with `https_port` + `tls_names` (via the Phase
     the control plane over the pinned TLS connection, and rejects a wrong
     out-of-band `--tls-fingerprint` (test_tls_client_pin).
 
-The plain-HTTP listener must keep answering so the legacy path is unaffected.
+Secure mode is TLS-only — the server serves no plain-HTTP listener, only the
+pinned-TLS (https_port) listener faces clients — so `_tls_overrides()` carries a
+secure auth block (https_port is a secure-mode-only surface).
 VZ-only (config mutation restarts the local dev server); the cert-generation +
 pin-verify logic is backend-agnostic Go covered by `internal/servertls` +
 `cmd/shed` unit tests. The CLI test runs against a throwaway $HOME so it never
@@ -20,20 +22,20 @@ touches the developer's real ~/.shed/config.yaml.
 
 from __future__ import annotations
 
-import hashlib
 import os
 import shutil
-import ssl
 import subprocess
 import tempfile
 import urllib.error
-import urllib.request
 from pathlib import Path
 
 import pytest
 
 from fixtures.devcontrol import SHED_SERVER_BIN, bootstrap_mint, dev_config
 from fixtures.server import resolve_server_entry
+from fixtures.tlsclient import fingerprint as _fingerprint
+from fixtures.tlsclient import https_status as _https_status
+from fixtures.tlsclient import server_cert_pem as _server_cert_pem
 
 HTTPS_PORT = 18443
 TEST_SAN = "shed-tls-test.example"
@@ -42,6 +44,12 @@ TEST_SAN = "shed-tls-test.example"
 DEV_TLS_DIR = Path.home() / ".shed" / "dev" / "tls-itest"
 SHED_BIN = SHED_SERVER_BIN.parent / "shed"
 
+# https_port is a secure-mode-only surface (an open-mode server serves plain
+# http only and is rejected at startup with https_port set), so the TLS
+# overrides carry a secure auth block with the local key allowlisted — the same
+# allowlisting the other secure-mode tests use.
+_LOCAL_PUBKEY = (Path.home() / ".ssh" / "id_ed25519.pub").read_text().strip()
+
 
 def _tls_overrides() -> dict:
     return {
@@ -49,6 +57,7 @@ def _tls_overrides() -> dict:
         "tls_names": [TEST_SAN],
         "tls_cert_file": str(DEV_TLS_DIR / "tls_cert.pem"),
         "tls_key_file": str(DEV_TLS_DIR / "tls_key.pem"),
+        "auth": {"mode": "secure", "ssh": {"authorized_keys": [_LOCAL_PUBKEY]}},
     }
 
 
@@ -59,17 +68,6 @@ def _shed(args: list[str], home: str, timeout: float = 30) -> subprocess.Complet
     return subprocess.run(
         [str(SHED_BIN), *args], capture_output=True, text=True, timeout=timeout, env=env
     )
-
-
-def _server_cert_pem(host: str, port: int) -> str:
-    # get_server_certificate retrieves the presented cert without trusting it,
-    # which is exactly what `shed server add` does before pinning.
-    return ssl.get_server_certificate((host, port))
-
-
-def _fingerprint(pem: str) -> str:
-    der = ssl.PEM_cert_to_DER_cert(pem)
-    return "sha256:" + hashlib.sha256(der).hexdigest()
 
 
 def _sans(pem: str) -> str:
@@ -126,13 +124,22 @@ def test_tls_listener_serves_pinnable_cert(vz_server_dev):
             finally:
                 Path(ca_path).unlink(missing_ok=True)
 
-            # The plain-HTTP listener is unaffected (legacy path).
+            # Secure mode is TLS-only: the plain-HTTP listener is NOT served, so
+            # nothing answers on http_port. curl gets a connection failure
+            # (non-zero exit, no HTTP status), confirming the plaintext surface
+            # is gone — only the pinned-TLS listener faces clients.
             r = subprocess.run(
                 ["curl", "-sS", "-o", "/dev/null", "-w", "%{http_code}",
                  f"http://localhost:{http_port}/api/info"],
                 capture_output=True, text=True, timeout=15,
             )
-            assert r.stdout.strip() == "200", f"plain HTTP regressed: {r.stdout!r} {r.stderr!r}"
+            assert r.returncode != 0, (
+                f"plain HTTP must not be served in secure mode, got exit 0: "
+                f"{r.stdout!r} {r.stderr!r}"
+            )
+            assert r.stdout.strip() != "200", (
+                f"plain HTTP must not answer in secure mode: {r.stdout!r} {r.stderr!r}"
+            )
     finally:
         shutil.rmtree(DEV_TLS_DIR, ignore_errors=True)
 
@@ -217,25 +224,6 @@ def test_tls_pin_rotation(vz_server_dev):
         shutil.rmtree(DEV_TLS_DIR, ignore_errors=True)
 
 
-def _https_status(port: int, path: str, ca_pem: str | None, token: str | None) -> int | None:
-    # ca_pem trusts exactly the server's cert (the pin); None uses the system
-    # CA bundle (which must NOT trust the self-signed cert).
-    if ca_pem:
-        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        ctx.load_verify_locations(cadata=ca_pem)
-    else:
-        ctx = ssl.create_default_context()
-    req = urllib.request.Request(f"https://localhost:{port}{path}")
-    if token:
-        req.add_header("Authorization", f"Bearer {token}")
-    try:
-        with urllib.request.urlopen(req, timeout=10, context=ctx) as resp:
-            return resp.status
-    except urllib.error.HTTPError as e:
-        e.close()  # warnings-as-errors: don't leak the response body
-        return e.code
-
-
 @pytest.mark.vz
 @pytest.mark.slow
 def test_tls_bus_over_tls_with_token(vz_server_dev):
@@ -244,18 +232,16 @@ def test_tls_bus_over_tls_with_token(vz_server_dev):
     authed host-agent (sdk WithTLSPin + WithToken) presents, and rejects the
     negatives — wrong scope, no token, and an untrusted (mis-pinned) cert."""
     server = vz_server_dev.name
-    pubkey = (Path.home() / ".ssh" / "id_ed25519.pub").read_text().strip()
     shutil.rmtree(DEV_TLS_DIR, ignore_errors=True)
     DEV_TLS_DIR.mkdir(parents=True, exist_ok=True)
-    # secure mode enforces HTTP tokens and keeps an explicitly-set https_port
-    # (18443 here, not the 8443 default), so the pinned-TLS shape is unchanged.
-    # Tokens are minted over SSH — the static auth.http.tokens list was removed.
-    overrides = {
-        **_tls_overrides(),
-        "auth": {"mode": "secure", "ssh": {"authorized_keys": [pubkey]}},
-    }
+    # _tls_overrides() already carries auth.mode: secure with the local key
+    # allowlisted (https_port is a secure-mode-only surface), so the pinned-TLS
+    # shape here is the same as the other secure-mode tests. secure enforces HTTP
+    # tokens and keeps the explicitly-set https_port (18443, not the 8443
+    # default); tokens are minted over SSH (the static auth.http.tokens list was
+    # removed).
     try:
-        with dev_config(overrides, server):
+        with dev_config(_tls_overrides(), server):
             creds = bootstrap_mint(server, "credentials")
             control = bootstrap_mint(server, "control")
             pin = _server_cert_pem("localhost", HTTPS_PORT)

--- a/tests/integration/test_token_ttl.py
+++ b/tests/integration/test_token_ttl.py
@@ -3,51 +3,42 @@
 Mints a control token with a 2s `auth.token_ttl` over the `_bootstrap` channel
 and verifies the server accepts it immediately, then rejects it (401) once it
 expires — the authtoken store validates each token's expiry on every request, so
-expiry is enforced at validate time (not only by the background sweeper). VZ-only
-(config mutation restarts the dev server); the TTL logic is backend-agnostic Go
-covered by internal/authtoken unit tests.
+expiry is enforced at validate time (not only by the background sweeper). Secure
+mode is TLS-only (no plain-HTTP listener), so the requests go over the pinned
+HTTPS listener. VZ-only (config mutation restarts the dev server); the TTL logic
+is backend-agnostic Go covered by internal/authtoken unit tests.
 """
 
 from __future__ import annotations
 
 import time
-import urllib.error
-import urllib.request
 from pathlib import Path
 
 import pytest
 
 from fixtures.devcontrol import bootstrap_mint, dev_config
-from fixtures.server import resolve_server_entry
+from fixtures.tlsclient import https_status as _status
+from fixtures.tlsclient import server_cert_pem
 
-
-def _status(port: int, path: str, token: str | None = None) -> int | None:
-    req = urllib.request.Request(f"http://localhost:{port}{path}")
-    if token:
-        req.add_header("Authorization", f"Bearer {token}")
-    try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            return resp.status
-    except urllib.error.HTTPError as e:
-        e.close()  # warnings-as-errors: don't leak the response body
-        return e.code
-    except urllib.error.URLError:
-        return None
+# Secure mode is TLS-only; pin the explicitly-set https_port (the port-safety
+# guard allows 18443) so requests reach the only listener facing clients.
+HTTPS_PORT = 18443
 
 
 @pytest.mark.vz
 @pytest.mark.slow
 def test_token_ttl_expiry(vz_server_dev):
     server = vz_server_dev.name
-    port = int(resolve_server_entry(server)["http_port"])
     pubkey = (Path.home() / ".ssh" / "id_ed25519.pub").read_text().strip()
     overrides = {
-        "auth": {"mode": "secure", "token_ttl": "2s", "ssh": {"authorized_keys": [pubkey]}}
+        "https_port": HTTPS_PORT,
+        "auth": {"mode": "secure", "token_ttl": "2s", "ssh": {"authorized_keys": [pubkey]}},
     }
     with dev_config(overrides, server):
+        pin = server_cert_pem("localhost", HTTPS_PORT)
         tok = bootstrap_mint(server, "control")
         # Freshly minted → accepted.
-        assert _status(port, "/api/sheds", tok) == 200
+        assert _status(HTTPS_PORT, "/api/sheds", pin, tok) == 200
         # After the 2s TTL elapses, the same token is rejected (per-request expiry).
         time.sleep(3)
-        assert _status(port, "/api/sheds", tok) == 401
+        assert _status(HTTPS_PORT, "/api/sheds", pin, tok) == 401


### PR DESCRIPTION
## Summary

Simplifies the v0.7.x auth surface to a clean binary posture so two invariants always hold: **tokens ⟺ TLS ⟺ secure** and **https ⟺ secure**.

- **Drop the independent `auth.http.mode`** (and `HTTPAuthConfig`): HTTP token enforcement derives purely from `auth.mode: secure` (`HTTPAuthEnforced() == Secure()`). The whole `auth.http` block is rejected at startup.
- **Reject footgun cross-field states** in `validateAuth`: `auth.ssh.mode: enforce` outside secure, `https_port` outside secure, and an explicit `auth.ssh.mode: off|warn` under secure (secure derives `enforce`).
- **Secure mode is TLS-only** — it no longer serves a plain-HTTP listener (not even on loopback); only the pinned-TLS listener faces clients. The opt-in `internal_http_port` loopback listener is untouched.
- `shed server add` hints `--https-port` when the plain-HTTP `/api/info` probe fails against a (now TLS-only) secure server.

`warn` remains the SSH-allowlist pre-flight (open posture). An opt-in unencrypted local channel is deferred.

## Breaking

A `0.7.x` patch (the auth interface is still settling). Rejected at startup: `auth.http`/`auth.http.mode`, `open + https_port`, `open + auth.ssh.mode: enforce`, `secure + auth.ssh.mode: off|warn`. Most LAN/Tailscale and plain `secure` + `github_users` configs are unaffected. See `docs/upgrades/v0.7.1-to-v0.7.2.md`.

## Validation

- Unit tests green; **VZ integration 77/0**, **FC integration 43/0** (parallel dev servers on this Mac + mini3).
- Reviewed: Codex + CodeRabbit panel on the plan; `/simplify` + CodeRabbit on the implementation.

## Docs

New **Security Configuration** guide (use-case driven: local/loopback/remote/co-located, each with `server.yaml` + the matching `shed server add`) + v0.7.1→v0.7.2 upgrade guide; `security.md` rewritten to the binary model with a connection-flow section; `configuration.md` / `vps-deployment.md` updated; CHANGELOG `Unreleased` entry.

Pairs with shed-extensions#38 (the host-agent gates minting on `https ⟺ secure`, now authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed `auth.http` configuration block
  * Secure mode now enforces TLS-only; plain HTTP listener no longer available
  * `https_port` and `auth.ssh.mode: enforce` now require `auth.mode: secure`

* **New Features**
  * Added `internal_http_port` for loopback credential-bus access in secure deployments

* **Documentation**
  * Added security configuration guide with practical deployment examples
  * Published v0.7.1→v0.7.2 migration guide with configuration mapping and upgrade steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->