### PR TITLE
feat: secure-server CLI UX — https_port on /api/info, security in server list, default-TLS add

### DIFF
--- a/cmd/shed/server.go
+++ b/cmd/shed/server.go
@@ -80,6 +80,7 @@ var (
 	serverAddTrustTOFU      bool
 	serverAddHTTPSPort      int
 	serverAddTLSFingerprint string
+	serverAddSecure         bool
 
 	serverUpdateTLSFingerprint string
 	serverUpdateRefetch        bool
@@ -93,6 +94,7 @@ func init() {
 	serverAddCmd.Flags().BoolVar(&serverAddTrustTOFU, "trust-on-first-use", false, "Trust the server's SSH host key (and TLS cert) without prompting")
 	serverAddCmd.Flags().IntVar(&serverAddHTTPSPort, "https-port", 0, "HTTPS port; when set, bootstrap over TLS and pin the server's self-signed cert")
 	serverAddCmd.Flags().StringVar(&serverAddTLSFingerprint, "tls-fingerprint", "", "Expected TLS cert fingerprint (sha256:...); verified out-of-band, fails on mismatch")
+	serverAddCmd.Flags().BoolVar(&serverAddSecure, "secure", false, "Bootstrap over TLS on the default secure port instead of probing plain HTTP first")
 
 	serverUpdateCmd.Flags().StringVar(&serverUpdateTLSFingerprint, "tls-fingerprint", "", "New pinned TLS cert fingerprint (sha256:...) to rotate to")
 	serverUpdateCmd.Flags().BoolVar(&serverUpdateRefetch, "refetch", false, "Re-fetch the cert from the server's api_url and re-pin it (TOFU/prompt)")
@@ -222,45 +224,83 @@ func confirmTLSCert(fingerprint, expected string, trustOnFirstUse, interactive, 
 	return nil
 }
 
-func runServerAdd(cmd *cobra.Command, args []string) error {
-	host := args[0]
+// defaultAddHTTPSPort is the TLS port `shed server add` falls back to — and the
+// port `--secure` bootstraps against — when no --https-port is given. It mirrors
+// the server's secure-mode default; kept as a var so tests can point the
+// fallback at a test server.
+var defaultAddHTTPSPort = 8443
 
-	// When --https-port is set, bootstrap over TLS: fetch the presented cert,
-	// confirm + pin its fingerprint, then drive /api/info + /api/ssh-host-key
-	// over the pinned connection. Otherwise the legacy plain-HTTP path runs.
-	var apiURL, tlsFingerprint string
-	var client *APIClient
-	if serverAddHTTPSPort > 0 {
-		fp, err := fetchTLSCertFingerprint(host, serverAddHTTPSPort)
-		if err != nil {
-			return err
-		}
-		if err := confirmTLSCert(fp, serverAddTLSFingerprint, serverAddTrustTOFU, isStdinTTY(), jsonFlag, true); err != nil {
-			return err
-		}
-		tlsFingerprint = fp
-		apiURL = "https://" + net.JoinHostPort(host, strconv.Itoa(serverAddHTTPSPort))
-		if verboseLevel > 0 {
-			fmt.Printf("Connecting to %s (TLS, pinned)...\n", apiURL)
-		}
-		client = newAPIClient(apiURL, "", tlsFingerprint, DefaultTimeout)
-	} else {
+// bootstrapTLSClient sets up a pinned-TLS client for host:httpsPort: it fetches
+// the presented cert, confirms + pins its fingerprint (interactive prompt, or
+// --tls-fingerprint / --trust-on-first-use; never silent-trust under --json),
+// and returns a client bound to the resulting https api_url.
+func bootstrapTLSClient(host string, httpsPort int) (client *APIClient, apiURL, fingerprint string, err error) {
+	fp, err := fetchTLSCertFingerprint(host, httpsPort)
+	if err != nil {
+		return nil, "", "", err
+	}
+	if err := confirmTLSCert(fp, serverAddTLSFingerprint, serverAddTrustTOFU, isStdinTTY(), jsonFlag, true); err != nil {
+		return nil, "", "", err
+	}
+	apiURL = "https://" + net.JoinHostPort(host, strconv.Itoa(httpsPort))
+	if verboseLevel > 0 {
+		fmt.Printf("Connecting to %s (TLS, pinned)...\n", apiURL)
+	}
+	return newAPIClient(apiURL, "", fp, DefaultTimeout), apiURL, fp, nil
+}
+
+// selectAddTransport chooses how `shed server add` reaches the server and
+// returns a ready client, the pinned TLS api_url + fingerprint (empty for a
+// plain-HTTP server), and the fetched /api/info:
+//
+//   - --https-port N  → pinned TLS on N.
+//   - --secure        → pinned TLS on the default secure port.
+//   - (default)       → try plain HTTP; if it is refused (a TLS-only secure
+//     server serves no plain-HTTP listener), auto-retry pinned TLS on the
+//     default secure port before giving up.
+func selectAddTransport(host string) (client *APIClient, apiURL, fingerprint string, info *config.ServerInfo, err error) {
+	switch {
+	case serverAddHTTPSPort > 0:
+		client, apiURL, fingerprint, err = bootstrapTLSClient(host, serverAddHTTPSPort)
+	case serverAddSecure:
+		client, apiURL, fingerprint, err = bootstrapTLSClient(host, defaultAddHTTPSPort)
+	default:
 		if verboseLevel > 0 {
 			fmt.Printf("Connecting to %s:%d...\n", host, serverAddPort)
 		}
-		client = NewAPIClient(host, serverAddPort, DefaultTimeout)
-	}
-
-	// Connect and get server info
-	info, err := client.GetInfo()
-	if err != nil {
-		// A secure server serves no plain-HTTP listener, so an unauthenticated
-		// /api/info probe over http fails. Point the operator at --https-port
-		// rather than leaving them with a bare connection error.
-		if serverAddHTTPSPort == 0 {
-			return fmt.Errorf("failed to get server info over plain HTTP: %w\n\nIf this is a secure server, it serves only HTTPS — re-run with --https-port (e.g. --https-port 8443)", err)
+		plain := NewAPIClient(host, serverAddPort, DefaultTimeout)
+		pinfo, perr := plain.GetInfo()
+		if perr == nil {
+			return plain, "", "", pinfo, nil
 		}
-		return fmt.Errorf("failed to get server info: %w", err)
+		// Plain HTTP is unreachable — likely a TLS-only secure server. Auto-retry
+		// pinned TLS on the default secure port before surfacing an error.
+		if !jsonFlag {
+			fmt.Fprintf(os.Stderr, "Plain HTTP on %s:%d is unreachable; trying secure TLS on :%d...\n", host, serverAddPort, defaultAddHTTPSPort)
+		}
+		client, apiURL, fingerprint, err = bootstrapTLSClient(host, defaultAddHTTPSPort)
+		if err != nil {
+			return nil, "", "", nil, fmt.Errorf("could not reach %s: plain HTTP on :%d failed (%v) and secure TLS on :%d failed (%w) — pass --https-port if the server uses a non-default TLS port", host, serverAddPort, perr, defaultAddHTTPSPort, err)
+		}
+	}
+	if err != nil {
+		return nil, "", "", nil, err
+	}
+	info, err = client.GetInfo()
+	if err != nil {
+		return nil, "", "", nil, fmt.Errorf("failed to get server info: %w", err)
+	}
+	return client, apiURL, fingerprint, info, nil
+}
+
+func runServerAdd(cmd *cobra.Command, args []string) error {
+	host := args[0]
+
+	// Pick the transport (explicit --https-port, --secure, or plain-HTTP with an
+	// automatic pinned-TLS fallback) and fetch /api/info over it.
+	client, apiURL, tlsFingerprint, info, err := selectAddTransport(host)
+	if err != nil {
+		return err
 	}
 
 	// Get SSH host key

--- a/cmd/shed/server.go
+++ b/cmd/shed/server.go
@@ -374,12 +374,17 @@ func runServerList(cmd *cobra.Command, args []string) error {
 
 	if jsonFlag {
 		type serverJSON struct {
-			Name     string `json:"name"`
-			Host     string `json:"host"`
-			HTTPPort int    `json:"http_port"`
-			SSHPort  int    `json:"ssh_port"`
-			Status   string `json:"status"`
-			Default  bool   `json:"default"`
+			Name               string `json:"name"`
+			Host               string `json:"host"`
+			Endpoint           string `json:"endpoint"`
+			HTTPPort           int    `json:"http_port"`
+			SSHPort            int    `json:"ssh_port"`
+			HTTPSPort          int    `json:"https_port,omitempty"`
+			Security           string `json:"security"`
+			TLSPinned          bool   `json:"tls_pinned"`
+			TLSCertFingerprint string `json:"tls_cert_fingerprint,omitempty"`
+			Status             string `json:"status"`
+			Default            bool   `json:"default"`
 		}
 		result := make([]serverJSON, 0, len(names))
 		for _, name := range names {
@@ -390,12 +395,17 @@ func runServerList(cmd *cobra.Command, args []string) error {
 				status = "online"
 			}
 			result = append(result, serverJSON{
-				Name:     name,
-				Host:     entry.Host,
-				HTTPPort: entry.HTTPPort,
-				SSHPort:  entry.SSHPort,
-				Status:   status,
-				Default:  name == clientConfig.DefaultServer,
+				Name:               name,
+				Host:               entry.Host,
+				Endpoint:           entry.BaseURL(),
+				HTTPPort:           entry.HTTPPort,
+				SSHPort:            entry.SSHPort,
+				HTTPSPort:          httpsPortFromAPIURL(entry.APIURL),
+				Security:           securityLabel(entry),
+				TLSPinned:          entry.TLSCertFingerprint != "",
+				TLSCertFingerprint: entry.TLSCertFingerprint,
+				Status:             status,
+				Default:            name == clientConfig.DefaultServer,
 			})
 		}
 		return outputJSON(result)
@@ -409,30 +419,66 @@ func runServerList(cmd *cobra.Command, args []string) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tHOST\tHTTP\tSSH\tSTATUS\tDEFAULT")
+	fmt.Fprintln(w, "NAME\tENDPOINT\tSSH\tSECURITY\tSTATUS\tDEFAULT")
 
 	for _, name := range names {
 		entry := clientConfig.Servers[name]
 
-		// Check if server is online
+		// Reachability is probed over the entry's real endpoint (BaseURL +
+		// pinned cert), so STATUS is correct for secure servers too.
 		client := NewAPIClientFromEntry(&entry, DefaultTimeout)
 		status := "offline"
 		if client.Ping() {
 			status = "online"
 		}
 
-		// Check if default
 		defaultMark := ""
 		if name == clientConfig.DefaultServer {
 			defaultMark = "*"
 		}
 
-		fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%s\t%s\n",
-			name, entry.Host, entry.HTTPPort, entry.SSHPort, status, defaultMark)
+		sshAddr := fmt.Sprintf("%s:%d", entry.Host, entry.SSHPort)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			name, entry.BaseURL(), sshAddr, securityLabel(entry), status, defaultMark)
 	}
 
 	w.Flush()
 	return nil
+}
+
+// securityLabel classifies a server entry's control-plane transport for the
+// `shed server list` SECURITY column, derived purely from local config (no
+// network call, so the list stays fast and works offline):
+//
+//	secure   — pinned TLS (https api_url + a pinned cert fingerprint)
+//	unpinned — https api_url with no pinned fingerprint (the client can't
+//	           verify the cert, so requests fail closed — misconfigured)
+//	open     — plain http (the trusted-network LAN/tailnet default)
+func securityLabel(entry config.ServerEntry) string {
+	if isHTTPSURL(entry.APIURL) {
+		if entry.TLSCertFingerprint != "" {
+			return "secure"
+		}
+		return "unpinned"
+	}
+	return "open"
+}
+
+// httpsPortFromAPIURL returns the TLS port from an https api_url (443 when the
+// url omits one), or 0 when the entry isn't https. Derived from the pinned
+// api_url rather than a live /api/info call.
+func httpsPortFromAPIURL(apiURL string) int {
+	if !isHTTPSURL(apiURL) {
+		return 0
+	}
+	u, err := url.Parse(apiURL)
+	if err != nil {
+		return 0
+	}
+	if port, err := strconv.Atoi(u.Port()); err == nil && port > 0 {
+		return port
+	}
+	return 443
 }
 
 func runServerRemove(cmd *cobra.Command, args []string) error {

--- a/cmd/shed/server.go
+++ b/cmd/shed/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -230,6 +231,15 @@ func confirmTLSCert(fingerprint, expected string, trustOnFirstUse, interactive, 
 // fallback at a test server.
 var defaultAddHTTPSPort = 8443
 
+// isUnreachableErr reports whether err is a transport-level failure to reach the
+// server (connection refused, no route, DNS failure, timeout) rather than the
+// server responding with an error — only the former should trigger the TLS
+// fallback in selectAddTransport.
+func isUnreachableErr(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}
+
 // bootstrapTLSClient sets up a pinned-TLS client for host:httpsPort: it fetches
 // the presented cert, confirms + pins its fingerprint (interactive prompt, or
 // --tls-fingerprint / --trust-on-first-use; never silent-trust under --json),
@@ -272,6 +282,11 @@ func selectAddTransport(host string) (client *APIClient, apiURL, fingerprint str
 		pinfo, perr := plain.GetInfo()
 		if perr == nil {
 			return plain, "", "", pinfo, nil
+		}
+		// Only fall back to TLS when plain HTTP was unreachable; a server that
+		// responded with an error is surfaced as-is, not masked by a TLS retry.
+		if !isUnreachableErr(perr) {
+			return nil, "", "", nil, fmt.Errorf("failed to get server info over plain HTTP: %w", perr)
 		}
 		// Plain HTTP is unreachable — likely a TLS-only secure server. Auto-retry
 		// pinned TLS on the default secure port before surfacing an error.

--- a/cmd/shed/server_add_transport_test.go
+++ b/cmd/shed/server_add_transport_test.go
@@ -147,4 +147,24 @@ func TestSelectAddTransport(t *testing.T) {
 			t.Errorf("expected TLS bootstrap on default port: apiURL=%q fp=%q info=%v", apiURL, fp, info)
 		}
 	})
+
+	t.Run("plain server error is surfaced, no TLS fallback", func(t *testing.T) {
+		errSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "boom", http.StatusInternalServerError)
+		}))
+		defer errSrv.Close()
+		_, errPort := hostPort(t, errSrv.URL)
+
+		withCleanAddFlags(t)
+		serverAddPort = errPort       // reachable, but responds 500 (not unreachable)
+		defaultAddHTTPSPort = tlsPort // a working TLS server: a wrong fallback would succeed
+		serverAddTrustTOFU = true
+		_, apiURL, _, _, err := selectAddTransport("127.0.0.1")
+		if err == nil {
+			t.Fatal("expected the plain 500 to surface, not a silent TLS fallback")
+		}
+		if apiURL != "" {
+			t.Errorf("must not fall back to TLS on a server error; apiURL=%q", apiURL)
+		}
+	})
 }

--- a/cmd/shed/server_add_transport_test.go
+++ b/cmd/shed/server_add_transport_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+// infoHandler serves a minimal /api/info, the only endpoint selectAddTransport hits.
+func infoHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/info" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(config.ServerInfo{
+			Name: "test-server", HTTPPort: 8080, SSHPort: 2222, Backend: "vz", AuthMode: "secure",
+		})
+	})
+}
+
+func hostPort(t *testing.T, rawURL string) (string, int) {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse %q: %v", rawURL, err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("port from %q: %v", rawURL, err)
+	}
+	return u.Hostname(), port
+}
+
+// freeClosedPort returns a port with nothing listening, so a dial is refused.
+func freeClosedPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+	return port
+}
+
+// withCleanAddFlags resets the package-level `shed server add` flags for a
+// subtest and restores them afterward (they are globals bound to cobra flags).
+func withCleanAddFlags(t *testing.T) {
+	t.Helper()
+	oHTTPS, oSecure, oPort, oTOFU, oFP, oDefault, oJSON :=
+		serverAddHTTPSPort, serverAddSecure, serverAddPort, serverAddTrustTOFU,
+		serverAddTLSFingerprint, defaultAddHTTPSPort, jsonFlag
+	serverAddHTTPSPort = 0
+	serverAddSecure = false
+	serverAddPort = 8080
+	serverAddTrustTOFU = false
+	serverAddTLSFingerprint = ""
+	jsonFlag = false
+	t.Cleanup(func() {
+		serverAddHTTPSPort, serverAddSecure, serverAddPort, serverAddTrustTOFU,
+			serverAddTLSFingerprint, defaultAddHTTPSPort, jsonFlag =
+			oHTTPS, oSecure, oPort, oTOFU, oFP, oDefault, oJSON
+	})
+}
+
+func TestSelectAddTransport(t *testing.T) {
+	tlsSrv := httptest.NewTLSServer(infoHandler())
+	defer tlsSrv.Close()
+	tlsHost, tlsPort := hostPort(t, tlsSrv.URL)
+	tlsURL := "https://" + net.JoinHostPort(tlsHost, strconv.Itoa(tlsPort))
+
+	plainSrv := httptest.NewServer(infoHandler())
+	defer plainSrv.Close()
+	plainHost, plainPort := hostPort(t, plainSrv.URL)
+
+	t.Run("explicit --https-port bootstraps TLS", func(t *testing.T) {
+		withCleanAddFlags(t)
+		serverAddHTTPSPort = tlsPort
+		serverAddTrustTOFU = true
+		client, apiURL, fp, info, err := selectAddTransport(tlsHost)
+		if err != nil {
+			t.Fatalf("selectAddTransport: %v", err)
+		}
+		if client == nil || info == nil || info.Name != "test-server" {
+			t.Fatalf("client/info not populated: %+v", info)
+		}
+		if apiURL != tlsURL {
+			t.Errorf("apiURL = %q, want %q", apiURL, tlsURL)
+		}
+		if fp == "" {
+			t.Error("expected a pinned TLS fingerprint")
+		}
+	})
+
+	t.Run("plain HTTP server uses plain transport", func(t *testing.T) {
+		withCleanAddFlags(t)
+		serverAddPort = plainPort
+		client, apiURL, fp, info, err := selectAddTransport(plainHost)
+		if err != nil {
+			t.Fatalf("selectAddTransport: %v", err)
+		}
+		if client == nil || info == nil {
+			t.Fatal("expected client + info for a reachable plain server")
+		}
+		if apiURL != "" || fp != "" {
+			t.Errorf("expected plain transport (no apiURL/fingerprint), got apiURL=%q fp=%q", apiURL, fp)
+		}
+	})
+
+	t.Run("plain refused falls back to the default TLS port", func(t *testing.T) {
+		withCleanAddFlags(t)
+		serverAddPort = freeClosedPort(t) // nothing listening → connection refused
+		defaultAddHTTPSPort = tlsPort     // the fallback target
+		serverAddTrustTOFU = true
+		client, apiURL, fp, info, err := selectAddTransport(tlsHost)
+		if err != nil {
+			t.Fatalf("expected TLS fallback to succeed: %v", err)
+		}
+		if client == nil || info == nil {
+			t.Fatal("expected client + info from the fallback")
+		}
+		if apiURL != tlsURL {
+			t.Errorf("apiURL = %q, want TLS fallback %q", apiURL, tlsURL)
+		}
+		if fp == "" {
+			t.Error("expected a pinned fingerprint from the fallback")
+		}
+	})
+
+	t.Run("--secure bootstraps TLS on the default port", func(t *testing.T) {
+		withCleanAddFlags(t)
+		serverAddSecure = true
+		defaultAddHTTPSPort = tlsPort
+		serverAddTrustTOFU = true
+		_, apiURL, fp, info, err := selectAddTransport(tlsHost)
+		if err != nil {
+			t.Fatalf("selectAddTransport: %v", err)
+		}
+		if info == nil || apiURL != tlsURL || fp == "" {
+			t.Errorf("expected TLS bootstrap on default port: apiURL=%q fp=%q info=%v", apiURL, fp, info)
+		}
+	})
+}

--- a/cmd/shed/server_security_test.go
+++ b/cmd/shed/server_security_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+func TestSecurityLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry config.ServerEntry
+		want  string
+	}{
+		{
+			name:  "secure: https api_url with pinned cert",
+			entry: config.ServerEntry{APIURL: "https://localhost:8443", TLSCertFingerprint: "sha256:abc"},
+			want:  "secure",
+		},
+		{
+			name:  "unpinned: https api_url, no fingerprint",
+			entry: config.ServerEntry{APIURL: "https://localhost:8443"},
+			want:  "unpinned",
+		},
+		{
+			name:  "open: no api_url (plain http via host:port)",
+			entry: config.ServerEntry{Host: "mini2", HTTPPort: 8080},
+			want:  "open",
+		},
+		{
+			name:  "open: explicit http api_url",
+			entry: config.ServerEntry{APIURL: "http://mini2:8080"},
+			want:  "open",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := securityLabel(tt.entry); got != tt.want {
+				t.Errorf("securityLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHTTPSPortFromAPIURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		apiURL string
+		want   int
+	}{
+		{name: "explicit https port", apiURL: "https://localhost:8443", want: 8443},
+		{name: "https without port defaults to 443", apiURL: "https://example.com", want: 443},
+		{name: "plain http yields 0", apiURL: "http://mini2:8080", want: 0},
+		{name: "empty yields 0", apiURL: "", want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := httpsPortFromAPIURL(tt.apiURL); got != tt.want {
+				t.Errorf("httpsPortFromAPIURL(%q) = %d, want %d", tt.apiURL, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,6 +34,7 @@ shed server add <host> [flags]
 | `--name` | `-n` | Derived from host | Friendly name for server |
 | `--port` | `-p` | `8080` | HTTP API port (bootstrap; ignored when `--https-port` is set) |
 | `--https-port` | | | HTTPS port; when set, bootstrap over TLS and pin the server's self-signed cert |
+| `--secure` | | `false` | Bootstrap over TLS on the default secure port (8443) without probing plain HTTP first |
 | `--fingerprint` | | | Expected SSH host-key fingerprint (`SHA256:...`); verified out-of-band and fails on mismatch |
 | `--tls-fingerprint` | | | Expected TLS cert fingerprint (`sha256:...`); verified out-of-band and fails on mismatch |
 | `--trust-on-first-use` | | `false` | Trust the server's SSH host key (and TLS cert) without prompting |
@@ -44,6 +45,8 @@ The command pins the server's SSH host key (in `~/.shed/known_hosts`). It prints
 
 With `--https-port`, the command also pins the server's TLS certificate (over a connection it verifies before trusting), shows its fingerprint, and writes `api_url` + `tls_cert_fingerprint` into the server entry so the control plane runs over TLS. See [Security](security.md#native-pinned-tls).
 
+If you omit `--https-port`, `server add` first tries plain HTTP and, when that is refused — a TLS-only `auth.mode: secure` server serves no plain-HTTP listener — automatically retries the pinned-TLS bootstrap on the default secure port (`8443`). Pass `--secure` to skip the plain-HTTP probe and go straight to TLS, or `--https-port` for a non-default TLS port.
+
 When the server runs in `auth.mode: secure`, `server add` also **mints a control token automatically** — there is no `shed-server token new` and no token to paste. After pinning the host key it reads `GET /api/info` to detect secure mode, then connects over the reserved `_bootstrap` SSH channel (the same pinned key); the server re-verifies your key against its allowlist and returns a scoped, short-TTL token, which the CLI writes as `control_token` + `control_token_expires_at` in the server entry. The token is never printed. Your SSH key must therefore be on the server's allowlist (`auth.ssh.github_users` / `authorized_keys`). From then on the CLI refreshes the token transparently — near expiry and on a `401` — so you never run a token command. See [HTTP tokens are minted over SSH](security.md#http-tokens-are-minted-over-ssh).
 
 **Example:**
@@ -52,6 +55,8 @@ When the server runs in `auth.mode: secure`, `server add` also **mints a control
 shed server add mini-desktop.tailnet.ts.net --name mini
 shed server add vps.example.com --name vps --fingerprint SHA256:HtYK...j4Y
 shed server add vps.example.com --https-port 8443 --name vps   # secure: pin TLS + mint a control token
+shed server add secure.example.com --secure --name sec         # secure on the default TLS port (8443)
+shed server add secure.example.com --name sec                  # same: plain HTTP refused → auto-retry TLS:8443
 ```
 
 ### shed server update
@@ -78,10 +83,12 @@ shed server list
 **Output:**
 
 ```
-NAME            HOST                              HTTP    SSH     STATUS     DEFAULT
-mini-desktop    mini-desktop.tailnet.ts.net       8080    2222    online     *
-cloud-vps       vps.tailnet.ts.net                8080    2222    offline
+NAME            ENDPOINT                                 SSH                               SECURITY  STATUS   DEFAULT
+mini-desktop    http://mini-desktop.tailnet.ts.net:8080  mini-desktop.tailnet.ts.net:2222  open      online   *
+cloud-vps       https://vps.tailnet.ts.net:8443          vps.tailnet.ts.net:2222           secure    offline
 ```
+
+The `ENDPOINT` is the control-plane URL the CLI actually uses (`https://…` for a pinned-TLS secure server, `http://…` otherwise). `SECURITY` is `secure` (pinned TLS), `open` (plain HTTP), or `unpinned` (an `https` endpoint with no pinned cert — misconfigured). Add `--json` for the full record, including `https_port`, `tls_pinned`, and the pinned fingerprint.
 
 ### shed server remove
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -34,6 +34,7 @@ func (s *Server) handleGetInfo(w http.ResponseWriter, r *http.Request) {
 		Backend:      s.cfg.DefaultBackend,
 		AuthMode:     authMode,
 		DefaultImage: s.cfg.ActiveDefaultImage(),
+		HTTPSPort:    s.cfg.HTTPSPort,
 	}
 
 	writeJSON(w, http.StatusOK, info)

--- a/internal/api/handlers_info_test.go
+++ b/internal/api/handlers_info_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+// TestHandleGetInfo_HTTPSPort verifies GET /api/info reports https_port only
+// when a TLS listener is configured (secure mode), and omits it otherwise so a
+// client that predates the field (v0.7.1) decodes a zero value without error.
+func TestHandleGetInfo_HTTPSPort(t *testing.T) {
+	tests := []struct {
+		name      string
+		httpsPort int
+		wantField bool
+		wantValue int
+	}{
+		{name: "secure reports https_port", httpsPort: 8443, wantField: true, wantValue: 8443},
+		{name: "open omits https_port", httpsPort: 0, wantField: false, wantValue: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := NewServer(nil, &config.ServerConfig{
+				Name:      "test-server",
+				HTTPPort:  8080,
+				HTTPSPort: tt.httpsPort,
+			}, "", nil, nil)
+
+			r := httptest.NewRequest(http.MethodGet, "/api/info", nil)
+			w := httptest.NewRecorder()
+			srv.Router().ServeHTTP(w, r)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+
+			// Presence check on the raw JSON — omitempty drops the key at 0.
+			var raw map[string]json.RawMessage
+			if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+				t.Fatalf("parse /api/info body: %v", err)
+			}
+			if _, present := raw["https_port"]; present != tt.wantField {
+				t.Fatalf("https_port present=%v, want %v (body: %s)", present, tt.wantField, w.Body.String())
+			}
+
+			// Typed decode mirrors what a client does; back-compat = zero value.
+			var info config.ServerInfo
+			if err := json.Unmarshal(w.Body.Bytes(), &info); err != nil {
+				t.Fatalf("decode ServerInfo: %v", err)
+			}
+			if info.HTTPSPort != tt.wantValue {
+				t.Fatalf("HTTPSPort=%d, want %d", info.HTTPSPort, tt.wantValue)
+			}
+		})
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -232,6 +232,11 @@ type ServerInfo struct {
 	// so clients can see which image a `shed create` without --image will
 	// use — useful when the ref is synthesized and never written in config.
 	DefaultImage string `json:"default_image,omitempty"`
+
+	// HTTPSPort is the pinned-TLS listener port in secure mode (auth.mode:
+	// secure), so a client adding a secure server can learn the TLS endpoint.
+	// 0/omitted in open mode (no HTTPS listener).
+	HTTPSPort int `json:"https_port,omitempty"`
 }
 
 // SSHHostKeyResponse is returned by GET /api/ssh-host-key.


### PR DESCRIPTION
## Summary

CLI/API polish so `auth.mode: secure` (TLS-only) servers are first-class in the `shed` client. Three fixes found while running localmac in secure mode.

## Changes (4 commits)

- **feat(api): report https_port on /api/info** — adds `https_port` to `ServerInfo` (omitempty) so a client can discover a secure server's TLS endpoint. Back-compatible: older servers omit it → decoded as zero.
- **feat(cli): show endpoint and security in server list** — `shed server list` shows the real `ENDPOINT` (BaseURL) + a `SECURITY` column (`secure`/`open`/`unpinned`) instead of the dead `HTTP 8080` column for secure servers. `--json` gains `endpoint`, `https_port`, `security`, `tls_pinned`, and the pinned fingerprint (never tokens). Derived purely from local config — no live `/api/info` call. (`Ping()` already used the real endpoint, so STATUS was correct; this is a display fix.)
- **feat(cli): server add tries the default TLS port for secure servers** — `shed server add <host>` with no `--https-port` auto-retries pinned TLS on `:8443` when plain HTTP is refused, so adding a secure server needs no flag. New `--secure` skips the plain probe. Reuses the existing trust gate (prompt / `--trust-on-first-use` / `--tls-fingerprint`; never silent-trust under `--json`).
- **docs(cli)** — updates the server-list output and documents `--secure` + the fallback.

## Tests

- `TestHandleGetInfo_HTTPSPort` — present in secure, omitted (v0.7.1 back-compat) in open.
- `TestSecurityLabel` / `TestHTTPSPortFromAPIURL` — table-driven on the pure helpers.
- `TestSelectAddTransport` — httptest TLS + plain servers cover all four add paths (explicit `--https-port`, plain success, plain-refused→TLS fallback, `--secure`).
- `make lint` clean; full `make test` green.

## Changelog (patch release — separate, discussed step)

No version bump / tag here. Proposed entry for the release:

> ### Added
> - `/api/info` reports `https_port` so clients can discover a secure server's TLS endpoint.
> - `shed server list` shows the real control-plane `ENDPOINT` + a `SECURITY` column (`secure`/`open`/`unpinned`); `--json` adds `endpoint`, `https_port`, `security`, `tls_pinned`, and the pinned fingerprint.
> - `shed server add` auto-discovers a secure server's TLS port (refused plain HTTP → retry TLS:8443) and a `--secure` flag; trust gate unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--secure` flag to `shed server add` for TLS bootstrap on the default secure port
  * Enhanced `shed server add` transport selection: retries pinned TLS when plain HTTP is unreachable, and surfaces errors on non-reachability failures
  * Expanded `shed server list`: adds `ENDPOINT` and `SECURITY` (and JSON includes TLS pinning details, plus `https_port`)

* **Documentation**
  * Updated CLI reference docs for the new `--secure` flag and revised `server add/list` output behavior

* **Tests**
  * Added coverage for transport probing, security labeling, HTTPS-port parsing, and `GET /api/info` `https_port` behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->