### PR TITLE
feat!: local-first network surface for v0.7.4 — bind_address, single listener, optional http_port

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -148,6 +148,14 @@ brews:
             http_port: 8080
             ssh_port: 2222
 
+            # bind_address: which interface every listener (HTTP/SSH) uses.
+            # Default loopback (127.0.0.1) = reachable on this machine only. To
+            # reach it from other hosts, prefer secure mode (auth.mode: secure;
+            # see the reference above) with bind_address: 0.0.0.0; or, for an
+            # OPEN server on a trusted private network, set bind_address: 0.0.0.0
+            # and allow_insecure_exposure: true.
+            bind_address: 127.0.0.1
+
             default_backend: vz
             log_level: info
 
@@ -216,6 +224,14 @@ brews:
 
             http_port: 8080
             ssh_port: 2222
+
+            # bind_address: which interface every listener (HTTP/SSH) uses.
+            # Default loopback (127.0.0.1) = reachable on this machine only. To
+            # reach it from other hosts, prefer secure mode (auth.mode: secure;
+            # see the reference above) with bind_address: 0.0.0.0; or, for an
+            # OPEN server on a trusted private network, set bind_address: 0.0.0.0
+            # and allow_insecure_exposure: true.
+            bind_address: 127.0.0.1
 
             default_backend: firecracker
             log_level: info
@@ -304,6 +320,10 @@ brews:
       Edit the config to enable credential mounts and extensions,
       then start shed-server as a background service:
         brew services start shed
+
+      By default shed-server listens on 127.0.0.1 only (the local-development
+      default). To reach it from other machines set bind_address in the config —
+      prefer auth.mode: secure for anything exposed on a network.
 
       To enable extensions (SSH agent forwarding, AWS credentials,
       Docker credentials), also install the host agent:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.7.4 — 2026-06-19
+
+Local-first, zero-plaintext-secure network surface — finishes the `0.7` auth
+line: the credential bus loses its plaintext escape hatch, binding is one knob
+that defaults to loopback, and `http_port` is no longer required in secure mode.
+A `0.7.x` patch that carries **breaking config changes** — see the
+[upgrade guide](docs/upgrades/v0.7.3-to-v0.7.4.md).
+
+### Changed
+
+- **One listener per mode — `internal_http_port` removed.** The credential bus
+  (`/api/plugins/*`) and Connect tunnel (`/api/sheds/*/connect/*`) now ride the
+  single listener (pinned TLS in secure mode, plain HTTP in open), gated by the
+  `credentials` scope — so secure mode has no plaintext listener anywhere. Remote
+  `shed forward` works uniformly again (the old split forced Connect to loopback).
+- **`http_bind`/`ssh_bind` unified into `bind_address`, defaulting to loopback.**
+  One interface governs every listener (HTTP, HTTPS, SSH) and **defaults to
+  127.0.0.1 in both modes** — shed is local-development-first. Bind a routable
+  address (`0.0.0.0`/`*`, `::`, or a LAN/tailnet IP) to expose it; in open mode a
+  non-loopback bind also requires the new `allow_insecure_exposure: true` ack
+  (secure mode needs none). A startup `WARNING` flags the new loopback default.
+- **`http_port` is optional in secure mode** (no plain HTTP served there); it is
+  omitted from `/api/info` and the written client entry. Open mode still requires it.
+
+### Breaking
+
+- `internal_http_port`, `http_bind`, and `ssh_bind` are **rejected at startup**
+  (the first removed; the binds renamed to `bind_address`).
+- With no `bind_address` set, every listener now binds **loopback only** (was all
+  interfaces) — a networked server becomes local-only until you set `bind_address`.
+  The deb postinstall warns on upgrade; other channels surface it via a startup
+  `WARNING`. Migration + recovery: [upgrade guide](docs/upgrades/v0.7.3-to-v0.7.4.md).
+
+### Packaging
+
+- Fresh brew/apt configs ship `bind_address: 127.0.0.1` with inline guidance for
+  exposing off-box (secure mode, or open + `allow_insecure_exposure`).
+
 ## v0.7.3 — 2026-06-18
 
 CLI/API polish so `auth.mode: secure` (TLS-only) servers are first-class in the

--- a/README.md
+++ b/README.md
@@ -70,11 +70,15 @@ pulled registry-direct from `ghcr.io`. See
 
 ## Security model
 
-Shed targets single-user setups where every machine is on a private network
-(e.g. Tailscale), the developer controls all of them, and network access implies
-trust. Workloads run as a non-root `shed` user (UID 1000) with passwordless sudo.
-It is **not** built for multi-tenant use, public-internet exposure, or untrusted
-networks.
+Shed is local-development-first: out of the box `bind_address` defaults to
+loopback (`127.0.0.1`), so the server is reachable only on the machine it runs
+on. Facing the network is opt-in, and **secure mode** (pinned TLS + minted
+bearer tokens + an SSH key allowlist) is the preferred posture for anything
+networked — it works locally too. Open mode (plain HTTP, no tokens) stays
+available for a trusted private network (e.g. Tailscale), but exposing it
+off-loopback is explicit. Workloads run as a non-root `shed` user (UID 1000) with
+passwordless sudo. Shed targets single-user setups and is **not** built for
+multi-tenant use.
 
 ## Development
 

--- a/cmd/shed-server/serve.go
+++ b/cmd/shed-server/serve.go
@@ -250,6 +250,19 @@ func runServe(cmd *cobra.Command, args []string) error {
 	apiServer.SetEgressAudit(egressAudit) // nil-safe: no-op when egress disabled
 	apiServer.SetTokenStore(tokenStore)   // shared with the SSH bootstrap handler (1c)
 
+	// Warn when bind_address is unset: as of v0.7.4 that defaults to loopback
+	// (was all-interfaces), so a server that relied on the old default is now
+	// local-only. This startup line is the only migration signal that reaches
+	// every install channel (brew has no upgrade hook); the listeners log their
+	// resolved addresses separately below.
+	if cfg.BindAddress == "" {
+		if cfg.PlainHTTPEnabled() {
+			log.Printf("WARNING: bind_address is unset — binding loopback (127.0.0.1) only. This was all-interfaces before v0.7.4. To reach this open-mode server off-box, set bind_address (e.g. 0.0.0.0) + allow_insecure_exposure: true, or switch to auth.mode: secure.")
+		} else {
+			log.Printf("bind_address is unset — binding loopback (127.0.0.1) only. Set bind_address (e.g. 0.0.0.0) to reach this secure server off-box.")
+		}
+	}
+
 	// One router carries every route; the HTTP and (when enabled) HTTPS
 	// listeners share this single handler.
 	publicHandler := apiServer.Router()

--- a/cmd/shed-server/serve.go
+++ b/cmd/shed-server/serve.go
@@ -250,24 +250,15 @@ func runServe(cmd *cobra.Command, args []string) error {
 	apiServer.SetEgressAudit(egressAudit) // nil-safe: no-op when egress disabled
 	apiServer.SetTokenStore(tokenStore)   // shared with the SSH bootstrap handler (1c)
 
-	// Public router (HTTP and, when enabled, HTTPS share one handler). When
-	// the internal-listener split is enabled, it omits the credential bus +
-	// Connect tunnel.
+	// One router carries every route; the HTTP and (when enabled) HTTPS
+	// listeners share this single handler.
 	publicHandler := apiServer.Router()
 
 	// Plain-HTTP listener. In secure mode it is not started — only the pinned-TLS
-	// (https_port) listener faces clients (TLS-only). The internal loopback
-	// listener below is a separate listener and is unaffected.
+	// (https_port) listener faces clients (TLS-only).
 	var httpServer *http.Server
 	if cfg.PlainHTTPEnabled() {
 		httpServer = newHTTPServer(cfg.HTTPListenAddr(), publicHandler)
-	}
-
-	// Optional internal (loopback) listener carrying the credential bus +
-	// Connect tunnel, kept off the public interface.
-	var internalServer *http.Server
-	if addr := cfg.InternalHTTPListenAddr(); addr != "" {
-		internalServer = newHTTPServer(addr, apiServer.InternalRouter())
 	}
 
 	// Optional HTTPS listener: same public router over TLS with a self-signed,
@@ -299,8 +290,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 		TokenTTL:       cfg.TokenTTL(),
 	})
 
-	// Channel to collect errors from servers (HTTP, HTTPS, SSH, internal HTTP).
-	errChan := make(chan error, 4)
+	// Channel to collect errors from servers (HTTP, HTTPS, SSH).
+	errChan := make(chan error, 3)
 
 	// Start HTTP server in goroutine (skipped in secure mode — TLS-only)
 	if httpServer != nil {
@@ -308,16 +299,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 			log.Printf("HTTP server listening on %s", httpServer.Addr)
 			if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 				errChan <- fmt.Errorf("HTTP server error: %w", err)
-			}
-		}()
-	}
-
-	// Start internal HTTP server in goroutine (when split enabled)
-	if internalServer != nil {
-		go func() {
-			log.Printf("Internal HTTP server (bus+connect) listening on %s", internalServer.Addr)
-			if err := internalServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				errChan <- fmt.Errorf("internal HTTP server error: %w", err)
 			}
 		}()
 	}
@@ -364,14 +345,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 		log.Printf("Shutting down HTTP server...")
 		if err := httpServer.Shutdown(ctx); err != nil {
 			log.Printf("HTTP server shutdown error: %v", err)
-		}
-	}
-
-	// Shutdown internal HTTP server (when enabled)
-	if internalServer != nil {
-		log.Printf("Shutting down internal HTTP server...")
-		if err := internalServer.Shutdown(ctx); err != nil {
-			log.Printf("internal HTTP server shutdown error: %v", err)
 		}
 	}
 

--- a/cmd/shed/server.go
+++ b/cmd/shed/server.go
@@ -388,7 +388,7 @@ func runServerAdd(cmd *cobra.Command, args []string) error {
 			Name:   name,
 			Details: struct {
 				Host               string `json:"host"`
-				HTTPPort           int    `json:"http_port"`
+				HTTPPort           int    `json:"http_port,omitempty"`
 				SSHPort            int    `json:"ssh_port"`
 				APIURL             string `json:"api_url,omitempty"`
 				TLSCertFingerprint string `json:"tls_cert_fingerprint,omitempty"`
@@ -432,7 +432,7 @@ func runServerList(cmd *cobra.Command, args []string) error {
 			Name               string `json:"name"`
 			Host               string `json:"host"`
 			Endpoint           string `json:"endpoint"`
-			HTTPPort           int    `json:"http_port"`
+			HTTPPort           int    `json:"http_port,omitempty"`
 			SSHPort            int    `json:"ssh_port"`
 			HTTPSPort          int    `json:"https_port,omitempty"`
 			Security           string `json:"security"`

--- a/configs/server.dev-parallel.linux-fc.yaml
+++ b/configs/server.dev-parallel.linux-fc.yaml
@@ -29,6 +29,12 @@ name: mini3-dev
 http_port: 18080
 ssh_port: 12222
 
+# This FC dev server runs on the remote (mini3) and is driven from the dev
+# workstation, so it must face the network. As of v0.7.4 every posture defaults
+# to loopback, so bind explicitly; open mode also requires the exposure ack.
+bind_address: 0.0.0.0
+allow_insecure_exposure: true
+
 default_backend: firecracker
 log_level: debug
 

--- a/configs/server.dev-parallel.mac.yaml
+++ b/configs/server.dev-parallel.mac.yaml
@@ -24,6 +24,10 @@ name: my-server-dev
 http_port: 18080
 ssh_port: 12222
 
+# Loopback (also the v0.7.4 default) — the suite drives this dev server over
+# localhost, so it stays on-box. Set explicitly to document intent.
+bind_address: 127.0.0.1
+
 default_backend: vz
 log_level: debug
 

--- a/configs/server.example.yaml
+++ b/configs/server.example.yaml
@@ -12,6 +12,14 @@ name: my-server
 http_port: 8080
 ssh_port: 2222
 
+# bind_address — the interface every listener (HTTP, HTTPS, SSH) binds.
+# Defaults to loopback (127.0.0.1): shed is a local-development tool unless
+# explicitly exposed. Set a routable address ("0.0.0.0"/"*" = all IPv4,
+# "::" = all interfaces, or a specific LAN/tailnet IP) to reach it off-box.
+# In OPEN mode (no TLS) a non-loopback bind also requires
+# allow_insecure_exposure: true; secure mode (auth.mode: secure) needs no ack.
+bind_address: 127.0.0.1
+
 # Backend configuration
 # Valid values: vz (macOS/arm64), firecracker (Linux), detect (auto-select)
 # "detect" picks vz on macOS Apple Silicon and firecracker on Linux.

--- a/docs/getting-started/linux-quickstart.md
+++ b/docs/getting-started/linux-quickstart.md
@@ -57,33 +57,64 @@ bridge network, IP forwarding + NAT, and capabilities:
 sudo shed-server setup
 ```
 
-## 3. Configure the server (optional)
+## 3. Configure the server for network access
 
-The default config at `/etc/shed/server.yaml` works out of the box. A minimal
-config looks like:
+The default config at `/etc/shed/server.yaml` binds **loopback only**
+(`bind_address` defaults to `127.0.0.1` since v0.7.4), so a fresh install is
+reachable only on the box itself. Since you reach this host from a workstation,
+edit the config so it faces the network.
+
+**Recommended — secure mode** (pinned TLS + minted bearer tokens + an SSH key
+allowlist; the preferred posture for anything networked):
 
 ```yaml
 # /etc/shed/server.yaml
 # Full reference: https://charliek.github.io/shed/reference/configuration/
 name: my-linux-host
-http_port: 8080
 ssh_port: 2222
 default_backend: firecracker
+
+auth:
+  mode: secure                   # forces SSH enforce + HTTP tokens + TLS-only
+  ssh:
+    github_users: [your-github-username]   # only these keys may SSH in (and mint tokens)
+bind_address: 0.0.0.0            # face the network (or a specific tailnet/LAN IP)
+# https_port defaults to 8443; http_port is optional in secure mode.
 
 firecracker:
   pull_policy: missing
   # default_image / image_aliases omitted -> synthesized from the server version.
 ```
 
-See [Configuration](../reference/configuration.md) for the Firecracker-specific
-fields (bridge name/CIDR, vsock, resource defaults).
+**Alternative — open on a trusted private network** (plaintext; Tailscale / LAN
+only, where the network is the trust boundary):
+
+```yaml
+# /etc/shed/server.yaml
+name: my-linux-host
+http_port: 8080
+ssh_port: 2222
+default_backend: firecracker
+
+bind_address: 0.0.0.0            # or a specific tailnet/LAN IP
+allow_insecure_exposure: true    # required: acknowledge a non-loopback bind with no TLS
+
+firecracker:
+  pull_policy: missing
+```
+
+See the [Security Configuration guide](../guides/security-configuration.md) for
+the full posture walkthrough and [Configuration](../reference/configuration.md)
+for the Firecracker-specific fields (bridge name/CIDR, vsock, resource defaults).
 
 ## 4. Start it
 
 ```bash
 sudo systemctl start shed-server
-systemctl status shed-server            # should be active (running)
-curl -s http://localhost:8080/api/info  # name, version, backend: firecracker
+systemctl status shed-server                  # should be active (running)
+# secure mode (TLS-only) — check over HTTPS on the box:
+curl -sk https://localhost:8443/api/info      # name, version, backend: firecracker
+# open mode instead? use: curl -s http://localhost:8080/api/info
 ```
 
 The first `shed create` pulls the matching `shed-fc-full` image automatically
@@ -91,13 +122,18 @@ The first `shed create` pulls the matching `shed-fc-full` image automatically
 
 ## 5. Connect from your workstation
 
-From the Mac/Linux box that has the `shed` CLI (over Tailscale/LAN):
+From the Mac/Linux box that has the `shed` CLI (over Tailscale/LAN). For a secure
+server, `shed server add --https-port` pins the TLS cert + SSH host key and mints
+your token over SSH (your key must be in the `github_users` allowlist):
 
 ```bash
-shed server add my-linux-host.tailnet.ts.net --name my-linux-host
+shed server add my-linux-host.tailnet.ts.net --https-port 8443 --name my-linux-host
 shed create demo --repo charliek/your-repo
 shed attach demo
 ```
+
+For an **open** server (the LAN alternative above), drop `--https-port`:
+`shed server add my-linux-host.tailnet.ts.net --name my-linux-host`.
 
 ## Upgrading
 

--- a/docs/getting-started/macos-quickstart.md
+++ b/docs/getting-started/macos-quickstart.md
@@ -49,6 +49,10 @@ http_port: 8080
 ssh_port: 2222
 default_backend: vz
 
+# Local-only by default: bind_address defaults to loopback (127.0.0.1), so the
+# server is reachable only on this Mac. You reach it as `shed server add localhost`.
+# To reach it from another machine, see the Security Configuration guide.
+
 # Host directories shared into every shed (VirtioFS). Add only what you need.
 mounts:
   claude:

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -24,13 +24,29 @@ running.
 
 ## Add a Server
 
-Register a server that has `shed-server` running:
+Register a server that has `shed-server` running. For a **local** server (the
+installed default — open, bound to loopback):
 
 ```bash
-shed server add my-server.tailnet.ts.net --name my-server
+shed server add localhost --name my-server
 ```
 
-This connects to the server, retrieves its SSH host key, and saves the configuration.
+For a server you reach **over the network**, the server must bind a non-loopback
+`bind_address` (since v0.7.4 the default is loopback-only). Secure mode is the
+preferred networked posture — pin its TLS cert and mint a token over SSH:
+
+```bash
+shed server add my-server.tailnet.ts.net --https-port 8443 --name my-server
+```
+
+For an open server on a trusted private network (configured with
+`allow_insecure_exposure: true`), drop `--https-port`:
+`shed server add my-server.tailnet.ts.net --name my-server`. See the
+[Security Configuration guide](../guides/security-configuration.md) for the
+server-side posture setup.
+
+This connects to the server, retrieves its SSH host key (and, in secure mode,
+pins the TLS cert and mints your token), and saves the configuration.
 
 ## Create a Shed
 

--- a/docs/guides/security-configuration.md
+++ b/docs/guides/security-configuration.md
@@ -1,19 +1,32 @@
 # Security Configuration
 
-shed's network security is two independent choices:
+shed is **local-development-first**: out of the box (the brew/apt install) it
+runs localhost-only. Networked access is opt-in. Its network security is two
+independent choices:
 
 1. **Posture** — `auth.mode: open | secure`. *Open* trusts the network (plain
    HTTP, no tokens, no TLS). *Secure* trusts nothing (pinned TLS + bearer tokens
    + an SSH key allowlist), and is **TLS-only** — it serves no plain-HTTP
    listener at all.
-2. **Where listeners bind** — `http_bind` / `ssh_bind` (and the optional
-   `internal_http_port`). This decides whether the server is reachable only on
-   `127.0.0.1` (this machine) or across the network.
+2. **Where listeners bind** — `bind_address` governs every listener (HTTP,
+   HTTPS, SSH). It **defaults to loopback (`127.0.0.1`)** in both modes, so the
+   server is reachable only on this machine until you set it to a routable
+   address.
+
+Think of it as two deployment shapes:
+
+- **Local development** (the default) — localhost-only, either open (the
+  installed default) or secure. Cases 1 and 2 below.
+- **Remote-facing** — reachable across the network. Secure is the preferred
+  posture (TLS + tokens); open is allowed only with an explicit `bind_address`
+  *and* `allow_insecure_exposure: true`. Cases 3 and 4 below.
 
 This guide walks the common shapes those two choices produce. For the underlying
 model — the invariants, the credential bus, and the exact connection flow — see
 the [Security reference](../reference/security.md). For a full internet-facing
-walkthrough, see [Public VPS Deployment](vps-deployment.md).
+walkthrough, see [Public VPS Deployment](vps-deployment.md). Upgrading from a
+pre-v0.7.4 server (the loopback default is new)? See
+[Upgrading v0.7.3 → v0.7.4](../upgrades/v0.7.3-to-v0.7.4.md).
 
 Server settings live in `server.yaml` (`/etc/shed/server.yaml` on Linux,
 `~/.config/shed/server.yaml` or the Homebrew `…/etc/shed/server.yaml` on macOS).
@@ -24,10 +37,10 @@ Client settings are written per server into `~/.shed/config.yaml` by
 
 | Question | If yes |
 |----------|--------|
-| Is everything on **one machine**, and do you want zero auth ceremony? | **Open + loopback** (Case 1) |
+| Is everything on **one machine**, and do you want zero auth ceremony? | **Open + loopback** (Case 1) — the installed default |
 | One machine, but you want TLS + key checking anyway (shared box, or mirror prod locally)? | **Secure + loopback** (Case 2) |
-| Reachable **over the network** / internet-facing? | **Secure, all interfaces** (Case 3) |
-| Network-facing **and** the credential host-agent runs on the same box? | **Secure + `internal_http_port`** (Case 4) |
+| Reachable **over the network** / internet-facing? | **Secure, all interfaces** (Case 3) — the preferred networked posture |
+| Reachable over the network, but a **trusted private network only** and you accept plaintext? | **Open on a LAN** (Case 4) — needs `allow_insecure_exposure: true` |
 
 Two invariants hold across every secure deployment, and explain the startup
 rejections you may hit (see [Troubleshooting](#troubleshooting-startup-rejections)):
@@ -49,12 +62,12 @@ wants nothing exposed to the LAN and no SSH allowlist / token / TLS ceremony.
 
 ```yaml
 auth:
-  mode: open        # the default — may be omitted
-http_bind: 127.0.0.1   # plain-HTTP API reachable only on this machine
-ssh_bind: 127.0.0.1    # SSH (shed sessions) reachable only on this machine
+  mode: open             # the default — may be omitted
+bind_address: 127.0.0.1  # the default — every listener (HTTP + SSH) binds loopback only
 ```
 
-Add the server (plain HTTP — no flags):
+`bind_address: 127.0.0.1` is the default, so this is also what you get with an
+empty `server.yaml`. Add the server (plain HTTP — no flags):
 
 ```bash
 shed server add localhost
@@ -80,8 +93,7 @@ auth:
   ssh:
     authorized_keys:
       - ssh-ed25519 AAAA…your-key… you@laptop   # the key you SSH/​bootstrap with
-http_bind: 127.0.0.1   # the HTTPS listener binds here → loopback-only TLS
-ssh_bind: 127.0.0.1
+bind_address: 127.0.0.1   # the default — HTTPS + SSH bind loopback only
 # https_port defaults to 8443 in secure mode
 ```
 
@@ -113,8 +125,15 @@ auth:
     github_users: [charliek]   # only these GitHub keys may SSH in (and mint tokens)
 tls_names:
   - shed.example.com           # your public hostname / IP (extra cert SANs)
-# http_bind empty → HTTPS binds all interfaces; https_port defaults to 8443
+bind_address: 0.0.0.0          # secure defaults to loopback too — set this to face the network
+# https_port defaults to 8443
 ```
+
+Secure mode defaults to loopback like every other posture, so a remote server
+**must set `bind_address`** explicitly (`0.0.0.0`/`*` for all IPv4, `::` for all
+interfaces, or a specific public/tailnet IP) — otherwise it is unreachable.
+Secure needs **no** `allow_insecure_exposure` ack to bind the network: TLS +
+tokens already make it safe.
 
 From your laptop:
 
@@ -125,41 +144,44 @@ shed server add shed.example.com --https-port 8443
 This fetches the cert + SSH host key, shows both fingerprints for confirmation,
 pins them, then mints a token over the `_bootstrap` SSH channel — no token to
 paste. **You get:** HTTPS on all interfaces (`8443`), SSH allowlist, tokens; no
-plaintext anywhere. See [Public VPS Deployment](vps-deployment.md) for the full
-flow, out-of-band fingerprint verification, and rotation.
+plaintext anywhere. A co-located host-agent (one running on the same box) reaches
+the credential bus over the same pinned-TLS listener at
+`https://127.0.0.1:8443`, gated by the `credentials` scope. See
+[Public VPS Deployment](vps-deployment.md) for the full flow, out-of-band
+fingerprint verification, and rotation.
 
 ---
 
-## Case 4 — Remote + co-located host-agent (secure + `internal_http_port`)
+## Case 4 — Remote, open on a trusted LAN (open + `allow_insecure_exposure`)
 
-**For:** a remote secure server where the credential **host-agent runs on the
-same box**. The credential bus should stay on loopback rather than ride the
-public TLS listener.
+**For:** a server reachable across a **trusted private network only** (a
+Tailscale tailnet or a closed LAN), where you accept plaintext and want no token
+/ TLS ceremony. **Prefer secure (Case 3) for anything networked** — this case
+has no transport security, so use it only when the network itself is the trust
+boundary.
 
 `server.yaml`:
 
 ```yaml
 auth:
-  mode: secure
-  ssh:
-    github_users: [charliek]
-tls_names: [shed.example.com]
-internal_http_port: 8081   # bus + Connect tunnel move to a loopback-only listener
+  mode: open               # plain HTTP, no tokens, no TLS
+bind_address: 0.0.0.0      # face the network (or a specific tailnet/LAN IP)
+allow_insecure_exposure: true   # required: acknowledge a non-loopback bind with no transport security
 ```
 
-Clients add the server exactly as in Case 3 (the control plane is unchanged):
+Binding a non-loopback interface in **open** mode requires
+`allow_insecure_exposure: true` — without it the server refuses to start, because
+open mode would otherwise put plaintext on the network silently. (Secure mode
+needs no such ack.) Add the server (plain HTTP — no flags):
 
 ```bash
-shed server add shed.example.com --https-port 8443
+shed server add my-host.tailnet.ts.net --name my-host
 ```
 
-The co-located host-agent reaches the bus over `http://127.0.0.1:8081` (loopback,
-on-box). **You get:** a public pinned-TLS control plane *plus* an on-box loopback
-bus. **Trade-off (important):** `internal_http_port` also moves the Connect
-tunnel to loopback, so **remote `shed forward` stops working** — use this only
-when the host-agent is on the same machine as shed-server. With it unset (Case 3),
-the bus + tunnel ride the public TLS listener, gated by the `credentials` scope,
-which is what a **remote** host-agent / `shed forward` needs.
+**You get:** plain HTTP + SSH on the LAN, no tokens, no TLS. **Trade-off:**
+everything is plaintext and any host that can reach the address can reach the
+API — the private network *is* the trust boundary. Move to secure (Case 3) the
+moment the server faces anything wider.
 
 ---
 
@@ -186,17 +208,19 @@ it blocks. `warn` is valid only in open mode; secure always enforces.
 
 ## Is anything plaintext in secure mode?
 
-No. Secure mode serves **no** plain-HTTP listener — only the pinned-TLS listener
-faces clients, and a client that holds a pin but is handed a non-`https` URL
-fails closed rather than send plaintext. The SSH channel (shed sessions and the
-token mint) is encrypted with the host key pinned in `known_hosts`. The only
-trust-on-first-use moment is `shed server add` showing you the cert fingerprint
-to confirm (or pass `--tls-fingerprint` / `--fingerprint` to verify out-of-band).
-See the [connection-flow table](../reference/security.md#connection-flow-whats-encrypted-where).
+No — nothing, anywhere. Secure mode serves **no** plain-HTTP listener at all (not
+even on loopback): a single pinned-TLS listener faces clients, and a client that
+holds a pin but is handed a non-`https` URL fails closed rather than send
+plaintext. The SSH channel (shed sessions and the token mint) is encrypted with
+the host key pinned in `known_hosts`. The only trust-on-first-use moment is
+`shed server add` showing you the cert fingerprint to confirm (or pass
+`--tls-fingerprint` / `--fingerprint` to verify out-of-band). See the
+[connection-flow table](../reference/security.md#connection-flow-whats-encrypted-where).
 
-The one exception is deliberate and opt-in: `internal_http_port` (Case 4) is a
-loopback-only plaintext listener for a co-located bus. There is no implicit
-plaintext channel.
+The credential bus and Connect tunnel ride that same TLS listener, gated by the
+`credentials` scope — so a co-located host-agent reaches them over
+`https://127.0.0.1:8443` with the pinned cert. There is no plaintext channel,
+implicit or opt-in.
 
 ## Troubleshooting startup rejections
 
@@ -211,12 +235,15 @@ the gap and exits):
 | `auth.ssh.mode: enforce requires auth.mode: secure` | enforcing the allowlist without secure | Use `secure`, or `warn` to stage (above). |
 | `auth.mode: secure forces auth.ssh.mode: enforce` | an explicit `off`/`warn` under secure | Remove `auth.ssh.mode` — secure derives `enforce`. |
 | `config key "auth.http" was removed` | a leftover `auth.http` block | Delete it — token enforcement derives from `auth.mode: secure`. |
+| `config key "http_bind"/"ssh_bind" was removed` | a leftover `http_bind`/`ssh_bind` | Replace both with a single `bind_address`. |
+| `config key "internal_http_port" was removed` | a leftover `internal_http_port` | Delete it — the bus + Connect tunnel ride the single listener (Case 3). |
+| `bind_address … requires allow_insecure_exposure` | a non-loopback `bind_address` in **open** mode | Add `allow_insecure_exposure: true` (Case 4), or switch to `secure` (Case 3). |
 
 ## Quick reference
 
-| Case | `auth.mode` | `http_bind` | TLS | `shed server add` |
-|------|-------------|-------------|-----|-------------------|
-| 1 — local simple | `open` | `127.0.0.1` | none | `shed server add localhost` |
-| 2 — local hardened | `secure` | `127.0.0.1` | loopback `:8443` | `shed server add localhost --https-port 8443` |
-| 3 — remote | `secure` | (all) | all ifaces `:8443` | `shed server add <host> --https-port 8443` |
-| 4 — remote + co-located agent | `secure` + `internal_http_port` | (all) | all ifaces `:8443` | `shed server add <host> --https-port 8443` |
+| Case | `auth.mode` | `bind_address` | TLS | `shed server add` |
+|------|-------------|----------------|-----|-------------------|
+| 1 — local simple | `open` | `127.0.0.1` (default) | none | `shed server add localhost` |
+| 2 — local hardened | `secure` | `127.0.0.1` (default) | loopback `:8443` | `shed server add localhost --https-port 8443` |
+| 3 — remote (preferred) | `secure` | `0.0.0.0` | all ifaces `:8443` | `shed server add <host> --https-port 8443` |
+| 4 — remote open on LAN | `open` + `allow_insecure_exposure` | `0.0.0.0` | none | `shed server add <host>` |

--- a/docs/guides/vps-deployment.md
+++ b/docs/guides/vps-deployment.md
@@ -5,17 +5,19 @@ This guide deploys shed-server on an internet-facing VPS, locked down so that
 token-authenticated**, and the **credential bus is reachable only with a
 credentials token over TLS**.
 
-The default shed posture is open-on-a-trusted-network (Tailscale/LAN). This
-guide is the opposite end: a hardened, internet-facing server. One switch —
+The default shed posture is local-only (open, bound to loopback). This guide is
+the opposite end: a hardened, internet-facing server. One switch —
 [`auth.mode: secure`](../reference/security.md#secure-mode) — derives the whole
 hardening bundle (SSH allowlist enforced + HTTP tokens enforced + TLS-only, with
-no plain-HTTP listener) and **refuses to start** if any piece is missing. There
-are no tokens to mint or paste: clients get them automatically over SSH.
+no plain-HTTP listener) and **refuses to start** if any piece is missing; one
+`bind_address` faces it at the network. There are no tokens to mint or paste:
+clients get them automatically over SSH.
 
 ## 1. Server config
 
-Write `/etc/shed/server.yaml`. The only thing `secure` requires from you is an
-SSH key source:
+Write `/etc/shed/server.yaml`. `secure` requires an SSH key source, and — since
+v0.7.4 every posture defaults to loopback — a `bind_address` so the VPS is
+reachable from off-box:
 
 ```yaml
 auth:
@@ -24,6 +26,7 @@ auth:
     github_users: [charliek]     # only these GitHub keys may SSH in (and mint tokens)
 tls_names:
   - shed.example.com             # your VPS hostname / public IP (extra cert SANs)
+bind_address: 0.0.0.0            # face the network (loopback is the default) — or a specific public IP
 ```
 
 `secure` mode forces `auth.ssh.mode: enforce`, enforces HTTP bearer tokens, turns
@@ -31,6 +34,12 @@ on pinned TLS (`https_port` defaults to `8443`), and serves **no plain-HTTP
 listener** (TLS-only) — so the only API is HTTPS on `8443`, with the credential
 bus and Connect tunnel gated by the `credentials` scope. (`shed server add`
 against a secure server therefore needs `--https-port`, as below.)
+
+!!! warning "`bind_address` is required for a remote server"
+    Since v0.7.4 `bind_address` **defaults to loopback (`127.0.0.1`) in secure
+    mode too**, so without the `bind_address: 0.0.0.0` line above the VPS binds
+    loopback only and is unreachable from your laptop. Secure mode needs no
+    `allow_insecure_exposure` ack — TLS + tokens make the network bind safe.
 
 Start (or restart) the server. If a required piece is missing it exits
 immediately, naming the gap:
@@ -112,11 +121,11 @@ SSH and TLS fingerprints. Tighten it further by verifying out-of-band
 bring your own TLS certificate instead of the self-signed one with
 `tls_cert_file` / `tls_key_file` in the server config.
 
-## Co-located alternative
+## Co-located host-agent
 
-If you instead run the host-agent **on the VPS itself**, set
-`internal_http_port: 8081` to move the credential bus to a loopback-only
-listener. Note this also moves the Connect tunnel to loopback, so remote
-`shed forward` is no longer available — use the co-located split only when the
-host-agent is on the same box. See the
-[route matrix](../reference/security.md#route-matrix).
+If you instead run the host-agent **on the VPS itself**, no extra config is
+needed: the credential bus and Connect tunnel ride the single pinned-TLS listener
+(gated by the `credentials` scope), and the on-box host-agent reaches them over
+`https://127.0.0.1:8443` with the pinned cert. Remote `shed forward` keeps
+working at the same time, because there is no longer a separate loopback-only
+listener. See the [network surface](../reference/security.md#network-surface).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -78,11 +78,10 @@ log_level: info
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `name` | string | `shed-server` | Server identifier |
-| `http_port` | int | `8080` | HTTP API port |
+| `http_port` | int | `8080` | Plain-HTTP API port. **Required in open mode; optional in secure mode** (secure serves no plain HTTP, so it is omitted from `/api/info` and the written client config entry). |
 | `ssh_port` | int | `2222` | SSH server port |
-| `http_bind` | string | `""` | Interface to bind the HTTP listener to (e.g. `127.0.0.1`, or a tailnet IP). Empty binds all interfaces. |
-| `ssh_bind` | string | `""` | Interface to bind the SSH listener to. Empty binds all interfaces. |
-| `internal_http_port` | int | `0` | When greater than 0, moves the credential bus (`/api/plugins/*`) and the Connect tunnel (`/api/sheds/*/connect/*`) onto a loopback-only listener on this port, keeping them off the public interface. `0` keeps every route on the public listener (default). |
+| `bind_address` | string | `127.0.0.1` | Interface every listener (HTTP, HTTPS, SSH) binds to. **Defaults to loopback in both modes** — shed is local-first. Set a specific IP (LAN/tailnet), `0.0.0.0` or `*` (all IPv4), or `::` (all interfaces) to face the network. A non-loopback bind in **open** mode also requires `allow_insecure_exposure: true`; secure mode needs no acknowledgment. |
+| `allow_insecure_exposure` | bool | `false` | Acknowledge binding a **non-loopback** `bind_address` in **open** mode (no transport security). Required there, ignored in secure mode and for loopback binds. |
 | `trusted_proxy` | bool | `false` | Trust the client-supplied `X-Forwarded-For` header for the request source IP. Only enable behind a reverse proxy that overwrites that header; the default uses the real TCP peer address. |
 | `default_backend` | string | `detect` | Backend to use when none is specified (`detect`, `firecracker`, `vz`). `detect` auto-selects based on platform: `vz` on macOS, `firecracker` on Linux. |
 | `mounts` | map | `{}` | Host directories to mount into sheds (formerly `credentials`) |
@@ -116,7 +115,10 @@ The pre-v0.7.1 `public_exposure` flag and `auth.http.tokens` list are removed an
 tokens over SSH. As of v0.7.2 the whole `auth.http` block is gone (HTTP
 enforcement derives from `auth.mode: secure`), and `https_port` /
 `auth.ssh.mode: enforce` are valid only in secure mode — see
-[Upgrading v0.7.1 → v0.7.2](../upgrades/v0.7.1-to-v0.7.2.md).
+[Upgrading v0.7.1 → v0.7.2](../upgrades/v0.7.1-to-v0.7.2.md). As of v0.7.4
+`http_bind`/`ssh_bind`/`internal_http_port` are removed in favour of a single
+`bind_address` (loopback by default), and `http_port` is optional in secure mode
+— see [Upgrading v0.7.3 → v0.7.4](../upgrades/v0.7.3-to-v0.7.4.md).
 
 ### SSH authentication
 
@@ -150,11 +152,11 @@ field — it is derived from `auth.mode: secure` (there is no `auth.http` block)
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `https_port` | int | `8443` in secure | Serve HTTPS with a self-signed, client-pinned cert. **Requires `auth.mode: secure`** (rejected in open mode); defaults to `8443` there. In secure mode this is the *only* listener — no plain HTTP is served. |
+| `https_port` | int | `8443` in secure | Serve HTTPS with a self-signed, client-pinned cert, bound to `bind_address`. **Requires `auth.mode: secure`** (rejected in open mode); defaults to `8443` there. In secure mode this is the *only* listener — no plain HTTP is served. |
 | `tls_names` | list | `[]` | Extra hostnames/IPs added as cert SANs. `localhost`, `127.0.0.1`, `::1` are always included. |
 | `tls_cert_file` / `tls_key_file` | string | next to host key | Override where the TLS cert + key are persisted. |
-| `http_bind` / `ssh_bind` | string | all interfaces | Restrict a listener to one interface (e.g. `127.0.0.1`, a tailnet IP). |
-| `internal_http_port` | int | - | Move the credential bus + Connect tunnel to a loopback-only internal listener (co-located host-agent model; see the [route matrix](security.md#route-matrix)). |
+| `bind_address` | string | `127.0.0.1` | Interface every listener binds to (loopback by default in both modes). Set a specific IP, `0.0.0.0`/`*` (all IPv4), or `::` (all interfaces) to face the network. A non-loopback bind in **open** mode also requires `allow_insecure_exposure: true`. |
+| `allow_insecure_exposure` | bool | `false` | Acknowledge a non-loopback `bind_address` in **open** mode (no transport security). Ignored in secure mode. |
 | `trusted_proxy` | bool | `false` | Trust `X-Forwarded-For` (only behind a proxy that overwrites it). |
 
 ### Mounts

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -7,9 +7,11 @@ auth:
   mode: open      # open (default) | secure
 ```
 
-- **`open`** (the default) is the right posture on a private network — a
-  Tailscale tailnet or a trusted LAN — where the network is the security
-  boundary. It serves plain HTTP only: no HTTP token, no TLS. The SSH allowlist
+- **`open`** (the default) serves plain HTTP only — no HTTP token, no TLS — and
+  binds loopback by default, so out of the box it is **local-development-only**.
+  It is also fine on a private network (a Tailscale tailnet or trusted LAN) where
+  the network is the security boundary, but exposing it there is explicit: set a
+  routable `bind_address` *and* `allow_insecure_exposure: true`. The SSH allowlist
   is the one independently-tunable layer here (`auth.ssh.mode: off|warn`, where
   `warn` stages an allowlist before you commit to enforcing it).
 - **`secure`** is for an internet-facing deployment. It derives the whole
@@ -20,8 +22,14 @@ auth:
 
 | `auth.mode` | SSH allowlist | HTTP tokens | Plain-HTTP listener | TLS |
 |-------------|---------------|-------------|---------------------|-----|
-| `open` | as configured (`auth.ssh`: `off`/`warn`) | off | all interfaces (`http_bind`) | none (`https_port` requires `secure`) |
+| `open` | as configured (`auth.ssh`: `off`/`warn`) | off | served (bound to `bind_address`) | none (`https_port` requires `secure`) |
 | `secure` | **forced `enforce`** (needs a key source) | **enforced** | **none — TLS-only** | **on** (`https_port` defaults to 8443) |
+
+Every listener (plain HTTP, HTTPS, SSH) binds the single `bind_address`, which
+**defaults to loopback (`127.0.0.1`) in both modes** — shed is local-first.
+Facing the network is opt-in: set `bind_address` to a routable address, and in
+**open** mode also set `allow_insecure_exposure: true` (open has no transport
+security). Secure mode needs no acknowledgment to bind the network.
 
 All server settings live in the server config (`/etc/shed/server.yaml` on
 Linux, `~/.config/shed/server.yaml` on macOS). Client settings live per server
@@ -180,34 +188,22 @@ Rotating an existing pin in a non-interactive session requires
 
 ## Network surface
 
-In open mode both listeners bind all interfaces on a single plain-HTTP listener.
-In `secure` mode there is **no plain-HTTP listener at all** — only the pinned-TLS
-(`https_port`) listener faces clients. These knobs shape what is reachable where:
+There is **one HTTP listener per mode** (SSH always listens separately on
+`ssh_port`): a single plain-HTTP listener in open mode, or a single pinned-TLS
+(`https_port`) listener in `secure` mode — in secure mode there is **no
+plain-HTTP listener at all**. The credential bus (`/api/plugins/*`)
+and the Connect tunnel (`/api/sheds/*/connect/*`) ride that same listener; in
+secure mode they are gated by the `credentials` scope (so a leaked `control`
+token can't reach them) and travel over TLS. A co-located host-agent reaches the
+bus over `https://127.0.0.1:8443` with the pinned cert. There is no separate
+internal/loopback listener. These knobs shape what is reachable where:
 
 | Field | Effect |
 |-------|--------|
-| `http_bind` | Interface for the plain-HTTP listener (e.g. `127.0.0.1`, a tailnet IP). Empty = all interfaces. **Not served in `secure` mode** (TLS-only). |
-| `ssh_bind` | Interface for the SSH listener. |
-| `https_port` | An HTTPS listener (shares `http_bind`) serving the control plane over pinned TLS. **Requires `secure` mode**; defaults to `8443` there. |
-| `internal_http_port` | When > 0, moves the credential bus (`/api/plugins/*`) **and the Connect tunnel** to an opt-in loopback-only internal listener; the public listener omits them. This is the one loopback channel available in secure mode. |
+| `bind_address` | Interface every listener (plain HTTP, HTTPS, SSH) binds to. **Defaults to loopback (`127.0.0.1`) in both modes.** Set a specific IP, `0.0.0.0`/`*` (all IPv4), or `::` (all interfaces) to face the network. |
+| `allow_insecure_exposure` | Required to bind a **non-loopback** `bind_address` in **open** mode (no transport security). Ignored in secure mode and for loopback binds. |
+| `https_port` | The HTTPS listener (bound to `bind_address`) serving the control plane, credential bus, and Connect tunnel over pinned TLS. **Requires `secure` mode**; defaults to `8443` there. |
 | `trusted_proxy` | Trust `X-Forwarded-For` (only safe behind a proxy that overwrites it). Default false uses the real TCP peer, so a source IP can't be forged to evade per-IP controls. |
-
-### Route matrix
-
-Where the bus and Connect tunnel are reachable depends on `internal_http_port`:
-
-| `internal_http_port` | Bus + Connect tunnel | Use case |
-|----------------------|----------------------|----------|
-| unset (0) | On the public listener, **gated by the `credentials` scope** when HTTP auth is enforced (and over TLS when `https_port` is set) | **Remote** host-agent / remote `shed forward` — the host-agent runs on your laptop and brokers to a remote shed. |
-| set (> 0) | On a **loopback-only** internal listener; omitted from the public listener | **Co-located** host-agent — runs on the same box as shed-server and reaches the bus over loopback. |
-
-!!! warning "Co-located split disables remote `shed forward`"
-    Setting `internal_http_port` moves the Connect tunnel to the loopback
-    listener, so `shed forward` and a remote host-agent can no longer reach it
-    over the network. Use the internal split only when the host-agent is
-    co-located with shed-server. For remote access, leave `internal_http_port`
-    unset — HTTP-enforce already gates the bus and tunnel by the `credentials`
-    scope.
 
 ## Connection flow — what's encrypted where
 
@@ -271,7 +267,7 @@ What `secure` derives:
 | `auth.ssh.mode: enforce` | Only allowlisted keys may SSH in — and that allowlist is what mints/revokes HTTP tokens. **Requires** a key source (`github_users`, `authorized_keys`, or `authorized_keys_file`), else startup fails. |
 | HTTP auth enforced | Every HTTP request needs a bearer token; the credential bus is gated by the `credentials` scope. |
 | `https_port: 8443` | The network-facing API is pinned TLS. |
-| no plain-HTTP listener | Secure mode serves **no** plain-HTTP listener at all (not even on loopback) — only the pinned-TLS listener faces clients. On-box tooling uses the HTTPS endpoint; a loopback credential-bus channel is available only via the explicit, opt-in `internal_http_port`. |
+| no plain-HTTP listener | Secure mode serves **no** plain-HTTP listener at all (not even on loopback) — only the pinned-TLS listener faces clients. On-box tooling (a co-located host-agent) reaches the control plane and credential bus over `https://127.0.0.1:8443` with the pinned cert; there is no plaintext channel. |
 
 The whole flow is hands-off: enable `secure`, list your `github_users`, and a
 client runs one `shed server add` to pin TLS and mint its token. See the
@@ -307,6 +303,22 @@ at startup**:
 
 Plus a behavior change: **secure mode no longer serves a loopback plain-HTTP
 listener** (TLS-only). See [Upgrading v0.7.1 → v0.7.2](../upgrades/v0.7.1-to-v0.7.2.md).
+
+### Removed/changed in v0.7.4
+
+v0.7.4 collapses to a single listener per mode and makes shed local-first. These
+are **rejected at startup**:
+
+| Removed / renamed | Replacement |
+|-------------------|-------------|
+| `internal_http_port` | Removed — the credential bus + Connect tunnel ride the single listener (gated by the `credentials` scope in secure mode); a co-located host-agent reaches them over `https://127.0.0.1:8443`. |
+| `http_bind` / `ssh_bind` | A single `bind_address` governs every listener (HTTP, HTTPS, SSH). |
+
+Plus a behavior change: **`bind_address` defaults to loopback (`127.0.0.1`) in
+both modes** (previously unset = all interfaces), and `http_port` is optional in
+secure mode. A non-loopback bind in open mode now requires
+`allow_insecure_exposure: true`; secure mode binds the network without an ack.
+See [Upgrading v0.7.3 → v0.7.4](../upgrades/v0.7.3-to-v0.7.4.md).
 
 ## Deferred
 

--- a/docs/upgrades/v0.7.3-to-v0.7.4.md
+++ b/docs/upgrades/v0.7.3-to-v0.7.4.md
@@ -1,0 +1,136 @@
+# Upgrade Guide: v0.7.3 to v0.7.4
+
+v0.7.4 finishes the local-first / zero-plaintext-secure direction of the `0.7` line. The
+headline `auth.mode: open | secure` is unchanged, but the network surface is simplified and
+the default posture is now **local-only**:
+
+- **One listener per mode.** `internal_http_port` is removed; the credential bus and the
+  Connect tunnel ride the single listener (pinned TLS in secure mode, plain HTTP in open),
+  gated by the credentials scope. Secure mode now has **no plaintext anywhere**.
+- **One bind knob, loopback by default.** `http_bind`/`ssh_bind` are unified into a single
+  `bind_address` that governs every listener and **defaults to loopback (127.0.0.1) in both
+  modes** — shed is a local-development tool unless explicitly exposed.
+- **`http_port` is optional in secure mode** (it serves no plain HTTP).
+
+!!! note "A breaking patch"
+    Like v0.7.1/v0.7.2, this is a `0.7.x` patch that carries **breaking config changes** —
+    the auth/network interface is still settling in the `0.7` line. The biggest behavior
+    change is the **loopback default**: a server that relied on the old all-interfaces
+    default becomes **local-only** after upgrade until you set `bind_address`. If you reach
+    your server from another machine, read the pre-upgrade checklist below first.
+
+## What changed
+
+- **`internal_http_port` removed.** The optional loopback-only listener that carried the
+  credential bus + Connect tunnel is gone. Both now ride the single listener (TLS in secure
+  mode, plain HTTP in open), gated by the `credentials` scope in secure mode. A co-located
+  host-agent reaches the bus at `https://127.0.0.1:8443` with the pinned cert. Bonus: remote
+  `shed forward` works uniformly again (the old split forced the Connect tunnel to loopback).
+- **`http_bind` + `ssh_bind` → `bind_address`.** One interface for every listener (HTTP,
+  HTTPS, SSH). It **defaults to loopback (127.0.0.1)** in both open and secure mode. Set a
+  routable address (`0.0.0.0`/`*` for all IPv4, `::` for all interfaces, or a specific
+  LAN/tailnet IP) to reach the server off-box. In **open** mode a non-loopback bind also
+  requires `allow_insecure_exposure: true` (open mode has no transport security); **secure**
+  mode needs no acknowledgment.
+- **`http_port` optional.** Secure mode serves no plain HTTP, so `http_port` is no longer
+  required there and is omitted from `/api/info` and the written client config entry. Open
+  mode still requires it.
+
+## Pre-upgrade checklist (do this first if your server is networked)
+
+Because the default flipped to loopback, **before upgrading a server you reach from other
+machines**, set `bind_address` so it stays reachable. Pick a posture:
+
+- **Recommended — secure mode** (pinned TLS + tokens + SSH allowlist):
+  ```yaml
+  auth:
+    mode: secure
+    ssh:
+      github_users: [your-github-username]
+  bind_address: 0.0.0.0          # or a specific LAN/tailnet IP
+  ```
+- **Open on a trusted private network** (plaintext — Tailscale / LAN only):
+  ```yaml
+  bind_address: 0.0.0.0          # or a specific LAN/tailnet IP
+  allow_insecure_exposure: true
+  ```
+
+A purely local server (used only on the same machine) needs **no change** — loopback is the
+new default.
+
+## Breaking: removed/renamed config now hard-fails
+
+Rejected at startup (the server names the gap and exits). **Edit your server config before
+upgrading** an affected host, or it will fail to restart:
+
+| v0.7.3 (now removed / renamed) | v0.7.4 replacement |
+|---|---|
+| `internal_http_port: <n>` | Remove it — the bus + Connect ride the single listener (credentials scope). For an off-network bus, bind the whole secure server to loopback. |
+| `http_bind: <addr>` | `bind_address: <addr>` (one interface for all listeners). |
+| `ssh_bind: <addr>` | `bind_address: <addr>` (HTTP and SSH now share one interface). |
+
+And a **silent** behavior change (the config still validates, but changes meaning):
+
+| Was (v0.7.3) | Now (v0.7.4) |
+|---|---|
+| unset bind → all interfaces | unset `bind_address` → **loopback only** |
+
+## Copy-paste migrations
+
+**Remote open server (Tailscale / LAN)** — before → after:
+```yaml
+# v0.7.3
+http_bind: 0.0.0.0
+ssh_bind: 0.0.0.0
+```
+```yaml
+# v0.7.4
+bind_address: 0.0.0.0
+allow_insecure_exposure: true   # open mode has no TLS; acknowledge LAN exposure
+```
+
+**Remote secure server (VPS)** — before → after:
+```yaml
+# v0.7.3 (bound all interfaces by default)
+auth: { mode: secure, ssh: { github_users: [charliek] } }
+tls_names: [shed.example.com]
+```
+```yaml
+# v0.7.4 — secure mode now defaults to loopback too, so set bind_address
+auth: { mode: secure, ssh: { github_users: [charliek] } }
+tls_names: [shed.example.com]
+bind_address: 0.0.0.0
+```
+
+**Co-located host-agent (was the `internal_http_port` "Case 4")** — before → after:
+```yaml
+# v0.7.3
+auth: { mode: secure, ssh: { github_users: [charliek] } }
+internal_http_port: 8081
+```
+```yaml
+# v0.7.4 — the bus rides the pinned-TLS listener (credentials scope); the
+# co-located agent reaches it at https://127.0.0.1:8443 with the pinned cert.
+auth: { mode: secure, ssh: { github_users: [charliek] } }
+bind_address: 0.0.0.0
+```
+
+## Locked out? (upgraded a remote server without reading this)
+
+If you upgraded a networked server and can no longer reach it, the daemon is now bound to
+loopback. Recover from the host console (or a local shell on the box):
+
+1. Edit `/etc/shed/server.yaml` (deb) or `$(brew --prefix)/etc/shed/server.yaml` (brew).
+2. Add `bind_address: 0.0.0.0` (and `allow_insecure_exposure: true` if open mode — or,
+   preferably, switch to `auth.mode: secure`).
+3. Restart: `sudo systemctl restart shed-server` (deb) or `brew services restart shed` (brew).
+
+## Clients
+
+Clients are unaffected. `shed server add … --https-port 8443` (or `--secure`, or the
+auto-fallback) and the auto-minted, auto-refreshing tokens work exactly as in v0.7.3. A
+secure server's `~/.shed/config.yaml` entry simply no longer carries a vestigial `http_port`.
+
+See **[Security](../reference/security.md)** and **[Security Configuration](../guides/security-configuration.md)**
+for the full model, and **[Public VPS Deployment](../guides/vps-deployment.md)** for the
+end-to-end secure flow.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -43,27 +43,6 @@ func NewServer(b backend.Backend, cfg *config.ServerConfig, sshHostKey string, p
 	}
 }
 
-// Router returns the chi router for the public HTTP listener.
-//
-// When the internal-listener split is disabled (InternalHTTPPort <= 0,
-// the default), this carries every route — the legacy single-listener
-// behavior. When the split is enabled, the credential bus (/api/plugins/*)
-// and the Connect tunnel (/api/sheds/*/connect/*) are omitted here and
-// served only by InternalRouter on a loopback listener.
-func (s *Server) Router() chi.Router {
-	// Split off: the bus stays on the public router. Split on: it moves to
-	// InternalRouter and the public router omits it.
-	includeBus := !s.cfg.InternalListenerEnabled()
-	return s.buildRouter(true, includeBus)
-}
-
-// InternalRouter returns the chi router for the loopback-only internal
-// listener: the credential bus and the Connect tunnel. Only used when the
-// split is enabled (InternalHTTPPort > 0).
-func (s *Server) InternalRouter() chi.Router {
-	return s.buildRouter(false, true)
-}
-
 // useCommonMiddleware installs the shared middleware stack. RealIP is
 // applied only behind a trusted proxy (it trusts client X-Forwarded-For);
 // otherwise the real TCP peer address is used so a source IP can't be
@@ -79,112 +58,105 @@ func (s *Server) useCommonMiddleware(r chi.Router) {
 	r.Use(s.authMiddleware)
 }
 
-// buildRouter registers routes gated by surface. includePublic covers the
-// control plane (info, lifecycle, images, system, snapshots, sessions);
-// includeBus covers the credential bus and the Connect tunnel.
-func (s *Server) buildRouter(includePublic, includeBus bool) chi.Router {
+// Router returns the chi router for the HTTP API — served over pinned TLS in
+// secure mode, plain HTTP in open mode. It registers the full route surface on
+// a single listener: the control plane (info, lifecycle, images, system,
+// snapshots, sessions, egress) plus the credential bus (/api/plugins/*) and the
+// Connect tunnel (/api/sheds/*/connect/*), which require a credentials-scoped
+// token in secure mode (see authMiddleware).
+func (s *Server) Router() chi.Router {
 	r := chi.NewRouter()
 	s.useCommonMiddleware(r)
 
 	r.Route("/api", func(r chi.Router) {
-		if includePublic {
-			// Server info (also the unauthenticated bootstrap endpoints
-			// used by `shed server add`).
-			r.Get("/info", s.handleGetInfo)
-			r.Get("/ssh-host-key", s.handleGetSSHHostKey)
+		// Server info (also the unauthenticated bootstrap endpoints
+		// used by `shed server add`).
+		r.Get("/info", s.handleGetInfo)
+		r.Get("/ssh-host-key", s.handleGetSSHHostKey)
 
-			// Sessions (aggregate across all sheds)
-			r.Get("/sessions", s.handleListAllSessions)
+		// Sessions (aggregate across all sheds)
+		r.Get("/sessions", s.handleListAllSessions)
 
-			// Images
-			r.Route("/images", func(r chi.Router) {
-				r.Get("/", s.handleListImages)
-				// Ref-keyed forms (?ref=) for slash-bearing Docker refs; see
-				// imageIdent. The legacy /{name} + /inspect/{name} forms below
-				// stay for slash-free identifiers from older clients.
+		// Images
+		r.Route("/images", func(r chi.Router) {
+			r.Get("/", s.handleListImages)
+			// Ref-keyed forms (?ref=) for slash-bearing Docker refs; see
+			// imageIdent. The legacy /{name} + /inspect/{name} forms below
+			// stay for slash-free identifiers from older clients.
+			r.Delete("/", s.handleDeleteImage)
+			r.Get("/inspect", s.handleInspectImage)
+			r.Post("/prune", s.handlePruneImages)
+			r.Post("/tag", s.handleTagImage)
+			r.Post("/pull", s.handlePullImage)
+			r.Post("/push", s.handlePushImage)
+			r.Get("/inspect/{name}", s.handleInspectImage)
+			// Wrap parametric /{name} in a sub-router so it doesn't shadow
+			// literal sibling routes like /pull, /push, /prune, /tag at the
+			// chi trie level (which would return 405 Method Not Allowed
+			// instead of dispatching to the literal POST handler).
+			r.Route("/{name}", func(r chi.Router) {
 				r.Delete("/", s.handleDeleteImage)
-				r.Get("/inspect", s.handleInspectImage)
-				r.Post("/prune", s.handlePruneImages)
-				r.Post("/tag", s.handleTagImage)
-				r.Post("/pull", s.handlePullImage)
-				r.Post("/push", s.handlePushImage)
-				r.Get("/inspect/{name}", s.handleInspectImage)
-				// Wrap parametric /{name} in a sub-router so it doesn't shadow
-				// literal sibling routes like /pull, /push, /prune, /tag at the
-				// chi trie level (which would return 405 Method Not Allowed
-				// instead of dispatching to the literal POST handler).
-				r.Route("/{name}", func(r chi.Router) {
-					r.Delete("/", s.handleDeleteImage)
-				})
 			})
+		})
 
-			// System (disk reporting + prune)
-			r.Route("/system", func(r chi.Router) {
-				r.Get("/df", s.handleSystemDF)
-				r.Post("/prune", s.handleSystemPrune)
-			})
+		// System (disk reporting + prune)
+		r.Route("/system", func(r chi.Router) {
+			r.Get("/df", s.handleSystemDF)
+			r.Post("/prune", s.handleSystemPrune)
+		})
 
-			// Snapshots
-			r.Route("/snapshots", func(r chi.Router) {
-				r.Get("/", s.handleListSnapshots)
-				r.Post("/", s.handleCreateSnapshot)
-				// Same defensive wrap as /images — drift insurance if we ever
-				// add literal sibling routes (e.g. /snapshots/prune).
-				r.Route("/{name}", func(r chi.Router) {
-					r.Get("/", s.handleGetSnapshot)
-					r.Delete("/", s.handleDeleteSnapshot)
-				})
+		// Snapshots
+		r.Route("/snapshots", func(r chi.Router) {
+			r.Get("/", s.handleListSnapshots)
+			r.Post("/", s.handleCreateSnapshot)
+			// Same defensive wrap as /images — drift insurance if we ever
+			// add literal sibling routes (e.g. /snapshots/prune).
+			r.Route("/{name}", func(r chi.Router) {
+				r.Get("/", s.handleGetSnapshot)
+				r.Delete("/", s.handleDeleteSnapshot)
 			})
+		})
 
-			// Egress control: the audit SSE stream (literal), plus per-shed
-			// status + live set/off. The /{name} routes are wrapped so the
-			// literal /stream sibling isn't shadowed at the chi trie level.
-			r.Route("/egress", func(r chi.Router) {
-				r.Get("/stream", s.handleEgressStream)
-				r.Route("/{name}", func(r chi.Router) {
-					r.Get("/", s.handleEgressShow)
-					r.Post("/", s.handleEgressSet)
-					r.Delete("/", s.handleEgressOff)
-				})
+		// Egress control: the audit SSE stream (literal), plus per-shed
+		// status + live set/off. The /{name} routes are wrapped so the
+		// literal /stream sibling isn't shadowed at the chi trie level.
+		r.Route("/egress", func(r chi.Router) {
+			r.Get("/stream", s.handleEgressStream)
+			r.Route("/{name}", func(r chi.Router) {
+				r.Get("/", s.handleEgressShow)
+				r.Post("/", s.handleEgressSet)
+				r.Delete("/", s.handleEgressOff)
 			})
-		}
+		})
 
 		// Plugins / Extensions (the credential bus)
-		if includeBus {
-			r.Route("/plugins", func(r chi.Router) {
-				r.Get("/listeners", s.handleListListeners)
-				r.Get("/listeners/{namespace}/messages", s.handlePluginSubscribe)
-				r.Post("/listeners/{namespace}/respond", s.handlePluginRespond)
-				r.Get("/sheds", s.handleListPluginSheds)
-			})
-		}
+		r.Route("/plugins", func(r chi.Router) {
+			r.Get("/listeners", s.handleListListeners)
+			r.Get("/listeners/{namespace}/messages", s.handlePluginSubscribe)
+			r.Post("/listeners/{namespace}/respond", s.handlePluginRespond)
+			r.Get("/sheds", s.handleListPluginSheds)
+		})
 
-		// Sheds: lifecycle routes are public; the Connect tunnel leaf is bus.
-		if includePublic || includeBus {
-			r.Route("/sheds", func(r chi.Router) {
-				if includePublic {
-					r.Get("/", s.handleListSheds)
-					r.Post("/", s.handleCreateShed)
-				}
-				r.Route("/{name}", func(r chi.Router) {
-					if includePublic {
-						r.Get("/", s.handleGetShed)
-						r.Delete("/", s.handleDeleteShed)
-						r.Post("/start", s.handleStartShed)
-						r.Post("/stop", s.handleStopShed)
-						r.Post("/reset", s.handleResetShed)
+		// Sheds: lifecycle routes plus the Connect tunnel leaf (credentials
+		// scope) — all on the single listener.
+		r.Route("/sheds", func(r chi.Router) {
+			r.Get("/", s.handleListSheds)
+			r.Post("/", s.handleCreateShed)
+			r.Route("/{name}", func(r chi.Router) {
+				r.Get("/", s.handleGetShed)
+				r.Delete("/", s.handleDeleteShed)
+				r.Post("/start", s.handleStartShed)
+				r.Post("/stop", s.handleStopShed)
+				r.Post("/reset", s.handleResetShed)
 
-						// Sessions within a shed
-						r.Get("/sessions", s.handleListSessions)
-						r.Delete("/sessions/{session}", s.handleKillSession)
-					}
-					if includeBus {
-						// Connect API: TCP tunnel via HTTP upgrade
-						r.Get("/connect/{port}", s.handleConnect)
-					}
-				})
+				// Sessions within a shed
+				r.Get("/sessions", s.handleListSessions)
+				r.Delete("/sessions/{session}", s.handleKillSession)
+
+				// Connect API: TCP tunnel via HTTP upgrade
+				r.Get("/connect/{port}", s.handleConnect)
 			})
-		}
+		})
 	})
 
 	return r

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -37,7 +37,7 @@ func (c *ClientConfig) GetCreateTimeout() time.Duration {
 // ServerEntry represents a configured server.
 type ServerEntry struct {
 	Host     string    `yaml:"host"`
-	HTTPPort int       `yaml:"http_port"`
+	HTTPPort int       `yaml:"http_port,omitempty"`
 	SSHPort  int       `yaml:"ssh_port"`
 	AddedAt  time.Time `yaml:"added_at"`
 	// ControlToken is the bearer token sent on control-plane HTTP requests

--- a/internal/config/http_port_test.go
+++ b/internal/config/http_port_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestValidateHTTPPort covers the mode-gated range check: http_port is required
+// (1..65535) in open mode and optional (0 = unset) in secure mode.
+func TestValidateHTTPPort(t *testing.T) {
+	secure := &AuthConfig{Mode: AuthModeSecure, SSH: &SSHAuthConfig{GitHubUsers: []string{"charliek"}}}
+	tests := []struct {
+		name     string
+		auth     *AuthConfig
+		httpPort int
+		wantErr  bool
+	}{
+		{"open requires http_port (0 invalid)", nil, 0, true},
+		{"open valid http_port", nil, 8080, false},
+		{"open out of range", nil, 70000, true},
+		{"secure allows unset http_port (0)", secure, 0, false},
+		{"secure allows a set http_port", secure, 8080, false},
+		{"secure out of range rejected", secure, 70000, true},
+		{"secure negative rejected", secure, -1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ServerConfig{HTTPPort: tt.httpPort, Auth: tt.auth}
+			if err := c.validateHTTPPort(); (err != nil) != tt.wantErr {
+				t.Errorf("validateHTTPPort() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestLoadServerConfigHTTPPortByMode verifies the loader defaults http_port to
+// 8080 in open mode and drops it to 0 in secure mode (where no plain-HTTP
+// listener is served), so /api/info and the written client entry omit it.
+func TestLoadServerConfigHTTPPortByMode(t *testing.T) {
+	backend, bcfg := platformTestBackend(t)
+	backendYAML := ""
+	if bcfg.vz != nil {
+		backendYAML = "vz:\n  vfkit_path: vfkit\n  kernel_path: /dev/null\n  default_image: /dev/null\n  instance_dir: /tmp/ti\n  socket_dir: /tmp/ts\n  default_cpus: 2\n  default_memory_mb: 4096\n  default_disk_gb: 20\n  console_port: 1024\n  notify_port: 1026\n"
+	}
+	if bcfg.fc != nil {
+		backendYAML = "firecracker:\n  kernel_path: /dev/null\n  default_image: /dev/null\n  instance_dir: /tmp/ti\n  socket_dir: /tmp/ts\n  default_cpus: 2\n  default_memory_mb: 4096\n  default_disk_gb: 20\n  vsock_base_cid: 100\n  console_port: 1024\n  notify_port: 1026\n  bridge_name: shed-br0\n  bridge_cidr: 172.30.0.1/24\n  tap_prefix: shed-tap\n"
+	}
+	secureAuth := "auth:\n  mode: secure\n  ssh:\n    github_users: [charliek]\n"
+	tests := []struct {
+		name         string
+		extra        string
+		wantHTTPPort int
+	}{
+		{"open keeps a set http_port", "http_port: 8080\n", 8080},
+		{"open defaults http_port when unset", "", 8080},
+		{"secure zeroes a set http_port", "http_port: 8080\n" + secureAuth, 0},
+		{"secure leaves http_port unset", secureAuth, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgYAML := "name: test\ndefault_backend: " + backend + "\n" + tt.extra + backendYAML
+			cfgPath := filepath.Join(t.TempDir(), "server.yaml")
+			if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := LoadServerConfigFromPath(cfgPath)
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			if cfg.HTTPPort != tt.wantHTTPPort {
+				t.Errorf("HTTPPort = %d, want %d", cfg.HTTPPort, tt.wantHTTPPort)
+			}
+		})
+	}
+}

--- a/internal/config/network_surface_test.go
+++ b/internal/config/network_surface_test.go
@@ -6,28 +6,41 @@ import (
 )
 
 func TestListenAddrHelpers(t *testing.T) {
+	// bind_address is shared by every listener and defaults to loopback.
 	tests := []struct {
 		name              string
 		cfg               ServerConfig
 		wantHTTP, wantSSH string
 	}{
 		{
-			name:     "defaults bind all interfaces",
+			name:     "unset binds loopback on both listeners",
 			cfg:      ServerConfig{HTTPPort: 8080, SSHPort: 2222},
-			wantHTTP: ":8080",
-			wantSSH:  ":2222",
-		},
-		{
-			name:     "http_bind restricts to loopback",
-			cfg:      ServerConfig{HTTPPort: 8080, SSHPort: 2222, HTTPBind: "127.0.0.1"},
 			wantHTTP: "127.0.0.1:8080",
-			wantSSH:  ":2222",
+			wantSSH:  "127.0.0.1:2222",
 		},
 		{
-			name:     "ssh_bind restricts to a tailnet ip",
-			cfg:      ServerConfig{HTTPPort: 8080, SSHPort: 2222, SSHBind: "100.64.0.1"},
-			wantHTTP: ":8080",
+			name:     "explicit loopback",
+			cfg:      ServerConfig{HTTPPort: 8080, SSHPort: 2222, BindAddress: "127.0.0.1"},
+			wantHTTP: "127.0.0.1:8080",
+			wantSSH:  "127.0.0.1:2222",
+		},
+		{
+			name:     "tailnet ip binds both listeners",
+			cfg:      ServerConfig{HTTPPort: 8080, SSHPort: 2222, BindAddress: "100.64.0.1"},
+			wantHTTP: "100.64.0.1:8080",
 			wantSSH:  "100.64.0.1:2222",
+		},
+		{
+			name:     "star is all IPv4",
+			cfg:      ServerConfig{HTTPPort: 8080, SSHPort: 2222, BindAddress: "*"},
+			wantHTTP: "0.0.0.0:8080",
+			wantSSH:  "0.0.0.0:2222",
+		},
+		{
+			name:     "double-colon is all interfaces",
+			cfg:      ServerConfig{HTTPPort: 8080, SSHPort: 2222, BindAddress: "::"},
+			wantHTTP: "[::]:8080",
+			wantSSH:  "[::]:2222",
 		},
 	}
 	for _, tt := range tests {
@@ -37,6 +50,37 @@ func TestListenAddrHelpers(t *testing.T) {
 			}
 			if got := tt.cfg.SSHListenAddr(); got != tt.wantSSH {
 				t.Errorf("SSHListenAddr() = %q, want %q", got, tt.wantSSH)
+			}
+		})
+	}
+}
+
+func TestValidateBindAddress(t *testing.T) {
+	// Open mode requires allow_insecure_exposure to bind a non-loopback
+	// interface; secure mode (TLS + tokens) needs no acknowledgment.
+	secure := &AuthConfig{Mode: AuthModeSecure, SSH: &SSHAuthConfig{GitHubUsers: []string{"charliek"}}}
+	tests := []struct {
+		name    string
+		cfg     ServerConfig
+		wantErr bool
+	}{
+		{"open unset is loopback (ok)", ServerConfig{}, false},
+		{"open explicit loopback ok", ServerConfig{BindAddress: "127.0.0.1"}, false},
+		{"open localhost ok", ServerConfig{BindAddress: "localhost"}, false},
+		{"open ::1 ok", ServerConfig{BindAddress: "::1"}, false},
+		{"open 0.0.0.0 without ack rejected", ServerConfig{BindAddress: "0.0.0.0"}, true},
+		{"open star without ack rejected", ServerConfig{BindAddress: "*"}, true},
+		{"open :: without ack rejected", ServerConfig{BindAddress: "::"}, true},
+		{"open tailnet ip without ack rejected", ServerConfig{BindAddress: "100.64.0.1"}, true},
+		{"open 0.0.0.0 with ack ok", ServerConfig{BindAddress: "0.0.0.0", AllowInsecureExposure: true}, false},
+		{"open tailnet ip with ack ok", ServerConfig{BindAddress: "100.64.0.1", AllowInsecureExposure: true}, false},
+		{"secure 0.0.0.0 ok without ack", ServerConfig{BindAddress: "0.0.0.0", Auth: secure}, false},
+		{"secure tailnet ip ok without ack", ServerConfig{BindAddress: "100.64.0.1", Auth: secure}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.cfg.validateBindAddress(); (err != nil) != tt.wantErr {
+				t.Errorf("validateBindAddress() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -111,6 +155,8 @@ func TestRejectRemovedNetworkKeys(t *testing.T) {
 		{"clean config ok", "name: x\nhttp_port: 8080\n", ""},
 		{"no network keys ok", "name: x\n", ""},
 		{"internal_http_port rejected", "name: x\ninternal_http_port: 8081\n", "internal_http_port"},
+		{"http_bind rejected (renamed to bind_address)", "name: x\nhttp_bind: 0.0.0.0\n", "bind_address"},
+		{"ssh_bind rejected (renamed to bind_address)", "name: x\nssh_bind: 0.0.0.0\n", "bind_address"},
 		{"malformed yaml deferred to typed unmarshal", "name: [unterminated", ""},
 	}
 	for _, tt := range tests {
@@ -180,8 +226,8 @@ func TestHTTPSListenAddr(t *testing.T) {
 		wantAddr string
 	}{
 		{"disabled by default", ServerConfig{HTTPPort: 8080}, false, ""},
-		{"all interfaces", ServerConfig{HTTPPort: 8080, HTTPSPort: 8443}, true, ":8443"},
-		{"bound to one interface", ServerConfig{HTTPPort: 8080, HTTPSPort: 8443, HTTPBind: "100.64.0.1"}, true, "100.64.0.1:8443"},
+		{"loopback by default", ServerConfig{HTTPPort: 8080, HTTPSPort: 8443}, true, "127.0.0.1:8443"},
+		{"bound to one interface", ServerConfig{HTTPPort: 8080, HTTPSPort: 8443, BindAddress: "100.64.0.1"}, true, "100.64.0.1:8443"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/config/network_surface_test.go
+++ b/internal/config/network_surface_test.go
@@ -7,37 +7,27 @@ import (
 
 func TestListenAddrHelpers(t *testing.T) {
 	tests := []struct {
-		name                            string
-		cfg                             ServerConfig
-		wantHTTP, wantSSH, wantInternal string
+		name              string
+		cfg               ServerConfig
+		wantHTTP, wantSSH string
 	}{
 		{
-			name:         "defaults bind all interfaces",
-			cfg:          ServerConfig{HTTPPort: 8080, SSHPort: 2222},
-			wantHTTP:     ":8080",
-			wantSSH:      ":2222",
-			wantInternal: "",
+			name:     "defaults bind all interfaces",
+			cfg:      ServerConfig{HTTPPort: 8080, SSHPort: 2222},
+			wantHTTP: ":8080",
+			wantSSH:  ":2222",
 		},
 		{
-			name:         "http_bind restricts to loopback",
-			cfg:          ServerConfig{HTTPPort: 8080, SSHPort: 2222, HTTPBind: "127.0.0.1"},
-			wantHTTP:     "127.0.0.1:8080",
-			wantSSH:      ":2222",
-			wantInternal: "",
+			name:     "http_bind restricts to loopback",
+			cfg:      ServerConfig{HTTPPort: 8080, SSHPort: 2222, HTTPBind: "127.0.0.1"},
+			wantHTTP: "127.0.0.1:8080",
+			wantSSH:  ":2222",
 		},
 		{
-			name:         "ssh_bind restricts to a tailnet ip",
-			cfg:          ServerConfig{HTTPPort: 8080, SSHPort: 2222, SSHBind: "100.64.0.1"},
-			wantHTTP:     ":8080",
-			wantSSH:      "100.64.0.1:2222",
-			wantInternal: "",
-		},
-		{
-			name:         "internal_http_port enables loopback internal listener",
-			cfg:          ServerConfig{HTTPPort: 8080, SSHPort: 2222, InternalHTTPPort: 8081},
-			wantHTTP:     ":8080",
-			wantSSH:      ":2222",
-			wantInternal: "127.0.0.1:8081",
+			name:     "ssh_bind restricts to a tailnet ip",
+			cfg:      ServerConfig{HTTPPort: 8080, SSHPort: 2222, SSHBind: "100.64.0.1"},
+			wantHTTP: ":8080",
+			wantSSH:  "100.64.0.1:2222",
 		},
 	}
 	for _, tt := range tests {
@@ -47,9 +37,6 @@ func TestListenAddrHelpers(t *testing.T) {
 			}
 			if got := tt.cfg.SSHListenAddr(); got != tt.wantSSH {
 				t.Errorf("SSHListenAddr() = %q, want %q", got, tt.wantSSH)
-			}
-			if got := tt.cfg.InternalHTTPListenAddr(); got != tt.wantInternal {
-				t.Errorf("InternalHTTPListenAddr() = %q, want %q", got, tt.wantInternal)
 			}
 		})
 	}
@@ -61,19 +48,12 @@ func TestValidateNetworkSurface(t *testing.T) {
 		cfg     ServerConfig
 		wantErr bool
 	}{
-		{"split disabled (0) ok", ServerConfig{HTTPPort: 8080, SSHPort: 2222, InternalHTTPPort: 0}, false},
-		{"valid offset port", ServerConfig{HTTPPort: 8080, SSHPort: 2222, InternalHTTPPort: 8081}, false},
-		{"out of range", ServerConfig{HTTPPort: 8080, SSHPort: 2222, InternalHTTPPort: 70000}, true},
-		{"negative", ServerConfig{HTTPPort: 8080, SSHPort: 2222, InternalHTTPPort: -1}, true},
-		{"collides with http_port", ServerConfig{HTTPPort: 8080, SSHPort: 2222, InternalHTTPPort: 8080}, true},
-		{"collides with ssh_port", ServerConfig{HTTPPort: 8080, SSHPort: 2222, InternalHTTPPort: 2222}, true},
 		{"https disabled (0) ok", ServerConfig{HTTPPort: 8080, SSHPort: 2222, HTTPSPort: 0}, false},
 		{"valid https port", ServerConfig{HTTPPort: 8080, SSHPort: 2222, HTTPSPort: 8443}, false},
 		{"https out of range", ServerConfig{HTTPPort: 8080, SSHPort: 2222, HTTPSPort: 70000}, true},
 		{"https negative", ServerConfig{HTTPPort: 8080, SSHPort: 2222, HTTPSPort: -1}, true},
 		{"https collides with http_port", ServerConfig{HTTPPort: 8080, SSHPort: 2222, HTTPSPort: 8080}, true},
 		{"https collides with ssh_port", ServerConfig{HTTPPort: 8080, SSHPort: 2222, HTTPSPort: 2222}, true},
-		{"https collides with internal", ServerConfig{HTTPPort: 8080, SSHPort: 2222, InternalHTTPPort: 8081, HTTPSPort: 8081}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -106,6 +86,36 @@ func TestRejectRemovedAuthKeys(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := rejectRemovedAuthKeys([]byte(tt.yaml))
+			if tt.want == "" {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error should name %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestRejectRemovedNetworkKeys(t *testing.T) {
+	// internal_http_port was removed in v0.7.4 — a config still carrying it must
+	// fail loudly rather than be silently ignored (it would otherwise imply a
+	// loopback bus listener the new binary never starts).
+	tests := []struct {
+		name string
+		yaml string
+		want string // substring the error must contain; "" means expect no error
+	}{
+		{"clean config ok", "name: x\nhttp_port: 8080\n", ""},
+		{"no network keys ok", "name: x\n", ""},
+		{"internal_http_port rejected", "name: x\ninternal_http_port: 8081\n", "internal_http_port"},
+		{"malformed yaml deferred to typed unmarshal", "name: [unterminated", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rejectRemovedNetworkKeys([]byte(tt.yaml))
 			if tt.want == "" {
 				if err != nil {
 					t.Errorf("expected no error, got %v", err)

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -32,15 +32,21 @@ type ServerConfig struct {
 	HTTPPort int    `yaml:"http_port"`
 	SSHPort  int    `yaml:"ssh_port"`
 
-	// Network surface. All optional. The bind/port zero values preserve the
-	// legacy all-interfaces, single-listener behavior. TrustedProxy defaults
-	// to false, which disables RealIP (see below) — the intended security
-	// default, not the legacy always-on RealIP.
+	// Network surface. All optional. TrustedProxy defaults to false, which
+	// disables RealIP (see below) — the intended security default, not the
+	// legacy always-on RealIP.
 	//
-	// HTTPBind / SSHBind restrict a listener to one interface (e.g.
-	// "127.0.0.1" or a tailnet IP). Empty = all interfaces (":port").
-	HTTPBind string `yaml:"http_bind,omitempty"`
-	SSHBind  string `yaml:"ssh_bind,omitempty"`
+	// BindAddress is the interface every listener (HTTP, HTTPS, SSH) binds. It
+	// defaults to loopback (127.0.0.1) — shed is a local-development tool by
+	// default. Set a routable address (a LAN/tailnet IP, "0.0.0.0"/"*" for all
+	// IPv4, or "::" for all interfaces) to reach it off-box. In open mode that
+	// also requires AllowInsecureExposure, since open mode has no transport
+	// security; secure mode (TLS + tokens) needs no acknowledgment.
+	BindAddress string `yaml:"bind_address,omitempty"`
+	// AllowInsecureExposure acknowledges binding an open-mode (plaintext,
+	// possibly unauthenticated) server to a non-loopback interface. Required to
+	// start such a server; ignored in secure mode. Prefer auth.mode: secure.
+	AllowInsecureExposure bool `yaml:"allow_insecure_exposure,omitempty"`
 	// TrustedProxy enables chi's RealIP middleware, which trusts the
 	// client-supplied X-Forwarded-For. Only safe behind a proxy that
 	// overwrites that header; the default (false) uses the real TCP peer
@@ -48,7 +54,7 @@ type ServerConfig struct {
 	// or poison audit logs.
 	TrustedProxy bool `yaml:"trusted_proxy,omitempty"`
 
-	// HTTPSPort, when >0, starts an HTTPS listener (bound to HTTPBind)
+	// HTTPSPort, when >0, starts an HTTPS listener (bound to bind_address)
 	// serving the same public router as the plain HTTP listener, presenting
 	// a self-signed cert that clients pin by fingerprint. 0 (default) = no
 	// HTTPS; plain HTTP only (legacy, unchanged).
@@ -200,11 +206,11 @@ func (c *ServerConfig) validateAuth() error {
 }
 
 // HTTPListenAddr returns the bind address for the plain-HTTP listener, honoring
-// http_bind (default all interfaces). The plain-HTTP listener is served only in
+// bind_address (default loopback). The plain-HTTP listener is served only in
 // open mode (see PlainHTTPEnabled); secure mode is TLS-only and starts no
 // plain-HTTP listener, so this is not consulted there.
 func (c *ServerConfig) HTTPListenAddr() string {
-	return listenAddr(c.HTTPBind, c.HTTPPort)
+	return listenAddr(c.BindAddress, c.HTTPPort)
 }
 
 // PlainHTTPEnabled reports whether the main plain-HTTP listener should be
@@ -215,16 +221,16 @@ func (c *ServerConfig) PlainHTTPEnabled() bool { return !c.Secure() }
 func (c *ServerConfig) HTTPSEnabled() bool { return c.HTTPSPort > 0 }
 
 // HTTPSListenAddr returns the bind address for the HTTPS listener (sharing
-// HTTPBind with the plain listener), or "" when HTTPS is disabled.
+// bind_address with the other listeners), or "" when HTTPS is disabled.
 func (c *ServerConfig) HTTPSListenAddr() string {
 	if !c.HTTPSEnabled() {
 		return ""
 	}
-	return listenAddr(c.HTTPBind, c.HTTPSPort)
+	return listenAddr(c.BindAddress, c.HTTPSPort)
 }
 
 // SSHListenAddr returns the bind address for the SSH listener.
-func (c *ServerConfig) SSHListenAddr() string { return listenAddr(c.SSHBind, c.SSHPort) }
+func (c *ServerConfig) SSHListenAddr() string { return listenAddr(c.BindAddress, c.SSHPort) }
 
 // PreflightSecure gates secure-mode startup: it refuses to start when
 // auth.mode: secure is set without any SSH key source (github_users /
@@ -241,11 +247,34 @@ func (c *ServerConfig) PreflightSecure() error {
 	return nil
 }
 
-// listenAddr joins a bind interface and port. An empty bind means all
-// interfaces (":port").
+// loopbackBind is the IPv4 loopback interface — the default bind for every
+// listener, so shed is a local-development tool unless explicitly exposed.
+const loopbackBind = "127.0.0.1"
+
+// isLoopbackBind reports whether bind keeps the listener on the local host
+// (loopback) rather than exposing it to the network. Unset ("") counts as
+// loopback because that is the effective default (see listenAddr), as does the
+// "localhost" hostname; any address in 127.0.0.0/8 or ::1 is loopback via the
+// stdlib. Mirrors isLoopbackRef in internal/vmimage.
+func isLoopbackBind(bind string) bool {
+	if bind == "" || bind == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(bind); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// listenAddr joins a bind interface and port. An empty bind defaults to
+// loopback (local-only); "*" is accepted as an alias for all IPv4 interfaces
+// ("0.0.0.0"), and "::" binds all interfaces.
 func listenAddr(bind string, port int) string {
-	if bind == "" {
-		return fmt.Sprintf(":%d", port)
+	switch bind {
+	case "":
+		bind = loopbackBind
+	case "*":
+		bind = "0.0.0.0"
 	}
 	return net.JoinHostPort(bind, strconv.Itoa(port))
 }
@@ -276,6 +305,18 @@ func (c *ServerConfig) validateHTTPPort() error {
 		return fmt.Errorf("invalid http_port: %d", c.HTTPPort)
 	}
 	return nil
+}
+
+// validateBindAddress gates non-loopback exposure of an open-mode server. Open
+// mode has no transport security (and may not enforce the SSH allowlist), so
+// binding a routable interface requires an explicit allow_insecure_exposure
+// acknowledgment. Secure mode (TLS + tokens) needs none; unset/loopback binds
+// are always allowed. Shared by Validate and ValidateNoHostCoupling.
+func (c *ServerConfig) validateBindAddress() error {
+	if c.Secure() || isLoopbackBind(c.BindAddress) || c.AllowInsecureExposure {
+		return nil
+	}
+	return fmt.Errorf("bind_address %q exposes an open-mode (plaintext, no-TLS) server beyond loopback; set allow_insecure_exposure: true to confirm, or use auth.mode: secure", c.BindAddress)
 }
 
 // ExtensionsConfig configures which extensions the agent should enable.
@@ -1312,6 +1353,12 @@ func rejectRemovedNetworkKeys(data []byte) error {
 		return fmt.Errorf("config key %q was removed in v0.7.4; the credential bus and Connect tunnel now ride the single listener (pinned TLS in secure mode), gated by the credentials scope (see docs/upgrades/v0.7.3-to-v0.7.4.md)",
 			"internal_http_port")
 	}
+	for _, removed := range []string{"http_bind", "ssh_bind"} {
+		if _, present := raw[removed]; present {
+			return fmt.Errorf("config key %q was unified into %q in v0.7.4 (one interface for all listeners; defaults to loopback). Use %q (and allow_insecure_exposure for non-loopback open-mode exposure) — see docs/upgrades/v0.7.3-to-v0.7.4.md",
+				removed, "bind_address", "bind_address")
+		}
+	}
 	return nil
 }
 
@@ -1610,6 +1657,9 @@ func (c *ServerConfig) ValidateNoHostCoupling() error {
 	if err := c.validateNetworkSurface(); err != nil {
 		return err
 	}
+	if err := c.validateBindAddress(); err != nil {
+		return err
+	}
 	if err := c.validateAuth(); err != nil {
 		return err
 	}
@@ -1682,6 +1732,9 @@ func (c *ServerConfig) Validate() error {
 		return fmt.Errorf("invalid ssh_port: %d", c.SSHPort)
 	}
 	if err := c.validateNetworkSurface(); err != nil {
+		return err
+	}
+	if err := c.validateBindAddress(); err != nil {
 		return err
 	}
 	if err := c.validateAuth(); err != nil {

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -264,6 +264,20 @@ func (c *ServerConfig) validateNetworkSurface() error {
 	return nil
 }
 
+// validateHTTPPort range-checks http_port: required (1..65535) in open mode,
+// where it drives the plain-HTTP listener; optional (0 = unset) in secure mode,
+// which serves no plain HTTP. Shared by Validate and ValidateNoHostCoupling.
+func (c *ServerConfig) validateHTTPPort() error {
+	minPort := 1
+	if c.Secure() {
+		minPort = 0
+	}
+	if c.HTTPPort < minPort || c.HTTPPort > 65535 {
+		return fmt.Errorf("invalid http_port: %d", c.HTTPPort)
+	}
+	return nil
+}
+
 // ExtensionsConfig configures which extensions the agent should enable.
 type ExtensionsConfig struct {
 	// Enabled lists the extension namespaces to activate in VMs
@@ -1370,8 +1384,13 @@ func LoadServerConfigFromPath(path string) (*ServerConfig, error) {
 
 	normalizeMounts(cfg, configPath)
 
-	// Apply defaults for zero values
-	if cfg.HTTPPort == 0 {
+	// Apply defaults for zero values. http_port drives the open-mode plain-HTTP
+	// listener; secure mode serves no plain HTTP, so drop any value there (set or
+	// constructor default) — /api/info and the written client entry then omit a
+	// vestigial port. Default it in open mode.
+	if cfg.Secure() {
+		cfg.HTTPPort = 0
+	} else if cfg.HTTPPort == 0 {
 		cfg.HTTPPort = 8080
 	}
 	// Secure mode turns TLS on; default the HTTPS port if the operator didn't
@@ -1537,7 +1556,11 @@ func loadServerConfigForCLI(path string) (*ServerConfig, error) {
 
 	normalizeMounts(cfg, configPath)
 
-	if cfg.HTTPPort == 0 {
+	// http_port: drop in secure (no plain HTTP served), default in open. Mirrors
+	// the serve loader so config-validate sees the same effective surface.
+	if cfg.Secure() {
+		cfg.HTTPPort = 0
+	} else if cfg.HTTPPort == 0 {
 		cfg.HTTPPort = 8080
 	}
 	// Secure mode turns TLS on; default the HTTPS port here too so config-validate
@@ -1578,8 +1601,8 @@ func (c *ServerConfig) ValidateNoHostCoupling() error {
 	if c.Name == "" {
 		return fmt.Errorf("server name is required")
 	}
-	if c.HTTPPort < 0 || c.HTTPPort > 65535 {
-		return fmt.Errorf("invalid http_port: %d", c.HTTPPort)
+	if err := c.validateHTTPPort(); err != nil {
+		return err
 	}
 	if c.SSHPort < 0 || c.SSHPort > 65535 {
 		return fmt.Errorf("invalid ssh_port: %d", c.SSHPort)
@@ -1652,8 +1675,8 @@ func (c *ServerConfig) Validate() error {
 	if c.Name == "" {
 		return fmt.Errorf("server name is required")
 	}
-	if c.HTTPPort < 1 || c.HTTPPort > 65535 {
-		return fmt.Errorf("invalid http_port: %d", c.HTTPPort)
+	if err := c.validateHTTPPort(); err != nil {
+		return err
 	}
 	if c.SSHPort < 1 || c.SSHPort > 65535 {
 		return fmt.Errorf("invalid ssh_port: %d", c.SSHPort)

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -41,12 +41,6 @@ type ServerConfig struct {
 	// "127.0.0.1" or a tailnet IP). Empty = all interfaces (":port").
 	HTTPBind string `yaml:"http_bind,omitempty"`
 	SSHBind  string `yaml:"ssh_bind,omitempty"`
-	// InternalHTTPPort, when >0, splits the HTTP surface: the credential
-	// bus (/api/plugins/*) and the Connect tunnel (/api/sheds/*/connect/*)
-	// move to a loopback-only listener on this port, and the public
-	// listener omits them. 0 (default) keeps every route on the public
-	// listener (legacy behavior), so existing clients are unaffected.
-	InternalHTTPPort int `yaml:"internal_http_port,omitempty"`
 	// TrustedProxy enables chi's RealIP middleware, which trusts the
 	// client-supplied X-Forwarded-For. Only safe behind a proxy that
 	// overwrites that header; the default (false) uses the real TCP peer
@@ -217,10 +211,6 @@ func (c *ServerConfig) HTTPListenAddr() string {
 // served. False in secure mode (TLS-only; the plain listener is not started).
 func (c *ServerConfig) PlainHTTPEnabled() bool { return !c.Secure() }
 
-// loopbackBind is the IPv4 loopback interface used for listeners that must not
-// be reachable off-box (the internal bus).
-const loopbackBind = "127.0.0.1"
-
 // HTTPSEnabled reports whether the HTTPS listener is configured.
 func (c *ServerConfig) HTTPSEnabled() bool { return c.HTTPSPort > 0 }
 
@@ -235,20 +225,6 @@ func (c *ServerConfig) HTTPSListenAddr() string {
 
 // SSHListenAddr returns the bind address for the SSH listener.
 func (c *ServerConfig) SSHListenAddr() string { return listenAddr(c.SSHBind, c.SSHPort) }
-
-// InternalListenerEnabled reports whether the HTTP surface is split onto a
-// separate loopback internal listener (credential bus + Connect). This is
-// the single definition of "split on" consulted by the router and serve.
-func (c *ServerConfig) InternalListenerEnabled() bool { return c.InternalHTTPPort > 0 }
-
-// InternalHTTPListenAddr returns the loopback address for the internal
-// HTTP listener, or "" when the split is disabled.
-func (c *ServerConfig) InternalHTTPListenAddr() string {
-	if !c.InternalListenerEnabled() {
-		return ""
-	}
-	return listenAddr(loopbackBind, c.InternalHTTPPort)
-}
 
 // PreflightSecure gates secure-mode startup: it refuses to start when
 // auth.mode: secure is set without any SSH key source (github_users /
@@ -274,22 +250,16 @@ func listenAddr(bind string, port int) string {
 	return net.JoinHostPort(bind, strconv.Itoa(port))
 }
 
-// validateNetworkSurface checks the optional internal-listener port. Shared
-// by Validate and ValidateNoHostCoupling, both of which range-check
-// HTTPPort/SSHPort immediately before calling this (the collision check
-// below assumes those are already valid).
+// validateNetworkSurface checks the optional HTTPS listener port. Shared by
+// Validate and ValidateNoHostCoupling, both of which range-check
+// HTTPPort/SSHPort immediately before calling this (the collision check below
+// assumes those are already valid).
 func (c *ServerConfig) validateNetworkSurface() error {
-	if c.InternalHTTPPort < 0 || c.InternalHTTPPort > 65535 {
-		return fmt.Errorf("invalid internal_http_port: %d", c.InternalHTTPPort)
-	}
-	if c.InternalHTTPPort > 0 && (c.InternalHTTPPort == c.HTTPPort || c.InternalHTTPPort == c.SSHPort) {
-		return fmt.Errorf("internal_http_port (%d) must differ from http_port and ssh_port", c.InternalHTTPPort)
-	}
 	if c.HTTPSPort < 0 || c.HTTPSPort > 65535 {
 		return fmt.Errorf("invalid https_port: %d", c.HTTPSPort)
 	}
-	if c.HTTPSPort > 0 && (c.HTTPSPort == c.HTTPPort || c.HTTPSPort == c.SSHPort || c.HTTPSPort == c.InternalHTTPPort) {
-		return fmt.Errorf("https_port (%d) must differ from http_port, ssh_port, and internal_http_port", c.HTTPSPort)
+	if c.HTTPSPort > 0 && (c.HTTPSPort == c.HTTPPort || c.HTTPSPort == c.SSHPort) {
+		return fmt.Errorf("https_port (%d) must differ from http_port and ssh_port", c.HTTPSPort)
 	}
 	return nil
 }
@@ -1315,6 +1285,22 @@ func rejectRemovedAuthKeys(data []byte) error {
 	return nil
 }
 
+// rejectRemovedNetworkKeys fails loudly if a config still carries network-surface
+// keys removed in v0.7.4. yaml.Unmarshal silently ignores unknown fields, so
+// without this an upgraded operator's stale internal_http_port would be accepted
+// while the new binary ignored it. Mirrors rejectRemovedAuthKeys.
+func rejectRemovedNetworkKeys(data []byte) error {
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil // malformed YAML — let the typed unmarshal surface the parse error
+	}
+	if _, present := raw["internal_http_port"]; present {
+		return fmt.Errorf("config key %q was removed in v0.7.4; the credential bus and Connect tunnel now ride the single listener (pinned TLS in secure mode), gated by the credentials scope (see docs/upgrades/v0.7.3-to-v0.7.4.md)",
+			"internal_http_port")
+	}
+	return nil
+}
+
 // LoadServerConfig loads server configuration from standard locations.
 // It checks in order: ./server.yaml, ~/.config/shed/server.yaml, /etc/shed/server.yaml
 func LoadServerConfig() (*ServerConfig, error) {
@@ -1376,6 +1362,9 @@ func LoadServerConfigFromPath(path string) (*ServerConfig, error) {
 		return nil, fmt.Errorf("%s: %w", configPath, err)
 	}
 	if err := rejectRemovedAuthKeys(data); err != nil {
+		return nil, fmt.Errorf("%s: %w", configPath, err)
+	}
+	if err := rejectRemovedNetworkKeys(data); err != nil {
 		return nil, fmt.Errorf("%s: %w", configPath, err)
 	}
 
@@ -1540,6 +1529,9 @@ func loadServerConfigForCLI(path string) (*ServerConfig, error) {
 		return nil, fmt.Errorf("%s: %w", configPath, err)
 	}
 	if err := rejectRemovedAuthKeys(data); err != nil {
+		return nil, fmt.Errorf("%s: %w", configPath, err)
+	}
+	if err := rejectRemovedNetworkKeys(data); err != nil {
 		return nil, fmt.Errorf("%s: %w", configPath, err)
 	}
 

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -1383,6 +1383,33 @@ func normalizeMounts(cfg *ServerConfig, configPath string) {
 	cfg.Credentials = nil
 }
 
+// applyModeAndCommonDefaults fills in the mode-derived and common zero-value
+// defaults shared by both loaders (serve + config-validate), so the two paths
+// can't drift. http_port drives the open-mode plain-HTTP listener; secure mode
+// serves no plain HTTP, so any value there is dropped (set or constructor
+// default) and /api/info + the written client entry omit a vestigial port.
+// Secure mode also defaults https_port so `auth.mode: secure` needs no extra
+// TLS config.
+func applyModeAndCommonDefaults(cfg *ServerConfig) {
+	if cfg.Secure() {
+		cfg.HTTPPort = 0
+	} else if cfg.HTTPPort == 0 {
+		cfg.HTTPPort = 8080
+	}
+	if cfg.Secure() && cfg.HTTPSPort == 0 {
+		cfg.HTTPSPort = 8443
+	}
+	if cfg.SSHPort == 0 {
+		cfg.SSHPort = 2222
+	}
+	if cfg.LogLevel == "" {
+		cfg.LogLevel = "info"
+	}
+	if cfg.Terminal == nil {
+		cfg.Terminal = terminal.DefaultConfig()
+	}
+}
+
 // LoadServerConfigFromPath loads server configuration from a specific path.
 // If path is empty, it searches standard locations.
 func LoadServerConfigFromPath(path string) (*ServerConfig, error) {
@@ -1431,29 +1458,7 @@ func LoadServerConfigFromPath(path string) (*ServerConfig, error) {
 
 	normalizeMounts(cfg, configPath)
 
-	// Apply defaults for zero values. http_port drives the open-mode plain-HTTP
-	// listener; secure mode serves no plain HTTP, so drop any value there (set or
-	// constructor default) — /api/info and the written client entry then omit a
-	// vestigial port. Default it in open mode.
-	if cfg.Secure() {
-		cfg.HTTPPort = 0
-	} else if cfg.HTTPPort == 0 {
-		cfg.HTTPPort = 8080
-	}
-	// Secure mode turns TLS on; default the HTTPS port if the operator didn't
-	// set one, so `auth.mode: secure` needs no extra TLS config.
-	if cfg.Secure() && cfg.HTTPSPort == 0 {
-		cfg.HTTPSPort = 8443
-	}
-	if cfg.SSHPort == 0 {
-		cfg.SSHPort = 2222
-	}
-	if cfg.LogLevel == "" {
-		cfg.LogLevel = "info"
-	}
-	if cfg.Terminal == nil {
-		cfg.Terminal = terminal.DefaultConfig()
-	}
+	applyModeAndCommonDefaults(cfg)
 
 	cfg.normalizeBackends()
 
@@ -1603,27 +1608,7 @@ func loadServerConfigForCLI(path string) (*ServerConfig, error) {
 
 	normalizeMounts(cfg, configPath)
 
-	// http_port: drop in secure (no plain HTTP served), default in open. Mirrors
-	// the serve loader so config-validate sees the same effective surface.
-	if cfg.Secure() {
-		cfg.HTTPPort = 0
-	} else if cfg.HTTPPort == 0 {
-		cfg.HTTPPort = 8080
-	}
-	// Secure mode turns TLS on; default the HTTPS port here too so config-validate
-	// sees the same effective TLS surface the serve loader derives.
-	if cfg.Secure() && cfg.HTTPSPort == 0 {
-		cfg.HTTPSPort = 8443
-	}
-	if cfg.SSHPort == 0 {
-		cfg.SSHPort = 2222
-	}
-	if cfg.LogLevel == "" {
-		cfg.LogLevel = "info"
-	}
-	if cfg.Terminal == nil {
-		cfg.Terminal = terminal.DefaultConfig()
-	}
+	applyModeAndCommonDefaults(cfg)
 
 	cfg.normalizeBackends()
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -218,10 +218,12 @@ func ValidateSessionName(name string) error {
 
 // ServerInfo is returned by GET /api/info.
 type ServerInfo struct {
-	Name     string `json:"name"`
-	Version  string `json:"version"`
-	SSHPort  int    `json:"ssh_port"`
-	HTTPPort int    `json:"http_port"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	SSHPort int    `json:"ssh_port"`
+	// HTTPPort is the plain-HTTP port (open mode). Omitted in secure mode, which
+	// serves no plain HTTP — clients use the HTTPS endpoint there.
+	HTTPPort int    `json:"http_port,omitempty"`
 	Backend  string `json:"backend"`
 	// AuthMode is the server's auth.mode ("secure" or "open"), so `shed server
 	// add` knows whether to bootstrap an HTTP token over SSH. Reported on the

--- a/internal/sshd/bootstrap.go
+++ b/internal/sshd/bootstrap.go
@@ -31,7 +31,7 @@ type BootstrapInfo struct {
 // own external hostname). The SDK/CLI decoders MUST keep these json tags in
 // sync.
 type bootstrapBundle struct {
-	HTTPPort           int       `json:"http_port"`
+	HTTPPort           int       `json:"http_port,omitempty"`
 	HTTPSPort          int       `json:"https_port"`
 	TLSCertFingerprint string    `json:"tls_cert_fingerprint"`
 	Token              string    `json:"token"`

--- a/internal/sshd/server.go
+++ b/internal/sshd/server.go
@@ -38,7 +38,8 @@ type Server struct {
 }
 
 // NewServer creates a new SSH server. listenAddr is the TCP bind address
-// (e.g. ":2222" for all interfaces, or "127.0.0.1:2222" / "<tailnet-ip>:2222").
+// (e.g. "127.0.0.1:2222" for loopback (the default), "<tailnet-ip>:2222", or
+// ":2222" for all interfaces).
 // allowlist gates public-key auth; pass an "off"-mode allowlist (or one built
 // from nil config) for the legacy accept-all behavior.
 func NewServer(b backend.Backend, hostKeyPath string, listenAddr string, termConfig *terminal.Config, allowlist *KeyAllowlist) (*Server, error) {

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -34,20 +34,40 @@ if [ -n "${2:-}" ]; then
     # rejects the old keys — so a blind restart would crash the service.
     # Preflight the config and SKIP the restart (pointing at the upgrade
     # guide) when it no longer validates, rather than take the service down.
-    if ! shed-server --config /etc/shed/server.yaml config-validate >/dev/null 2>&1; then
+    if ! validate_err="$(shed-server --config /etc/shed/server.yaml config-validate 2>&1)"; then
         echo ""
         echo "shed-server was upgraded, but /etc/shed/server.yaml did not validate"
         echo "against the new binary, so the service was NOT restarted (the old"
-        echo "process keeps running)."
+        echo "process keeps running). The error was:"
         echo ""
-        echo "This usually means the config still uses keys removed in v0.6.0"
-        echo "(base_rootfs / images). Migrate to default_image + image_aliases +"
-        echo "pull_policy, then restart:"
+        echo "  ${validate_err}"
+        echo ""
+        echo "This usually means the config uses keys removed in a breaking release"
+        echo "(e.g. base_rootfs/images in v0.6.0, or http_bind/ssh_bind/"
+        echo "internal_http_port in v0.7.4). Migrate per the upgrade guides, then:"
         echo "  sudo shed-server --config /etc/shed/server.yaml config-validate"
         echo "  sudo systemctl restart shed-server"
         echo ""
-        echo "Upgrade guide: https://github.com/charliek/shed/blob/main/docs/upgrades/v0.5.9-to-v0.6.0.md"
+        echo "Upgrade guides: https://github.com/charliek/shed/tree/main/docs/upgrades"
         exit 0
+    fi
+
+    # v0.7.4: with no bind_address, shed-server now binds 127.0.0.1 only (it was
+    # all-interfaces before). config-validate still passes — the config is valid,
+    # it just changed meaning — so warn explicitly that a networked server has
+    # become local-only. (Loose grep: a commented "# bind_address" won't match.)
+    if ! grep -Eq '^[[:space:]]*bind_address:' /etc/shed/server.yaml; then
+        echo ""
+        echo "NOTE (v0.7.4): /etc/shed/server.yaml sets no 'bind_address', so"
+        echo "shed-server now binds 127.0.0.1 only (was all-interfaces). If you"
+        echo "reach this server from other machines it is now LOCAL-ONLY. To"
+        echo "restore network access, add to /etc/shed/server.yaml:"
+        echo "    bind_address: 0.0.0.0"
+        echo "  (open mode also requires allow_insecure_exposure: true; prefer"
+        echo "   auth.mode: secure for anything exposed on a network)"
+        echo "then: sudo systemctl restart shed-server"
+        echo "Guide: https://github.com/charliek/shed/blob/main/docs/upgrades/v0.7.3-to-v0.7.4.md"
+        echo ""
     fi
 
     # `try-restart` is the Debian-standard primitive for "restart only if

--- a/packaging/server.yaml.tmpl
+++ b/packaging/server.yaml.tmpl
@@ -6,6 +6,13 @@ name: my-server
 http_port: 8080
 ssh_port: 2222
 
+# bind_address: which interface every listener (HTTP/SSH) uses. Default
+# loopback (127.0.0.1) = reachable on this machine only. To reach it from
+# other hosts, prefer secure mode (auth.mode: secure) with bind_address:
+# 0.0.0.0; or, for an OPEN server on a trusted private network, set
+# bind_address: 0.0.0.0 and allow_insecure_exposure: true.
+bind_address: 127.0.0.1
+
 default_backend: firecracker
 log_level: info
 

--- a/sdk/bootstrap.go
+++ b/sdk/bootstrap.go
@@ -28,7 +28,7 @@ var bootstrapTimeout = 15 * time.Second
 // URL from the host it dialed plus HTTPSPort (preferred, pinned via
 // TLSCertFingerprint) or HTTPPort.
 type Bundle struct {
-	HTTPPort           int       `json:"http_port"`
+	HTTPPort           int       `json:"http_port,omitempty"`
 	HTTPSPort          int       `json:"https_port"`
 	TLSCertFingerprint string    `json:"tls_cert_fingerprint"`
 	Token              string    `json:"token"`

--- a/tests/integration/test_network_surface.py
+++ b/tests/integration/test_network_surface.py
@@ -1,18 +1,14 @@
-"""Phase 1: network-surface route split.
+"""Network surface: the credential bus + Connect tunnel ride the single listener.
 
-Verifies (on the live VZ dev server, via the Phase 0.5 `dev_config` harness):
+Verifies (on the live VZ dev server) that the credential bus (`/api/plugins/*`)
+and the Connect tunnel (`/api/sheds/*/connect/*`) are served on the same
+listener as the control plane. v0.7.4 removed `internal_http_port`, so there is
+no separate loopback listener: in open mode everything is on the plain-HTTP
+port; in secure mode everything is on the pinned-TLS port, with the bus +
+Connect gated by the credentials scope (covered by `internal/api` unit tests).
 
-  - Default (no `internal_http_port`): the credential bus is reachable on
-    the public HTTP listener — legacy behavior, unchanged.
-  - With `internal_http_port` set: the bus (`/api/plugins/*`) and the
-    Connect tunnel (`/api/sheds/*/connect/*`) move to the loopback-only
-    internal listener and are gone from the public listener, while the
-    control plane (info, sheds, …) stays on the public listener.
-
-Config mutation is VZ-only (the harness restarts the local VZ dev server);
-the route-registration logic itself is backend-agnostic Go covered by
-`internal/config` + `internal/api` unit tests, so FC needs no separate
-live case here.
+The route-registration logic is backend-agnostic Go covered by `internal/config`
++ `internal/api` unit tests, so FC needs no separate live case here.
 """
 
 from __future__ import annotations
@@ -22,7 +18,6 @@ import urllib.request
 
 import pytest
 
-from fixtures.devcontrol import dev_config
 from fixtures.server import resolve_server_entry
 
 
@@ -44,35 +39,17 @@ def _status(port: int, path: str) -> int | None:
 
 
 @pytest.mark.vz
-def test_bus_on_public_listener_by_default(vz_server_dev):
-    """Default config (split off): the bus is served on the public port."""
+def test_bus_and_connect_on_single_listener(vz_server_dev):
+    """The credential bus and the Connect tunnel are served on the single
+    public listener (open dev server) alongside the control plane — there is no
+    separate internal listener after v0.7.4."""
     public = int(resolve_server_entry(vz_server_dev.name)["http_port"])
+    # Control plane.
+    assert _status(public, "/api/info") == 200
+    assert _status(public, "/api/sheds") == 200
+    # Credential bus.
     assert _status(public, "/api/plugins/listeners") == 200
-
-
-@pytest.mark.vz
-@pytest.mark.slow
-def test_split_moves_bus_and_connect_to_internal(vz_server_dev):
-    """With internal_http_port set, bus + Connect are loopback-only and the
-    control plane stays on the public listener."""
-    server = vz_server_dev.name
-    public = int(resolve_server_entry(server)["http_port"])
-    internal = public + 1  # e.g. 18081 alongside the dev server's 18080
-
-    with dev_config({"internal_http_port": internal}, server):
-        # Control plane + bootstrap endpoints stay on the public listener.
-        assert _status(public, "/api/info") == 200
-        assert _status(public, "/api/sheds") == 200
-        # Bus + Connect are removed from the public listener. Using port 0:
-        # if the Connect route were still registered here, handleConnect would
-        # run and return 400 (INVALID_PORT); a 404 proves the route itself is
-        # absent (not merely a missing shed, which also 404s on a live route).
-        assert _status(public, "/api/plugins/listeners") == 404
-        assert _status(public, "/api/sheds/nope/connect/0") == 404
-        # ...and present on the internal loopback listener: the bus answers,
-        # and the Connect handler runs and rejects port 0 with 400 (proving the
-        # route is registered here, not 404'd away).
-        assert _status(internal, "/api/plugins/listeners") == 200
-        assert _status(internal, "/api/sheds/nope/connect/0") == 400
-        # The internal listener does NOT serve the control plane.
-        assert _status(internal, "/api/info") == 404
+    # Connect tunnel: the route is registered on this listener — handleConnect
+    # runs and rejects port 0 with 400 (INVALID_PORT). A 404 would mean the
+    # route is absent; 400 proves it is present here.
+    assert _status(public, "/api/sheds/nope/connect/0") == 400


### PR DESCRIPTION
## Summary

Finishes the local-first / zero-plaintext-secure direction of the `0.7` auth line (targets **v0.7.4**). Three coupled changes, plus packaging + docs:

1. **Zero plaintext in secure mode** — removes `internal_http_port`; the credential bus (`/api/plugins/*`) and Connect tunnel (`/api/sheds/*/connect/*`) ride the single listener (pinned TLS in secure, plain HTTP in open), gated by the `credentials` scope. Side benefit: remote `shed forward` works uniformly again (the old split forced Connect to loopback).
2. **One bind knob, loopback by default** — unifies `http_bind`/`ssh_bind` into a single `bind_address` governing every listener, defaulting to **loopback (127.0.0.1) in both modes**. A non-loopback bind in **open** mode requires the new `allow_insecure_exposure: true` ack; secure mode (TLS + tokens) needs none. `*` aliases `0.0.0.0`; `::` binds all. A startup `WARNING` flags the new default for upgraders.
3. **`http_port` optional in secure mode** — secure serves no plain HTTP, so it's no longer required there and is omitted from `/api/info` + the written client entry. Mirrors the change already in shed-remote-agent.

This was planned with `/planning:ask-panel` (Codex + Kimi + CodeRabbit); their findings (the pre-filled-struct `http_port` gotcha, both-loaders/both-validators consistency, `BootstrapInfo`, the channel-independent startup WARN, the `ssh_bind` scope decision) are incorporated.

## Breaking changes (a `0.7.x` patch — the auth interface is still settling)

- `internal_http_port`, `http_bind`, `ssh_bind` are **rejected at startup** (first removed; binds renamed → `bind_address`).
- With no `bind_address`, every listener now binds **loopback only** (was all-interfaces) — a networked server is local-only until `bind_address` is set. Deb postinstall warns on upgrade; other channels surface it via the startup `WARNING`.

Migration + recovery: **[docs/upgrades/v0.7.3-to-v0.7.4.md](docs/upgrades/v0.7.3-to-v0.7.4.md)**.

## Commits (phased)

- `refactor(server)!: drop internal_http_port — one listener per mode`
- `feat(server): make http_port optional, required only for open mode`
- `feat(server)!: unify http_bind/ssh_bind into bind_address, default loopback`
- `build(packaging): ship loopback bind_address default + v0.7.4 migration warning`
- `docs: rework auth/network docs for v0.7.4 (bind_address, loopback default)`
- `chore(configs): set bind_address on the parallel-dev configs`

Each commit was kept green (`make check`), run through `/simplify` (code commits), and reviewed (CodeRabbit per commit). WS2 is a clean `git revert <commit>` if the bind-flip ever needs backing out.

## Validation

- `make check` (full unit suite + `golangci-lint`) — green.
- `config-validate` end-to-end: open + non-loopback `bind_address` without the ack **fails**; with `allow_insecure_exposure: true` **passes**.
- Live VZ dev server (parallel dev-server): boots clean, both listeners bind `127.0.0.1`, `/api/info` + `/api/sheds` serve 200.
- `make test-integration-dev` (VZ create-cycle, new binary on the parallel dev-server): **76 passed, 3 skipped** (~16 min), incl. the `create_agent_p50` timing gate (no perf regression), TLS listener/pin/rotation/**bus-over-TLS-with-token**, and SSH allowlist enforce/warn. (Skips are environmental: brew server not configured in the dev run, local-dir mount paths, FC-only rootfs fast-path.) FC code paths are backend-agnostic (config/listeners/router; the VM boot path is untouched) and covered by unit tests; the suite's FC cases passed against the mini3 deb baseline.
- `mkdocs build --strict` — clean.

## Sibling repos

No code changes required — verified: shed-remote-agent (its `http_port`-optional change is what shed now matches), shed-extensions host-agent (prefers `api_url`, tolerates missing `http_port`, no `internal_http_port` coupling), shed-desktop (defaults missing `http_port`, uses `api_url`). The brew/apt publish repos (homebrew-tap, apt-charliek) auto-update from the shed release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Server now defaults to binding on `127.0.0.1` only; remote access requires explicitly setting `bind_address`.
  * Removed `http_bind`, `ssh_bind`, and `internal_http_port`; use unified `bind_address` (and `allow_insecure_exposure` for off-loopback in open mode).
  * `http_port` is optional/omitted in secure mode, and removed/legacy keys now fail validation at startup/upgrade time.

* **New Features**
  * Credential bus and Connect routing now run on the single configured listener (no separate internal loopback listener).

* **Packaging**
  * Upgrade/install preflight validation improved, with clearer guidance when `bind_address` is missing.

* **Documentation**
  * Updated quickstarts, security configuration, VPS guidance, and configuration reference + migration guide for v0.7.3 → v0.7.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->