### PR TITLE
Bake shed-ext-rc into the full image (shed-extensions v0.4.6)

### DIFF
--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -24,7 +24,7 @@
 
 # Bump this when shed-extensions releases a new version.
 # The extensions and full variants pull binaries from this tag.
-ARG SHED_EXT_VERSION=v0.4.3
+ARG SHED_EXT_VERSION=v0.4.6
 FROM ghcr.io/charliek/shed-extensions:${SHED_EXT_VERSION} AS shed-extensions
 
 # Note: the shed initramfs (overlay-on-the-guest init) is built from
@@ -235,6 +235,7 @@ RUN --mount=type=bind,from=shed-extensions,source=/,target=/ext \
     install -m 0755 /ext/usr/local/bin/shed-ext-ssh-agent       /usr/local/bin/shed-ext-ssh-agent && \
     install -m 0755 /ext/usr/local/bin/shed-ext-aws-credentials /usr/local/bin/shed-ext-aws-credentials && \
     install -m 0755 /ext/usr/local/bin/docker-credential-shed   /usr/local/bin/docker-credential-shed && \
+    install -m 0755 /ext/usr/local/bin/shed-ext-rc              /usr/local/bin/shed-ext-rc && \
     install -m 0644 /ext/etc/systemd/system/shed-ext-ssh-agent.service       /etc/systemd/system/shed-ext-ssh-agent.service && \
     install -m 0644 /ext/etc/systemd/system/shed-ext-aws-credentials.service /etc/systemd/system/shed-ext-aws-credentials.service && \
     install -m 0644 /ext/etc/environment.d/shed-extensions.conf              /etc/environment.d/shed-extensions.conf && \

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -24,7 +24,7 @@
 
 # Bump this when shed-extensions releases a new version.
 # The extensions and full variants pull binaries from this tag.
-ARG SHED_EXT_VERSION=v0.4.3
+ARG SHED_EXT_VERSION=v0.4.6
 FROM ghcr.io/charliek/shed-extensions:${SHED_EXT_VERSION} AS shed-extensions
 
 # Note: the shed initramfs (overlay-on-the-guest init) is built from
@@ -236,6 +236,7 @@ RUN --mount=type=bind,from=shed-extensions,source=/,target=/ext \
     install -m 0755 /ext/usr/local/bin/shed-ext-ssh-agent       /usr/local/bin/shed-ext-ssh-agent && \
     install -m 0755 /ext/usr/local/bin/shed-ext-aws-credentials /usr/local/bin/shed-ext-aws-credentials && \
     install -m 0755 /ext/usr/local/bin/docker-credential-shed   /usr/local/bin/docker-credential-shed && \
+    install -m 0755 /ext/usr/local/bin/shed-ext-rc              /usr/local/bin/shed-ext-rc && \
     install -m 0644 /ext/etc/systemd/system/shed-ext-ssh-agent.service       /etc/systemd/system/shed-ext-ssh-agent.service && \
     install -m 0644 /ext/etc/systemd/system/shed-ext-aws-credentials.service /etc/systemd/system/shed-ext-aws-credentials.service && \
     install -m 0644 /ext/etc/environment.d/shed-extensions.conf              /etc/environment.d/shed-extensions.conf && \


### PR DESCRIPTION
Bakes the new **`shed-ext-rc`** guest binary into the vz + firecracker **full** images, which unblocks the RC Session Convention v2 work in shed-remote-agent and shed-desktop.

### Why
Those apps no longer build SSH+tmux commands inline — they invoke `shed-ext-rc` over SSH to create/list/probe/prompt/kill remote-control sessions (`rc-<slug>`), so the binary must be on `PATH` inside the shed. Until it's here, both apps return `SHED_EXT_RC_MISSING`.

### What
- Installs `shed-ext-rc` from the pinned shed-extensions image, exactly like the other guest binaries (`shed-ext-ssh-agent`, `shed-ext-aws-credentials`, `docker-credential-shed`) — in the `shed-{vz,fc}-extensions` stage that `shed-{vz,fc}-full` inherits. It's a one-shot CLI like `docker-credential-shed`, so it needs **no systemd unit**.
- Bumps `SHED_EXT_VERSION` `v0.4.3` → `v0.4.6` (also picks up the v0.4.4/v0.4.5 host-agent token + config fixes).

### Where it lands
The binary is RC tooling, so it pairs with claude in the **full** image: `shed-{vz,fc}-full` builds `FROM shed-{vz,fc}-extensions`, and claude (`claude.ai/install.sh`) + `CLAUDE_CONFIG_DIR=/home/shed/.claude` are set in the full stage — which is exactly the config the binary's native-Go trust pre-seed targets.

### Verified
- The published `ghcr.io/charliek/shed-extensions:v0.4.6` image ships `/usr/local/bin/shed-ext-rc` (confirmed via `docker export | tar tf`).
- The binary itself is live-proven inside a real shed (create `claude-rc --wait` → ready with a claude.ai URL, trust auto-cleared, prompt via stdin, list/probe/kill) — see shed-extensions #42.
- Final validation is a full image build (CI / your release).

### Merge order
Merge + release the shed image first, then merge the two dependent app PRs:
shed-remote-agent#12 and shed-desktop#21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shed-extensions to v0.4.6 (from v0.4.3) for improved platform compatibility
  * Added shed-ext-rc binary to extend system capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->