### PR TITLE
feat(config): bind_address format validation + removed-key scan dedup

### DIFF
--- a/internal/config/network_surface_test.go
+++ b/internal/config/network_surface_test.go
@@ -76,6 +76,12 @@ func TestValidateBindAddress(t *testing.T) {
 		{"open tailnet ip with ack ok", ServerConfig{BindAddress: "100.64.0.1", AllowInsecureExposure: true}, false},
 		{"secure 0.0.0.0 ok without ack", ServerConfig{BindAddress: "0.0.0.0", Auth: secure}, false},
 		{"secure tailnet ip ok without ack", ServerConfig{BindAddress: "100.64.0.1", Auth: secure}, false},
+		// Format validation runs before the mode/ack gate, so a malformed bind is
+		// rejected in every mode (it would otherwise fail cryptically at net.Listen).
+		{"malformed ip rejected", ServerConfig{BindAddress: "127.0.0.l"}, true},
+		{"hostname rejected", ServerConfig{BindAddress: "box.example"}, true},
+		{"over-long ipv4 rejected", ServerConfig{BindAddress: "0.0.0.0.0"}, true},
+		{"malformed rejected even in secure", ServerConfig{BindAddress: "nope", Auth: secure}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -307,12 +307,18 @@ func (c *ServerConfig) validateHTTPPort() error {
 	return nil
 }
 
-// validateBindAddress gates non-loopback exposure of an open-mode server. Open
-// mode has no transport security (and may not enforce the SSH allowlist), so
-// binding a routable interface requires an explicit allow_insecure_exposure
-// acknowledgment. Secure mode (TLS + tokens) needs none; unset/loopback binds
-// are always allowed. Shared by Validate and ValidateNoHostCoupling.
+// validateBindAddress validates the bind_address format and gates non-loopback
+// exposure of an open-mode server. The format check accepts the special tokens
+// ("" = loopback default, "*" = all IPv4) plus "localhost" and any IP literal;
+// a hostname or typo is rejected here rather than failing cryptically at
+// net.Listen on startup. Open mode has no transport security, so binding a
+// routable interface also requires an explicit allow_insecure_exposure
+// acknowledgment; secure mode (TLS + tokens) needs none. Shared by Validate and
+// ValidateNoHostCoupling.
 func (c *ServerConfig) validateBindAddress() error {
+	if b := c.BindAddress; b != "" && b != "*" && b != "localhost" && net.ParseIP(b) == nil {
+		return fmt.Errorf("invalid bind_address %q (want an IP address, \"0.0.0.0\"/\"*\" for all IPv4, \"::\" for all interfaces, \"localhost\", or empty for loopback)", b)
+	}
 	if c.Secure() || isLoopbackBind(c.BindAddress) || c.AllowInsecureExposure {
 		return nil
 	}
@@ -1383,6 +1389,20 @@ func normalizeMounts(cfg *ServerConfig, configPath string) {
 	cfg.Credentials = nil
 }
 
+// rejectRemovedKeys runs every removed-key scan in one place so the two loaders
+// can't drift on which checks they apply. Each scan re-parses data and returns
+// nil on malformed YAML (deferring the parse error to the typed unmarshal).
+func rejectRemovedKeys(data []byte) error {
+	for _, check := range []func([]byte) error{
+		rejectRemovedImageKeys, rejectRemovedAuthKeys, rejectRemovedNetworkKeys,
+	} {
+		if err := check(data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // applyModeAndCommonDefaults fills in the mode-derived and common zero-value
 // defaults shared by both loaders (serve + config-validate), so the two paths
 // can't drift. http_port drives the open-mode plain-HTTP listener; secure mode
@@ -1446,13 +1466,7 @@ func LoadServerConfigFromPath(path string) (*ServerConfig, error) {
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config file %s: %w", configPath, err)
 	}
-	if err := rejectRemovedImageKeys(data); err != nil {
-		return nil, fmt.Errorf("%s: %w", configPath, err)
-	}
-	if err := rejectRemovedAuthKeys(data); err != nil {
-		return nil, fmt.Errorf("%s: %w", configPath, err)
-	}
-	if err := rejectRemovedNetworkKeys(data); err != nil {
+	if err := rejectRemovedKeys(data); err != nil {
 		return nil, fmt.Errorf("%s: %w", configPath, err)
 	}
 
@@ -1596,13 +1610,7 @@ func loadServerConfigForCLI(path string) (*ServerConfig, error) {
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config file %s: %w", configPath, err)
 	}
-	if err := rejectRemovedImageKeys(data); err != nil {
-		return nil, fmt.Errorf("%s: %w", configPath, err)
-	}
-	if err := rejectRemovedAuthKeys(data); err != nil {
-		return nil, fmt.Errorf("%s: %w", configPath, err)
-	}
-	if err := rejectRemovedNetworkKeys(data); err != nil {
+	if err := rejectRemovedKeys(data); err != nil {
 		return nil, fmt.Errorf("%s: %w", configPath, err)
 	}
 


### PR DESCRIPTION
Two small config-validation refinements deferred from #210 (v0.7.4).

1. **bind_address format validation** — a malformed bind (hostname, typo, zoned IPv6) is now rejected at `config-validate` time with a clear message instead of failing cryptically at `net.Listen` on startup. Accepts the special tokens (`""`, `*`, `localhost`) and any IP literal; the check runs before the open-mode exposure gate, so it applies in every mode (incl. secure). Completes the `bind_address` feature.
2. **removed-key scan dedup** — the three scans (image/auth/network) now run behind one `rejectRemovedKeys` wrapper that both loaders call, so the serve and config-validate paths can't drift on which checks they run (same drift-prevention as the shared loader defaulting).

## Validation
- `make check` (full unit suite + `golangci-lint`) — green.
- New `TestValidateBindAddress` cases cover malformed / hostname / over-long / secure-mode rejection.
- CodeRabbit review (pre-open): 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened bind address configuration validation to immediately reject invalid or malformed formats.
  * Unified server configuration “removed key” checks so all config loading paths apply the same validation behavior.

* **Tests**
  * Expanded bind address validation test coverage with additional edge cases and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->