### PR TITLE
fix(packaging): absolute shed-server path in postinst config-validate

### DIFF
--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -34,7 +34,13 @@ if [ -n "${2:-}" ]; then
     # rejects the old keys — so a blind restart would crash the service.
     # Preflight the config and SKIP the restart (pointing at the upgrade
     # guide) when it no longer validates, rather than take the service down.
-    if ! validate_err="$(shed-server --config /etc/shed/server.yaml config-validate 2>&1)"; then
+    #
+    # Use the ABSOLUTE binary path: dpkg runs maintainer scripts with a minimal
+    # PATH (/usr/sbin:/usr/bin:/sbin:/bin) that excludes /usr/local/bin, so a bare
+    # `shed-server` is "command not found" here. That made the preflight *always*
+    # fail (validation never ran), so every upgrade skipped the restart and left
+    # the old binary serving. The path matches the unit's ExecStart.
+    if ! validate_err="$(/usr/local/bin/shed-server --config /etc/shed/server.yaml config-validate 2>&1)"; then
         echo ""
         echo "shed-server was upgraded, but /etc/shed/server.yaml did not validate"
         echo "against the new binary, so the service was NOT restarted (the old"
@@ -45,7 +51,7 @@ if [ -n "${2:-}" ]; then
         echo "This usually means the config uses keys removed in a breaking release"
         echo "(e.g. base_rootfs/images in v0.6.0, or http_bind/ssh_bind/"
         echo "internal_http_port in v0.7.4). Migrate per the upgrade guides, then:"
-        echo "  sudo shed-server --config /etc/shed/server.yaml config-validate"
+        echo "  sudo /usr/local/bin/shed-server --config /etc/shed/server.yaml config-validate"
         echo "  sudo systemctl restart shed-server"
         echo ""
         echo "Upgrade guides: https://github.com/charliek/shed/tree/main/docs/upgrades"


### PR DESCRIPTION
## Problem

The `shed-server` deb postinst preflights the config with `config-validate` and skips the auto-restart if it fails — but it invoked the validator as a **bare `shed-server`**. dpkg runs maintainer scripts with a minimal PATH (`/usr/sbin:/usr/bin:/sbin:/bin`) that **excludes `/usr/local/bin`** (where the binary is installed — matching the unit's `ExecStart`). So the validator was `command not found`, the `if !` read that as "config invalid," and **every `apt upgrade shed-server` skipped the restart** — leaving the old binary serving while `dpkg` reported the new version. That's the exact regression the preflight's v0.5.9 predecessor was added to prevent, reintroduced via PATH.

## How it surfaced

Upgrading **mini2/mini3 (Ubuntu 24.04) 0.7.3 → 0.7.4**, the postinst printed:

```
shed-server was upgraded, but /etc/shed/server.yaml did not validate
against the new binary, so the service was NOT restarted ...
  /var/lib/dpkg/info/shed-server.postinst: line 37: shed-server: command not found
```

…despite a perfectly valid config. A manual `sudo systemctl restart shed-server` then ran the new binary fine.

## Fix

Use the **absolute `/usr/local/bin/shed-server`** for the validation (line 37), and in the echoed recovery instruction (line 48) so a copy-paste works regardless of `sudo`'s `secure_path`. The path matches the unit's `ExecStart`. No behavior change when the config genuinely fails to validate — the skip-and-warn path is preserved.

```bash
bash -n packaging/postinstall.sh   # syntax OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration validation during Debian package upgrades to ensure the service properly restarts when updating to new versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->