### PR TITLE
egress: snake_case `show --json` + recommended starter profiles + docs fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- **`shed egress show --json` emits snake_case keys.** The `rules` map's profile
+  definitions serialized with Go field names (`Mode`/`Allow`/`Deny`/`Rule`, plus a
+  noisy `"Deny":null`) because `config.EgressProfile` lacked JSON tags —
+  inconsistent with the rest of the API (`shed`, `resolved_ip`, …) and the YAML
+  config keys. They are now `mode`/`allow`/`deny`/`rule` with `omitempty`. A minor
+  `--json` **output-shape change**: no first-party consumer parsed the old shape,
+  and Go clients interop across it (`encoding/json` matches field names
+  case-insensitively).
+
+### Docs
+
+- **Egress: quickstart + recommended starter profiles.** `docs/reference/egress.md`
+  gains a 3-step quickstart and a "Recommended starter profiles" section
+  (`ai-agents`, `github`, `package-registries`, `os-updates`, `containers`, sourced
+  from real-world sandbox allowlists) with apex-vs-wildcard guidance; a matching
+  commented `egress:` block lands in `configs/server.example.yaml` (guarded by a
+  validation test). The "plain HTTP is deny-by-default" caveat is corrected — plain
+  HTTP uses the same allow/deny/rule chain as HTTPS.
+
 ## v0.7.4 — 2026-06-19
 
 Local-first, zero-plaintext-secure network surface — finishes the `0.7` auth

--- a/configs/server.example.yaml
+++ b/configs/server.example.yaml
@@ -114,3 +114,45 @@ log_level: info
 #   # version (see "Images and the server version" above).
 #   pull_policy: missing   # missing (default) | always | never
 #   images_dir: /var/lib/shed/firecracker/images
+
+# --- Egress control (opt-in; Level-1 cooperative HTTP(S)_PROXY) ---
+# Off by default. Set enabled: true to start a shed-egress-proxy child; sheds
+# then opt in with `--egress <profiles>`. default: [] means existing sheds are
+# unaffected. Level 1 is cooperative, NOT a security boundary — see
+# docs/reference/egress.md for the policy language and the bypass inventory.
+# The profiles below are starter examples (real-world sandbox allowlists), not
+# guaranteed-complete safe defaults; run a shed in `audit` first, then tighten.
+# Compose per shed, e.g. `shed create web --egress github,package-registries`.
+egress:
+  enabled: false
+  port_range: "20000-30000"
+  default: []
+  profiles:
+    audit: { mode: audit }                 # allow + log everything (guards still deny)
+
+    ai-agents:                             # Anthropic + OpenAI API & telemetry
+      allow: [api.anthropic.com, statsig.anthropic.com, statsig.com, sentry.io,
+              api.openai.com, auth.openai.com, chatgpt.com]
+
+    github:                                # clone + API + actions + GHCR (apex AND wildcard)
+      allow: [github.com, api.github.com, codeload.github.com,
+              objects.githubusercontent.com, raw.githubusercontent.com,
+              "*.actions.githubusercontent.com", pkg-containers.githubusercontent.com,
+              ghcr.io]
+
+    package-registries:                    # npm, PyPI, Go, Rust, RubyGems, Maven
+      allow: [registry.npmjs.org, pypi.org, files.pythonhosted.org,
+              proxy.golang.org, sum.golang.org, index.golang.org,
+              crates.io, index.crates.io, static.crates.io,
+              rubygems.org, index.rubygems.org,
+              repo.maven.apache.org, repo1.maven.org]
+
+    os-updates:                            # Debian/Ubuntu apt (ports.ubuntu.com = Apple-Silicon arm64)
+      allow: [deb.debian.org, security.debian.org, archive.ubuntu.com,
+              security.ubuntu.com, ports.ubuntu.com, keyserver.ubuntu.com]
+
+    containers:                            # Docker Hub + GHCR + Quay + MCR
+      allow: [registry-1.docker.io, auth.docker.io,
+              production.cloudflare.docker.com, production.cloudfront.docker.com,
+              ghcr.io, pkg-containers.githubusercontent.com,
+              quay.io, cdn.quay.io, mcr.microsoft.com]

--- a/docs/reference/egress.md
+++ b/docs/reference/egress.md
@@ -33,6 +33,35 @@ proxy drop-in, so `docker pull` is covered too). The proxy:
 Attribution is by **per-shed listener port + a per-shed token** injected into the
 proxy URL — a shed that guesses another shed's port still lacks its token.
 
+## Quickstart
+
+Three steps from off to a filtered shed:
+
+```yaml
+# 1. Enable egress and define profiles in the server config (server.yaml), then
+#    restart shed-server. default: [] keeps existing sheds unaffected.
+egress:
+  enabled: true
+  default: []
+  profiles:
+    audit:  { mode: audit }
+    github: { allow: ["github.com", "*.github.com"] }
+```
+
+```bash
+# 2. Create a shed that composes one or more profiles.
+shed create web --egress github
+```
+
+```bash
+# 3. See its policy and live allow/deny decisions.
+shed egress show web
+```
+
+A good rollout is to start a shed in `audit` to *see* what it reaches, then
+tighten to an allowlist. The [recommended starter profiles](#recommended-starter-profiles)
+below are a sensible base to copy from.
+
 ## Enabling it
 
 Egress is configured in the shed-server config (`server.yaml`). It is **off**
@@ -94,6 +123,99 @@ host == "registry.internal" && protocol == "https"
 
 A CEL evaluation error **fails closed** (the connection is denied). For the full
 language see the [cel-go spec](https://github.com/google/cel-spec/blob/master/doc/langdef.md).
+
+## Recommended starter profiles
+
+These are a **starting point, not guaranteed-complete "safe defaults."** They are
+copied from public sandbox allowlists — Anthropic's Claude Code devcontainer
+firewall, OpenAI's Codex "common dependencies" preset, GitHub/StepSecurity
+Harden-Runner, and each ecosystem's registry docs. Upstream domains drift, so
+treat these as a base you **own and tighten**: run a shed in `audit` first to
+confirm what it actually needs, then pin an allowlist.
+
+!!! note "Apex vs. wildcard"
+    A `*.example.com` glob matches subdomains **only**, never the apex
+    `example.com`. When a service answers at both (e.g. `github.com` *and*
+    `api.github.com`), list **both** — the profiles below already do this where
+    it's needed.
+
+Paste the ones you need into `egress.profiles` and compose them per shed, e.g.
+`shed create web --egress github,package-registries,os-updates`.
+
+```yaml
+profiles:
+  # Visibility-first: allow + log everything (guards still deny). Best first
+  # step — run a shed in audit to SEE what it reaches, then tighten.
+  audit: { mode: audit }
+
+  # AI coding agents: Anthropic + OpenAI APIs and the telemetry/config
+  # endpoints Claude Code and Codex actually dial.
+  ai-agents:
+    allow:
+      - api.anthropic.com          # Claude API
+      - statsig.anthropic.com      # Claude Code feature flags
+      - statsig.com
+      - sentry.io                  # error telemetry
+      - api.openai.com             # OpenAI / Codex API
+      - auth.openai.com
+      - chatgpt.com                # Codex CLI sign-in
+
+  # GitHub: clone/checkout + API + action/source/raw downloads + GHCR.
+  github:
+    allow:
+      - github.com                           # apex (clone/checkout/releases)
+      - api.github.com
+      - codeload.github.com                  # tarball/zipball + action downloads
+      - objects.githubusercontent.com        # release assets / LFS
+      - raw.githubusercontent.com
+      - "*.actions.githubusercontent.com"    # Actions runtime/artifacts
+      - pkg-containers.githubusercontent.com # GHCR layer blobs
+      - ghcr.io
+
+  # Language package managers: npm, PyPI, Go, Rust, RubyGems, Maven.
+  package-registries:
+    allow:
+      - registry.npmjs.org
+      - pypi.org                   # apex (index)
+      - files.pythonhosted.org     # package files
+      - proxy.golang.org
+      - sum.golang.org
+      - index.golang.org
+      - crates.io                  # apex (API)
+      - index.crates.io            # sparse index
+      - static.crates.io           # downloads
+      - rubygems.org               # apex
+      - index.rubygems.org
+      - repo.maven.apache.org
+      - repo1.maven.org
+
+  # OS package updates (Debian/Ubuntu apt).
+  os-updates:
+    allow:
+      - deb.debian.org
+      - security.debian.org
+      - archive.ubuntu.com
+      - security.ubuntu.com
+      - ports.ubuntu.com           # arm64/ports — REQUIRED on Apple-Silicon VZ
+      - keyserver.ubuntu.com
+
+  # Container image pulls: Docker Hub + GHCR + Quay + MCR.
+  containers:
+    allow:
+      - registry-1.docker.io               # Docker Hub registry API
+      - auth.docker.io                     # Docker Hub token auth
+      - production.cloudflare.docker.com   # Docker Hub blob CDN
+      - production.cloudfront.docker.com   # Docker Hub blob CDN (alt)
+      - ghcr.io
+      - pkg-containers.githubusercontent.com
+      - quay.io                            # apex
+      - cdn.quay.io
+      - mcr.microsoft.com
+```
+
+!!! warning "Apple-Silicon VZ guests need `ports.ubuntu.com`"
+    `archive.ubuntu.com` carries amd64 only; arm64 packages come from
+    `ports.ubuntu.com`. Omit it and `apt-get` breaks on the VZ backend.
 
 ## CLI
 
@@ -171,8 +293,10 @@ netns/pf or a userspace netstack) is tracked as future work
 - **Audit is best-effort under load** — records are dropped (not blocked) at
   each buffer if a consumer can't keep up. The data path is never stalled by
   auditing.
-- **Plain HTTP** is deny-by-default (allow `protocol == "http"` explicitly if
-  you need it); only the first request on a kept-alive plain-HTTP proxy
+- **Plain HTTP** is evaluated by the *same* allow/deny/rule chain as HTTPS — an
+  `allow:` host glob matches regardless of protocol, so `http://<allowed-host>`
+  is allowed too (write a CEL `rule` on `protocol` if you must treat `http` and
+  `https` differently). Only the first request on a kept-alive plain-HTTP proxy
   connection is policy-checked.
 - **shed-server restart**: a running shed's egress listener is re-established
   when the shed itself is next started; after a shed-server restart, restart an

--- a/internal/config/egress.go
+++ b/internal/config/egress.go
@@ -32,11 +32,16 @@ type EgressConfig struct {
 // EgressProfile is one named policy fragment. Allow/Deny are domain globs
 // ("*.github.com" suffix, "github.com" exact); Rule is a CEL expression (the
 // power path); Mode "audit" makes the fall-through allow+log instead of deny.
+//
+// The json tags are the wire contract for the `rules` map in
+// `shed egress show --json` (GET /api/egress/{name}). They are snake_case to
+// match the rest of the API (egress.AuditRecord, EgressStatus); omitempty keeps
+// the output to the fields a profile actually sets.
 type EgressProfile struct {
-	Mode  string   `yaml:"mode,omitempty"`
-	Allow []string `yaml:"allow,omitempty"`
-	Deny  []string `yaml:"deny,omitempty"`
-	Rule  string   `yaml:"rule,omitempty"`
+	Mode  string   `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Allow []string `json:"allow,omitempty" yaml:"allow,omitempty"`
+	Deny  []string `json:"deny,omitempty" yaml:"deny,omitempty"`
+	Rule  string   `json:"rule,omitempty" yaml:"rule,omitempty"`
 }
 
 // EgressStatus is the `shed egress show` response: a shed's active egress

--- a/internal/config/egress_test.go
+++ b/internal/config/egress_test.go
@@ -106,13 +106,15 @@ func TestEgressProfileJSONContract(t *testing.T) {
 		{"deny+allow", EgressProfile{Deny: []string{"evil.com"}, Allow: []string{"good.com"}}, `{"allow":["good.com"],"deny":["evil.com"]}`},
 	}
 	for _, c := range cases {
-		b, err := json.Marshal(c.p)
-		if err != nil {
-			t.Fatalf("%s: marshal: %v", c.name, err)
-		}
-		if string(b) != c.want {
-			t.Errorf("%s: marshal = %s, want %s", c.name, b, c.want)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			b, err := json.Marshal(c.p)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(b) != c.want {
+				t.Errorf("marshal = %s, want %s", b, c.want)
+			}
+		})
 	}
 
 	// No PascalCase key leaks (this is what the json tags actually fix).
@@ -157,9 +159,11 @@ func TestEgressStatusJSONKeys(t *testing.T) {
 	}
 	s := string(b)
 	for _, want := range []string{`"shed":"web"`, `"rules":{"github":{"allow":["github.com"]}}`} {
-		if !strings.Contains(s, want) {
-			t.Errorf("EgressStatus json missing %s in %s", want, s)
-		}
+		t.Run("contains "+want, func(t *testing.T) {
+			if !strings.Contains(s, want) {
+				t.Errorf("EgressStatus json missing %s in %s", want, s)
+			}
+		})
 	}
 	if strings.Contains(s, `"Allow"`) || strings.Contains(s, `"Mode"`) {
 		t.Errorf("PascalCase profile key leaked: %s", s)

--- a/internal/config/egress_test.go
+++ b/internal/config/egress_test.go
@@ -2,8 +2,11 @@ package config
 
 import (
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func mkEgress() *EgressConfig {
@@ -160,5 +163,29 @@ func TestEgressStatusJSONKeys(t *testing.T) {
 	}
 	if strings.Contains(s, `"Allow"`) || strings.Contains(s, `"Mode"`) {
 		t.Errorf("PascalCase profile key leaked: %s", s)
+	}
+}
+
+// TestExampleConfigEgressValidates guards configs/server.example.yaml from
+// rotting: its starter egress profiles must compile (globs/CEL) so copy-paste
+// users get a config that loads. The example ships enabled:false, so validate a
+// force-enabled copy to actually exercise profile compilation (Validate is a
+// no-op when disabled).
+func TestExampleConfigEgressValidates(t *testing.T) {
+	data, err := os.ReadFile("../../configs/server.example.yaml")
+	if err != nil {
+		t.Fatalf("read example config: %v", err)
+	}
+	var cfg ServerConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse example config: %v", err)
+	}
+	if cfg.Egress == nil {
+		t.Fatal("example config has no egress block (expected the documented starter profiles)")
+	}
+	e := *cfg.Egress
+	e.Enabled = true
+	if err := e.Validate(); err != nil {
+		t.Errorf("example egress profiles do not validate: %v", err)
 	}
 }

--- a/internal/config/egress_test.go
+++ b/internal/config/egress_test.go
@@ -1,6 +1,10 @@
 package config
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
 func mkEgress() *EgressConfig {
 	return &EgressConfig{
@@ -80,5 +84,81 @@ func TestEgressPortRangeBounds(t *testing.T) {
 	lo, hi = (&EgressConfig{}).PortRangeBounds()
 	if lo != 20000 || hi != 30000 {
 		t.Errorf("default bounds = %d-%d", lo, hi)
+	}
+}
+
+// TestEgressProfileJSONContract pins the `shed egress show --json` rules-map wire
+// shape: snake_case keys, omitempty dropping unset fields. The raw-bytes
+// assertions are deliberate — a struct round-trip would pass even without the
+// json tags because encoding/json matches field names case-insensitively.
+func TestEgressProfileJSONContract(t *testing.T) {
+	cases := []struct {
+		name string
+		p    EgressProfile
+		want string
+	}{
+		{"allow only", EgressProfile{Allow: []string{"*.github.com", "github.com"}}, `{"allow":["*.github.com","github.com"]}`},
+		{"audit mode", EgressProfile{Mode: "audit"}, `{"mode":"audit"}`},
+		{"rule only", EgressProfile{Rule: "port == 443"}, `{"rule":"port == 443"}`},
+		{"deny+allow", EgressProfile{Deny: []string{"evil.com"}, Allow: []string{"good.com"}}, `{"allow":["good.com"],"deny":["evil.com"]}`},
+	}
+	for _, c := range cases {
+		b, err := json.Marshal(c.p)
+		if err != nil {
+			t.Fatalf("%s: marshal: %v", c.name, err)
+		}
+		if string(b) != c.want {
+			t.Errorf("%s: marshal = %s, want %s", c.name, b, c.want)
+		}
+	}
+
+	// No PascalCase key leaks (this is what the json tags actually fix).
+	b, _ := json.Marshal(EgressProfile{Allow: []string{"x"}})
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	for _, bad := range []string{"Mode", "Allow", "Deny", "Rule"} {
+		if _, ok := m[bad]; ok {
+			t.Errorf("PascalCase key %q leaked into %s", bad, b)
+		}
+	}
+	if _, ok := m["allow"]; !ok {
+		t.Errorf("missing snake_case key 'allow' in %s", b)
+	}
+
+	// Backward-compat: a legacy PascalCase document still unmarshals, so a new CLI
+	// reading an old server's response (and vice-versa) keeps working.
+	var p EgressProfile
+	if err := json.Unmarshal([]byte(`{"Mode":"audit","Allow":["a.com"]}`), &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Mode != "audit" || len(p.Allow) != 1 || p.Allow[0] != "a.com" {
+		t.Errorf("legacy unmarshal = %+v", p)
+	}
+}
+
+// TestEgressStatusJSONKeys guards the full GET /api/egress/{name} response shape:
+// the nested rules-map profile values must be snake_case, like the rest of it.
+func TestEgressStatusJSONKeys(t *testing.T) {
+	st := EgressStatus{
+		Shed:     "web",
+		Enabled:  true,
+		Profiles: []string{"github"},
+		Port:     20001,
+		Rules:    map[string]EgressProfile{"github": {Allow: []string{"github.com"}}},
+	}
+	b, err := json.Marshal(st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, want := range []string{`"shed":"web"`, `"rules":{"github":{"allow":["github.com"]}}`} {
+		if !strings.Contains(s, want) {
+			t.Errorf("EgressStatus json missing %s in %s", want, s)
+		}
+	}
+	if strings.Contains(s, `"Allow"`) || strings.Contains(s, `"Mode"`) {
+		t.Errorf("PascalCase profile key leaked: %s", s)
 	}
 }


### PR DESCRIPTION
## Summary

Live end-to-end test of the v0.7.1 **egress-control** feature on the VZ backend,
plus the fixes/doc improvements it surfaced. The feature itself works well — this
PR is one small serialization fix and a documentation/onboarding pass.

### What was tested (all ✅)
Enforce allow/deny + default-deny · subdomain globs · within-profile deny
precedence · CEL (host+port) · audit-fallthrough · **guards deny even in audit**
(`::1`, `10/8`) · **per-shed token isolation** (shed A's token → 407 on shed B's
port) · plain-HTTP forwarding · live `egress set`/`off`/re-enable · persistence
across shed restart · **dockerd drop-in routes pulls** (enforce blocks
`docker pull` with `registry-1.docker.io: Forbidden`) · audit JSONL + recent ring
+ `shed egress show` table + server denial log · profile composition ·
unknown-profile error · config fail-fast on bad CEL · **desktop Egress pane
rendering real per-shed decisions** · host-agent→desktop pipeline incl. 401→re-mint
recovery (~1s) after a server restart.

## Changes

### Fixed — `shed egress show --json` emits snake_case (`config.EgressProfile`)
`EgressProfile` carried only `yaml:` tags, so the `rules` map in
`shed egress show --json` (`GET /api/egress/{name}`) serialized with PascalCase
keys (`Mode`/`Allow`/`Deny`/`Rule`) and a noisy `"Deny":null` — inconsistent with
the rest of the API (`shed`, `resolved_ip`, `verdict`) and the YAML config keys.
Added `json:"...,omitempty"` tags (dual `json`+`yaml`, matching `config.Shed`).

- **Blast radius:** only `GET /api/egress/{name}`'s `rules` field. The SSE stream
  uses `egress.AuditRecord` (already snake_case) and is untouched.
- **Non-breaking on 0.7.x:** no first-party consumer parses this shape (verified
  across shed CLI, shed-desktop, shed-extensions — the desktop/host-agent consume
  only the SSE `AuditRecord`). Go's `encoding/json` matches field names
  case-insensitively, so new-CLI↔old-server and old-CLI↔new-server both interop.
- **Before:** `"rules":{"web":{"Mode":"","Allow":["github.com"],"Deny":null,"Rule":""}}`
  **After:** `"rules":{"web":{"allow":["github.com"]}}`

### Docs — egress onboarding + recommended starter profiles
- `docs/reference/egress.md`: a 3-step **quickstart** and a **"Recommended starter
  profiles"** section — `ai-agents`, `github`, `package-registries`, `os-updates`,
  `containers` — sourced from real-world sandbox allowlists (Anthropic Claude Code
  devcontainer firewall, OpenAI Codex preset, GitHub/StepSecurity Harden-Runner,
  ecosystem registry docs), with prominent **apex-vs-wildcard** guidance and a
  "starter examples, **not** safe defaults" framing.
- `configs/server.example.yaml`: a matching commented `egress:` block (the file had
  none, despite being the "full reference"), guarded by `TestExampleConfigEgressValidates`
  so it can't rot and break copy-paste users.
- Corrected the **"Plain HTTP is deny-by-default"** caveat — plain HTTP is evaluated
  by the *same* allow/deny/rule chain as HTTPS (`allow:` globs match regardless of
  protocol; verified `http://<allowed>` → 200). Only the kept-alive first-request
  caveat is HTTP-specific.

## Tests / validation
- New: `TestEgressProfileJSONContract` (asserts **raw JSON bytes** — a struct
  round-trip would false-pass since unmarshal is case-insensitive — + legacy
  PascalCase still unmarshals), `TestEgressStatusJSONKeys`, `TestExampleConfigEgressValidates`.
- `make lint` → 0 issues · `make test` → green · `mkdocs build --strict` → clean.
- Live check: rebuilt `shed` against this branch → `shed egress show <shed> --json`
  now emits snake_case against the running brew server.
- The F1 server change is a pure serialization tag exercised directly by the unit
  tests (the marshal path the server uses) and verified live; the integration suite
  covers boot-path/SSE/timing, which this doesn't touch.

## Review
Plan reviewed by a 3-model panel (Codex + Kimi K2.6 + CodeRabbit), unanimous; the
F1 diff additionally reviewed by Codex (LGTM). Raw-JSON test assertions, the
plain-HTTP second-line fix, the example-config rot guard, and the docs-only
(no built-in profiles) decision all came from that review.

## Follow-ups (not in this PR)
- **#214** — ad-hoc per-shed egress rules from the CLI without editing the server
  config (investigation + design; CLI-only v1, desktop stays view-only).
- A small **shed-desktop** PR adds the (already-working) `egress` pane to
  `shedctl ui navigate`'s advertised list + the screenshot smoke loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON output format for `shed egress show --json` command to use proper field naming.

* **New Features**
  * Added example egress control configuration with starter profiles for audit, AI agents, GitHub, package registries, OS updates, and containers.

* **Documentation**
  * Added egress quickstart guide and recommended starter profiles documentation with configuration examples.

* **Tests**
  * Added validation tests for example egress configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->