### PR TITLE
egress: user-managed named profiles (runtime, no server-config edit) (#214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- **User-managed egress profiles (runtime, no server-config edit).** A second,
+  runtime-editable profile store alongside `server.yaml`: `shed egress profile
+  set <name> --file <doc>` / `edit` / `ls` / `show` / `rm`, backed by
+  `GET/PUT/DELETE /api/egress/profiles[/{name}]` (control-scoped). User profiles
+  are referenced by name exactly like config profiles (`--egress
+  github,my-stack`). Server-config profiles stay a **read-only baseline** (a
+  collision is rejected; `ls` tags each `source: config|user`); **editing a
+  profile live-re-pushes every running shed that references it**; deleting a
+  referenced profile is rejected. Profiles persist under
+  `{state}/egress-profiles/`. See
+  [Egress Control](docs/reference/egress.md#user-managed-profiles) (shed #214).
+
 ### Fixed
 
 - **`shed egress show --json` emits snake_case keys.** The `rules` map's profile

--- a/cmd/shed-server/serve.go
+++ b/cmd/shed-server/serve.go
@@ -137,6 +137,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	var egressSocketDir string // runtime dir for the control socket
 	var egressStateDir string  // persistent dir for the durable audit log
 	var attachEgress func(*egress.Manager)
+	var attachEgressStore func(*config.UserProfileStore)
 	switch cfg.DefaultBackend {
 	case config.BackendFirecracker:
 		fcCfg := cfg.Firecracker
@@ -152,6 +153,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		egressSocketDir = fcCfg.SocketDir
 		egressStateDir = filepath.Dir(fcCfg.InstanceDir)
 		attachEgress = fcClient.SetEgressManager
+		attachEgressStore = fcClient.SetEgressUserStore
 
 	case config.BackendVZ:
 		vzCfg := cfg.VZ
@@ -167,6 +169,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		egressSocketDir = vzCfg.SocketDir
 		egressStateDir = filepath.Dir(vzCfg.InstanceDir)
 		attachEgress = vzClient.SetEgressManager
+		attachEgressStore = vzClient.SetEgressUserStore
 
 	default:
 		return fmt.Errorf("unsupported backend type: %s", cfg.DefaultBackend)
@@ -177,6 +180,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// failure is a hard startup error — never a silent disable (AC-11).
 	var egressMgr *egress.Manager
 	var egressAudit *egress.AuditLog
+	var egressUserStore *config.UserProfileStore
 	if cfg.Egress != nil && cfg.Egress.Enabled {
 		lo, hi := cfg.Egress.PortRangeBounds()
 		sockPath := filepath.Join(egressSocketDir, "egress-proxy.sock")
@@ -200,7 +204,25 @@ func runServe(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("egress: start proxy: %w", err)
 		}
 		attachEgress(egressMgr)
-		log.Printf("Initialized egress-control proxy (ports %d-%d, socket %s, audit %s)", lo, hi, sockPath, auditPath)
+
+		// Runtime user-editable profile store (`shed egress profile ...`), in the
+		// state dir next to the audit log. Fails startup on a malformed file.
+		storeDir := filepath.Join(egressStateDir, "egress-profiles")
+		egressUserStore, err = config.OpenUserProfileStore(storeDir)
+		if err != nil {
+			return fmt.Errorf("egress: open user profile store: %w", err)
+		}
+		// Config profiles are the read-only baseline: a user profile shadowed by a
+		// same-named config profile resolves to config. Warn so the dead user file
+		// is visible (the API rejects new colliding PUTs; this catches a config edit
+		// that collides with a pre-existing user profile).
+		for name := range cfg.Egress.Profiles {
+			if _, ok := egressUserStore.Get(name); ok {
+				log.Printf("egress: user profile %q is shadowed by a server-config profile of the same name (config wins)", name)
+			}
+		}
+		attachEgressStore(egressUserStore)
+		log.Printf("Initialized egress-control proxy (ports %d-%d, socket %s, audit %s, profiles %s)", lo, hi, sockPath, auditPath, storeDir)
 	}
 	defer func() {
 		if egressMgr != nil {
@@ -247,8 +269,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	// Initialize HTTP API server
 	apiServer := api.NewServer(be, cfg, hostKey, pluginRegistry, pluginBridge)
-	apiServer.SetEgressAudit(egressAudit) // nil-safe: no-op when egress disabled
-	apiServer.SetTokenStore(tokenStore)   // shared with the SSH bootstrap handler (1c)
+	apiServer.SetEgressAudit(egressAudit)         // nil-safe: no-op when egress disabled
+	apiServer.SetEgressUserStore(egressUserStore) // nil-safe: no-op when egress disabled
+	apiServer.SetTokenStore(tokenStore)           // shared with the SSH bootstrap handler (1c)
 
 	// Warn when bind_address is unset: as of v0.7.4 that defaults to loopback
 	// (was all-interfaces), so a server that relied on the old default is now

--- a/cmd/shed-server/serve.go
+++ b/cmd/shed-server/serve.go
@@ -204,6 +204,16 @@ func runServe(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("egress: start proxy: %w", err)
 		}
 		attachEgress(egressMgr)
+		// Register cleanup now — before the user-profile-store open below can
+		// early-return, which would otherwise leak the proxy child + audit log.
+		defer func() {
+			if egressMgr != nil {
+				_ = egressMgr.Close()
+			}
+			if egressAudit != nil {
+				_ = egressAudit.Close()
+			}
+		}()
 
 		// Runtime user-editable profile store (`shed egress profile ...`), in the
 		// state dir next to the audit log. Fails startup on a malformed file.
@@ -224,14 +234,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 		attachEgressStore(egressUserStore)
 		log.Printf("Initialized egress-control proxy (ports %d-%d, socket %s, audit %s, profiles %s)", lo, hi, sockPath, auditPath, storeDir)
 	}
-	defer func() {
-		if egressMgr != nil {
-			_ = egressMgr.Close()
-		}
-		if egressAudit != nil {
-			_ = egressAudit.Close()
-		}
-	}()
 
 	// Build the SSH key allowlist (default off = accept all). GitHub-seeded
 	// keys are cached next to the host key. Fails closed (returns an error)

--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -552,6 +552,39 @@ func (c *APIClient) EgressOff(name string) (*config.Shed, error) {
 	return &shed, nil
 }
 
+// EgressProfilesList returns all egress profiles (config baseline + user store),
+// each tagged with its source.
+func (c *APIClient) EgressProfilesList() ([]config.EgressProfileInfo, error) {
+	var infos []config.EgressProfileInfo
+	if err := c.doRequest(http.MethodGet, "/api/egress/profiles", nil, &infos); err != nil {
+		return nil, err
+	}
+	return infos, nil
+}
+
+// EgressProfileGet returns one egress profile by name.
+func (c *APIClient) EgressProfileGet(name string) (*config.EgressProfileInfo, error) {
+	var info config.EgressProfileInfo
+	if err := c.doRequest(http.MethodGet, "/api/egress/profiles/"+name, nil, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// EgressProfilePut creates or replaces a user profile (whole document).
+func (c *APIClient) EgressProfilePut(name string, p config.EgressProfile) (*config.EgressProfileInfo, error) {
+	var info config.EgressProfileInfo
+	if err := c.doRequest(http.MethodPut, "/api/egress/profiles/"+name, p, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// EgressProfileDelete removes a user profile.
+func (c *APIClient) EgressProfileDelete(name string) error {
+	return c.doRequest(http.MethodDelete, "/api/egress/profiles/"+name, nil, nil)
+}
+
 // DeleteShed deletes a shed.
 func (c *APIClient) DeleteShed(name string, keepVolume bool) error {
 	path := "/api/sheds/" + name

--- a/cmd/shed/egress_profile.go
+++ b/cmd/shed/egress_profile.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+var egressProfileCmd = &cobra.Command{
+	Use:   "profile",
+	Short: "Manage runtime user egress profiles (no server-config edit)",
+	Long: `Manage user-defined egress profiles stored on the server at runtime.
+
+A user profile is a named set of allow/deny/rule, authored as a whole document
+(--file or 'edit'), and referenced by sheds exactly like a server-config profile
+(shed create --egress <name>, shed egress set <shed> --profile <name>). Editing a
+profile live-re-pushes running sheds that use it. Server-config profiles are a
+read-only baseline and cannot be changed here.`,
+}
+
+var egressProfileFile string
+
+var egressProfileLsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "List egress profiles (config baseline + user)",
+	Args:  cobra.NoArgs,
+	RunE:  runEgressProfileLs,
+}
+
+var egressProfileShowCmd = &cobra.Command{
+	Use:   "show <name>",
+	Short: "Show one egress profile",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runEgressProfileShow,
+}
+
+var egressProfileSetCmd = &cobra.Command{
+	Use:   "set <name>",
+	Short: "Create or replace a user profile from a file",
+	Long: `Create or replace a user egress profile from a YAML file (whole document).
+
+The file is a profile fragment:
+  allow: [example.com, "*.internal.corp"]
+  deny:  [tracker.io]
+  rule:  'port == 443'   # optional CEL
+  # mode: audit          # optional
+
+Example:
+  shed egress profile set my-stack --file ./my-stack.yaml`,
+	Args: cobra.ExactArgs(1),
+	RunE: runEgressProfileSet,
+}
+
+var egressProfileEditCmd = &cobra.Command{
+	Use:   "edit <name>",
+	Short: "Create or edit a user profile in $EDITOR",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runEgressProfileEdit,
+}
+
+var egressProfileRmCmd = &cobra.Command{
+	Use:   "rm <name>",
+	Short: "Remove a user profile",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runEgressProfileRm,
+}
+
+func init() {
+	egressProfileSetCmd.Flags().StringVar(&egressProfileFile, "file", "", "Path to a profile YAML document (required)")
+	egressProfileCmd.AddCommand(egressProfileLsCmd, egressProfileShowCmd, egressProfileSetCmd, egressProfileEditCmd, egressProfileRmCmd)
+	egressCmd.AddCommand(egressProfileCmd)
+}
+
+func egressProfileClient() (*APIClient, error) {
+	entry, _, err := getServerEntry()
+	if err != nil {
+		return nil, err
+	}
+	return NewAPIClientFromEntry(entry, DefaultTimeout), nil
+}
+
+func runEgressProfileLs(cmd *cobra.Command, args []string) error {
+	client, err := egressProfileClient()
+	if err != nil {
+		return err
+	}
+	infos, err := client.EgressProfilesList()
+	if err != nil {
+		return fmt.Errorf("failed to list egress profiles: %w", err)
+	}
+	if jsonFlag {
+		return outputJSON(infos)
+	}
+	if len(infos) == 0 {
+		fmt.Println("No egress profiles defined.")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tSOURCE\tRULES")
+	for _, info := range infos {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", info.Name, info.Source, egressProfileSummary(info.Profile))
+	}
+	return w.Flush()
+}
+
+func runEgressProfileShow(cmd *cobra.Command, args []string) error {
+	client, err := egressProfileClient()
+	if err != nil {
+		return err
+	}
+	info, err := client.EgressProfileGet(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to get egress profile %s: %w", args[0], err)
+	}
+	if jsonFlag {
+		return outputJSON(info)
+	}
+	fmt.Printf("Name:   %s\n", info.Name)
+	fmt.Printf("Source: %s\n", info.Source)
+	out, _ := yaml.Marshal(info.Profile)
+	fmt.Printf("\n%s", out)
+	return nil
+}
+
+func runEgressProfileSet(cmd *cobra.Command, args []string) error {
+	if egressProfileFile == "" {
+		return fmt.Errorf("--file is required (path to a profile YAML document)")
+	}
+	data, err := os.ReadFile(egressProfileFile)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", egressProfileFile, err)
+	}
+	var p config.EgressProfile
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return fmt.Errorf("parse %s: %w", egressProfileFile, err)
+	}
+	client, err := egressProfileClient()
+	if err != nil {
+		return err
+	}
+	info, err := client.EgressProfilePut(args[0], p)
+	if err != nil {
+		return fmt.Errorf("failed to set egress profile %s: %w", args[0], err)
+	}
+	if jsonFlag {
+		return outputJSON(info)
+	}
+	fmt.Printf("Egress profile %q saved.\n", info.Name)
+	return nil
+}
+
+func runEgressProfileRm(cmd *cobra.Command, args []string) error {
+	client, err := egressProfileClient()
+	if err != nil {
+		return err
+	}
+	if err := client.EgressProfileDelete(args[0]); err != nil {
+		return fmt.Errorf("failed to remove egress profile %s: %w", args[0], err)
+	}
+	if jsonFlag {
+		return outputJSON(map[string]string{"status": "ok", "profile": args[0]})
+	}
+	fmt.Printf("Egress profile %q removed.\n", args[0])
+	return nil
+}
+
+const egressProfileTemplate = `# Egress profile — edit and save to create/update it. An unchanged file aborts.
+# allow/deny are domain globs: "*.github.com" matches subdomains (not the apex),
+# "github.com" matches exactly. rule is an optional CEL expression. mode: audit
+# allows + logs all non-guard traffic.
+allow:
+  - example.com
+# deny:
+#   - tracker.io
+# rule: 'port == 443'
+# mode: audit
+`
+
+func runEgressProfileEdit(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	client, err := egressProfileClient()
+	if err != nil {
+		return err
+	}
+	// Seed from the existing profile, or a template for a new one. A GET error is
+	// treated as "new profile" (most commonly a 404).
+	seed := []byte(egressProfileTemplate)
+	if info, err := client.EgressProfileGet(name); err == nil {
+		if info.Source == "config" { // server-config baseline is read-only
+			return fmt.Errorf("profile %q is a server-config profile (read-only); it can't be edited here", name)
+		}
+		if out, mErr := yaml.Marshal(info.Profile); mErr == nil {
+			seed = out
+		}
+	}
+	edited, err := editInEditor(name, seed)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(bytes.TrimSpace(edited), bytes.TrimSpace(seed)) {
+		fmt.Println("No changes; aborted.")
+		return nil
+	}
+	var p config.EgressProfile
+	if err := yaml.Unmarshal(edited, &p); err != nil {
+		return fmt.Errorf("parse edited profile: %w", err)
+	}
+	info, err := client.EgressProfilePut(name, p)
+	if err != nil {
+		return fmt.Errorf("failed to save egress profile %s: %w", name, err)
+	}
+	fmt.Printf("Egress profile %q saved.\n", info.Name)
+	return nil
+}
+
+// editInEditor writes seed to a temp file, opens $EDITOR (or vi) on it, and
+// returns the edited bytes.
+func editInEditor(name string, seed []byte) ([]byte, error) {
+	f, err := os.CreateTemp("", "shed-egress-"+name+"-*.yaml")
+	if err != nil {
+		return nil, err
+	}
+	tmp := f.Name()
+	defer os.Remove(tmp)
+	if _, err := f.Write(seed); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if err := f.Close(); err != nil {
+		return nil, err
+	}
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "vi"
+	}
+	ed := exec.Command(editor, tmp) //nolint:gosec // the user's own $EDITOR on a temp file
+	ed.Stdin, ed.Stdout, ed.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := ed.Run(); err != nil {
+		return nil, fmt.Errorf("editor %q: %w", editor, err)
+	}
+	return os.ReadFile(tmp)
+}
+
+// egressProfileSummary renders a one-line summary of a profile's rules for `ls`.
+func egressProfileSummary(p config.EgressProfile) string {
+	var parts []string
+	if p.Mode != "" {
+		parts = append(parts, "mode="+p.Mode)
+	}
+	if len(p.Allow) > 0 {
+		parts = append(parts, "allow="+strings.Join(p.Allow, ","))
+	}
+	if len(p.Deny) > 0 {
+		parts = append(parts, "deny="+strings.Join(p.Deny, ","))
+	}
+	if p.Rule != "" {
+		parts = append(parts, "rule="+p.Rule)
+	}
+	if len(parts) == 0 {
+		return "(empty)"
+	}
+	return strings.Join(parts, " ")
+}

--- a/cmd/shed/egress_profile.go
+++ b/cmd/shed/egress_profile.go
@@ -138,8 +138,8 @@ func runEgressProfileSet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("read %s: %w", egressProfileFile, err)
 	}
-	var p config.EgressProfile
-	if err := yaml.Unmarshal(data, &p); err != nil {
+	p, err := decodeEgressProfileYAML(data)
+	if err != nil {
 		return fmt.Errorf("parse %s: %w", egressProfileFile, err)
 	}
 	client, err := egressProfileClient()
@@ -200,6 +200,10 @@ func runEgressProfileEdit(cmd *cobra.Command, args []string) error {
 		if out, mErr := yaml.Marshal(info.Profile); mErr == nil {
 			seed = out
 		}
+	} else if !strings.Contains(err.Error(), config.ErrProfileNotFound) {
+		// Only a genuine not-found falls back to the template (create-on-save);
+		// surface any other error rather than risk overwriting on save.
+		return fmt.Errorf("failed to read egress profile %s: %w", name, err)
 	}
 	edited, err := editInEditor(name, seed)
 	if err != nil {
@@ -209,8 +213,8 @@ func runEgressProfileEdit(cmd *cobra.Command, args []string) error {
 		fmt.Println("No changes; aborted.")
 		return nil
 	}
-	var p config.EgressProfile
-	if err := yaml.Unmarshal(edited, &p); err != nil {
+	p, err := decodeEgressProfileYAML(edited)
+	if err != nil {
 		return fmt.Errorf("parse edited profile: %w", err)
 	}
 	info, err := client.EgressProfilePut(name, p)
@@ -268,4 +272,16 @@ func egressProfileSummary(p config.EgressProfile) string {
 		return "(empty)"
 	}
 	return strings.Join(parts, " ")
+}
+
+// decodeEgressProfileYAML strict-decodes a profile document so a typo'd key
+// (e.g. "allowed:") is rejected rather than silently dropped.
+func decodeEgressProfileYAML(data []byte) (config.EgressProfile, error) {
+	var p config.EgressProfile
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&p); err != nil {
+		return config.EgressProfile{}, err
+	}
+	return p, nil
 }

--- a/cmd/shed/egress_profile_test.go
+++ b/cmd/shed/egress_profile_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+func TestEgressProfileSummary(t *testing.T) {
+	cases := []struct {
+		name string
+		p    config.EgressProfile
+		want string
+	}{
+		{"empty", config.EgressProfile{}, "(empty)"},
+		{"audit", config.EgressProfile{Mode: "audit"}, "mode=audit"},
+		{"allow+deny", config.EgressProfile{Allow: []string{"a.com", "b.com"}, Deny: []string{"x.com"}}, "allow=a.com,b.com deny=x.com"},
+		{"rule", config.EgressProfile{Rule: "port == 443"}, "rule=port == 443"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := egressProfileSummary(c.p); got != c.want {
+				t.Errorf("summary = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -257,6 +257,20 @@ Turns egress control off for a shed.
 shed egress off <name>
 ```
 
+### shed egress profile
+
+Manage runtime **user profiles** — named rule sets authored as whole documents,
+without a server-config edit. They compose with config profiles by name. See
+[Egress Control](egress.md#user-managed-profiles).
+
+```bash
+shed egress profile ls [--json]              # list (config + user, with source)
+shed egress profile show <name> [--json]
+shed egress profile set <name> --file <path> # create/replace from a YAML document
+shed egress profile edit <name>              # edit in $EDITOR
+shed egress profile rm <name>
+```
+
 ## Snapshots
 
 A snapshot captures a stopped shed's rootfs as a named, immutable artifact.

--- a/docs/reference/egress.md
+++ b/docs/reference/egress.md
@@ -253,6 +253,50 @@ Recent decisions (most recent last):
   14:22:32  deny     pypi.org        443   default-deny
 ```
 
+## User-managed profiles
+
+Server-config `egress.profiles` are the **read-only baseline** (changing them
+needs a `server.yaml` edit + restart). For day-to-day work you can also define
+**user profiles** at runtime — same schema, authored as a whole document, no
+server-config access — and reference them by name exactly like config profiles.
+
+```bash
+# Author a profile from a file (the whole document), or edit it in $EDITOR
+shed egress profile set my-stack --file ./my-stack.yaml
+shed egress profile edit my-stack
+
+# List (shows source: config|user), inspect, remove
+shed egress profile ls
+shed egress profile show my-stack
+shed egress profile rm my-stack
+
+# Reference it like any profile
+shed create web --egress github,my-stack
+shed egress set web --profile github,my-stack
+```
+
+The file is a profile fragment — the same shape as an `egress.profiles` entry:
+
+```yaml
+allow: [example.com, "*.internal.corp"]
+deny:  [tracker.io]
+rule:  'port == 443'   # optional CEL
+# mode: audit          # optional
+```
+
+- **Config is authoritative.** A server-config profile and a user profile can't
+  share a name — a `set` to a config-owned (or reserved `off`/`none`/`default`)
+  name is rejected. `ls`/`show` tag each profile `source: config|user`.
+- **Edits apply live.** Saving a profile **re-pushes every running shed that
+  references it**, so the change takes effect without restarting the shed.
+  Deleting a profile a shed still references is rejected (remove it from the shed
+  first).
+- **Storage.** User profiles live on the server under `{state}/egress-profiles/`
+  (one `<name>.yaml` per profile) and survive restarts, read/written via
+  `GET/PUT/DELETE /api/egress/profiles[/{name}]` (control-scoped). The same
+  honest posture applies: a self-served `allow` is convenience/visibility, not a
+  sandbox boundary.
+
 ## Auditing
 
 Every decision is appended as one JSON line to `{state}/egress-audit.jsonl`

--- a/internal/api/egress_handler_test.go
+++ b/internal/api/egress_handler_test.go
@@ -21,7 +21,9 @@ import (
 type egressFakeBackend struct {
 	fakeBackend
 	shed          *config.Shed
+	sheds         []config.Shed // returned by ListSheds (re-push fan-out / referenced-by)
 	setCalledWith []string
+	rePushed      []string // shed names passed to SetShedEgress
 	cleared       bool
 }
 
@@ -29,8 +31,13 @@ func (f *egressFakeBackend) GetShed(_ context.Context, _ string) (*config.Shed, 
 	return f.shed, nil
 }
 
+func (f *egressFakeBackend) ListSheds(_ context.Context) ([]config.Shed, error) {
+	return f.sheds, nil
+}
+
 func (f *egressFakeBackend) SetShedEgress(_ context.Context, name string, profiles []string) (*config.Shed, error) {
 	f.setCalledWith = profiles
+	f.rePushed = append(f.rePushed, name)
 	return &config.Shed{Name: name, EgressProfiles: profiles, EgressPort: 20002}, nil
 }
 

--- a/internal/api/egress_profiles.go
+++ b/internal/api/egress_profiles.go
@@ -137,6 +137,10 @@ func (s *Server) handleDeleteProfile(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusConflict, config.ErrProfileReserved, fmt.Sprintf("%q is a server-config profile (read-only)", name))
 		return
 	}
+	if _, ok := s.egressStore.Get(name); !ok {
+		writeError(w, http.StatusNotFound, config.ErrProfileNotFound, fmt.Sprintf("egress profile %q not found", name))
+		return
+	}
 	refs, err := s.profileReferencedBy(r.Context(), name)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, config.ErrInternalError, err.Error())
@@ -147,7 +151,8 @@ func (s *Server) handleDeleteProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := s.egressStore.Delete(name); err != nil {
-		writeError(w, http.StatusNotFound, config.ErrProfileNotFound, err.Error())
+		// Existence was checked above, so an error here is a storage failure.
+		writeError(w, http.StatusInternalServerError, config.ErrInternalError, err.Error())
 		return
 	}
 	log.Printf("egress: profile %q deleted", name)

--- a/internal/api/egress_profiles.go
+++ b/internal/api/egress_profiles.go
@@ -1,0 +1,203 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/charliek/shed/internal/config"
+	"github.com/go-chi/chi/v5"
+)
+
+const (
+	egressSourceConfig = "config"
+	egressSourceUser   = "user"
+)
+
+// rePushTimeout bounds the live re-push fan-out (independent of the request ctx).
+const rePushTimeout = 60 * time.Second
+
+// egressProfilesEnabled reports whether egress + the user-profile store are active.
+func (s *Server) egressProfilesEnabled() bool {
+	return s.cfg.Egress != nil && s.cfg.Egress.Enabled && s.egressStore != nil
+}
+
+// requireEgressProfiles writes a 501 and returns false when egress / the profile
+// store is not active; the profile handlers early-return on false.
+func (s *Server) requireEgressProfiles(w http.ResponseWriter) bool {
+	if s.egressProfilesEnabled() {
+		return true
+	}
+	writeError(w, http.StatusNotImplemented, config.ErrBackendError, "egress control is not enabled")
+	return false
+}
+
+// isConfigProfile reports whether name is a read-only server-config profile.
+func (s *Server) isConfigProfile(name string) bool {
+	_, ok := s.cfg.Egress.Profiles[name]
+	return ok
+}
+
+// shedReferencesProfile reports whether sh's egress profile list includes name.
+func shedReferencesProfile(sh config.Shed, name string) bool {
+	for _, p := range sh.EgressProfiles {
+		if p == name {
+			return true
+		}
+	}
+	return false
+}
+
+// handleListProfiles returns every egress profile — the server-config baseline
+// plus the runtime user store — each tagged with its source. Config wins on a
+// name collision. GET /api/egress/profiles
+func (s *Server) handleListProfiles(w http.ResponseWriter, r *http.Request) {
+	if !s.requireEgressProfiles(w) {
+		return
+	}
+	byName := map[string]config.EgressProfileInfo{}
+	for name, p := range s.egressStore.List() {
+		byName[name] = config.EgressProfileInfo{Name: name, Source: egressSourceUser, Profile: p}
+	}
+	for name, p := range s.cfg.Egress.Profiles {
+		byName[name] = config.EgressProfileInfo{Name: name, Source: egressSourceConfig, Profile: p} // config wins
+	}
+	infos := make([]config.EgressProfileInfo, 0, len(byName))
+	for _, info := range byName {
+		infos = append(infos, info)
+	}
+	sort.Slice(infos, func(i, j int) bool { return infos[i].Name < infos[j].Name })
+	writeJSON(w, http.StatusOK, infos)
+}
+
+// handleGetProfile returns one profile (config wins on collision).
+// GET /api/egress/profiles/{name}
+func (s *Server) handleGetProfile(w http.ResponseWriter, r *http.Request) {
+	if !s.requireEgressProfiles(w) {
+		return
+	}
+	name := chi.URLParam(r, "name")
+	if p, ok := s.cfg.Egress.Profiles[name]; ok {
+		writeJSON(w, http.StatusOK, config.EgressProfileInfo{Name: name, Source: egressSourceConfig, Profile: p})
+		return
+	}
+	if p, ok := s.egressStore.Get(name); ok {
+		writeJSON(w, http.StatusOK, config.EgressProfileInfo{Name: name, Source: egressSourceUser, Profile: p})
+		return
+	}
+	writeError(w, http.StatusNotFound, config.ErrProfileNotFound, fmt.Sprintf("egress profile %q not found", name))
+}
+
+// handlePutProfile creates or replaces a user profile (whole document), then
+// live-re-pushes running sheds that reference it. PUT /api/egress/profiles/{name}
+func (s *Server) handlePutProfile(w http.ResponseWriter, r *http.Request) {
+	if !s.requireEgressProfiles(w) {
+		return
+	}
+	name := chi.URLParam(r, "name")
+	// Server-config profiles are a read-only baseline — a user PUT must not shadow one.
+	if s.isConfigProfile(name) {
+		writeError(w, http.StatusConflict, config.ErrProfileReserved, fmt.Sprintf("%q is a server-config profile (read-only); choose another name", name))
+		return
+	}
+	if config.IsReservedEgressName(name) {
+		writeError(w, http.StatusConflict, config.ErrProfileReserved, fmt.Sprintf("%q is a reserved name", name))
+		return
+	}
+	var p config.EgressProfile
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, "invalid request body")
+		return
+	}
+	if err := s.egressStore.Put(name, p); err != nil {
+		writeError(w, http.StatusBadRequest, config.ErrInvalidRequest, err.Error())
+		return
+	}
+	if warnings := s.rePushProfile(name); len(warnings) > 0 {
+		log.Printf("egress: profile %q saved with %d live re-push warning(s): %s", name, len(warnings), strings.Join(warnings, "; "))
+	}
+	log.Printf("egress: profile %q saved (user)", name)
+	stored, _ := s.egressStore.Get(name)
+	writeJSON(w, http.StatusOK, config.EgressProfileInfo{Name: name, Source: egressSourceUser, Profile: stored})
+}
+
+// handleDeleteProfile removes a user profile, rejecting the delete if any shed
+// still references it. DELETE /api/egress/profiles/{name}
+func (s *Server) handleDeleteProfile(w http.ResponseWriter, r *http.Request) {
+	if !s.requireEgressProfiles(w) {
+		return
+	}
+	name := chi.URLParam(r, "name")
+	if s.isConfigProfile(name) {
+		writeError(w, http.StatusConflict, config.ErrProfileReserved, fmt.Sprintf("%q is a server-config profile (read-only)", name))
+		return
+	}
+	refs, err := s.profileReferencedBy(r.Context(), name)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, config.ErrInternalError, err.Error())
+		return
+	}
+	if len(refs) > 0 {
+		writeError(w, http.StatusConflict, config.ErrProfileInUse, "egress profile in use by sheds: "+strings.Join(refs, ", "))
+		return
+	}
+	if err := s.egressStore.Delete(name); err != nil {
+		writeError(w, http.StatusNotFound, config.ErrProfileNotFound, err.Error())
+		return
+	}
+	log.Printf("egress: profile %q deleted", name)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "profile": name})
+}
+
+// profileReferencedBy returns the sorted names of sheds whose egress profile list
+// includes name (running OR stopped — a stopped shed would fail to resolve on
+// next start if its profile vanished).
+func (s *Server) profileReferencedBy(ctx context.Context, name string) ([]string, error) {
+	sheds, err := s.backend.ListSheds(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var refs []string
+	for _, sh := range sheds {
+		if shedReferencesProfile(sh, name) {
+			refs = append(refs, sh.Name)
+		}
+	}
+	sort.Strings(refs)
+	return refs, nil
+}
+
+// rePushProfile re-applies egress to every RUNNING shed referencing name so a
+// profile edit takes effect live. Best-effort: the profile is already persisted,
+// so a per-shed failure is logged and collected (returned as warnings), never
+// failing the caller. Runs on a bounded internal context (NOT the request ctx)
+// so a client disconnect can't leave running sheds stale. Stopped sheds
+// re-resolve on next start, so they need no fan-out.
+func (s *Server) rePushProfile(name string) []string {
+	ec, ok := s.backend.(egressController)
+	if !ok {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), rePushTimeout)
+	defer cancel()
+	sheds, err := s.backend.ListSheds(ctx)
+	if err != nil {
+		log.Printf("egress: re-push %q: list sheds: %v", name, err)
+		return []string{fmt.Sprintf("list sheds: %v", err)}
+	}
+	var warnings []string
+	for _, sh := range sheds {
+		if sh.Status != config.StatusRunning || !shedReferencesProfile(sh, name) {
+			continue
+		}
+		if _, err := ec.SetShedEgress(ctx, sh.Name, sh.EgressProfiles); err != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: %v", sh.Name, err))
+		}
+	}
+	return warnings
+}

--- a/internal/api/egress_profiles_test.go
+++ b/internal/api/egress_profiles_test.go
@@ -1,0 +1,203 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+// newEgressProfileServer builds a server with egress enabled, one config profile
+// ("base"), a user store in a temp dir, and the given sheds (for the fan-out).
+func newEgressProfileServer(t *testing.T, sheds []config.Shed) (*Server, *egressFakeBackend, *config.UserProfileStore) {
+	t.Helper()
+	store, err := config.OpenUserProfileStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.ServerConfig{
+		Name: "test",
+		Egress: &config.EgressConfig{
+			Enabled:  true,
+			Profiles: map[string]config.EgressProfile{"base": {Allow: []string{"*.ubuntu.com"}}},
+		},
+	}
+	be := &egressFakeBackend{sheds: sheds}
+	srv := NewServer(be, cfg, "", nil, nil)
+	srv.SetEgressUserStore(store)
+	return srv, be, store
+}
+
+func doReq(t *testing.T, srv *Server, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body != "" {
+		r = httptest.NewRequest(method, path, strings.NewReader(body))
+	} else {
+		r = httptest.NewRequest(method, path, nil)
+	}
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+	return w
+}
+
+func TestHandlePutAndGetProfile(t *testing.T) {
+	srv, _, _ := newEgressProfileServer(t, nil)
+
+	w := doReq(t, srv, http.MethodPut, "/api/egress/profiles/mine", `{"allow":["example.com"]}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT = %d, body %s", w.Code, w.Body.String())
+	}
+	var info config.EgressProfileInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &info); err != nil {
+		t.Fatal(err)
+	}
+	if info.Source != "user" || len(info.Profile.Allow) != 1 || info.Profile.Allow[0] != "example.com" {
+		t.Fatalf("PUT resp = %+v", info)
+	}
+
+	// GET it back
+	if w := doReq(t, srv, http.MethodGet, "/api/egress/profiles/mine", ""); w.Code != http.StatusOK {
+		t.Fatalf("GET = %d", w.Code)
+	}
+
+	// a config profile reports source "config"
+	w = doReq(t, srv, http.MethodGet, "/api/egress/profiles/base", "")
+	_ = json.Unmarshal(w.Body.Bytes(), &info)
+	if info.Source != "config" {
+		t.Errorf("base source = %q, want config", info.Source)
+	}
+
+	// unknown → 404
+	if w := doReq(t, srv, http.MethodGet, "/api/egress/profiles/nope", ""); w.Code != http.StatusNotFound {
+		t.Errorf("GET unknown = %d, want 404", w.Code)
+	}
+}
+
+func TestHandlePutProfileRejections(t *testing.T) {
+	srv, _, _ := newEgressProfileServer(t, nil)
+	cases := []struct {
+		name, body string
+		want       int
+	}{
+		{"base", `{"allow":["x.com"]}`, http.StatusConflict},    // config-name collision
+		{"off", `{"mode":"audit"}`, http.StatusConflict},        // reserved name
+		{"bad", `{"rule":"garbage ++"}`, http.StatusBadRequest}, // bad CEL
+		{"Up", `{"allow":["x.com"]}`, http.StatusBadRequest},    // uppercase name
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w := doReq(t, srv, http.MethodPut, "/api/egress/profiles/"+c.name, c.body)
+			if w.Code != c.want {
+				t.Errorf("PUT %s = %d, want %d (%s)", c.name, w.Code, c.want, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleListProfiles(t *testing.T) {
+	srv, _, store := newEgressProfileServer(t, nil)
+	if err := store.Put("mine", config.EgressProfile{Allow: []string{"a.com"}}); err != nil {
+		t.Fatal(err)
+	}
+	w := doReq(t, srv, http.MethodGet, "/api/egress/profiles", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("list = %d", w.Code)
+	}
+	var infos []config.EgressProfileInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &infos); err != nil {
+		t.Fatal(err)
+	}
+	// base (config) + mine (user), sorted by name
+	if len(infos) != 2 || infos[0].Name != "base" || infos[0].Source != "config" || infos[1].Name != "mine" || infos[1].Source != "user" {
+		t.Fatalf("list = %+v", infos)
+	}
+}
+
+func TestHandlePutProfileRePushesRunningSheds(t *testing.T) {
+	sheds := []config.Shed{
+		{Name: "running-ref", Status: config.StatusRunning, EgressProfiles: []string{"mine"}},
+		{Name: "stopped-ref", Status: config.StatusStopped, EgressProfiles: []string{"mine"}},
+		{Name: "running-other", Status: config.StatusRunning, EgressProfiles: []string{"base"}},
+	}
+	srv, be, _ := newEgressProfileServer(t, sheds)
+	if w := doReq(t, srv, http.MethodPut, "/api/egress/profiles/mine", `{"allow":["example.com"]}`); w.Code != http.StatusOK {
+		t.Fatalf("PUT = %d", w.Code)
+	}
+	// only the RUNNING shed that references "mine" is re-pushed
+	if len(be.rePushed) != 1 || be.rePushed[0] != "running-ref" {
+		t.Fatalf("rePushed = %v, want [running-ref]", be.rePushed)
+	}
+}
+
+func TestHandleDeleteProfile(t *testing.T) {
+	sheds := []config.Shed{{Name: "web", Status: config.StatusRunning, EgressProfiles: []string{"mine"}}}
+	srv, _, store := newEgressProfileServer(t, sheds)
+	if err := store.Put("mine", config.EgressProfile{Allow: []string{"a.com"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// referenced → 409 naming the shed
+	w := doReq(t, srv, http.MethodDelete, "/api/egress/profiles/mine", "")
+	if w.Code != http.StatusConflict || !strings.Contains(w.Body.String(), "web") {
+		t.Fatalf("delete referenced = %d %s", w.Code, w.Body.String())
+	}
+
+	// config profile → 409 (read-only)
+	if w := doReq(t, srv, http.MethodDelete, "/api/egress/profiles/base", ""); w.Code != http.StatusConflict {
+		t.Errorf("delete config = %d, want 409", w.Code)
+	}
+
+	// unreferenced user profile → 200
+	if err := store.Put("free", config.EgressProfile{Allow: []string{"b.com"}}); err != nil {
+		t.Fatal(err)
+	}
+	if w := doReq(t, srv, http.MethodDelete, "/api/egress/profiles/free", ""); w.Code != http.StatusOK {
+		t.Errorf("delete free = %d, want 200", w.Code)
+	}
+
+	// missing → 404
+	if w := doReq(t, srv, http.MethodDelete, "/api/egress/profiles/ghost", ""); w.Code != http.StatusNotFound {
+		t.Errorf("delete ghost = %d, want 404", w.Code)
+	}
+}
+
+// TestEgressProfilesRouteNotShadowed guards that the literal /profiles routes win
+// over /egress/{name} at the chi trie (no 405, not dispatched to handleEgressShow).
+func TestEgressProfilesRouteNotShadowed(t *testing.T) {
+	srv, _, _ := newEgressProfileServer(t, nil)
+	// GET /profiles must reach the list handler (200 + JSON array), not show.
+	w := doReq(t, srv, http.MethodGet, "/api/egress/profiles", "")
+	if w.Code != http.StatusOK || !strings.HasPrefix(strings.TrimSpace(w.Body.String()), "[") {
+		t.Fatalf("GET /profiles = %d, body %s (shadowed by /{name}?)", w.Code, w.Body.String())
+	}
+	// PUT /profiles/{name} must not 405
+	if w := doReq(t, srv, http.MethodPut, "/api/egress/profiles/x", `{"allow":["a.com"]}`); w.Code == http.StatusMethodNotAllowed {
+		t.Fatal("PUT /profiles/x returned 405 (route shadowed)")
+	}
+}
+
+// TestHandleEgressShowMergesUserProfile: `shed egress show` must include a user
+// profile's rules, not only config profiles.
+func TestHandleEgressShowMergesUserProfile(t *testing.T) {
+	srv, be, store := newEgressProfileServer(t, nil)
+	if err := store.Put("mine", config.EgressProfile{Allow: []string{"example.com"}}); err != nil {
+		t.Fatal(err)
+	}
+	be.shed = &config.Shed{Name: "web", EgressProfiles: []string{"mine"}, EgressPort: 20001}
+	w := doReq(t, srv, http.MethodGet, "/api/egress/web", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("show = %d", w.Code)
+	}
+	var st config.EgressStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &st); err != nil {
+		t.Fatal(err)
+	}
+	def, ok := st.Rules["mine"]
+	if !ok || len(def.Allow) != 1 || def.Allow[0] != "example.com" {
+		t.Fatalf("show.Rules missing user profile: %+v", st.Rules)
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -331,6 +331,8 @@ func (s *Server) handleEgressShow(w http.ResponseWriter, r *http.Request) {
 		status.Rules = map[string]config.EgressProfile{}
 		for _, p := range status.Profiles {
 			if def, ok := s.cfg.Egress.Profiles[p]; ok {
+				status.Rules[p] = def // config wins on a name collision
+			} else if def, ok := s.egressStore.Get(p); ok { // nil-safe; runtime user profile
 				status.Rules[p] = def
 			}
 		}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -18,14 +18,21 @@ type Server struct {
 	sshHostKey  string
 	plugins     *plugin.Registry
 	bridge      *plugin.Bridge
-	egressAudit *egress.AuditLog // nil when egress is disabled
-	tokens      *authtoken.Store // nil until SetTokenStore; consulted only in secure mode (auth.mode: secure)
+	egressAudit *egress.AuditLog         // nil when egress is disabled
+	egressStore *config.UserProfileStore // nil when egress is disabled
+	tokens      *authtoken.Store         // nil until SetTokenStore; consulted only in secure mode (auth.mode: secure)
 }
 
 // SetEgressAudit attaches the durable egress audit log so `shed egress show`
 // can return recent decisions. Called by shed-server at startup when egress is
 // enabled; nil leaves the egress routes reporting no recent activity.
 func (s *Server) SetEgressAudit(a *egress.AuditLog) { s.egressAudit = a }
+
+// SetEgressUserStore attaches the runtime user-profile store backing the
+// `/api/egress/profiles` routes and merged into `shed egress show`. Called at
+// startup when egress is enabled; nil leaves the profile routes reporting only
+// config profiles (and PUT/DELETE returning 501).
+func (s *Server) SetEgressUserStore(st *config.UserProfileStore) { s.egressStore = st }
 
 // SetTokenStore attaches the HTTP bearer-token store. The same store is shared
 // with the SSH bootstrap handler (which mints into it); the auth middleware
@@ -117,11 +124,19 @@ func (s *Server) Router() chi.Router {
 			})
 		})
 
-		// Egress control: the audit SSE stream (literal), plus per-shed
-		// status + live set/off. The /{name} routes are wrapped so the
-		// literal /stream sibling isn't shadowed at the chi trie level.
+		// Egress control: the audit SSE stream (literal), user-profile CRUD
+		// (literal /profiles), plus per-shed status + live set/off. The literal
+		// /stream and /profiles siblings are registered before the /{name} wrap
+		// so they aren't shadowed at the chi trie level — which also makes
+		// "stream" and "profiles" reserved shed names on these routes.
 		r.Route("/egress", func(r chi.Router) {
 			r.Get("/stream", s.handleEgressStream)
+			r.Get("/profiles", s.handleListProfiles)
+			r.Route("/profiles/{name}", func(r chi.Router) {
+				r.Get("/", s.handleGetProfile)
+				r.Put("/", s.handlePutProfile)
+				r.Delete("/", s.handleDeleteProfile)
+			})
 			r.Route("/{name}", func(r chi.Router) {
 				r.Get("/", s.handleEgressShow)
 				r.Post("/", s.handleEgressSet)

--- a/internal/config/egress.go
+++ b/internal/config/egress.go
@@ -60,7 +60,20 @@ type EgressSetRequest struct {
 	Profiles []string `json:"profiles"`
 }
 
+// EgressProfileInfo is one entry in the `GET /api/egress/profiles` response: a
+// named profile plus whether it comes from the server config (read-only baseline)
+// or the runtime user store.
+type EgressProfileInfo struct {
+	Name    string        `json:"name"`
+	Source  string        `json:"source"` // "config" | "user"
+	Profile EgressProfile `json:"profile"`
+}
+
 var egressReservedNames = map[string]bool{"off": true, "none": true, "default": true}
+
+// IsReservedEgressName reports whether name is reserved (cannot be a user/config
+// profile name): "off", "none", "default" (case-insensitive).
+func IsReservedEgressName(name string) bool { return egressReservedNames[strings.ToLower(name)] }
 
 func (p EgressProfile) spec() egress.ProfileSpec {
 	return egress.ProfileSpec{Mode: p.Mode, Allow: p.Allow, Deny: p.Deny, Rule: p.Rule}

--- a/internal/config/egress.go
+++ b/internal/config/egress.go
@@ -66,6 +66,19 @@ func (p EgressProfile) spec() egress.ProfileSpec {
 	return egress.ProfileSpec{Mode: p.Mode, Allow: p.Allow, Deny: p.Deny, Rule: p.Rule}
 }
 
+// clone returns a deep copy (Allow/Deny slices duplicated) so a profile handed
+// out of the user store can't be mutated by — or race — the store.
+func (p EgressProfile) clone() EgressProfile {
+	cp := p
+	if p.Allow != nil {
+		cp.Allow = append([]string(nil), p.Allow...)
+	}
+	if p.Deny != nil {
+		cp.Deny = append([]string(nil), p.Deny...)
+	}
+	return cp
+}
+
 // Validate fails fast at config load on a bad port range, a reserved/dangling
 // profile name, or an uncompilable glob/CEL rule.
 func (c *EgressConfig) Validate() error {
@@ -108,10 +121,14 @@ func (c *EgressConfig) PortRangeBounds() (int, int) {
 }
 
 // ResolveProfiles returns the composed profile specs for a shed's requested
-// profile list (empty inherits Default). It returns (nil, nil) when egress is
-// disabled or the effective list is empty / "off" / "none" — meaning this shed
-// gets no egress proxy at all.
-func (c *EgressConfig) ResolveProfiles(req []string) ([]egress.ProfileSpec, error) {
+// profile list (empty inherits Default), resolving names from the config
+// profiles MERGED with the caller-supplied runtime user profiles. It returns
+// (nil, nil) when egress is disabled or the effective list is empty / "off" /
+// "none" — meaning this shed gets no egress proxy at all.
+//
+// user is the UserProfileStore snapshot (pass store.List(), nil-safe); a nil/empty
+// map makes resolution byte-identical to the config-only behavior.
+func (c *EgressConfig) ResolveProfiles(req []string, user map[string]EgressProfile) ([]egress.ProfileSpec, error) {
 	if c == nil || !c.Enabled {
 		return nil, nil
 	}
@@ -125,15 +142,32 @@ func (c *EgressConfig) ResolveProfiles(req []string) ([]egress.ProfileSpec, erro
 	if len(list) == 0 {
 		return nil, nil
 	}
+	effective := c.effectiveProfiles(user)
 	specs := make([]egress.ProfileSpec, 0, len(list))
 	for _, name := range list {
-		p, ok := c.Profiles[name]
+		p, ok := effective[name]
 		if !ok {
 			return nil, fmt.Errorf("unknown egress profile %q", name)
 		}
 		specs = append(specs, p.spec())
 	}
 	return specs, nil
+}
+
+// effectiveProfiles merges runtime user profiles with the server-config profiles.
+// Config WINS on a name collision: the server-config baseline is the authoritative,
+// read-only layer (the API rejects user PUTs that collide, but a config file edited
+// to add a colliding name after a user profile exists must resolve deterministically
+// to config). Centralized here so every ResolveProfiles call site gets one rule.
+func (c *EgressConfig) effectiveProfiles(user map[string]EgressProfile) map[string]EgressProfile {
+	eff := make(map[string]EgressProfile, len(user)+len(c.Profiles))
+	for k, v := range user {
+		eff[k] = v
+	}
+	for k, v := range c.Profiles {
+		eff[k] = v // config wins
+	}
+	return eff
 }
 
 func parseEgressPortRange(s string) (int, int, error) {

--- a/internal/config/egress_test.go
+++ b/internal/config/egress_test.go
@@ -52,30 +52,65 @@ func TestEgressConfigValidate(t *testing.T) {
 func TestEgressResolveProfiles(t *testing.T) {
 	c := mkEgress()
 	// disabled → nil
-	if specs, _ := (&EgressConfig{Enabled: false}).ResolveProfiles(nil); specs != nil {
+	if specs, _ := (&EgressConfig{Enabled: false}).ResolveProfiles(nil, nil); specs != nil {
 		t.Error("disabled should resolve to nil")
 	}
 	// empty req → default ([audit])
-	specs, err := c.ResolveProfiles(nil)
+	specs, err := c.ResolveProfiles(nil, nil)
 	if err != nil || len(specs) != 1 || specs[0].Mode != "audit" {
 		t.Errorf("default resolve = %v, %v", specs, err)
 	}
 	// explicit list composes
-	specs, err = c.ResolveProfiles([]string{"github", "corp"})
+	specs, err = c.ResolveProfiles([]string{"github", "corp"}, nil)
 	if err != nil || len(specs) != 2 {
 		t.Errorf("compose resolve = %v, %v", specs, err)
 	}
 	// "off" disables
-	if specs, _ := c.ResolveProfiles([]string{"off"}); specs != nil {
+	if specs, _ := c.ResolveProfiles([]string{"off"}, nil); specs != nil {
 		t.Error(`["off"] should resolve to nil`)
 	}
 	// unknown profile errors
-	if _, err := c.ResolveProfiles([]string{"ghost"}); err == nil {
+	if _, err := c.ResolveProfiles([]string{"ghost"}, nil); err == nil {
 		t.Error("unknown profile should error")
 	}
 	// absent default (empty) → nil
-	if specs, _ := (&EgressConfig{Enabled: true}).ResolveProfiles(nil); specs != nil {
+	if specs, _ := (&EgressConfig{Enabled: true}).ResolveProfiles(nil, nil); specs != nil {
 		t.Error("empty default should resolve to nil (no egress)")
+	}
+}
+
+// TestEgressResolveProfilesUserMerge covers the config+user merge: user profiles
+// resolve, compose with config, and config WINS on a name collision (the
+// read-only baseline is authoritative). AC1: a nil user map is byte-identical to
+// the config-only behavior.
+func TestEgressResolveProfilesUserMerge(t *testing.T) {
+	c := &EgressConfig{
+		Enabled:  true,
+		Profiles: map[string]EgressProfile{"github": {Allow: []string{"*.github.com"}}},
+	}
+	user := map[string]EgressProfile{
+		"mine":   {Allow: []string{"example.com"}},
+		"github": {Allow: []string{"evil.com"}}, // collides with config — config must win
+	}
+	// a user-only profile resolves
+	specs, err := c.ResolveProfiles([]string{"mine"}, user)
+	if err != nil || len(specs) != 1 || len(specs[0].Allow) != 1 || specs[0].Allow[0] != "example.com" {
+		t.Fatalf("user profile resolve = %v, %v", specs, err)
+	}
+	// compose config + user
+	if specs, err := c.ResolveProfiles([]string{"github", "mine"}, user); err != nil || len(specs) != 2 {
+		t.Fatalf("compose config+user = %v, %v", specs, err)
+	}
+	// config WINS on a name collision
+	specs, err = c.ResolveProfiles([]string{"github"}, user)
+	if err != nil || len(specs) != 1 || specs[0].Allow[0] != "*.github.com" {
+		t.Errorf("config should win collision, got %v", specs)
+	}
+	// AC1: nil user map == empty user map == config-only behavior
+	a, _ := c.ResolveProfiles([]string{"github"}, nil)
+	b, _ := c.ResolveProfiles([]string{"github"}, map[string]EgressProfile{})
+	if len(a) != 1 || len(b) != 1 || a[0].Allow[0] != b[0].Allow[0] {
+		t.Errorf("nil vs empty user should be identical: %v vs %v", a, b)
 	}
 }
 

--- a/internal/config/egress_userstore.go
+++ b/internal/config/egress_userstore.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -68,7 +69,11 @@ func loadUserProfile(path string) (EgressProfile, error) {
 		return EgressProfile{}, err
 	}
 	var p EgressProfile
-	if err := yaml.Unmarshal(data, &p); err != nil {
+	// Strict decode: a typo'd key (e.g. "allowed:") fails the load rather than
+	// silently dropping the rule.
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&p); err != nil {
 		return EgressProfile{}, err
 	}
 	if err := egress.ValidateProfile(p.spec()); err != nil {

--- a/internal/config/egress_userstore.go
+++ b/internal/config/egress_userstore.go
@@ -1,0 +1,172 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/charliek/shed/internal/egress"
+	"gopkg.in/yaml.v3"
+)
+
+// userProfileNameRe constrains user-profile names to lowercase so that names can
+// be safe filenames AND can't case-collide on a case-insensitive filesystem
+// (APFS): "Foo" and "foo" would otherwise share one <name>.yaml.
+var userProfileNameRe = regexp.MustCompile(`^[a-z0-9_-]+$`)
+
+// UserProfileStore is the runtime, user-editable egress-profile store — a second
+// source of named profiles alongside the read-only server.yaml ones. Each profile
+// is one whole-document <name>.yaml file, CRUD'd via the API/CLI. It is the FIRST
+// writer into the egress resolution read path (server.yaml is immutable after
+// load), so List/Get return deep copies and all access is RWMutex-guarded.
+type UserProfileStore struct {
+	dir string
+	mu  sync.RWMutex
+	m   map[string]EgressProfile
+}
+
+// OpenUserProfileStore loads every <name>.yaml under dir into memory. It FAILS
+// HARD on a malformed file or an invalid profile spec — a bad runtime policy file
+// must not be silently skipped (a profile the user thought they had, gone after a
+// restart) nor produce a half-valid effective policy.
+func OpenUserProfileStore(dir string) (*UserProfileStore, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("egress profile store %s: %w", dir, err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("egress profile store %s: %w", dir, err)
+	}
+	s := &UserProfileStore{dir: dir, m: make(map[string]EgressProfile)}
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".yaml")
+		if !userProfileNameRe.MatchString(name) {
+			return nil, fmt.Errorf("egress profile file %q: name must match %s", e.Name(), userProfileNameRe.String())
+		}
+		p, err := loadUserProfile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("egress profile %q: %w", name, err)
+		}
+		s.m[name] = p
+	}
+	return s, nil
+}
+
+func loadUserProfile(path string) (EgressProfile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return EgressProfile{}, err
+	}
+	var p EgressProfile
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return EgressProfile{}, err
+	}
+	if err := egress.ValidateProfile(p.spec()); err != nil {
+		return EgressProfile{}, err
+	}
+	return p, nil
+}
+
+// List returns a deep copy of every user profile (map + Allow/Deny slices cloned)
+// so a caller can't mutate store state or race a concurrent Put. nil receiver →
+// nil (lets callers pass store.List() unconditionally).
+func (s *UserProfileStore) List() map[string]EgressProfile {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]EgressProfile, len(s.m))
+	for k, v := range s.m {
+		out[k] = v.clone()
+	}
+	return out
+}
+
+// Get returns a deep copy of one profile.
+func (s *UserProfileStore) Get(name string) (EgressProfile, bool) {
+	if s == nil {
+		return EgressProfile{}, false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	p, ok := s.m[name]
+	if !ok {
+		return EgressProfile{}, false
+	}
+	return p.clone(), true
+}
+
+// Names returns the user-profile names, sorted (deterministic CLI/UX output).
+func (s *UserProfileStore) Names() []string {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	names := make([]string, 0, len(s.m))
+	for k := range s.m {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Put validates then atomically writes a profile (<name>.yaml, temp+rename) and
+// updates the in-memory map. On a validation or write error the map is unchanged.
+// Config-name collisions are the API layer's job (the store has no config view).
+func (s *UserProfileStore) Put(name string, p EgressProfile) error {
+	if !userProfileNameRe.MatchString(name) {
+		return fmt.Errorf("profile name %q must match %s", name, userProfileNameRe.String())
+	}
+	if egressReservedNames[name] {
+		return fmt.Errorf("profile name %q is reserved", name)
+	}
+	if err := egress.ValidateProfile(p.spec()); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(p)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := atomicWriteFile(filepath.Join(s.dir, name+".yaml"), data); err != nil {
+		return err
+	}
+	s.m[name] = p.clone()
+	return nil
+}
+
+// Delete removes a user profile (file + map). Returns an error if it doesn't exist.
+func (s *UserProfileStore) Delete(name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.m[name]; !ok {
+		return fmt.Errorf("profile %q not found", name)
+	}
+	if err := os.Remove(filepath.Join(s.dir, name+".yaml")); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	delete(s.m, name)
+	return nil
+}
+
+func atomicWriteFile(path string, data []byte) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/internal/config/egress_userstore.go
+++ b/internal/config/egress_userstore.go
@@ -50,6 +50,9 @@ func OpenUserProfileStore(dir string) (*UserProfileStore, error) {
 		if !userProfileNameRe.MatchString(name) {
 			return nil, fmt.Errorf("egress profile file %q: name must match %s", e.Name(), userProfileNameRe.String())
 		}
+		if IsReservedEgressName(name) {
+			return nil, fmt.Errorf("egress profile file %q: %q is a reserved name", e.Name(), name)
+		}
 		p, err := loadUserProfile(filepath.Join(dir, e.Name()))
 		if err != nil {
 			return nil, fmt.Errorf("egress profile %q: %w", name, err)
@@ -126,7 +129,7 @@ func (s *UserProfileStore) Put(name string, p EgressProfile) error {
 	if !userProfileNameRe.MatchString(name) {
 		return fmt.Errorf("profile name %q must match %s", name, userProfileNameRe.String())
 	}
-	if egressReservedNames[name] {
+	if IsReservedEgressName(name) {
 		return fmt.Errorf("profile name %q is reserved", name)
 	}
 	if err := egress.ValidateProfile(p.spec()); err != nil {

--- a/internal/config/egress_userstore_test.go
+++ b/internal/config/egress_userstore_test.go
@@ -135,6 +135,16 @@ func TestUserProfileStoreFailHardOnBadFile(t *testing.T) {
 	if _, err := OpenUserProfileStore(dir3); err == nil {
 		t.Fatal("Open must reject an illegal profile filename")
 	}
+
+	// reserved filename (off/none/default) — would otherwise load as a real
+	// profile and shadow the off/none sentinel.
+	dir4 := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir4, "off.yaml"), []byte("allow: [a.com]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenUserProfileStore(dir4); err == nil {
+		t.Fatal("Open must reject a reserved profile filename (off.yaml)")
+	}
 }
 
 func TestUserProfileStoreNilSafe(t *testing.T) {

--- a/internal/config/egress_userstore_test.go
+++ b/internal/config/egress_userstore_test.go
@@ -1,0 +1,173 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestUserProfileStoreCRUDAndPersistence(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenUserProfileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Put("mine", EgressProfile{Allow: []string{"example.com"}}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := s.Get("mine")
+	if !ok || len(got.Allow) != 1 || got.Allow[0] != "example.com" {
+		t.Fatalf("get = %v %v", got, ok)
+	}
+	if names := s.Names(); len(names) != 1 || names[0] != "mine" {
+		t.Fatalf("names = %v", names)
+	}
+
+	// reopen → persisted
+	s2, err := OpenUserProfileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s2.Get("mine"); !ok {
+		t.Fatal("profile did not persist across reopen")
+	}
+
+	// delete removes file + map entry, and is idempotent-erroring
+	if err := s.Delete("mine"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.Get("mine"); ok {
+		t.Fatal("profile should be gone after delete")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "mine.yaml")); !os.IsNotExist(err) {
+		t.Fatal("file should be removed on delete")
+	}
+	if err := s.Delete("mine"); err == nil {
+		t.Fatal("delete of a missing profile should error")
+	}
+}
+
+func TestUserProfileStoreSortedNames(t *testing.T) {
+	s, _ := OpenUserProfileStore(t.TempDir())
+	for _, n := range []string{"zeta", "alpha", "mike"} {
+		if err := s.Put(n, EgressProfile{Allow: []string{"a.com"}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := s.Names()
+	want := []string{"alpha", "mike", "zeta"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Names not sorted: %v", got)
+		}
+	}
+}
+
+func TestUserProfileStoreValidation(t *testing.T) {
+	s, _ := OpenUserProfileStore(t.TempDir())
+	bad := []struct {
+		desc string
+		name string
+		p    EgressProfile
+	}{
+		{"bad cel", "x", EgressProfile{Rule: "garbage ++"}},
+		{"reserved name", "off", EgressProfile{Mode: "audit"}},
+		{"uppercase name (apfs collision)", "Foo", EgressProfile{Allow: []string{"a.com"}}},
+		{"bad char", "a b", EgressProfile{Allow: []string{"a.com"}}},
+		{"empty name", "", EgressProfile{Allow: []string{"a.com"}}},
+	}
+	for _, b := range bad {
+		if err := s.Put(b.name, b.p); err == nil {
+			t.Errorf("%s: expected Put error", b.desc)
+		}
+	}
+	// a rejected Put leaves the store unchanged (no map entry, no file)
+	if _, ok := s.Get("x"); ok {
+		t.Error("failed Put should not persist to the map")
+	}
+	if _, err := os.Stat(filepath.Join(s.dir, "x.yaml")); !os.IsNotExist(err) {
+		t.Error("failed Put should not write a file")
+	}
+}
+
+func TestUserProfileStoreDeepCopy(t *testing.T) {
+	s, _ := OpenUserProfileStore(t.TempDir())
+	if err := s.Put("p", EgressProfile{Allow: []string{"a.com"}}); err != nil {
+		t.Fatal(err)
+	}
+	// mutate a Get() copy
+	got, _ := s.Get("p")
+	got.Allow[0] = "mutated-via-get"
+	// mutate a List() copy
+	listed := s.List()["p"]
+	listed.Allow[0] = "mutated-via-list"
+
+	again, _ := s.Get("p")
+	if again.Allow[0] != "a.com" {
+		t.Errorf("store mutated through a returned slice: %v", again.Allow)
+	}
+}
+
+func TestUserProfileStoreFailHardOnBadFile(t *testing.T) {
+	// malformed YAML
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte("allow: [unclosed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenUserProfileStore(dir); err == nil {
+		t.Fatal("Open must fail hard on a malformed profile file (no silent skip)")
+	}
+	// valid YAML, invalid CEL
+	dir2 := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir2, "badcel.yaml"), []byte("rule: \"garbage ++\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenUserProfileStore(dir2); err == nil {
+		t.Fatal("Open must fail hard on a bad-CEL profile file")
+	}
+	// illegal filename (uppercase)
+	dir3 := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir3, "Bad.yaml"), []byte("allow: [a.com]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenUserProfileStore(dir3); err == nil {
+		t.Fatal("Open must reject an illegal profile filename")
+	}
+}
+
+func TestUserProfileStoreNilSafe(t *testing.T) {
+	var s *UserProfileStore
+	if s.List() != nil {
+		t.Error("nil store List should be nil")
+	}
+	if _, ok := s.Get("x"); ok {
+		t.Error("nil store Get should be false")
+	}
+	if s.Names() != nil {
+		t.Error("nil store Names should be nil")
+	}
+}
+
+// TestUserProfileStoreConcurrent is the -race guard: this is the first writer
+// into the egress resolution read path, so concurrent Put vs List/Get/Names must
+// be race-free.
+func TestUserProfileStoreConcurrent(t *testing.T) {
+	s, _ := OpenUserProfileStore(t.TempDir())
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			name := fmt.Sprintf("p%d", i)
+			for j := 0; j < 25; j++ {
+				_ = s.Put(name, EgressProfile{Allow: []string{"a.com", "b.com"}})
+				_ = s.List()
+				_ = s.Names()
+				_, _ = s.Get(name)
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/internal/config/egress_userstore_test.go
+++ b/internal/config/egress_userstore_test.go
@@ -145,6 +145,15 @@ func TestUserProfileStoreFailHardOnBadFile(t *testing.T) {
 	if _, err := OpenUserProfileStore(dir4); err == nil {
 		t.Fatal("Open must reject a reserved profile filename (off.yaml)")
 	}
+
+	// unknown key (typo) — strict decode must reject it, not silently drop it.
+	dir5 := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir5, "typo.yaml"), []byte("allowed: [a.com]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenUserProfileStore(dir5); err == nil {
+		t.Fatal("Open must reject a profile file with an unknown key (allowed:)")
+	}
 }
 
 func TestUserProfileStoreNilSafe(t *testing.T) {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -681,6 +681,10 @@ const (
 	ErrSnapshotSourceRunning   = "SNAPSHOT_SOURCE_RUNNING"
 	ErrSnapshotBackendMismatch = "SNAPSHOT_BACKEND_MISMATCH"
 	ErrInvalidSnapshotName     = "INVALID_SNAPSHOT_NAME"
+
+	ErrProfileNotFound = "PROFILE_NOT_FOUND"
+	ErrProfileReserved = "PROFILE_RESERVED" // name collides with a config/reserved profile
+	ErrProfileInUse    = "PROFILE_IN_USE"   // referenced by one or more sheds
 )
 
 // Backend type constants for Shed.Backend field.

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -407,7 +407,7 @@ func (c *Client) SetShedEgress(ctx context.Context, name string, profiles []stri
 		return nil, err
 	}
 
-	specs, err := c.serverCfg.Egress.ResolveProfiles(profiles)
+	specs, err := c.serverCfg.Egress.ResolveProfiles(profiles, c.userProfiles())
 	if err != nil {
 		return nil, fmt.Errorf("egress: resolve profiles: %w", err)
 	}

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -64,11 +64,22 @@ type Client struct {
 	// egressMgr drives the optional egress-control proxy. nil ⇒ egress
 	// disabled, in which case the ConfigureEgressProxy hook is a no-op.
 	egressMgr *egress.Manager
+
+	// egressUserStore is the runtime user-profile store; nil ⇒ config profiles
+	// only. Merged into resolution via userProfiles().
+	egressUserStore *config.UserProfileStore
 }
 
 // SetEgressManager attaches the egress-control proxy manager, called by
 // shed-server at startup when egress is enabled. nil leaves egress off.
 func (c *Client) SetEgressManager(m *egress.Manager) { c.egressMgr = m }
+
+// SetEgressUserStore attaches the runtime user-profile store (mirrors
+// SetEgressManager). nil ⇒ config profiles only.
+func (c *Client) SetEgressUserStore(s *config.UserProfileStore) { c.egressUserStore = s }
+
+// userProfiles snapshots the user-profile store for resolution (nil-safe).
+func (c *Client) userProfiles() map[string]config.EgressProfile { return c.egressUserStore.List() }
 
 // NewClient creates a new Firecracker client.
 func NewClient(cfg *config.FirecrackerConfig, serverCfg *config.ServerConfig, bridge *plugin.Bridge) (*Client, error) {

--- a/internal/firecracker/orchestrator.go
+++ b/internal/firecracker/orchestrator.go
@@ -434,7 +434,7 @@ func (b *fcCreator) ConfigureEgressProxy(ctx context.Context, req config.CreateS
 	if b.c.egressMgr == nil {
 		return nil
 	}
-	specs, err := b.c.serverCfg.Egress.ResolveProfiles(req.Egress)
+	specs, err := b.c.serverCfg.Egress.ResolveProfiles(req.Egress, b.c.userProfiles())
 	if err != nil {
 		return fmt.Errorf("egress: resolve profiles: %w", err)
 	}
@@ -670,7 +670,7 @@ func (b *fcStarter) ConfigureEgressProxy(ctx context.Context, metaRaw orchestrat
 	if meta.EgressPort == 0 && len(meta.EgressProfiles) == 0 {
 		return nil // egress was off for this shed
 	}
-	specs, err := b.c.serverCfg.Egress.ResolveProfiles(meta.EgressProfiles)
+	specs, err := b.c.serverCfg.Egress.ResolveProfiles(meta.EgressProfiles, b.c.userProfiles())
 	if err != nil {
 		return fmt.Errorf("egress: resolve profiles: %w", err)
 	}

--- a/internal/firecracker/stub_nonlinux.go
+++ b/internal/firecracker/stub_nonlinux.go
@@ -37,6 +37,9 @@ func (c *Client) Close() error {
 // SetEgressManager is a no-op for the stub client.
 func (c *Client) SetEgressManager(_ *egress.Manager) {}
 
+// SetEgressUserStore is a no-op for the stub client.
+func (c *Client) SetEgressUserStore(_ *config.UserProfileStore) {}
+
 // FirecrackerBackend is a stub for non-linux builds.
 type FirecrackerBackend struct{}
 

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -59,11 +59,22 @@ type Client struct {
 	// egressMgr drives the optional egress-control proxy. nil ⇒ egress
 	// disabled, in which case the ConfigureEgressProxy hook is a no-op.
 	egressMgr *egress.Manager
+
+	// egressUserStore is the runtime user-profile store; nil ⇒ config profiles
+	// only. Merged into resolution via userProfiles().
+	egressUserStore *config.UserProfileStore
 }
 
 // SetEgressManager attaches the egress-control proxy manager, called by
 // shed-server at startup when egress is enabled. nil leaves egress off.
 func (c *Client) SetEgressManager(m *egress.Manager) { c.egressMgr = m }
+
+// SetEgressUserStore attaches the runtime user-profile store (mirrors
+// SetEgressManager). nil ⇒ config profiles only.
+func (c *Client) SetEgressUserStore(s *config.UserProfileStore) { c.egressUserStore = s }
+
+// userProfiles snapshots the user-profile store for resolution (nil-safe).
+func (c *Client) userProfiles() map[string]config.EgressProfile { return c.egressUserStore.List() }
 
 // NewClient creates a new VZ client.
 func NewClient(cfg *config.VZConfig, serverCfg *config.ServerConfig, bridge *plugin.Bridge) (*Client, error) {
@@ -437,7 +448,7 @@ func (c *Client) SetShedEgress(ctx context.Context, name string, profiles []stri
 		return nil, err
 	}
 
-	specs, err := c.serverCfg.Egress.ResolveProfiles(profiles)
+	specs, err := c.serverCfg.Egress.ResolveProfiles(profiles, c.userProfiles())
 	if err != nil {
 		return nil, fmt.Errorf("egress: resolve profiles: %w", err)
 	}

--- a/internal/vz/orchestrator.go
+++ b/internal/vz/orchestrator.go
@@ -415,7 +415,7 @@ func (b *vzCreator) ConfigureEgressProxy(ctx context.Context, req config.CreateS
 	if b.c.egressMgr == nil {
 		return nil
 	}
-	specs, err := b.c.serverCfg.Egress.ResolveProfiles(req.Egress)
+	specs, err := b.c.serverCfg.Egress.ResolveProfiles(req.Egress, b.c.userProfiles())
 	if err != nil {
 		return fmt.Errorf("egress: resolve profiles: %w", err)
 	}
@@ -658,7 +658,7 @@ func (b *vzStarter) ConfigureEgressProxy(ctx context.Context, metaRaw orchestrat
 	if meta.EgressPort == 0 && len(meta.EgressProfiles) == 0 {
 		return nil // egress was off for this shed
 	}
-	specs, err := b.c.serverCfg.Egress.ResolveProfiles(meta.EgressProfiles)
+	specs, err := b.c.serverCfg.Egress.ResolveProfiles(meta.EgressProfiles, b.c.userProfiles())
 	if err != nil {
 		return fmt.Errorf("egress: resolve profiles: %w", err)
 	}

--- a/internal/vz/stub_nondarwin.go
+++ b/internal/vz/stub_nondarwin.go
@@ -35,6 +35,9 @@ func (c *Client) Close() error {
 // SetEgressManager is a no-op for the stub client.
 func (c *Client) SetEgressManager(_ *egress.Manager) {}
 
+// SetEgressUserStore is a no-op for the stub client.
+func (c *Client) SetEgressUserStore(_ *config.UserProfileStore) {}
+
 // VZBackend is a stub for non-darwin builds.
 type VZBackend struct{}
 


### PR DESCRIPTION
## Summary

Implements **#214 v1** — user-managed named egress profiles: a second,
**runtime-editable** profile store alongside `server.yaml`, so a user can author a
*named set of rules* (whole document, via file or `$EDITOR`) and reference it on
sheds **without a server-config edit or restart**. Editing a profile
**live-re-pushes** every running shed that uses it.

Design + decisions: **#214** (panel-reviewed: Codex + Kimi + CodeRabbit). This is
the CLI + server core; the read-only desktop **Profiles** view (direct
`ShedServerClient` path, no host-agent change) follows in a shed-desktop PR.

## What's here
- **`config.UserProfileStore`** — one `<name>.yaml` per profile under
  `{state}/egress-profiles/`; atomic writes, RWMutex, **deep-copy reads**,
  **fail-hard load** (malformed/bad-CEL/reserved/uppercase filename → startup
  error), lowercase names.
- **Resolution merge** — `ResolveProfiles(req, user)` composes config ∪ user with
  **config winning** on a name collision (read-only baseline), centralized in
  `effectiveProfiles`. Nil/empty user map ⇒ **byte-identical to today** (AC1).
- **API** (control-scoped) — `GET/PUT/DELETE /api/egress/profiles[/{name}]`:
  list tags `source: config|user`; PUT rejects config/reserved-name collisions
  (409) + bad globs/CEL (400); DELETE rejects a referenced profile (409 naming the
  sheds). **`handleEgressShow` now merges user profiles** into its `rules`.
- **Live re-push** — PUT best-effort re-applies egress to **running** sheds
  referencing the profile, on a **bounded internal context** (not the request
  ctx); per-shed failures are logged + collected, never failing the PUT (the
  profile is already persisted). Stopped sheds re-resolve on next start.
- **CLI** — `shed egress profile ls|show|set --file|edit|rm`.
- **Routing** — `/profiles` registered before `/{name}` (no shadow; `profiles`/
  `stream` are reserved shed names on these routes), with a no-405 regression test.
- Docs (egress.md "User-managed profiles" + cli.md + CHANGELOG).

## Tests / validation
- **Unit**: store CRUD/persistence/validation/deep-copy/fail-hard/sorted/nil-safe +
  **`-race`**; resolution merge + config-wins + nil-identity; API list/get/put/delete
  + rejections + **route-not-shadowed** + **re-push fan-out (running-only)** +
  **show-merge**; reserved-filename load; CLI summary. `make lint` 0 issues;
  `mkdocs build --strict` clean; **both `GOOS=linux` and `GOOS=darwin` build**.
- **Dev-server live validation** (`configs/server.dev-parallel.mac.yaml`, VZ, this
  branch's binary — per CLAUDE.md): profile CRUD; **409** config-collision +
  reserved, **400** bad-CEL; created a shed on a **user** profile, enforced
  allow/deny; **edited the profile → the running shed picked up the change live
  with no restart** (AC4); delete-referenced → **409 naming the shed**; `egress
  show` showed the user profile's rules.
- **Integration suite** (`make test-integration-dev`, VZ, this branch's dev build):
  **75 passed, 3 skipped, 1 failed** (18.5 min). **All create-cycle + timing tests
  passed** (`test_create_agent_p50[vz]`, `test_create_rootfs_template_present[vz]`,
  smoke) — no boot/timing regression from the create-path resolution change. The 1
  failure (`test_ssh_auth::test_enforce_denies_offlist_admits_onlist`) is an
  environmental harness flake unrelated to this change (the diff touches **no
  ssh/auth code**): on a workstation with a populated ssh-agent the off-list probe
  hit "too many authentication failures" (server `MaxAuthTries`, from the agent's
  keys) instead of "Permission denied".

## Review trail
Plan panel-reviewed (3 models, unanimous); `/simplify` on the diff caught a real
**`GOOS=linux` build break** (the fc client lacked the field/setter the call sites
referenced) — fixed; `/codex:rescue` caught a reserved-**filename** load gap
(`off.yaml` would shadow the off/none sentinel) — fixed + tested.

## Follow-ups
- shed-desktop: read-only Egress **Profiles** view via the direct `ShedServerClient`
  path (no host-agent change; live profile-change *events* would later ride the
  existing host-agent egress-event pipeline — no shed-extensions work needed for v1).
- Desktop *editing* of profiles (PUT from the GUI) stays out of v1 — a deliberate
  posture change (desktop → server policy writes) + likely an `egress:write` scope.

Closes #214 (v1 server/CLI; desktop view tracked as the follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-managed egress profiles with new `shed egress profile` subcommands (list, show, set from YAML, edit in `$EDITOR`, remove).
  * Introduced REST API endpoints to list/get/create/update/delete profiles, with `--json` support for listing/showing.
  * Added persistence for user profiles on disk and automatic live updates for running sheds that reference modified profiles.
  * Enforced name collision rules (config profiles take precedence; reserved names are rejected) and safe handling of deletion when in use.
* **Documentation**
  * Updated CLI reference and egress documentation with user profile workflows, YAML format, and API/persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->