### PR TITLE
Set up Cursor Cloud dev environment for Shed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+Project-specific guidance for AI agents. See `CLAUDE.md` for the full developer
+guide (build/test/lint commands, project structure, backends, storage model).
+
+## Cursor Cloud specific instructions
+
+The Cursor Cloud VM is **Linux x86_64 without `/dev/kvm`** (no nested
+virtualization) and is **not macOS**. This constrains what can run here:
+
+- **Builds, unit tests, and lint all work.** Use the standard `Makefile`
+  targets documented in `CLAUDE.md`: `make build`, `make test`, `make lint`.
+  Go 1.25 is on the system `PATH` (no `mise` needed); `golangci-lint` 2.10.1
+  (the version pinned in `.mise.toml`) is installed at `/usr/local/bin`.
+- **`make test` shows exactly one expected failure here:**
+  `TestAllocateNetwork` in `internal/firecracker`. It is **environmental, not a
+  code defect** — this VM's `eth0` holds `172.30.0.2`, which collides with
+  shed's default Firecracker bridge CIDR `172.30.0.0/16`, so the allocator
+  correctly skips the IP the test hard-codes as the first allocation. Every
+  other test (and the SDK module under `sdk/`) passes. To confirm the rest of
+  the package is green: `go test ./internal/firecracker/ -skip TestAllocateNetwork`.
+- **You cannot boot a shed (`shed create`) here** — the Firecracker backend
+  needs `/dev/kvm`, and the VZ backend is macOS-only. `make test-integration`,
+  `scripts/e2e-test.sh`, and `scripts/smoke-test-linux.sh`'s create-cycle all
+  skip/stop at this boundary (matching the project's own Linux CI, which runs
+  install-only smoke). The create path is still wired and reachable up to the
+  image-resolution/boot step.
+- **Running `shed-server` + `shed` for API-level testing (no KVM needed):**
+  the server serves HTTP/SSH fine without KVM — KVM is only required at
+  create/boot time. The repo's `configs/server.dev.yaml` (and siblings)
+  reference the maintainer's personal mount/env paths and resolve the backend
+  to `firecracker`, which requires a `firecracker:` block. For local API
+  testing, run with a minimal throwaway config that sets `pull_policy: never`,
+  writable `*_dir` paths under `/tmp`, and a **non-colliding** `bridge_cidr`
+  (e.g. `172.31.250.1/24`, to avoid the `172.30.0.0/16` collision above), then:
+  `./bin/shed server add localhost` and `./bin/shed list`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Shed codebase in the Cursor Cloud VM and documents the cloud-specific constraints for future agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the no-KVM / Linux-x86 (non-macOS) constraints, the one expected environmental test failure, and how to run `shed-server`/`shed` for API-level testing without KVM.
- Update script (configured via the environment tooling, not committed): `go mod download` for the root module and the `sdk/` module.
- No application code changed.

## Environment

- Go 1.25.0 (already on system `PATH`), `golangci-lint` 2.10.1 installed to `/usr/local/bin` (matches `.mise.toml` pin).
- VM is Linux x86_64 with **no `/dev/kvm`**, so VMs cannot be booted (`shed create`) and the VZ backend (macOS-only) is unavailable — matching the project's own Linux CI (install-only smoke).

## Testing

- ✅ `make build` — all 5 binaries (`shed`, `shed-server`, `shed-egress-proxy`, `shed-agent`, `shed-firstboot`).
- ⚠️ `make test` — all pass except `TestAllocateNetwork` in `internal/firecracker`, which fails only because this VM's `eth0` holds `172.30.0.2`, colliding with shed's default Firecracker bridge CIDR `172.30.0.0/16` (environmental, not a code defect). Verified the rest green via `go test ./internal/firecracker/ -skip TestAllocateNetwork` and the `sdk/` module tests pass.
- ✅ `make lint` — 0 issues.
- ✅ Hello-world: started `shed-server`, ran `shed server add localhost` (live host-key + `/info` handshake), and `shed list` successfully queried the server API over HTTP.

[shed_hello_world.log](https://cursor.com/artifacts/c/art-34f3f0a8-5461-44e3-9f5d-6e90bdbf10ec)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ece713f7-97f3-48c1-b69d-a7bba480f9bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ece713f7-97f3-48c1-b69d-a7bba480f9bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

