### PR TITLE
feat: send a plan to a shed and run it autonomously (sessions RC metadata, attach RC mode, shed-plan skill)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Run a plan autonomously on a shed (`shed attach` Remote Control mode + the
+  `shed-plan` skill).** `shed attach <shed> --plan <file> -d` ships a plan into a shed
+  and starts a Claude Remote Control session that executes it unattended, printing a
+  `claude.ai/code` URL to watch/steer (the laptop can close). `--kind`/`--prompt`/
+  `--prompt-file`/`--edit`/`--plan-edit` cover session kind and kickoff-prompt sources;
+  `--permission-mode` (default `auto`) and `--skip` (full bypass) set the autonomy
+  posture; `--slug` connects to an existing `rc-<slug>`. Plain `shed attach` is
+  unchanged. Requires Claude to be logged in inside the shed. The new `shed-plan`
+  skill drives the end-to-end author → fresh shed → run → report flow. Supersedes the
+  HTTP-enumeration approach in #199 (the same metadata is surfaced over SSH).
+- **`shed sessions` surfaces RC metadata.** `rc-*` sessions show `KIND` and `RC-STATE`
+  columns (and an `rc` object in `--json`), read from the in-shed `shed-ext-rc` binary;
+  degrades silently when a shed is unreachable or lacks the binary.
 - **User-managed egress profiles (runtime, no server-config edit).** A second,
   runtime-editable profile store alongside `server.yaml`: `shed egress profile
   set <name> --file <doc>` / `edit` / `ls` / `show` / `rm`, backed by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ All notable changes to this project will be documented in this file.
 - **Run a plan autonomously on a shed (`shed attach` Remote Control mode + the
   `shed-plan` skill).** `shed attach <shed> --plan <file> -d` ships a plan into a shed
   and starts a Claude Remote Control session that executes it unattended, printing a
-  `claude.ai/code` URL to watch/steer (the laptop can close). `--kind`/`--prompt`/
+  `claude.ai/code` URL to watch/steer (the laptop can close). The plan is shipped to
+  Claude's plans directory (`~/.claude/plans/plan-<slug>.md`, outside the workspace) and
+  the kickoff references it; `--plan` and `-p` combine (generic kickoff by default, your
+  prompt + appended plan path when given). `--kind`/`--prompt`/
   `--prompt-file`/`--edit`/`--plan-edit` cover session kind and kickoff-prompt sources;
   `--permission-mode` (default `auto`) and `--skip` (full bypass) set the autonomy
   posture; `--slug` connects to an existing `rc-<slug>`. Plain `shed attach` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to this project will be documented in this file.
 - **`shed sessions` surfaces RC metadata.** `rc-*` sessions show `KIND` and `RC-STATE`
   columns (and an `rc` object in `--json`), read from the in-shed `shed-ext-rc` binary;
   degrades silently when a shed is unreachable or lacks the binary.
+- **Multi-line kickoff prompts.** `shed attach --prompt-file`/`--edit` may now be
+  multi-line; `shed-ext-rc` delivers them as one input via a bracketed paste (prefer a
+  plan file for large/multi-step work).
 - **User-managed egress profiles (runtime, no server-config edit).** A second,
   runtime-editable profile store alongside `server.yaml`: `shed egress profile
   set <name> --file <doc>` / `edit` / `ls` / `show` / `rm`, backed by

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Firecracker microVMs on Linux or Apple Virtualization VMs on macOS Apple Silicon
 - **Multi-server** — manage sheds across home servers and cloud VPS instances.
 - **IDE integration** — native Cursor / VS Code Remote-SSH support.
 - **AI-ready** — pre-configured for Claude Code and OpenCode workflows.
+- **Autonomous agents** — hand a plan to a shed with `shed attach --plan`; Claude executes it unattended while you watch from `claude.ai/code` (laptop can close).
 - **VM backends** — Firecracker microVMs (Linux) or Apple VZ (macOS Apple Silicon).
 
 ## Quick start

--- a/cmd/shed/attach.go
+++ b/cmd/shed/attach.go
@@ -262,17 +262,23 @@ func runAttachRCCreate(name, serverName string, entry *config.ServerEntry) error
 		displayName = name + "/" + slug
 	}
 
-	// Ship the plan and default the kickoff prompt to reference it.
+	// Ship the plan into claude's plans dir and, unless the caller gave a prompt,
+	// kick off with a natural "here's a plan, implement it" line referencing the file
+	// — what you'd type starting a fresh session against a saved plan.
 	if havePlan {
-		relPath, perr := streamPlanToShed(name, entry, slug, planContent)
+		planPath, perr := streamPlanToShed(name, entry, slug, planContent)
 		if perr != nil {
 			return perr
 		}
 		if verboseLevel > 0 {
-			fmt.Printf("Shipped plan to %s in %s\n", relPath, name)
+			fmt.Printf("Shipped plan to %s in %s\n", planPath, name)
 		}
 		if prompt == "" {
-			prompt = "Read and execute the plan at " + relPath + " autonomously to completion. Do not ask for confirmation; make reasonable decisions and keep going until the plan is done."
+			prompt = "Read the plan at " + planPath + " and implement it. Work through it to completion autonomously — don't stop to ask for confirmation; make reasonable decisions and keep going until the plan is done."
+		} else {
+			// Caller supplied their own kickoff. They can't know the generated plan
+			// path, so append it — their prompt leads, the plan is still findable.
+			prompt += "\n\nThe plan to follow is at " + planPath + "."
 		}
 	}
 

--- a/cmd/shed/attach.go
+++ b/cmd/shed/attach.go
@@ -75,7 +75,7 @@ func init() {
 	attachCmd.Flags().StringVar(&attachKindFlag, "kind", "", "RC session kind: claude-rc|claude-broker|shell (triggers RC create)")
 	attachCmd.Flags().StringVar(&attachNameFlag, "name", "", "RC session display name (default <shed>/<slug>)")
 	attachCmd.Flags().StringVar(&attachSlugFlag, "slug", "", "RC slug: connect to rc-<slug>, or set the slug for a new session")
-	attachCmd.Flags().StringVarP(&attachPromptFlag, "prompt", "p", "", "Kickoff prompt line (single line)")
+	attachCmd.Flags().StringVarP(&attachPromptFlag, "prompt", "p", "", "Kickoff prompt (use --prompt-file/--edit for multi-line)")
 	attachCmd.Flags().StringVar(&attachPromptFileFlag, "prompt-file", "", "Read the kickoff prompt from a file (- for stdin)")
 	attachCmd.Flags().BoolVar(&attachEditFlag, "edit", false, "Compose the kickoff prompt in $EDITOR")
 	attachCmd.Flags().StringVar(&attachPlanFlag, "plan", "", "Ship a plan file to the shed and execute it (- for stdin)")

--- a/cmd/shed/attach.go
+++ b/cmd/shed/attach.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strconv"
+	"regexp"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -15,60 +15,160 @@ import (
 var (
 	attachSessionFlag string
 	attachNewFlag     bool
+
+	// Remote Control (RC) flags. When any create flag is set, `attach` creates an
+	// rc-<slug> session via the in-shed shed-ext-rc binary instead of a plain tmux
+	// session. --slug alone (no create flags) connects to an existing rc-<slug>.
+	attachKindFlag       string
+	attachNameFlag       string
+	attachSlugFlag       string
+	attachPromptFlag     string
+	attachPromptFileFlag string
+	attachEditFlag       bool
+	attachPlanFlag       string
+	attachPlanEditFlag   bool
+	attachPermModeFlag   string
+	attachSkipFlag       bool
+	attachDetachFlag     bool
 )
+
+// validRCKinds / validRCPermModes mirror shed-ext-rc's accepted values so the CLI
+// can reject a bad flag before the SSH round-trip; shed-ext-rc re-validates as the
+// source of truth. Keep in sync with shed-extensions internal/rc.
+var validRCKinds = map[string]bool{"claude-rc": true, "claude-broker": true, "shell": true}
+var validRCPermModes = map[string]bool{
+	"default": true, "acceptEdits": true, "plan": true,
+	"auto": true, "dontAsk": true, "bypassPermissions": true,
+}
+var rcSlugRe = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?$`)
 
 var attachCmd = &cobra.Command{
 	Use:   "attach <name>",
-	Short: "Attach to a tmux session in a shed",
+	Short: "Attach to a tmux session in a shed (or start a Remote Control session)",
 	Long: `Attach to a tmux session in a shed container.
 
-By default, attaches to or creates a session named "default".
-Use --session to specify a different session name.
+By default, attaches to or creates a session named "default" and drops you into it
+(tmux gives you detach/reconnect persistence).
 
-This command uses tmux for session persistence, allowing you to:
-- Detach from a running session (Ctrl-B D)
-- Reconnect later to continue where you left off
-- Run multiple named sessions in the same shed
+Remote Control (autonomous agent) sessions:
+  With --kind (or --plan/--prompt), attach instead creates an rc-<slug> Remote
+  Control session via the in-shed shed-ext-rc binary: it starts claude connected to
+  claude.ai, ships an optional plan, and types a kickoff prompt. With -d/--detach it
+  prints the session URL and returns (laptop can close); otherwise it attaches.
+  Permission posture defaults to "auto"; use --skip for full bypass.
 
 Examples:
-  shed attach myproj                    # Attach to default session
-  shed attach myproj --session debug    # Attach to "debug" session
-  shed attach myproj --new --session exp # Create new "exp" session`,
+  shed attach myproj                         # attach/create the "default" tmux session
+  shed attach myproj --session debug         # a named tmux session
+  shed attach myproj --kind claude-rc -d     # start an RC agent, print the URL, return
+  shed attach myproj --plan plan.md -d       # ship a plan and run it autonomously (auto)
+  shed attach myproj --plan plan.md --skip -d  # ...with full permission bypass
+  shed attach myproj --slug abc234           # attach to an existing rc-abc234 session`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAttach,
 }
 
 func init() {
-	attachCmd.Flags().StringVarP(&attachSessionFlag, "session", "S", config.DefaultSessionName, "Session name to attach to")
+	attachCmd.Flags().StringVarP(&attachSessionFlag, "session", "S", config.DefaultSessionName, "Session name to attach to (plain mode)")
 	attachCmd.Flags().BoolVar(&attachNewFlag, "new", false, "Force create a new session (error if exists)")
 
+	attachCmd.Flags().StringVar(&attachKindFlag, "kind", "", "RC session kind: claude-rc|claude-broker|shell (triggers RC create)")
+	attachCmd.Flags().StringVar(&attachNameFlag, "name", "", "RC session display name (default <shed>/<slug>)")
+	attachCmd.Flags().StringVar(&attachSlugFlag, "slug", "", "RC slug: connect to rc-<slug>, or set the slug for a new session")
+	attachCmd.Flags().StringVarP(&attachPromptFlag, "prompt", "p", "", "Kickoff prompt line (single line)")
+	attachCmd.Flags().StringVar(&attachPromptFileFlag, "prompt-file", "", "Read the kickoff prompt from a file (- for stdin)")
+	attachCmd.Flags().BoolVar(&attachEditFlag, "edit", false, "Compose the kickoff prompt in $EDITOR")
+	attachCmd.Flags().StringVar(&attachPlanFlag, "plan", "", "Ship a plan file to the shed and execute it (- for stdin)")
+	attachCmd.Flags().BoolVar(&attachPlanEditFlag, "plan-edit", false, "Compose the plan in $EDITOR")
+	attachCmd.Flags().StringVar(&attachPermModeFlag, "permission-mode", "", "Claude permission mode (default auto): acceptEdits|auto|bypassPermissions|default|dontAsk|plan")
+	attachCmd.Flags().BoolVar(&attachSkipFlag, "skip", false, "Shorthand for --permission-mode bypassPermissions")
+	attachCmd.Flags().BoolVarP(&attachDetachFlag, "detach", "d", false, "Create the RC session and print its URL without attaching")
+
 	rootCmd.AddCommand(attachCmd)
+}
+
+// rcCreateRequested reports whether any flag that should create an RC session is set.
+func rcCreateRequested() bool {
+	return attachKindFlag != "" || rcInputRequested()
+}
+
+// rcInputRequested reports whether any prompt/plan input flag is set.
+func rcInputRequested() bool {
+	return attachPromptFlag != "" || attachPromptFileFlag != "" || attachEditFlag ||
+		attachPlanFlag != "" || attachPlanEditFlag
+}
+
+// validateAttachFlags runs cheap, mode-specific validation before the shed is found
+// or auto-started — so a bad invocation fails fast without side effects (no
+// auto-start, no $EDITOR, no SSH).
+func validateAttachFlags() error {
+	switch {
+	case rcCreateRequested():
+		kind := attachKindFlag
+		if kind == "" {
+			kind = "claude-rc"
+		}
+		if !validRCKinds[kind] {
+			return fmt.Errorf("invalid --kind %q (want claude-rc|claude-broker|shell)", kind)
+		}
+		if attachSkipFlag && attachPermModeFlag != "" {
+			return fmt.Errorf("--skip and --permission-mode are mutually exclusive")
+		}
+		if attachPermModeFlag != "" && !validRCPermModes[attachPermModeFlag] {
+			return fmt.Errorf("invalid --permission-mode %q", attachPermModeFlag)
+		}
+		if kind == "claude-broker" && rcInputRequested() {
+			return fmt.Errorf("claude-broker sessions are driven from claude.ai and take no prompt/plan")
+		}
+		if attachSlugFlag != "" && !rcSlugRe.MatchString(attachSlugFlag) {
+			return fmt.Errorf("invalid slug %q", attachSlugFlag)
+		}
+	case attachSlugFlag != "":
+		if !rcSlugRe.MatchString(attachSlugFlag) {
+			return fmt.Errorf("invalid slug %q", attachSlugFlag)
+		}
+	default:
+		if err := config.ValidateSessionName(attachSessionFlag); err != nil {
+			return fmt.Errorf("invalid session name: %w", err)
+		}
+	}
+	return nil
 }
 
 func runAttach(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
-	// Validate session name
-	if err := config.ValidateSessionName(attachSessionFlag); err != nil {
-		return fmt.Errorf("invalid session name: %w", err)
+	// Validate flags before touching the network, so a bad invocation fails fast
+	// without auto-starting a stopped shed (or opening $EDITOR) just to error.
+	if err := validateAttachFlags(); err != nil {
+		return err
 	}
 
-	// Find the server hosting this shed
 	serverName, entry, err := findShedServer(name)
 	if err != nil {
 		return err
 	}
-
-	// Ensure the shed is running (auto-start if stopped)
 	client := NewAPIClientFromEntry(entry, clientConfig.GetCreateTimeout())
 	shed, err := ensureRunningShed(client, name)
 	if err != nil {
 		return err
 	}
 
-	// If --new flag is set, verify session doesn't already exist
+	switch {
+	case rcCreateRequested():
+		return runAttachRCCreate(name, serverName, entry)
+	case attachSlugFlag != "":
+		return attachToRCSlug(name, entry, attachSlugFlag)
+	default:
+		return attachPlain(name, serverName, entry, shed)
+	}
+}
+
+// attachPlain is the original behavior: attach to (or create) a named tmux session.
+// (The session name was validated in validateAttachFlags.)
+func attachPlain(name, serverName string, entry *config.ServerEntry, shed *config.Shed) error {
 	if attachNewFlag {
-		sessions, err := client.ListSessions(name)
+		sessions, err := listShedSessions(entry, name)
 		if err != nil {
 			return fmt.Errorf("failed to check existing sessions: %w", err)
 		}
@@ -78,58 +178,164 @@ func runAttach(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
-
 	if verboseLevel > 0 {
 		fmt.Printf("Attaching to session %q in %s on %s...\n", attachSessionFlag, name, serverName)
 	}
-
-	// Build SSH command with tmux
-	knownHostsPath := config.GetKnownHostsPath()
-
-	// Start the session in the shed's landing directory (cloned repo,
-	// --local-dir mount, or the home directory). Older sheds without a
-	// landing dir fall back to the home directory. The path is shell-quoted
-	// because mount basenames may contain spaces.
 	landingDir := shed.LandingDir
 	if landingDir == "" {
 		landingDir = config.HomePath
 	}
-
-	// Build the tmux command to run on the remote
-	// -s: session name
-	// -c: start directory
-	// -A: attach if exists, create if not (only when --new is NOT set)
 	var tmuxCmd string
 	if attachNewFlag {
-		// Without -A: tmux will fail if session already exists (extra safety)
 		tmuxCmd = fmt.Sprintf("tmux new-session -s %s -c %s", attachSessionFlag, shellQuoteArg(landingDir))
 	} else {
-		// With -A: attach to existing session or create new one
 		tmuxCmd = fmt.Sprintf("tmux new-session -A -s %s -c %s", attachSessionFlag, shellQuoteArg(landingDir))
 	}
+	return execSSHTmux(name, entry, tmuxCmd)
+}
 
-	sshArgs := []string{
-		"ssh",
-		"-t", // Force pseudo-terminal allocation
-		"-p", strconv.Itoa(entry.SSHPort),
-		"-o", "UserKnownHostsFile=" + knownHostsPath,
-		"-o", "StrictHostKeyChecking=yes",
-		name + "@" + entry.Host,
-		"--", // Separator for remote command
-		tmuxCmd,
+// attachToRCSlug attaches the terminal to an existing rc-<slug> session.
+func attachToRCSlug(name string, entry *config.ServerEntry, slug string) error {
+	if !rcSlugRe.MatchString(slug) {
+		return fmt.Errorf("invalid slug %q", slug)
 	}
+	return execSSHTmux(name, entry, "tmux attach -t "+rcTmuxPrefix+slug)
+}
 
-	// Find ssh binary
+// execSSHTmux replaces this process with `ssh -t … <tmuxCmd>` (the plain/connect
+// paths). Interactive, so it intentionally omits BatchMode/ConnectTimeout (an
+// interactive session may legitimately prompt); the rest is shared via baseSSHArgs.
+func execSSHTmux(name string, entry *config.ServerEntry, tmuxCmd string) error {
+	sshArgs := append([]string{"ssh", "-t"}, baseSSHArgs(name, entry)...)
+	sshArgs = append(sshArgs, "--", tmuxCmd)
 	sshPath, err := exec.LookPath("ssh")
 	if err != nil {
 		return fmt.Errorf("ssh not found in PATH: %w", err)
 	}
-
-	// Replace current process with ssh
 	if err := syscall.Exec(sshPath, sshArgs, os.Environ()); err != nil {
 		return fmt.Errorf("failed to exec ssh: %w", err)
 	}
-
-	// This should never be reached
 	return nil
+}
+
+// runAttachRCCreate creates an rc-<slug> Remote Control session via shed-ext-rc:
+// resolves prompt/plan, ships the plan, sets the permission posture, starts the
+// session, then prints the URL (--detach) or attaches.
+func runAttachRCCreate(name, serverName string, entry *config.ServerEntry) error {
+	// Kind, posture mutual-exclusivity/validity, and broker/input rules were
+	// validated in validateAttachFlags; here we just derive the effective values.
+	kind := attachKindFlag
+	if kind == "" {
+		kind = "claude-rc"
+	}
+	explicitMode := attachSkipFlag || attachPermModeFlag != ""
+	mode := attachPermModeFlag
+	if attachSkipFlag {
+		mode = "bypassPermissions"
+	}
+	if mode == "" {
+		mode = "auto"
+	}
+
+	prompt, planContent, havePlan, err := resolveRCInputs(rcInputs{
+		prompt:     attachPromptFlag,
+		promptFile: attachPromptFileFlag,
+		edit:       attachEditFlag,
+		plan:       attachPlanFlag,
+		planEdit:   attachPlanEditFlag,
+	})
+	if err != nil {
+		return err
+	}
+
+	slug := attachSlugFlag
+	if slug == "" {
+		if slug, err = genRCSlug(); err != nil {
+			return err
+		}
+	}
+	displayName := attachNameFlag
+	if displayName == "" {
+		displayName = name + "/" + slug
+	}
+
+	// Ship the plan and default the kickoff prompt to reference it.
+	if havePlan {
+		relPath, perr := streamPlanToShed(name, entry, slug, planContent)
+		if perr != nil {
+			return perr
+		}
+		if verboseLevel > 0 {
+			fmt.Printf("Shipped plan to %s in %s\n", relPath, name)
+		}
+		if prompt == "" {
+			prompt = "Read and execute the plan at " + relPath + " autonomously to completion. Do not ask for confirmation; make reasonable decisions and keep going until the plan is done."
+		}
+	}
+
+	if verboseLevel > 0 {
+		fmt.Printf("Creating %s session rc-%s in %s on %s (mode=%s)...\n", kind, slug, name, serverName, modeLabel(mode))
+	}
+	opts := rcCreateOptions{
+		shedName:       name,
+		entry:          entry,
+		kind:           kind,
+		displayName:    displayName,
+		slug:           slug,
+		permissionMode: mode,
+		prompt:         prompt,
+	}
+	dto, err := createRCSession(opts)
+	if isOldBinaryPermModeErr(err) {
+		// Image predates --permission-mode. Fail loudly if the user asked for a
+		// posture; otherwise drop the default and retry so the session still comes up.
+		// (create rejects the flag before making the tmux session, so retry is clean.)
+		if explicitMode {
+			return fmt.Errorf("this shed's shed-ext-rc predates --permission-mode/--skip; upgrade the shed image, or omit it to start without an autonomous posture")
+		}
+		fmt.Fprintln(os.Stderr, "Warning: shed-ext-rc predates --permission-mode; starting without an autonomous posture (upgrade the shed image to enable).")
+		opts.permissionMode = ""
+		dto, err = createRCSession(opts)
+	}
+	if err != nil {
+		return err
+	}
+
+	switch dto.State {
+	case "needs-auth":
+		fmt.Printf("Session rc-%s created but Claude is not logged in in this shed.\n", slug)
+		fmt.Printf("Log in once: shed attach %s  →  run `claude` →  /login, then retry.\n", name)
+		return nil
+	case "needs-trust":
+		fmt.Printf("Session rc-%s created but the workspace trust prompt is showing; attach to accept it:\n  shed attach %s --slug %s\n", slug, name, slug)
+		return nil
+	}
+
+	if attachDetachFlag || kind == "claude-broker" {
+		printRCSummary(name, dto)
+		return nil
+	}
+	return attachToRCSlug(name, entry, slug)
+}
+
+func modeLabel(mode string) string {
+	if mode == "" {
+		return "default (no posture)"
+	}
+	return mode
+}
+
+func printRCSummary(shedName string, dto rcSessionDTO) {
+	fmt.Printf("Started %s session rc-%s (%s)\n", dto.Kind, dto.Slug, dto.State)
+	if dto.URL != "" {
+		fmt.Printf("  URL:    %s\n", dto.URL)
+	}
+	fmt.Printf("  Watch:  shed attach %s --slug %s\n", shedName, dto.Slug)
+	fmt.Printf("  Status: shed sessions %s\n", shedName)
+}
+
+// listShedSessions is a thin wrapper so attachPlain can list sessions for the
+// --new guard without reaching for a package-level client.
+func listShedSessions(entry *config.ServerEntry, name string) ([]config.Session, error) {
+	return NewAPIClientFromEntry(entry, DefaultTimeout).ListSessions(name)
 }

--- a/cmd/shed/attach.go
+++ b/cmd/shed/attach.go
@@ -87,9 +87,12 @@ func init() {
 	rootCmd.AddCommand(attachCmd)
 }
 
-// rcCreateRequested reports whether any flag that should create an RC session is set.
+// rcCreateRequested reports whether any RC-only flag is set — so posture/presentation
+// modifiers (--skip, --permission-mode, --name, -d/--detach) also trigger RC create
+// rather than silently routing to plain attach and discarding the user's intent.
 func rcCreateRequested() bool {
-	return attachKindFlag != "" || rcInputRequested()
+	return attachKindFlag != "" || rcInputRequested() ||
+		attachSkipFlag || attachPermModeFlag != "" || attachNameFlag != "" || attachDetachFlag
 }
 
 // rcInputRequested reports whether any prompt/plan input flag is set.

--- a/cmd/shed/rc.go
+++ b/cmd/shed/rc.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+// rcTmuxPrefix is the session-name prefix that marks a Remote Control session
+// under the RC Session Convention (e.g. "rc-abc234").
+const rcTmuxPrefix = "rc-"
+
+// rcEnrichTimeout bounds a single `shed-ext-rc list` SSH round-trip so a slow or
+// unreachable shed never stalls `shed sessions`.
+const rcEnrichTimeout = 6 * time.Second
+
+// rcEnrichConcurrency caps concurrent SSH enrichment calls so `sessions --all`
+// across many sheds doesn't fan out unbounded.
+const rcEnrichConcurrency = 6
+
+// rcSessionDTO mirrors shed-ext-rc's neutral `list` DTO (one entry of the
+// `{"rc_sessions":[...]}` payload). It is decoded verbatim from the binary's
+// stdout so the shed CLI stays aligned with the cross-repo golden fixture
+// (shed-extensions internal/rc + shed-remote-agent); fields beyond those we
+// display are accepted and ignored.
+type rcSessionDTO struct {
+	Slug        string `json:"slug"`
+	TmuxSession string `json:"tmux_session"`
+	Kind        string `json:"kind"`
+	State       string `json:"state"`
+	Managed     bool   `json:"managed"`
+	DisplayName string `json:"display_name"`
+	URL         string `json:"url"`
+	CreatedBy   string `json:"created_by"`
+}
+
+// rcListResponse is the `shed-ext-rc list` stdout shape.
+type rcListResponse struct {
+	RCSessions []rcSessionDTO `json:"rc_sessions"`
+}
+
+// toSessionRC projects the decoded DTO onto the display type carried on
+// config.Session (the decode type is kept separate so it stays aligned with the
+// shed-ext-rc golden contract independent of presentation).
+func (d rcSessionDTO) toSessionRC() *config.SessionRC {
+	return &config.SessionRC{
+		Kind:        d.Kind,
+		State:       d.State,
+		Managed:     d.Managed,
+		DisplayName: d.DisplayName,
+		URL:         d.URL,
+		CreatedBy:   d.CreatedBy,
+	}
+}
+
+// parseRcList decodes `shed-ext-rc list` stdout into a map keyed by tmux session
+// name (e.g. "rc-abc234") for O(1) merge onto enumerated tmux sessions.
+func parseRcList(stdout []byte) (map[string]rcSessionDTO, error) {
+	var resp rcListResponse
+	if err := json.Unmarshal(stdout, &resp); err != nil {
+		return nil, fmt.Errorf("decoding shed-ext-rc list: %w", err)
+	}
+	out := make(map[string]rcSessionDTO, len(resp.RCSessions))
+	for _, s := range resp.RCSessions {
+		if s.TmuxSession != "" {
+			out[s.TmuxSession] = s
+		}
+	}
+	return out, nil
+}
+
+// sshCaptureArgs builds the `ssh` argv for a non-interactive, output-capturing
+// command against a shed (no PTY; BatchMode so a key/auth issue fails fast
+// instead of hanging). The shed name is the SSH user; the host/port come from
+// the server entry; host-key checking uses shed's pinned known_hosts.
+func sshCaptureArgs(shedName string, entry *config.ServerEntry, remoteArgv ...string) []string {
+	args := []string{
+		"-p", strconv.Itoa(entry.SSHPort),
+		"-o", "UserKnownHostsFile=" + config.GetKnownHostsPath(),
+		"-o", "StrictHostKeyChecking=yes",
+		"-o", "BatchMode=yes",
+		"-o", "ConnectTimeout=10",
+		shedName + "@" + entry.Host,
+		"--",
+	}
+	return append(args, remoteArgv...)
+}
+
+// rcListOverSSH runs `shed-ext-rc list` in the shed and returns the parsed
+// sessions keyed by tmux name. A missing binary, transport failure, or non-zero
+// exit is reported as an error for the caller to treat as "no RC data".
+func rcListOverSSH(ctx context.Context, shedName string, entry *config.ServerEntry) (map[string]rcSessionDTO, error) {
+	args := sshCaptureArgs(shedName, entry, "shed-ext-rc", "list")
+	cmd := exec.CommandContext(ctx, "ssh", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("shed-ext-rc list on %s: %w", shedName, err)
+	}
+	return parseRcList(out)
+}
+
+// rcShedKey identifies a shed by server + name (a shed name is unique only
+// within a server, so the aggregated `--all` listing must key by both).
+type rcShedKey struct{ server, shed string }
+
+// enrichSessionsRC fills the RC field of every "rc-*" session in sessions by
+// querying the in-shed shed-ext-rc binary. It runs one `shed-ext-rc list` per
+// distinct (server, shed) that actually has an rc-* session — bounded by
+// rcEnrichConcurrency and time-limited per call — resolving each shed's SSH
+// endpoint from the client config by the session's ServerName. It mutates
+// sessions in place and degrades silently (rows keep their plain tmux data) when
+// a shed is unreachable, lacks the binary, or its server is unknown. Non-RC
+// listings touch nothing and never dial. Call once, after the full session list
+// (with ServerName populated) is assembled.
+func enrichSessionsRC(sessions []config.Session) {
+	if clientConfig == nil {
+		return // config not loaded (e.g. a direct test caller); nothing to resolve
+	}
+	idxByShed := make(map[rcShedKey][]int)
+	for i := range sessions {
+		if strings.HasPrefix(sessions[i].Name, rcTmuxPrefix) {
+			k := rcShedKey{sessions[i].ServerName, sessions[i].ShedName}
+			idxByShed[k] = append(idxByShed[k], i)
+		}
+	}
+	if len(idxByShed) == 0 {
+		return
+	}
+
+	sem := make(chan struct{}, rcEnrichConcurrency)
+	var wg sync.WaitGroup
+	for key, idxs := range idxByShed {
+		entry, ok := clientConfig.Servers[key.server]
+		if !ok {
+			continue // unknown server -> leave rows un-enriched
+		}
+		wg.Add(1)
+		go func(key rcShedKey, idxs []int, entry config.ServerEntry) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			ctx, cancel := context.WithTimeout(context.Background(), rcEnrichTimeout)
+			defer cancel()
+			byTmux, err := rcListOverSSH(ctx, key.shed, &entry)
+			if err != nil {
+				if verboseLevel > 0 {
+					fmt.Fprintf(os.Stderr, "Warning: RC metadata unavailable for %s: %v\n", key.shed, err)
+				}
+				return
+			}
+			// Distinct indices per (server, shed) -> safe concurrent writes.
+			for _, i := range idxs {
+				if dto, ok := byTmux[sessions[i].Name]; ok {
+					sessions[i].RC = dto.toSessionRC()
+				}
+			}
+		}(key, idxs, entry)
+	}
+	wg.Wait()
+}

--- a/cmd/shed/rc.go
+++ b/cmd/shed/rc.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"io"
+	"math/big"
 	"os"
 	"os/exec"
 	"strconv"
@@ -12,6 +16,7 @@ import (
 	"time"
 
 	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/version"
 )
 
 // rcTmuxPrefix is the session-name prefix that marks a Remote Control session
@@ -77,20 +82,30 @@ func parseRcList(stdout []byte) (map[string]rcSessionDTO, error) {
 	return out, nil
 }
 
-// sshCaptureArgs builds the `ssh` argv for a non-interactive, output-capturing
-// command against a shed (no PTY; BatchMode so a key/auth issue fails fast
-// instead of hanging). The shed name is the SSH user; the host/port come from
-// the server entry; host-key checking uses shed's pinned known_hosts.
-func sshCaptureArgs(shedName string, entry *config.ServerEntry, remoteArgv ...string) []string {
+// baseSSHArgs returns the SSH args common to every shed connection: port, pinned
+// known_hosts, strict host-key check, any extra -o options, then <shed>@<host>.
+// Callers prepend "ssh" (and "-t" for an interactive PTY) and append "--" + the
+// remote command. Shared by the interactive attach path and the capture path so
+// the connection options can't drift.
+func baseSSHArgs(shedName string, entry *config.ServerEntry, extraOpts ...string) []string {
 	args := []string{
 		"-p", strconv.Itoa(entry.SSHPort),
 		"-o", "UserKnownHostsFile=" + config.GetKnownHostsPath(),
 		"-o", "StrictHostKeyChecking=yes",
-		"-o", "BatchMode=yes",
-		"-o", "ConnectTimeout=10",
-		shedName + "@" + entry.Host,
-		"--",
 	}
+	args = append(args, extraOpts...)
+	return append(args, shedName+"@"+entry.Host)
+}
+
+// sshCaptureArgs builds the `ssh` argv for a non-interactive, output-capturing
+// command against a shed (no PTY; BatchMode so a key/auth issue fails fast instead
+// of hanging). remoteArgv elements are sent to the server as-is (joined by ssh and
+// re-parsed by the server's `bash -lc`), so a caller passing user data as a single
+// element must shell-quote it first (see createRCSession); literal tokens like
+// "shed-ext-rc","list" need no quoting.
+func sshCaptureArgs(shedName string, entry *config.ServerEntry, remoteArgv ...string) []string {
+	args := baseSSHArgs(shedName, entry, "-o", "BatchMode=yes", "-o", "ConnectTimeout=10")
+	args = append(args, "--")
 	return append(args, remoteArgv...)
 }
 
@@ -166,4 +181,297 @@ func enrichSessionsRC(sessions []config.Session) {
 		}(key, idxs, entry)
 	}
 	wg.Wait()
+}
+
+// --- RC session creation (shed attach --kind ...) ---------------------------
+
+// rcCreateTimeout bounds a `shed-ext-rc create --wait` round-trip (the binary
+// itself polls ~20s for ready, then delivers the prompt; allow generous headroom).
+const rcCreateTimeout = 75 * time.Second
+
+// rcSlugAlphabet is the convention's confusable-free alphabet (no 0/o, 1/l/i).
+const rcSlugAlphabet = "abcdefghjkmnpqrstuvwxyz23456789"
+
+// genRCSlug returns a 6-char slug. Generated CLI-side so the caller knows the slug
+// before create (to name the plan file and reference it in the kickoff prompt).
+func genRCSlug() (string, error) {
+	var b strings.Builder
+	for range 6 {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(rcSlugAlphabet))))
+		if err != nil {
+			return "", fmt.Errorf("generating slug: %w", err)
+		}
+		b.WriteByte(rcSlugAlphabet[n.Int64()])
+	}
+	return b.String(), nil
+}
+
+// sshShell runs a single shell command in a shed over SSH (the server wraps it in
+// `bash -lc`), feeding stdin and capturing stdout. A non-zero exit returns an error
+// carrying stderr. Used for one-shot guest commands (shed-ext-rc, plan transfer).
+func sshShell(ctx context.Context, shedName string, entry *config.ServerEntry, stdin, cmdStr string) ([]byte, error) {
+	args := sshCaptureArgs(shedName, entry, cmdStr)
+	cmd := exec.CommandContext(ctx, "ssh", args...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	var out, errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(errb.String())
+		if msg != "" {
+			return out.Bytes(), fmt.Errorf("%w: %s", err, msg)
+		}
+		return out.Bytes(), err
+	}
+	return out.Bytes(), nil
+}
+
+// isOldBinaryPermModeErr reports whether a createRCSession error is the shed's
+// shed-ext-rc rejecting --permission-mode as an unknown flag (Go's flag package
+// prints "flag provided but not defined: -permission-mode"), i.e. an image that
+// predates posture support. Matched precisely so a transient or unrelated failure
+// is never mistaken for an old binary.
+func isOldBinaryPermModeErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "permission-mode") &&
+		(strings.Contains(s, "not defined") || strings.Contains(s, "flag provided"))
+}
+
+// streamPlanToShed writes plan content to `<workdir>/.shed/plan-<slug>.md` inside the
+// shed (workdir = $SHED_WORKSPACE, falling back to $HOME — matching how shed-ext-rc
+// resolves its own workdir) and returns the workdir-relative path for the kickoff
+// prompt (claude runs with cwd = workdir).
+func streamPlanToShed(shedName string, entry *config.ServerEntry, slug, content string) (string, error) {
+	rel := ".shed/plan-" + slug + ".md"
+	ctx, cancel := context.WithTimeout(context.Background(), rcEnrichTimeout)
+	defer cancel()
+	// The server's bash -lc expands the shed's login env; mirror shed-ext-rc's
+	// SHED_WORKSPACE-or-HOME workdir resolution so the plan lands in the session cwd.
+	cmd := `wd="${SHED_WORKSPACE:-$HOME}"; mkdir -p "$wd/.shed" && cat > "$wd/` + rel + `"`
+	if _, err := sshShell(ctx, shedName, entry, content, cmd); err != nil {
+		return "", fmt.Errorf("shipping plan to shed: %w", err)
+	}
+	return rel, nil
+}
+
+// rcCreateOptions configures createRCSession.
+type rcCreateOptions struct {
+	shedName       string
+	entry          *config.ServerEntry
+	kind           string
+	displayName    string
+	slug           string
+	permissionMode string // "" omits the flag
+	prompt         string // kickoff line (empty -> none)
+}
+
+// createRCSession invokes `shed-ext-rc create --wait` over SSH and returns the
+// parsed session DTO. Each shed-ext-rc argument is shell-quoted into one command
+// string (the server re-parses through bash -lc), and the kickoff prompt is piped on
+// stdin (never argv) per the convention.
+func createRCSession(opts rcCreateOptions) (rcSessionDTO, error) {
+	argv := []string{
+		"shed-ext-rc", "create",
+		"--kind", opts.kind,
+		"--slug", opts.slug,
+		"--created-by", "shed/" + version.Version,
+		"--target", "shed:" + opts.shedName + "@" + opts.entry.Host,
+		"--wait",
+	}
+	if opts.displayName != "" {
+		argv = append(argv, "--name", opts.displayName)
+	}
+	if opts.permissionMode != "" {
+		argv = append(argv, "--permission-mode", opts.permissionMode)
+	}
+	if opts.prompt != "" {
+		argv = append(argv, "--prompt-stdin")
+	}
+	quoted := make([]string, len(argv))
+	for i, a := range argv {
+		quoted[i] = shellQuoteArg(a)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rcCreateTimeout)
+	defer cancel()
+	out, err := sshShell(ctx, opts.shedName, opts.entry, opts.prompt, strings.Join(quoted, " "))
+	if err != nil {
+		return rcSessionDTO{}, fmt.Errorf("shed-ext-rc create: %w", err)
+	}
+	var dto rcSessionDTO
+	if err := json.Unmarshal(bytes.TrimSpace(out), &dto); err != nil {
+		return rcSessionDTO{}, fmt.Errorf("decoding shed-ext-rc create output: %w (raw: %q)", err, string(out))
+	}
+	return dto, nil
+}
+
+// editorInput opens $VISUAL/$EDITOR on a temp file seeded with template, returns the
+// saved content with lines starting with commentPrefix stripped (use "#" for a
+// git-commit-style prompt, "<!--" for a markdown plan so real `#` headers survive).
+// Errors (never hangs) when no editor is set or the session isn't interactive — the
+// skill path must not use it.
+func editorInput(template, suffix, commentPrefix string) (string, error) {
+	editor := firstNonEmptyEnv("VISUAL", "EDITOR")
+	if editor == "" {
+		return "", fmt.Errorf("no $VISUAL or $EDITOR set; pass the text with a flag instead")
+	}
+	if !stdioIsInteractive() {
+		return "", fmt.Errorf("editor input needs an interactive terminal; pass the text with a flag instead")
+	}
+	f, err := os.CreateTemp("", "shed-*"+suffix)
+	if err != nil {
+		return "", err
+	}
+	path := f.Name()
+	defer func() { _ = os.Remove(path) }()
+	if template != "" {
+		_, _ = f.WriteString(template)
+	}
+	_ = f.Close()
+
+	cmd := exec.Command("sh", "-c", editor+" \"$1\"", "sh", path)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("editor exited with error: %w", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	for _, line := range strings.Split(string(data), "\n") {
+		if commentPrefix != "" && strings.HasPrefix(line, commentPrefix) {
+			continue
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return strings.TrimSpace(b.String()), nil
+}
+
+const promptEditTemplate = "# Write the single-line kickoff prompt for the agent.\n# Lines starting with '#' are ignored.\n"
+const planEditTemplate = "<!-- Write the plan (markdown) for the agent to execute below.\n     Lines starting with '<!--' are ignored. Markdown '#' headers are kept. -->\n\n"
+
+// rcInputs holds the raw prompt/plan flag values for resolveRCInputs.
+type rcInputs struct {
+	prompt     string // -p value
+	promptFile string // --prompt-file value ("-" = stdin)
+	edit       bool   // --edit ($EDITOR)
+	plan       string // --plan value ("-" = stdin)
+	planEdit   bool   // --plan-edit ($EDITOR)
+}
+
+// resolveRCInputs resolves the kickoff prompt and (optional) plan content from the
+// flags, enforcing: at most one prompt source, at most one plan source, at most one
+// stdin (`-`) reader, a single-line prompt, and non-empty editor results.
+func resolveRCInputs(in rcInputs) (prompt, planContent string, havePlan bool, err error) {
+	if n := boolCount(in.prompt != "", in.promptFile != "", in.edit); n > 1 {
+		return "", "", false, fmt.Errorf("choose at most one of --prompt/--prompt-file/--edit")
+	}
+	if n := boolCount(in.plan != "", in.planEdit); n > 1 {
+		return "", "", false, fmt.Errorf("choose at most one of --plan/--plan-edit")
+	}
+	promptStdin := in.promptFile == "-"
+	planStdin := in.plan == "-"
+	if promptStdin && planStdin {
+		return "", "", false, fmt.Errorf("only one input can read stdin (-)")
+	}
+
+	// Plan.
+	switch {
+	case in.plan != "":
+		if planStdin {
+			if planContent, err = readStdinTrimmed(); err != nil {
+				return "", "", false, err
+			}
+		} else {
+			b, e := os.ReadFile(in.plan)
+			if e != nil {
+				return "", "", false, fmt.Errorf("reading plan file: %w", e)
+			}
+			planContent = string(b)
+		}
+		havePlan = true
+	case in.planEdit:
+		if planContent, err = editorInput(planEditTemplate, ".md", "<!--"); err != nil {
+			return "", "", false, err
+		}
+		if strings.TrimSpace(planContent) == "" {
+			return "", "", false, fmt.Errorf("empty plan; aborting")
+		}
+		havePlan = true
+	}
+
+	// Prompt.
+	switch {
+	case in.prompt != "":
+		prompt = in.prompt
+	case in.promptFile != "":
+		if promptStdin {
+			if prompt, err = readStdinTrimmed(); err != nil {
+				return "", "", false, err
+			}
+		} else {
+			b, e := os.ReadFile(in.promptFile)
+			if e != nil {
+				return "", "", false, fmt.Errorf("reading prompt file: %w", e)
+			}
+			prompt = strings.TrimSpace(string(b))
+		}
+	case in.edit:
+		if prompt, err = editorInput(promptEditTemplate, ".txt", "#"); err != nil {
+			return "", "", false, err
+		}
+		if prompt == "" {
+			return "", "", false, fmt.Errorf("empty prompt; aborting")
+		}
+	}
+	if strings.ContainsAny(prompt, "\n\r") {
+		return "", "", false, fmt.Errorf("the kickoff prompt must be a single line; put multi-step detail in --plan")
+	}
+	return prompt, planContent, havePlan, nil
+}
+
+func boolCount(bs ...bool) int {
+	n := 0
+	for _, b := range bs {
+		if b {
+			n++
+		}
+	}
+	return n
+}
+
+func firstNonEmptyEnv(keys ...string) string {
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// stdioIsInteractive reports whether stdin and stdout are both terminals.
+func stdioIsInteractive() bool {
+	for _, f := range []*os.File{os.Stdin, os.Stdout} {
+		fi, err := f.Stat()
+		if err != nil || fi.Mode()&os.ModeCharDevice == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// readStdinTrimmed reads all of stdin and trims trailing newlines (for `-` sources).
+func readStdinTrimmed() (string, error) {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(data), "\n"), nil
 }

--- a/cmd/shed/rc.go
+++ b/cmd/shed/rc.go
@@ -251,21 +251,28 @@ func isOldBinaryPermModeErr(err error) bool {
 		(strings.Contains(s, "not defined") || strings.Contains(s, "flag provided"))
 }
 
-// streamPlanToShed writes plan content to `<workdir>/.shed/plan-<slug>.md` inside the
-// shed (workdir = $SHED_WORKSPACE, falling back to $HOME — matching how shed-ext-rc
-// resolves its own workdir) and returns the workdir-relative path for the kickoff
-// prompt (claude runs with cwd = workdir).
+// streamPlanToShed writes the plan into claude's native plans directory inside the
+// shed — `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plans/plan-<slug>.md` — and returns its
+// absolute path for the kickoff prompt. Keeping it out of the workspace means it never
+// pollutes the repo (or a --local-dir host copy); claude reads it fine in auto and
+// bypass modes when the kickoff references the absolute path (verified live). The path
+// is echoed back behind a sentinel so any login-shell output can't be mistaken for it.
 func streamPlanToShed(shedName string, entry *config.ServerEntry, slug, content string) (string, error) {
-	rel := ".shed/plan-" + slug + ".md"
 	ctx, cancel := context.WithTimeout(context.Background(), rcEnrichTimeout)
 	defer cancel()
-	// The server's bash -lc expands the shed's login env; mirror shed-ext-rc's
-	// SHED_WORKSPACE-or-HOME workdir resolution so the plan lands in the session cwd.
-	cmd := `wd="${SHED_WORKSPACE:-$HOME}"; mkdir -p "$wd/.shed" && cat > "$wd/` + rel + `"`
-	if _, err := sshShell(ctx, shedName, entry, content, cmd); err != nil {
+	file := "plan-" + slug + ".md"
+	cmd := `d="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plans"; mkdir -p "$d" && cat > "$d/` + file +
+		`" && printf 'SHED_PLAN_PATH=%s\n' "$d/` + file + `"`
+	out, err := sshShell(ctx, shedName, entry, content, cmd)
+	if err != nil {
 		return "", fmt.Errorf("shipping plan to shed: %w", err)
 	}
-	return rel, nil
+	for _, line := range strings.Split(string(out), "\n") {
+		if p, ok := strings.CutPrefix(strings.TrimSpace(line), "SHED_PLAN_PATH="); ok && p != "" {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("shipping plan to shed: could not determine the plan path")
 }
 
 // rcCreateOptions configures createRCSession.

--- a/cmd/shed/rc.go
+++ b/cmd/shed/rc.go
@@ -355,7 +355,11 @@ func editorInput(template, suffix, commentPrefix string) (string, error) {
 }
 
 const promptEditTemplate = "# Write the single-line kickoff prompt for the agent.\n# Lines starting with '#' are ignored.\n"
-const planEditTemplate = "<!-- Write the plan (markdown) for the agent to execute below.\n     Lines starting with '<!--' are ignored. Markdown '#' headers are kept. -->\n\n"
+
+// Single-line so the whole template is one stripped comment (a wrapped second line
+// would not start with the prefix and would leak into the plan); markdown '#'
+// headers in the body are preserved because the prefix is "<!--", not "#".
+const planEditTemplate = "<!-- Write the plan (markdown) below and delete this line; markdown '#' headers are kept. -->\n\n"
 
 // rcInputs holds the raw prompt/plan flag values for resolveRCInputs.
 type rcInputs struct {
@@ -395,6 +399,9 @@ func resolveRCInputs(in rcInputs) (prompt, planContent string, havePlan bool, er
 				return "", "", false, fmt.Errorf("reading plan file: %w", e)
 			}
 			planContent = string(b)
+		}
+		if strings.TrimSpace(planContent) == "" {
+			return "", "", false, fmt.Errorf("plan is empty; nothing to execute")
 		}
 		havePlan = true
 	case in.planEdit:

--- a/cmd/shed/rc.go
+++ b/cmd/shed/rc.go
@@ -104,7 +104,10 @@ func baseSSHArgs(shedName string, entry *config.ServerEntry, extraOpts ...string
 // element must shell-quote it first (see createRCSession); literal tokens like
 // "shed-ext-rc","list" need no quoting.
 func sshCaptureArgs(shedName string, entry *config.ServerEntry, remoteArgv ...string) []string {
-	args := baseSSHArgs(shedName, entry, "-o", "BatchMode=yes", "-o", "ConnectTimeout=10")
+	// -T disables PTY allocation so ssh doesn't print "Pseudo-terminal will not be
+	// allocated…" to our captured stderr (the shed's sshd folds the remote command's
+	// stderr into the stdout channel, so command diagnostics arrive on stdout anyway).
+	args := baseSSHArgs(shedName, entry, "-T", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10")
 	args = append(args, "--")
 	return append(args, remoteArgv...)
 }
@@ -219,9 +222,15 @@ func sshShell(ctx context.Context, shedName string, entry *config.ServerEntry, s
 	cmd.Stdout = &out
 	cmd.Stderr = &errb
 	if err := cmd.Run(); err != nil {
-		msg := strings.TrimSpace(errb.String())
-		if msg != "" {
-			return out.Bytes(), fmt.Errorf("%w: %s", err, msg)
+		// The shed's sshd folds the remote command's stderr into stdout, so prefer
+		// stderr but fall back to stdout for the diagnostic (e.g. a guest binary's
+		// "flag provided but not defined: …" arrives on stdout).
+		detail := strings.TrimSpace(errb.String())
+		if detail == "" {
+			detail = strings.TrimSpace(out.String())
+		}
+		if detail != "" {
+			return out.Bytes(), fmt.Errorf("%w: %s", err, detail)
 		}
 		return out.Bytes(), err
 	}
@@ -372,7 +381,9 @@ type rcInputs struct {
 
 // resolveRCInputs resolves the kickoff prompt and (optional) plan content from the
 // flags, enforcing: at most one prompt source, at most one plan source, at most one
-// stdin (`-`) reader, a single-line prompt, and non-empty editor results.
+// stdin (`-`) reader, and non-empty editor results. The prompt may be multi-line
+// (shed-ext-rc delivers it as one input via a bracketed paste); prefer a plan file
+// for large/multi-step work.
 func resolveRCInputs(in rcInputs) (prompt, planContent string, havePlan bool, err error) {
 	if n := boolCount(in.prompt != "", in.promptFile != "", in.edit); n > 1 {
 		return "", "", false, fmt.Errorf("choose at most one of --prompt/--prompt-file/--edit")
@@ -437,9 +448,6 @@ func resolveRCInputs(in rcInputs) (prompt, planContent string, havePlan bool, er
 		if prompt == "" {
 			return "", "", false, fmt.Errorf("empty prompt; aborting")
 		}
-	}
-	if strings.ContainsAny(prompt, "\n\r") {
-		return "", "", false, fmt.Errorf("the kickoff prompt must be a single line; put multi-step detail in --plan")
 	}
 	return prompt, planContent, havePlan, nil
 }

--- a/cmd/shed/rc_test.go
+++ b/cmd/shed/rc_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/charliek/shed/internal/config"
+)
+
+// TestParseRcListGolden decodes the cross-repo golden DTO fixture (byte-identical
+// to shed-extensions internal/rc/testdata/rcSessionDto.golden.json and
+// shed-remote-agent's). Keeping a copy here makes the shed CLI a participant in
+// the shed-ext-rc stdout contract guard.
+func TestParseRcListGolden(t *testing.T) {
+	data, err := os.ReadFile("testdata/rcSessionDto.golden.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	byTmux, err := parseRcList(data)
+	if err != nil {
+		t.Fatalf("parseRcList: %v", err)
+	}
+	if len(byTmux) != 2 {
+		t.Fatalf("want 2 sessions, got %d", len(byTmux))
+	}
+
+	full, ok := byTmux["rc-abc234"]
+	if !ok {
+		t.Fatal("missing rc-abc234")
+	}
+	if full.Kind != "claude-rc" || full.State != "ready" || !full.Managed ||
+		full.DisplayName != "charliek/abc234" || !strings.Contains(full.URL, "session_") ||
+		full.CreatedBy != "shed-remote-agent/0.1.0" {
+		t.Fatalf("full session mismatch: %+v", full)
+	}
+
+	minimal, ok := byTmux["rc-brk900"]
+	if !ok {
+		t.Fatal("missing rc-brk900")
+	}
+	if minimal.Kind != "claude-broker" || minimal.Managed ||
+		minimal.DisplayName != "" || minimal.URL != "" {
+		t.Fatalf("minimal session should omit optionals: %+v", minimal)
+	}
+}
+
+func TestParseRcListEmptyAndBad(t *testing.T) {
+	t.Run("empty list", func(t *testing.T) {
+		m, err := parseRcList([]byte(`{"rc_sessions":[]}`))
+		if err != nil || len(m) != 0 {
+			t.Fatalf("want empty map no error, got %v %v", m, err)
+		}
+	})
+	t.Run("malformed json", func(t *testing.T) {
+		if _, err := parseRcList([]byte(`not json`)); err == nil {
+			t.Fatal("want error on malformed json")
+		}
+	})
+	t.Run("entry without tmux_session is skipped", func(t *testing.T) {
+		m, err := parseRcList([]byte(`{"rc_sessions":[{"slug":"x","kind":"shell"}]}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(m) != 0 {
+			t.Fatalf("entry without tmux_session must be skipped, got %v", m)
+		}
+	})
+}
+
+func TestSSHCaptureArgs(t *testing.T) {
+	entry := &config.ServerEntry{Host: "mini3", SSHPort: 2222}
+	args := sshCaptureArgs("myshed", entry, "shed-ext-rc", "list")
+	joined := strings.Join(args, " ")
+
+	for _, want := range []string{
+		"-p 2222",
+		"StrictHostKeyChecking=yes",
+		"BatchMode=yes",
+		"myshed@mini3",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("args missing %q: %v", want, args)
+		}
+	}
+	// The remote argv must come after the "--" separator, in order.
+	sep := -1
+	for i, a := range args {
+		if a == "--" {
+			sep = i
+			break
+		}
+	}
+	if sep == -1 || sep+2 >= len(args) || args[sep+1] != "shed-ext-rc" || args[sep+2] != "list" {
+		t.Errorf("remote argv not placed after --: %v", args)
+	}
+}
+
+func TestRCColumns(t *testing.T) {
+	tests := []struct {
+		name      string
+		session   config.Session
+		wantKind  string
+		wantState string
+	}{
+		{
+			name:    "non-rc session renders blank",
+			session: config.Session{Name: "default"},
+		},
+		{
+			name:      "rc session without metadata renders dashes",
+			session:   config.Session{Name: "rc-abc234"},
+			wantKind:  "-",
+			wantState: "-",
+		},
+		{
+			name: "managed rc session",
+			session: config.Session{
+				Name: "rc-abc234",
+				RC:   &config.SessionRC{Kind: "claude-rc", State: "ready", Managed: true},
+			},
+			wantKind:  "claude-rc",
+			wantState: "ready",
+		},
+		{
+			name: "legacy rc session labelled",
+			session: config.Session{
+				Name: "rc-brk900",
+				RC:   &config.SessionRC{Kind: "claude-broker", State: "starting", Managed: false},
+			},
+			wantKind:  "claude-broker (legacy)",
+			wantState: "starting",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kind, state := rcColumns(tc.session)
+			if kind != tc.wantKind || state != tc.wantState {
+				t.Errorf("rcColumns = (%q,%q), want (%q,%q)", kind, state, tc.wantKind, tc.wantState)
+			}
+		})
+	}
+}
+
+// TestEnrichSessionsRCNoOp guards the no-op fast path: a listing with no rc-*
+// sessions must return before any config lookup or SSH dial (the test would hang
+// or panic on an unreachable/absent server if it didn't).
+func TestEnrichSessionsRCNoOp(t *testing.T) {
+	sessions := []config.Session{
+		{Name: "default", ShedName: "s", ServerName: "srv"},
+		{Name: "work", ShedName: "s", ServerName: "srv"},
+	}
+	enrichSessionsRC(sessions)
+	for i := range sessions {
+		if sessions[i].RC != nil {
+			t.Fatalf("non-rc session %q must not be enriched", sessions[i].Name)
+		}
+	}
+}

--- a/cmd/shed/rc_test.go
+++ b/cmd/shed/rc_test.go
@@ -142,6 +142,76 @@ func TestRCColumns(t *testing.T) {
 	}
 }
 
+func TestResolveRCInputs(t *testing.T) {
+	t.Run("multiple prompt sources error", func(t *testing.T) {
+		_, _, _, err := resolveRCInputs(rcInputs{prompt: "x", edit: true})
+		if err == nil {
+			t.Fatal("want error for >1 prompt source")
+		}
+	})
+	t.Run("multiple plan sources error", func(t *testing.T) {
+		_, _, _, err := resolveRCInputs(rcInputs{plan: "p.md", planEdit: true})
+		if err == nil {
+			t.Fatal("want error for >1 plan source")
+		}
+	})
+	t.Run("both stdin error", func(t *testing.T) {
+		_, _, _, err := resolveRCInputs(rcInputs{promptFile: "-", plan: "-"})
+		if err == nil {
+			t.Fatal("want error when prompt and plan both read stdin")
+		}
+	})
+	t.Run("multiline prompt rejected", func(t *testing.T) {
+		_, _, _, err := resolveRCInputs(rcInputs{prompt: "line one\nline two"})
+		if err == nil {
+			t.Fatal("want error for a multi-line kickoff prompt")
+		}
+	})
+	t.Run("prompt flag passes through", func(t *testing.T) {
+		p, _, havePlan, err := resolveRCInputs(rcInputs{prompt: "do the thing"})
+		if err != nil || p != "do the thing" || havePlan {
+			t.Fatalf("got (%q,%v,%v)", p, havePlan, err)
+		}
+	})
+	t.Run("plan file read; markdown headers preserved", func(t *testing.T) {
+		dir := t.TempDir()
+		path := dir + "/plan.md"
+		body := "# Goal\n\nDo step 1\nDo step 2\n"
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, plan, havePlan, err := resolveRCInputs(rcInputs{plan: path})
+		if err != nil || !havePlan {
+			t.Fatalf("got havePlan=%v err=%v", havePlan, err)
+		}
+		if !strings.Contains(plan, "# Goal") {
+			t.Fatalf("markdown header stripped: %q", plan)
+		}
+	})
+}
+
+func TestGenRCSlug(t *testing.T) {
+	seen := map[string]bool{}
+	for range 50 {
+		s, err := genRCSlug()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(s) != 6 {
+			t.Fatalf("slug len = %d, want 6 (%q)", len(s), s)
+		}
+		for _, r := range s {
+			if !strings.ContainsRune(rcSlugAlphabet, r) {
+				t.Fatalf("slug %q has char outside alphabet", s)
+			}
+		}
+		seen[s] = true
+	}
+	if len(seen) < 40 {
+		t.Fatalf("slugs not random enough: %d unique of 50", len(seen))
+	}
+}
+
 // TestEnrichSessionsRCNoOp guards the no-op fast path: a listing with no rc-*
 // sessions must return before any config lookup or SSH dial (the test would hang
 // or panic on an unreachable/absent server if it didn't).

--- a/cmd/shed/rc_test.go
+++ b/cmd/shed/rc_test.go
@@ -161,10 +161,10 @@ func TestResolveRCInputs(t *testing.T) {
 			t.Fatal("want error when prompt and plan both read stdin")
 		}
 	})
-	t.Run("multiline prompt rejected", func(t *testing.T) {
-		_, _, _, err := resolveRCInputs(rcInputs{prompt: "line one\nline two"})
-		if err == nil {
-			t.Fatal("want error for a multi-line kickoff prompt")
+	t.Run("multiline prompt allowed", func(t *testing.T) {
+		p, _, _, err := resolveRCInputs(rcInputs{prompt: "line one\nline two"})
+		if err != nil || p != "line one\nline two" {
+			t.Fatalf("multi-line prompt should pass through, got (%q,%v)", p, err)
 		}
 	})
 	t.Run("prompt flag passes through", func(t *testing.T) {

--- a/cmd/shed/sessions.go
+++ b/cmd/shed/sessions.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -108,6 +109,11 @@ func runSessions(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Enrich rc-* sessions with RC Session Convention metadata in one pass over
+	// the assembled list, so every code path above benefits and new branches
+	// can't forget it. No-op (no dial) when there are no rc-* sessions.
+	enrichSessionsRC(allSessions)
+
 	if jsonFlag {
 		if allSessions == nil {
 			allSessions = make([]config.Session, 0)
@@ -153,8 +159,22 @@ func printSessionsTable(sessions []config.Session) error {
 		return nil
 	}
 
+	// Only widen the table with RC columns when at least one rc-* session is
+	// present, so the common (non-RC) listing stays compact.
+	showRC := false
+	for _, s := range sessions {
+		if strings.HasPrefix(s.Name, rcTmuxPrefix) {
+			showRC = true
+			break
+		}
+	}
+
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "SHED\tSESSION\tSTATUS\tCREATED\tWINDOWS")
+	if showRC {
+		fmt.Fprintln(w, "SHED\tSESSION\tSTATUS\tCREATED\tWINDOWS\tKIND\tRC-STATE")
+	} else {
+		fmt.Fprintln(w, "SHED\tSESSION\tSTATUS\tCREATED\tWINDOWS")
+	}
 
 	for _, s := range sessions {
 		status := "detached"
@@ -164,16 +184,37 @@ func printSessionsTable(sessions []config.Session) error {
 
 		created := formatTimeAgo(s.CreatedAt)
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n",
-			s.ShedName,
-			s.Name,
-			status,
-			created,
-			s.WindowCount,
-		)
+		if showRC {
+			kind, rcState := rcColumns(s)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+				s.ShedName, s.Name, status, created, s.WindowCount, kind, rcState)
+		} else {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n",
+				s.ShedName, s.Name, status, created, s.WindowCount)
+		}
 	}
 
 	return w.Flush()
+}
+
+// rcColumns renders the KIND and RC-STATE cells for a session. Non-RC sessions
+// render blank; rc-* sessions whose metadata couldn't be read render "-"; legacy
+// (unmanaged) RC sessions are labelled.
+func rcColumns(s config.Session) (kind, state string) {
+	if s.RC == nil {
+		if strings.HasPrefix(s.Name, rcTmuxPrefix) {
+			return "-", "-"
+		}
+		return "", ""
+	}
+	kind = s.RC.Kind
+	if kind == "" {
+		kind = "?"
+	}
+	if !s.RC.Managed {
+		kind += " (legacy)"
+	}
+	return kind, s.RC.State
 }
 
 func formatTimeAgo(t time.Time) string {

--- a/cmd/shed/testdata/rcSessionDto.golden.json
+++ b/cmd/shed/testdata/rcSessionDto.golden.json
@@ -1,0 +1,25 @@
+{
+  "rc_sessions": [
+    {
+      "slug": "abc234",
+      "tmux_session": "rc-abc234",
+      "kind": "claude-rc",
+      "state": "ready",
+      "managed": true,
+      "display_name": "charliek/abc234",
+      "workdir": "/home/shed",
+      "url": "https://claude.ai/code/session_01RCkTDrdZ2Rr12sD5dfMjgr",
+      "id": "9f1c0e7a-1111-4222-8333-444455556666",
+      "created_by": "shed-remote-agent/0.1.0",
+      "created_at": "2026-06-19T18:53:00Z",
+      "target_label": "shed:t1@localmac-dev"
+    },
+    {
+      "slug": "brk900",
+      "tmux_session": "rc-brk900",
+      "kind": "claude-broker",
+      "state": "starting",
+      "managed": false
+    }
+  ]
+}

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -123,6 +123,21 @@ claude
 shed attach myproj
 ```
 
+### Run a plan autonomously
+
+Hand a plan to a shed and let Claude execute it unattended — you get a `claude.ai/code`
+URL to watch/steer from your phone, and your laptop can close. Requires the `full` image
+with Claude logged in inside the shed.
+
+```bash
+# Write a self-contained plan (goal, steps, how to verify), then:
+shed attach myproj --plan ./plan.md -d      # ships the plan, starts an agent, prints the URL
+```
+
+Defaults to `auto` permission mode; add `--skip` for full bypass (safe in a disposable
+shed). For the end-to-end author → fresh shed → run → report flow, use the **`shed-plan`**
+skill. See [`shed attach` Remote Control sessions](../reference/cli.md#remote-control-sessions-autonomous-agents).
+
 ### Port forwarding
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Shed is a lightweight tool for managing persistent, VM-based development environ
 - **Multi-Server** - Manage sheds across home servers and cloud VPS instances
 - **IDE Integration** - Native Cursor/VS Code support via SSH Remote
 - **AI-Ready** - Pre-configured for Claude Code and OpenCode workflows
+- **Autonomous Agents** - Ship a plan to a shed with `shed attach --plan`; Claude executes it unattended while you watch from `claude.ai/code`
 - **VM Backends** - Firecracker microVMs (Linux) or Apple VZ virtual machines (macOS Apple Silicon)
 
 ## Architecture

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -916,7 +916,7 @@ Remote Control (`rc-*`) sessions are enriched with metadata read from the in-she
 `--json`). Enrichment degrades silently to the plain tmux row if a shed is unreachable
 or lacks the binary.
 
-```
+```text
 SHED     SESSION    STATUS    CREATED   WINDOWS  KIND       RC-STATE
 myproj   rc-abc234  detached  5m ago    1        claude-rc  ready
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -874,9 +874,14 @@ shed attach myproj --plan plan.md --skip -d       # ...with full permission bypa
 shed attach myproj --slug abc234                  # attach to an existing rc-abc234 session
 ```
 
-The kickoff **prompt** may be multi-line (`--prompt-file`/`--edit`; delivered as one
-input via a bracketed paste), but large/multi-step work belongs in the **plan** file
-(shipped to `<workdir>/.shed/plan-<slug>.md`). Claude must be logged in inside the shed
+A **plan** (`--plan`) is shipped to Claude's plans directory in the shed
+(`~/.claude/plans/plan-<slug>.md`, outside the workspace so it never touches the repo)
+and the kickoff prompt references it. You can pass a **prompt** and a **plan** together:
+with no prompt, a generic "read the plan at `<path>` and implement it" kickoff is the
+default; with your own `-p`/`--prompt-file`/`--edit`, your prompt leads and the plan's
+location is appended so the agent still finds it. The kickoff **prompt** may be
+multi-line (`--prompt-file`/`--edit`; delivered as one input via a bracketed paste), but
+large/multi-step work belongs in the **plan** file. Claude must be logged in inside the shed
 (see the `shed-plan` skill). Defaults to `auto`; `--skip` is safe because a shed is an
 isolated VM. For the end-to-end "author a plan and run it on a fresh shed" workflow, use
 the `shed-plan` skill.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -832,7 +832,7 @@ shed attach <name> [flags]
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--session` | `-S` | `default` | Session name |
+| `--session` | `-S` | `default` | Session name (plain mode) |
 | `--new` | | `false` | Force create new session |
 
 **Examples:**
@@ -844,6 +844,41 @@ shed attach codelens --new --session experiment
 ```
 
 Detach with `Ctrl-B D`.
+
+#### Remote Control sessions (autonomous agents)
+
+With `--kind` (or `--plan`/`--prompt`), `attach` instead creates a **Remote Control**
+`rc-<slug>` session via the in-shed `shed-ext-rc` binary: it starts Claude connected to
+`claude.ai/code`, ships an optional plan, and types a single-line kickoff prompt. With
+`-d/--detach` it prints the session URL and returns (the laptop can close); otherwise it
+attaches. Use `--slug` to connect to an existing `rc-<slug>` session.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--kind` | | `claude-rc` | RC kind: `claude-rc`, `claude-broker`, `shell` (triggers RC create) |
+| `--plan` | | | Ship a plan file into the shed and execute it (`-` = stdin) |
+| `--plan-edit` | | `false` | Compose the plan in `$EDITOR` |
+| `--prompt` | `-p` | | Single-line kickoff prompt |
+| `--prompt-file` | | | Read the kickoff prompt from a file (`-` = stdin) |
+| `--edit` | | `false` | Compose the kickoff prompt in `$EDITOR` |
+| `--permission-mode` | | `auto` | `auto`, `acceptEdits`, `plan`, `dontAsk`, `default`, `bypassPermissions` |
+| `--skip` | | `false` | Shorthand for `--permission-mode bypassPermissions` (full bypass) |
+| `--name` | | `<shed>/<slug>` | Session display name |
+| `--slug` | | generated | Connect to `rc-<slug>`, or set the slug for a new session |
+| `--detach` | `-d` | `false` | Create the RC session, print its URL, and return without attaching |
+
+```bash
+shed attach myproj --kind claude-rc -d            # start an agent, print the URL, return
+shed attach myproj --plan plan.md -d              # ship a plan and run it autonomously (auto)
+shed attach myproj --plan plan.md --skip -d       # ...with full permission bypass
+shed attach myproj --slug abc234                  # attach to an existing rc-abc234 session
+```
+
+The kickoff **prompt** is a single line; put multi-step detail in the **plan** file
+(shipped to `<workdir>/.shed/plan-<slug>.md`). Claude must be logged in inside the shed
+(see the `shed-plan` skill). Defaults to `auto`; `--skip` is safe because a shed is an
+isolated VM. For the end-to-end "author a plan and run it on a fresh shed" workflow, use
+the `shed-plan` skill.
 
 ## Session Management
 
@@ -865,6 +900,7 @@ shed sessions [shed-name] [flags]
 shed sessions                  # All sessions on default server
 shed sessions myproj           # Sessions in specific shed
 shed sessions --all            # Across all servers
+shed sessions --json           # Structured output (includes the rc block)
 ```
 
 **Output:**
@@ -873,6 +909,16 @@ shed sessions --all            # Across all servers
 SHED        SESSION      STATUS      CREATED      WINDOWS
 codelens    default      attached    2h ago       1
 codelens    debug        detached    30m ago      2
+```
+
+Remote Control (`rc-*`) sessions are enriched with metadata read from the in-shed
+`shed-ext-rc` binary, adding `KIND` and `RC-STATE` columns (and an `rc` object in
+`--json`). Enrichment degrades silently to the plain tmux row if a shed is unreachable
+or lacks the binary.
+
+```
+SHED     SESSION    STATUS    CREATED   WINDOWS  KIND       RC-STATE
+myproj   rc-abc234  detached  5m ago    1        claude-rc  ready
 ```
 
 ### shed sessions kill

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -874,7 +874,8 @@ shed attach myproj --plan plan.md --skip -d       # ...with full permission bypa
 shed attach myproj --slug abc234                  # attach to an existing rc-abc234 session
 ```
 
-The kickoff **prompt** is a single line; put multi-step detail in the **plan** file
+The kickoff **prompt** may be multi-line (`--prompt-file`/`--edit`; delivered as one
+input via a bracketed paste), but large/multi-step work belongs in the **plan** file
 (shipped to `<workdir>/.shed/plan-<slug>.md`). Claude must be logged in inside the shed
 (see the `shed-plan` skill). Defaults to `auto`; `--skip` is safe because a shed is an
 isolated VM. For the end-to-end "author a plan and run it on a fresh shed" workflow, use

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -41,12 +41,18 @@ steps.
 | Variant | Description |
 |---------|-------------|
 | `base` | Minimal OS layer: systemd, SSH, git, gh, build-essential, jq, ripgrep, neovim, tmux, and the shed-agent. No Docker, no coding agents, no language runtimes. |
-| `extensions` | `base` + [shed-extensions](https://charliek.github.io/shed-extensions/) credential brokering (SSH agent forwarding, AWS STS proxy, Docker credential helper). No Docker daemon, no coding agents pinned — start here for custom images. |
+| `extensions` | `base` + [shed-extensions](https://charliek.github.io/shed-extensions/) credential brokering (SSH agent forwarding, AWS STS proxy, Docker credential helper) and the `shed-ext-rc` Remote Control helper. No Docker daemon, no coding agents pinned — start here for custom images. |
 | `full` | `extensions` + Docker CE (with `docker compose`), [mise](https://mise.jdx.dev/), [bun](https://bun.sh/), and coding agents (Claude Code, OpenCode, Codex CLI). The batteries-included default. |
 
 Each variant inherits from the one above it as a discrete OCI layer, so
 `shed image pull shed-vz-full` reuses the `base` and `extensions` layers
 already cached locally.
+
+!!! note "Autonomous Remote Control sessions need `full`"
+    `shed attach --plan` / Remote Control autonomous sessions drive Claude Code
+    via `shed-ext-rc`. `shed-ext-rc` ships in `extensions` and `full`, but Claude
+    Code is only in `full` — so the autonomous-plan workflow requires the `full`
+    variant (and Claude logged in inside the shed).
 
 !!! note "Docker is only in `full`"
     The Docker daemon ships **only** in the `full` variant. `base` and

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -186,6 +186,23 @@ type Session struct {
 	CreatedAt   time.Time `json:"created_at"`
 	Attached    bool      `json:"attached"`
 	WindowCount int       `json:"window_count,omitempty"`
+	// RC carries Remote Control Session Convention metadata for "rc-*" sessions,
+	// sourced client-side from the in-shed shed-ext-rc binary over SSH. It is nil
+	// for non-RC sessions and when enrichment was unavailable; server API
+	// responses never populate it.
+	RC *SessionRC `json:"rc,omitempty"`
+}
+
+// SessionRC holds the RC Session Convention fields surfaced for an "rc-*"
+// session (a subset of shed-ext-rc's neutral DTO, for display). Managed is
+// false for legacy/unmanaged rc-* sessions.
+type SessionRC struct {
+	Kind        string `json:"kind,omitempty"`
+	State       string `json:"state,omitempty"`
+	Managed     bool   `json:"managed"`
+	DisplayName string `json:"display_name,omitempty"`
+	URL         string `json:"url,omitempty"`
+	CreatedBy   string `json:"created_by,omitempty"`
 }
 
 // Session constants.

--- a/skills/shed-plan/SKILL.md
+++ b/skills/shed-plan/SKILL.md
@@ -41,8 +41,10 @@ already authed. If a run reports `needs-auth`, tell the user to
    - Defaults to `auto` permission mode (autonomous with safety checks).
    - Pass `--skip` **only if the user explicitly asks for full bypass** (no permission
      prompts at all) — confirm first; it is safe because the shed is an isolated VM.
-   - To override the default kickoff prompt, add `-p "..."` (a single line); otherwise
-     a default prompt that references the shipped plan is used.
+   - The plan is shipped to Claude's plans dir (`~/.claude/plans/plan-<slug>.md`), and a
+     generic "read the plan and implement it" kickoff is the default. To lead with your
+     own framing, add `-p "..."` (or `--prompt-file`) — your prompt runs and the plan
+     location is appended automatically, so you can send both.
 
 4. **Report back.** Surface the shed name, the `rc-<slug>` session, the
    `claude.ai/code/session_…` URL, and how to follow along:
@@ -55,7 +57,8 @@ already authed. If a run reports `needs-auth`, tell the user to
 - **Never use `--edit` / `--plan-edit`** here — they open `$EDITOR` and can't run
   unattended. Always pass the plan via `--plan <file>` and any prompt via `-p`.
 - **Default to `auto`.** Only use `--skip` on explicit user request, and say so.
-- Keep the kickoff **prompt** a single line; put all multi-step detail in the **plan**.
+- Put the multi-step detail in the **plan** file; keep any `-p` prompt to high-level
+  framing (prompts may be multi-line, but the plan is the place for the steps).
 - If `shed attach` reports `needs-auth`/`needs-trust`, relay the one-time fix rather
   than retrying blindly.
 - For the underlying shed operations (create, list, delete, servers), defer to the

--- a/skills/shed-plan/SKILL.md
+++ b/skills/shed-plan/SKILL.md
@@ -35,7 +35,7 @@ already authed. If a run reports `needs-auth`, tell the user to
    - Pick a short, recognizable shed name (e.g. `plan-<topic>`).
 
 3. **Ship the plan and start the run (detached):**
-   ```
+   ```bash
    shed attach <shed> --plan ./plan.md -d
    ```
    - Defaults to `auto` permission mode (autonomous with safety checks).

--- a/skills/shed-plan/SKILL.md
+++ b/skills/shed-plan/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: shed-plan
+description: "Use when the user wants to hand a plan or task off to a shed to run autonomously — phrases like 'send this plan to a shed', 'run this plan on a remote shed', 'spin up a shed and have it do X', 'kick off an agent on a shed to work on this while I close my laptop', or 'execute this autonomously on mini2/mini3'. This skill authors a plan file, creates (or reuses) a shed on a server, ships the plan, and starts an autonomous Claude Remote Control session you can watch from claude.ai. For everyday shed usage (create/list/attach/exec/sync without the autonomous-plan flow) use the `shed` skill instead."
+---
+
+# Shed Plan: run a plan autonomously on a remote shed
+
+Hand a multi-step plan to a **shed** (an isolated remote VM) and let a Claude agent
+execute it autonomously. You keep a `claude.ai/code` URL to watch and steer from your
+phone or browser; the laptop can close. Built on `shed attach`'s Remote Control mode,
+which drives the in-shed `shed-ext-rc` binary over SSH.
+
+Prerequisite: **Claude must be logged in inside the shed.** This is assumed, not set
+up by this skill — host login does not reach the shed VM. On servers that mount a
+persistent Claude config dir into sheds (e.g. the user's local Mac), a fresh shed is
+already authed. If a run reports `needs-auth`, tell the user to
+`shed attach <shed>` → run `claude` → `/login` once, then retry.
+
+## The flow
+
+1. **Author the plan.** Work with the user to produce a concrete, self-contained
+   markdown plan (goal, steps, acceptance criteria, how to verify). Save it to a local
+   file (e.g. `./plan.md` or under the scratchpad). The plan is shipped verbatim and
+   the agent is told to execute it to completion, so it must stand on its own — assume
+   no further human input mid-run.
+
+2. **Choose the target shed.**
+   - **Default: create a fresh, disposable shed per plan** (clean blast radius). Clone
+     the repo the work targets: `shed create <name> --repo <owner/repo> -s <server>`.
+     Use `--repo` (not `--local-dir`) — the value here is remote execution.
+   - **Ask which server** if the user didn't say (e.g. their default, `mini2`, `mini3`).
+     Don't guess across servers silently.
+   - **Reuse an existing shed only when the user directs it** ("use my shed X"): skip
+     `create` and target that shed.
+   - Pick a short, recognizable shed name (e.g. `plan-<topic>`).
+
+3. **Ship the plan and start the run (detached):**
+   ```
+   shed attach <shed> --plan ./plan.md -d
+   ```
+   - Defaults to `auto` permission mode (autonomous with safety checks).
+   - Pass `--skip` **only if the user explicitly asks for full bypass** (no permission
+     prompts at all) — confirm first; it is safe because the shed is an isolated VM.
+   - To override the default kickoff prompt, add `-p "..."` (a single line); otherwise
+     a default prompt that references the shipped plan is used.
+
+4. **Report back.** Surface the shed name, the `rc-<slug>` session, the
+   `claude.ai/code/session_…` URL, and how to follow along:
+   - Watch / steer: `shed attach <shed> --slug <slug>`
+   - Status across sheds: `shed sessions` (shows kind + state for `rc-*` sessions)
+   - Stop it: `shed sessions kill <shed> rc-<slug>`
+
+## Guardrails
+
+- **Never use `--edit` / `--plan-edit`** here — they open `$EDITOR` and can't run
+  unattended. Always pass the plan via `--plan <file>` and any prompt via `-p`.
+- **Default to `auto`.** Only use `--skip` on explicit user request, and say so.
+- Keep the kickoff **prompt** a single line; put all multi-step detail in the **plan**.
+- If `shed attach` reports `needs-auth`/`needs-trust`, relay the one-time fix rather
+  than retrying blindly.
+- For the underlying shed operations (create, list, delete, servers), defer to the
+  `shed` skill / `shed <cmd> --help`; this skill is the high-level workflow, not a CLI
+  manual — see `references/usage.md` for the exact flags it relies on.

--- a/skills/shed-plan/references/usage.md
+++ b/skills/shed-plan/references/usage.md
@@ -1,0 +1,59 @@
+# shed-plan: command reference
+
+The flags this skill relies on. `shed <command> --help` is the authoritative,
+version-matched source.
+
+## Create a fresh shed (default path)
+
+```
+shed create <name> --repo <owner/repo> -s <server>
+```
+
+| Flag | Purpose |
+|------|---------|
+| `--repo <owner/repo>` | Clone the target repo into the shed (preferred over `--local-dir` for remote autonomous runs). |
+| `-s, --server <name>` | Which server to create on. **Ask the user if unspecified.** |
+
+## Start an autonomous Remote Control run
+
+```
+shed attach <shed> --plan <file> -d [--skip] [-p "<single-line kickoff>"]
+```
+
+| Flag | Purpose |
+|------|---------|
+| `--plan <file>` | Ship a plan file into the shed (`-` reads stdin); the agent is told to execute it. |
+| `-d, --detach` | Create the session, print the `claude.ai` URL, and return without attaching. |
+| `--kind <k>` | Session kind: `claude-rc` (default), `claude-broker`, `shell`. The plan flow uses `claude-rc`. |
+| `-p, --prompt <line>` | Override the kickoff prompt (single line). Default references the shipped plan. |
+| `--permission-mode <m>` | `auto` (default) \| `acceptEdits` \| `plan` \| `dontAsk` \| `default` \| `bypassPermissions`. |
+| `--skip` | Shorthand for `--permission-mode bypassPermissions` (full bypass). Confirm with the user first. |
+| `--name <display>` | Session display name (default `<shed>/<slug>`). |
+| `--slug <slug>` | Set the session slug (otherwise generated). |
+
+Notes:
+- The plan is written to `<workdir>/.shed/plan-<slug>.md` inside the shed and the
+  default kickoff prompt references it. The kickoff prompt must be a single line.
+- Do **not** use `--edit` / `--plan-edit` in the autonomous flow (they open `$EDITOR`).
+- On an old shed image whose `shed-ext-rc` predates `--permission-mode`: an explicit
+  `--skip`/`--permission-mode` errors with an upgrade hint; the default `auto` falls
+  back to starting without an autonomous posture (with a warning).
+
+## Watch, list, stop
+
+```
+shed attach <shed> --slug <slug>     # attach a terminal to rc-<slug>
+shed sessions [<shed>] [--all] [--json]   # list (rc-* rows show KIND + RC-STATE)
+shed sessions kill <shed> rc-<slug>  # stop the session
+```
+
+## Auth prerequisite
+
+Claude must be logged in **inside the shed VM**. If a run reports `needs-auth`:
+
+```
+shed attach <shed>     # then run `claude`, do /login once, exit
+```
+
+then retry. Servers that mount a persistent Claude config dir into sheds make this
+automatic for fresh sheds.

--- a/skills/shed-plan/references/usage.md
+++ b/skills/shed-plan/references/usage.md
@@ -32,8 +32,12 @@ shed attach <shed> --plan <file> -d [--skip] [-p "<single-line kickoff>"]
 | `--slug <slug>` | Set the session slug (otherwise generated). |
 
 Notes:
-- The plan is written to `<workdir>/.shed/plan-<slug>.md` inside the shed and the
-  default kickoff prompt references it. The kickoff prompt must be a single line.
+- The plan is shipped to Claude's plans directory in the shed
+  (`~/.claude/plans/plan-<slug>.md`, outside the workspace so it never touches the repo);
+  the kickoff prompt references its absolute path.
+- `--plan` and `-p` can be combined: with no `-p`, a generic "read the plan and implement
+  it" kickoff is the default; with `-p`, your prompt leads and the plan location is
+  appended. Prompts may be multi-line (`--prompt-file`/`--edit`).
 - Do **not** use `--edit` / `--plan-edit` in the autonomous flow (they open `$EDITOR`).
 - On an old shed image whose `shed-ext-rc` predates `--permission-mode`: an explicit
   `--skip`/`--permission-mode` errors with an upgrade hint; the default `auto` falls

--- a/skills/shed-plan/references/usage.md
+++ b/skills/shed-plan/references/usage.md
@@ -5,7 +5,7 @@ version-matched source.
 
 ## Create a fresh shed (default path)
 
-```
+```bash
 shed create <name> --repo <owner/repo> -s <server>
 ```
 
@@ -16,7 +16,7 @@ shed create <name> --repo <owner/repo> -s <server>
 
 ## Start an autonomous Remote Control run
 
-```
+```bash
 shed attach <shed> --plan <file> -d [--skip] [-p "<single-line kickoff>"]
 ```
 
@@ -41,7 +41,7 @@ Notes:
 
 ## Watch, list, stop
 
-```
+```bash
 shed attach <shed> --slug <slug>     # attach a terminal to rc-<slug>
 shed sessions [<shed>] [--all] [--json]   # list (rc-* rows show KIND + RC-STATE)
 shed sessions kill <shed> rc-<slug>  # stop the session
@@ -51,7 +51,7 @@ shed sessions kill <shed> rc-<slug>  # stop the session
 
 Claude must be logged in **inside the shed VM**. If a run reports `needs-auth`:
 
-```
+```bash
 shed attach <shed>     # then run `claude`, do /login once, exit
 ```
 

--- a/skills/shed/SKILL.md
+++ b/skills/shed/SKILL.md
@@ -67,7 +67,7 @@ Usage notes that matter:
 - **One-off vs interactive:** `shed exec <name> <command...>` runs a single command over SSH with the argv passed through verbatim (it is not a shell), e.g. `shed exec myproj git status`. For pipes, `&&`, redirection, or `cd`, wrap it yourself: `shed exec myproj bash -lc "cd /workspace && npm test"`. Reserve `attach`/`console` for interactive work.
 - **Multi-server:** target one with `-s <server>`; sweep all with `--all` (on `list`, `sessions`, `system`).
 - **Scripting:** `--json` emits structured output. Destructive commands require `--force` when combined with `--json` (no interactive prompt).
-- **Autonomous agents:** to hand a plan to a shed and have Claude run it unattended (`shed attach --kind/--plan` creates a Remote Control `rc-*` session and returns a `claude.ai/code` URL), use the **`shed-plan`** skill — it covers authoring the plan, picking/creating the shed, and launching the run.
+- **Autonomous agents:** to hand a plan to a shed and have Claude run it unattended (`shed attach --kind/--plan` creates a Remote Control `rc-*` session; with `-d/--detach` it prints a `claude.ai/code` URL and returns instead of attaching), use the **`shed-plan`** skill — it covers authoring the plan, picking/creating the shed, and launching the run.
 
 ## Reaching services inside a shed (tunnels)
 

--- a/skills/shed/SKILL.md
+++ b/skills/shed/SKILL.md
@@ -67,6 +67,7 @@ Usage notes that matter:
 - **One-off vs interactive:** `shed exec <name> <command...>` runs a single command over SSH with the argv passed through verbatim (it is not a shell), e.g. `shed exec myproj git status`. For pipes, `&&`, redirection, or `cd`, wrap it yourself: `shed exec myproj bash -lc "cd /workspace && npm test"`. Reserve `attach`/`console` for interactive work.
 - **Multi-server:** target one with `-s <server>`; sweep all with `--all` (on `list`, `sessions`, `system`).
 - **Scripting:** `--json` emits structured output. Destructive commands require `--force` when combined with `--json` (no interactive prompt).
+- **Autonomous agents:** to hand a plan to a shed and have Claude run it unattended (`shed attach --kind/--plan` creates a Remote Control `rc-*` session and returns a `claude.ai/code` URL), use the **`shed-plan`** skill — it covers authoring the plan, picking/creating the shed, and launching the run.
 
 ## Reaching services inside a shed (tunnels)
 


### PR DESCRIPTION
## What

Adds the shed-CLI side of **"send a plan to a shed and run it autonomously"** — author a plan, ship it to a remote shed, and start a Claude Remote Control session that executes it unattended, with a `claude.ai/code` URL to watch/steer from your phone (laptop can close). Built on the existing `shed-ext-rc` convention (the same machinery shed-desktop / shed-remote-agent use). The shed-extensions binary side is **charliek/shed-extensions#43** (the `--permission-mode`/`--skip` posture); this PR works against it.

Three commits, each reviewed (`/simplify` + Codex):

1. **`shed sessions` RC enrichment** — `rc-*` sessions show `KIND`/`RC-STATE` (and an `rc` block in `--json`), read from `shed-ext-rc list` over SSH; bounded concurrency + per-call timeout; degrades silently. Decodes the cross-repo golden DTO fixture.
2. **`shed attach` Remote Control mode** — `--kind`/`--plan`/`--prompt` create an `rc-<slug>` session via `shed-ext-rc`; ships the plan into `<workdir>/.shed/plan-<slug>.md`; single-line kickoff prompt; posture `--permission-mode` (default `auto`) / `--skip`; `-d/--detach` prints the URL and returns; `--slug` connects to an existing session. Plain `shed attach` is unchanged. Old images (no `--permission-mode`) degrade gracefully. Shared `baseSSHArgs`; cheap validation before any auto-start.
3. **`shed-plan` skill + docs + changelog** — the end-to-end author → fresh shed (`--repo`, asks which server) → run (`auto`; `--skip` on request) → report flow.

## Validated live (end-to-end on a real shed)

Built the matching `shed-ext-rc` (shed-extensions#43), pushed it to a shed, and ran the whole CLI path:

- `shed attach <shed> --plan plan.md -d` (auto) → ships the plan, creates the RC session, prints the URL, and the plan **executes unattended** (proof file written).
- Same with `--skip` (bypass) → auto-accepts the one-time bypass dialog and executes unattended.
- `shed sessions` shows the enriched `claude-rc`/`ready` row.

## Scope / release

Pure client/CLI change — no server API or backend edits. Closes #199 (RC discovery now flows over SSH via `shed-ext-rc`). **Does not** bump `SHED_EXT_VERSION` in the Dockerfiles — that pin bump is a release-time step once shed-extensions#43 is released (lockstep); until then the CLI feature-detects and degrades. No version bump (release is gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added best-effort Remote Control (RC) metadata to `shed sessions` (shows `KIND` and `RC-STATE` for `rc-*` sessions, plus `rc` in `--json`).
  * Enhanced `shed attach` with Remote Control session creation/attachment, including prompt/plan support, slug generation, permission modes/skip, and detached workflows.
* **Documentation**
  * Added `shed-plan` skill documentation and updated CLI/guides/image notes for autonomous `shed attach --plan` with `claude.ai/code` monitoring.
* **Tests**
  * Expanded coverage for RC parsing, session rendering, SSH arg construction, input validation, slug generation, and RC enrichment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->