### PR TITLE
fix(tunnels): truly daemonize `shed tunnels start -d` + graceful stop (#223)

### DIFF
--- a/cmd/shed/tunnels.go
+++ b/cmd/shed/tunnels.go
@@ -292,6 +292,10 @@ func runForegroundTunnel(mgr *tunnels.Manager, shedName string, target tunnels.C
 	defer stop()
 	<-ctx.Done()
 
+	// Restore default signal handling before draining, so a second Ctrl+C
+	// force-quits instead of being swallowed if a connection is slow to close.
+	stop()
+
 	fmt.Println("\nStopping tunnels...")
 	for _, t := range activeTunnels {
 		t.Stop()

--- a/cmd/shed/tunnels.go
+++ b/cmd/shed/tunnels.go
@@ -332,8 +332,16 @@ func startBackgroundTunnel(mgr *tunnels.Manager, shedName, serverName string, ta
 	for _, t := range activeTunnels {
 		t.Stop()
 	}
-	mgr.State().RemoveTunnel(shedName)
-	_ = mgr.State().Save()
+	// Remove our own entry transactionally, and only if we still own it, so a
+	// tunnel started for another shed (or a --replace that swapped in a new
+	// daemon) isn't clobbered by this shutdown.
+	if err := mgr.State().Update(func(entries map[string]tunnels.TunnelEntry) {
+		if e, ok := entries[shedName]; ok && e.PID == os.Getpid() {
+			delete(entries, shedName)
+		}
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to clear tunnel state: %v\n", err)
+	}
 
 	return nil
 }

--- a/cmd/shed/tunnels.go
+++ b/cmd/shed/tunnels.go
@@ -52,6 +52,7 @@ var (
 	tunnelProfiles   []string
 	tunnelPorts      []string
 	tunnelBackground bool
+	tunnelDaemon     bool
 	tunnelReplace    bool
 	tunnelStopAll    bool
 )
@@ -131,6 +132,11 @@ func init() {
 	tunnelsStartCmd.Flags().StringArrayVarP(&tunnelPorts, "tunnel", "t", nil, "Explicit tunnel - \"3000\" or \"3001:3000\" (repeatable)")
 	tunnelsStartCmd.Flags().BoolVarP(&tunnelBackground, "background", "d", false, "Run as background daemon")
 	tunnelsStartCmd.Flags().BoolVar(&tunnelReplace, "replace", false, "Replace existing tunnel without prompting")
+	// --daemon is the internal re-exec marker: the detached worker spawned by -d.
+	// Users never set it directly; it tells runTunnelsStart to be the worker
+	// rather than fork another one.
+	tunnelsStartCmd.Flags().BoolVar(&tunnelDaemon, "daemon", false, "internal: run as the detached daemon worker")
+	_ = tunnelsStartCmd.Flags().MarkHidden("daemon")
 
 	tunnelsStopCmd.Flags().BoolVar(&tunnelStopAll, "all", false, "Stop all tunnels")
 
@@ -215,32 +221,35 @@ func runTunnelsStart(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "Warning: failed to clean up dead tunnels: %v\n", err)
 	}
 
-	// Check for existing tunnel
-	if existingEntry, ok := mgr.State().GetTunnel(shedName); ok {
-		alive, err := mgr.CheckHealth(shedName)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to check tunnel health: %v\n", err)
-		}
-		if alive {
-			if !tunnelReplace {
-				if jsonFlag {
-					return fmt.Errorf("tunnel already running for %s; use --replace with --json", shedName)
-				}
-				fmt.Printf("Tunnel already running for %s (profile: %s, PID %d).\n",
-					shedName, existingEntry.Profile, existingEntry.PID)
-				if stat, err := os.Stdin.Stat(); err == nil && (stat.Mode()&os.ModeCharDevice) == 0 {
-					return fmt.Errorf("tunnel already running for %s; use --replace in non-interactive mode", shedName)
-				}
-				if !confirmAction("Replace? [y/N] ") {
-					fmt.Println("Cancelled.")
-					return nil
-				}
+	// Check for existing tunnel. Skipped for the detached worker: the parent
+	// already handled replacement, and the worker has no stdin to prompt on.
+	if !tunnelDaemon {
+		if existingEntry, ok := mgr.State().GetTunnel(shedName); ok {
+			alive, err := mgr.CheckHealth(shedName)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to check tunnel health: %v\n", err)
 			}
-			if !jsonFlag {
-				fmt.Println("Stopping existing tunnel...")
-			}
-			if err := mgr.Stop(shedName); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to stop existing tunnel: %v\n", err)
+			if alive {
+				if !tunnelReplace {
+					if jsonFlag {
+						return fmt.Errorf("tunnel already running for %s; use --replace with --json", shedName)
+					}
+					fmt.Printf("Tunnel already running for %s (profile: %s, PID %d).\n",
+						shedName, existingEntry.Profile, existingEntry.PID)
+					if stat, err := os.Stdin.Stat(); err == nil && (stat.Mode()&os.ModeCharDevice) == 0 {
+						return fmt.Errorf("tunnel already running for %s; use --replace in non-interactive mode", shedName)
+					}
+					if !confirmAction("Replace? [y/N] ") {
+						fmt.Println("Cancelled.")
+						return nil
+					}
+				}
+				if !jsonFlag {
+					fmt.Println("Stopping existing tunnel...")
+				}
+				if err := mgr.Stop(shedName); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to stop existing tunnel: %v\n", err)
+				}
 			}
 		}
 	}
@@ -258,20 +267,26 @@ func runTunnelsStart(cmd *cobra.Command, args []string) error {
 	}
 
 	// Resolve how to reach the Connect API: pinned TLS + credentials token when
-	// the entry has an https api_url, else the legacy plain-TCP dial.
+	// the entry has an https api_url, else the legacy plain-TCP dial. Done here
+	// (before the daemon fork) so a misconfigured target fails in the user's
+	// terminal; the detached worker re-resolves it from config itself, keeping
+	// the credentials token off its command line.
 	target, err := connectTargetFromEntry(entry)
 	if err != nil {
 		return err
 	}
 
-	if tunnelBackground {
-		// Start tunnels, save state, and stay alive as a daemon process.
-		// Re-exec ourselves with a --daemon flag to detach from the terminal.
-		return startBackgroundTunnel(mgr, shedName, serverName, target, allPorts, profileName)
+	switch {
+	case tunnelBackground && !tunnelDaemon:
+		// Parent: re-exec a detached worker, wait for it to start, then return.
+		return spawnTunnelDaemon(shedName, allPorts)
+	case tunnelDaemon:
+		// Detached worker: start tunnels, report readiness, block on signal.
+		return runDaemonWorker(mgr, shedName, serverName, target, allPorts, profileName)
+	default:
+		// Foreground mode: start tunnels and block on signal.
+		return runForegroundTunnel(mgr, shedName, target, allPorts, profileName)
 	}
-
-	// Foreground mode: start tunnels and block on signal.
-	return runForegroundTunnel(mgr, shedName, target, allPorts, profileName)
 }
 
 func runForegroundTunnel(mgr *tunnels.Manager, shedName string, target tunnels.ConnectTarget, ports []tunnels.PortMapping, profile string) error {
@@ -299,52 +314,6 @@ func runForegroundTunnel(mgr *tunnels.Manager, shedName string, target tunnels.C
 	fmt.Println("\nStopping tunnels...")
 	for _, t := range activeTunnels {
 		t.Stop()
-	}
-
-	return nil
-}
-
-func startBackgroundTunnel(mgr *tunnels.Manager, shedName, serverName string, target tunnels.ConnectTarget, ports []tunnels.PortMapping, profile string) error {
-	// Start the tunnels in this process.
-	activeTunnels, err := mgr.StartTunnels(target, shedName, ports)
-	if err != nil {
-		return fmt.Errorf("failed to start tunnels: %w", err)
-	}
-
-	// Save state with our own PID so stop/list can find us.
-	if err := mgr.SaveBackground(shedName, serverName, profile, os.Getpid(), ports); err != nil {
-		for _, t := range activeTunnels {
-			t.Stop()
-		}
-		return fmt.Errorf("failed to save tunnel state: %w", err)
-	}
-
-	// The tunnel daemon keeps this process alive. The PID is saved to state
-	// so `shed tunnels stop` can send SIGTERM to tear it down.
-	// A future version could fork/detach for true daemonization.
-	printSuccess("Tunnel started for %s (profile: %s, PID %d)", shedName, profile, os.Getpid())
-	fmt.Println("Forwarding:")
-	for _, pm := range ports {
-		fmt.Printf("  localhost:%d -> %s:%d\n", pm.Local, shedName, pm.Remote)
-	}
-
-	// Block until signal (daemon behavior)
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
-	<-ctx.Done()
-
-	for _, t := range activeTunnels {
-		t.Stop()
-	}
-	// Remove our own entry transactionally, and only if we still own it, so a
-	// tunnel started for another shed (or a --replace that swapped in a new
-	// daemon) isn't clobbered by this shutdown.
-	if err := mgr.State().Update(func(entries map[string]tunnels.TunnelEntry) {
-		if e, ok := entries[shedName]; ok && e.PID == os.Getpid() {
-			delete(entries, shedName)
-		}
-	}); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to clear tunnel state: %v\n", err)
 	}
 
 	return nil

--- a/cmd/shed/tunnels_daemon.go
+++ b/cmd/shed/tunnels_daemon.go
@@ -102,10 +102,19 @@ func spawnTunnelDaemon(shedName string, ports []tunnels.PortMapping) error {
 // terminator if present so cobra parses it as a flag, not a positional.
 func daemonChildArgs(args []string) []string {
 	filtered := make([]string, 0, len(args)+1)
+	afterTerminator := false
 	for _, a := range args {
-		if a != "--daemon" {
+		if a == "--" {
+			afterTerminator = true
 			filtered = append(filtered, a)
+			continue
 		}
+		// Only dedupe the hidden flag among real flags; after "--" it's a
+		// positional value Cobra must keep verbatim.
+		if !afterTerminator && a == "--daemon" {
+			continue
+		}
+		filtered = append(filtered, a)
 	}
 	for i, a := range filtered {
 		if a == "--" {

--- a/cmd/shed/tunnels_daemon.go
+++ b/cmd/shed/tunnels_daemon.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/charliek/shed/internal/config"
+	"github.com/charliek/shed/internal/tunnels"
+)
+
+// readyFDEnv names the inherited pipe fd the detached worker writes its startup
+// result to. spawnTunnelDaemon passes the pipe as ExtraFiles[0], which the child
+// sees as fd 3.
+const readyFDEnv = "SHED_TUNNEL_READY_FD"
+
+// daemonReadyTimeout bounds how long the parent waits for the worker to report
+// it is listening. It must cover the worker's config load + findShedServer +
+// ensureRunningShed + listener bind; the parent already started the shed, so
+// those are fast, but be generous.
+const daemonReadyTimeout = 15 * time.Second
+
+// spawnTunnelDaemon re-execs this binary as a detached background worker for the
+// given shed, waits for it to report that the tunnels are listening, then
+// returns — handing the terminal back while the worker keeps running. The
+// worker re-resolves its connect target from config, so the credentials token
+// never appears on its command line.
+func spawnTunnelDaemon(shedName string, ports []tunnels.PortMapping) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate shed binary: %w", err)
+	}
+
+	if err := os.MkdirAll(config.GetTunnelLogDir(), 0700); err != nil {
+		return fmt.Errorf("create tunnel log dir: %w", err)
+	}
+	logPath := config.GetTunnelLogPath(shedName)
+	// O_TRUNC: each start resets the per-shed log. The log is error-only and not
+	// rotated (see docs/reference/tunnels.md).
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("open tunnel log %s: %w", logPath, err)
+	}
+	defer logFile.Close()
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", os.DevNull, err)
+	}
+	defer devNull.Close()
+
+	readyR, readyW, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("create readiness pipe: %w", err)
+	}
+	defer readyR.Close()
+
+	cmd := exec.Command(exe, daemonChildArgs(os.Args[1:])...)
+	cmd.Stdin = devNull
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile // same *os.File as Stdout: one fd, no interleaving
+	cmd.ExtraFiles = []*os.File{readyW}
+	cmd.Env = append(os.Environ(), readyFDEnv+"=3")
+	// New session: detach from the controlling terminal so closing it (SIGHUP)
+	// doesn't kill the tunnel. Deliberately no Pdeathsig — unlike the egress
+	// proxy, this child must outlive its parent.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	if err := cmd.Start(); err != nil {
+		readyW.Close()
+		return fmt.Errorf("start tunnel daemon: %w", err)
+	}
+	// The child holds its own copy of the write end; close ours so our read
+	// unblocks with EOF if the child dies without reporting.
+	readyW.Close()
+
+	if err := awaitDaemonReady(readyR, daemonReadyTimeout); err != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		return fmt.Errorf("%w (see %s)", err, logPath)
+	}
+
+	printSuccess("Tunnel started for %s (PID %d)", shedName, cmd.Process.Pid)
+	fmt.Println("Forwarding:")
+	for _, pm := range ports {
+		fmt.Printf("  localhost:%d -> %s:%d\n", pm.Local, shedName, pm.Remote)
+	}
+	fmt.Printf("Logs: %s\n", logPath)
+	return nil
+}
+
+// daemonChildArgs builds the argv for the detached worker: the parent's args
+// with exactly one hidden --daemon flag. Any existing --daemon is dropped first
+// (so a stray re-exec can't compound it), and the flag is inserted before a "--"
+// terminator if present so cobra parses it as a flag, not a positional.
+func daemonChildArgs(args []string) []string {
+	filtered := make([]string, 0, len(args)+1)
+	for _, a := range args {
+		if a != "--daemon" {
+			filtered = append(filtered, a)
+		}
+	}
+	for i, a := range filtered {
+		if a == "--" {
+			return append(filtered[:i:i], append([]string{"--daemon"}, filtered[i:]...)...)
+		}
+	}
+	return append(filtered, "--daemon")
+}
+
+// awaitDaemonReady reads one readiness line from the worker, bounded by timeout.
+// A bare EOF (no line) means the worker died during startup.
+func awaitDaemonReady(r *os.File, timeout time.Duration) error {
+	type result struct {
+		line string
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		// *os.File deadlines aren't reliable on pipes, so read in a goroutine
+		// and race it against the timeout instead.
+		line, err := bufio.NewReader(r).ReadString('\n')
+		ch <- result{line: line, err: err}
+	}()
+
+	select {
+	case res := <-ch:
+		if strings.TrimSpace(res.line) == "" {
+			return fmt.Errorf("tunnel daemon exited before reporting readiness")
+		}
+		return parseReadyMessage(res.line)
+	case <-time.After(timeout):
+		return fmt.Errorf("tunnel daemon did not report readiness within %s", timeout)
+	}
+}
+
+// parseReadyMessage interprets the worker's readiness line: "OK" means the
+// tunnels are listening; "ERR:<msg>" carries a startup failure.
+func parseReadyMessage(line string) error {
+	line = strings.TrimSpace(line)
+	switch {
+	case line == "OK":
+		return nil
+	case strings.HasPrefix(line, "ERR:"):
+		return fmt.Errorf("tunnel daemon failed: %s", strings.TrimSpace(strings.TrimPrefix(line, "ERR:")))
+	default:
+		return fmt.Errorf("tunnel daemon sent unexpected readiness message %q", line)
+	}
+}
+
+// runDaemonWorker is the detached worker (the --daemon re-exec). It starts the
+// tunnels, records state under its own detached PID, reports the outcome to the
+// parent over the inherited pipe, then blocks until signalled and tears down.
+// The ordering is load-bearing: listeners bound -> state saved -> "OK" written,
+// so `shed tunnels list` immediately after the parent returns sees the entry.
+func runDaemonWorker(mgr *tunnels.Manager, shedName, serverName string, target tunnels.ConnectTarget, ports []tunnels.PortMapping, profile string) error {
+	ready, err := openReadyPipe()
+	if err != nil {
+		return err
+	}
+
+	// Bind listeners, then record state under our own (detached) PID.
+	activeTunnels, startErr := mgr.StartTunnels(target, shedName, ports)
+	if startErr != nil {
+		startErr = fmt.Errorf("failed to start tunnels: %w", startErr)
+	} else if saveErr := mgr.SaveBackground(shedName, serverName, profile, os.Getpid(), ports); saveErr != nil {
+		for _, t := range activeTunnels {
+			t.Stop()
+		}
+		startErr = fmt.Errorf("failed to save tunnel state: %w", saveErr)
+	}
+	if startErr != nil {
+		fmt.Fprintf(ready, "ERR:%s\n", startErr)
+		_ = ready.Close()
+		return startErr
+	}
+
+	if _, err := fmt.Fprintln(ready, "OK"); err != nil {
+		// The parent is gone or the pipe broke; tear down rather than leak an
+		// untracked daemon.
+		stopDaemonTunnels(mgr, shedName, activeTunnels)
+		_ = ready.Close()
+		return fmt.Errorf("signal readiness: %w", err)
+	}
+	_ = ready.Close()
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	<-ctx.Done()
+
+	stopDaemonTunnels(mgr, shedName, activeTunnels)
+	return nil
+}
+
+// openReadyPipe returns the inherited readiness pipe, or an error if this
+// process wasn't launched as a worker — so a manual `--daemon` invocation fails
+// fast instead of hanging on or writing to a bogus fd.
+func openReadyPipe() (*os.File, error) {
+	v := os.Getenv(readyFDEnv)
+	if v == "" {
+		return nil, fmt.Errorf("--daemon is internal and must be launched by `shed tunnels start -d` (%s not set)", readyFDEnv)
+	}
+	fd, err := strconv.Atoi(v)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s=%q: %w", readyFDEnv, v, err)
+	}
+	return os.NewFile(uintptr(fd), "tunnel-ready"), nil
+}
+
+func stopDaemonTunnels(mgr *tunnels.Manager, shedName string, activeTunnels []*tunnels.Tunnel) {
+	for _, t := range activeTunnels {
+		t.Stop()
+	}
+	if err := mgr.RemoveOwnedTunnel(shedName, os.Getpid()); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to clear tunnel state: %v\n", err)
+	}
+}

--- a/cmd/shed/tunnels_daemon_test.go
+++ b/cmd/shed/tunnels_daemon_test.go
@@ -32,6 +32,11 @@ func TestDaemonChildArgs(t *testing.T) {
 			in:   []string{"tunnels", "start", "myshed", "-d", "--", "extra"},
 			want: []string{"tunnels", "start", "myshed", "-d", "--daemon", "--", "extra"},
 		},
+		{
+			name: "keeps a positional --daemon after the terminator",
+			in:   []string{"tunnels", "start", "myshed", "--", "--daemon"},
+			want: []string{"tunnels", "start", "myshed", "--daemon", "--", "--daemon"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/shed/tunnels_daemon_test.go
+++ b/cmd/shed/tunnels_daemon_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestDaemonChildArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "appends --daemon",
+			in:   []string{"tunnels", "start", "myshed", "-t", "3000", "-d"},
+			want: []string{"tunnels", "start", "myshed", "-t", "3000", "-d", "--daemon"},
+		},
+		{
+			name: "preserves global flags",
+			in:   []string{"-s", "srv", "-c", "/cfg.yaml", "tunnels", "start", "myshed", "-p", "dev", "-d"},
+			want: []string{"-s", "srv", "-c", "/cfg.yaml", "tunnels", "start", "myshed", "-p", "dev", "-d", "--daemon"},
+		},
+		{
+			name: "dedups an existing --daemon",
+			in:   []string{"tunnels", "start", "myshed", "--daemon", "-d"},
+			want: []string{"tunnels", "start", "myshed", "-d", "--daemon"},
+		},
+		{
+			name: "inserts before a -- terminator",
+			in:   []string{"tunnels", "start", "myshed", "-d", "--", "extra"},
+			want: []string{"tunnels", "start", "myshed", "-d", "--daemon", "--", "extra"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := daemonChildArgs(tc.in)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("daemonChildArgs(%v)\n  = %v\n want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDaemonChildArgsNoTokenInjected documents the token-hygiene contract: the
+// child argv is exactly the parent's argv (+ --daemon). The credentials token
+// comes from config, never the command line, so it cannot leak into the worker's
+// argv / `ps`.
+func TestDaemonChildArgsNoTokenInjected(t *testing.T) {
+	in := []string{"tunnels", "start", "myshed", "-d"}
+	got := daemonChildArgs(in)
+	for _, a := range got {
+		if a != "--daemon" && !slices.Contains(in, a) {
+			t.Errorf("daemonChildArgs injected an unexpected arg %q (token leak risk)", a)
+		}
+	}
+}
+
+func TestParseReadyMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		wantErr bool
+		wantMsg string // substring expected in the error, when wantErr
+	}{
+		{name: "ok", line: "OK\n", wantErr: false},
+		{name: "ok no newline", line: "OK", wantErr: false},
+		{name: "error carries message", line: "ERR:port 3000 in use\n", wantErr: true, wantMsg: "port 3000 in use"},
+		{name: "empty is unexpected", line: "", wantErr: true, wantMsg: "unexpected"},
+		{name: "garbage is unexpected", line: "weird line\n", wantErr: true, wantMsg: "unexpected"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := parseReadyMessage(tc.line)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("parseReadyMessage(%q) err = %v, wantErr = %v", tc.line, err, tc.wantErr)
+			}
+			if tc.wantErr && tc.wantMsg != "" && !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("parseReadyMessage(%q) err = %q, want substring %q", tc.line, err.Error(), tc.wantMsg)
+			}
+		})
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -949,8 +949,13 @@ shed tunnels start <shed> [flags]
 |------|-------|---------|-------------|
 | `--profile` | `-p` | None | Use tunnel profile |
 | `--tunnel` | `-t` | None | Port mapping (local:remote) |
-| `--background` | `-d` | `false` | Run in background |
+| `--background` | `-d` | `false` | Detach and run as a background daemon |
 | `--replace` | | `false` | Replace existing tunnel without prompting |
+
+Without `-d`, runs in the foreground (`Ctrl+C` to stop). With `-d`, detaches
+into a daemon that outlives the terminal and returns your shell once the tunnels
+are listening; manage it with `shed tunnels list` / `shed tunnels stop`. See
+[Tunnels › Background Mode](tunnels.md#background-mode) for details.
 
 **Examples:**
 

--- a/docs/reference/tunnels.md
+++ b/docs/reference/tunnels.md
@@ -111,14 +111,29 @@ shed tunnels config <shed> [flags]
 
 Shows the port mappings and server address that would be used, without starting tunnels.
 
+## Foreground Mode
+
+Without `-d`, `shed tunnels start` runs in the foreground and prints the active
+forwards. Press `Ctrl+C` to stop — open connections are torn down and the
+command exits promptly. (A second `Ctrl+C` force-quits if a connection is slow
+to close.)
+
 ## Background Mode
 
-When running with `-d`, the tunnel process stays alive in the background:
+With `-d`, `shed tunnels start` detaches: it starts the tunnels in a separate
+daemon process, prints the forwards, and returns your shell. The daemon keeps
+running after the launching terminal is closed.
 
-- The process PID is saved to `~/.shed/tunnels.state`
-- Use `shed tunnels list` to see active tunnels
-- Use `shed tunnels stop <shed>` to terminate
-- Dead tunnel processes are automatically cleaned up on next `list` or `start`
+- `shed tunnels start <shed> -d` returns once the tunnels are listening (it
+  reports a real error if startup fails, rather than hanging).
+- The daemon's PID is recorded in `~/.shed/tunnel-state.json`.
+- Use `shed tunnels list` to see active tunnels and `shed tunnels stop <shed>`
+  to terminate one (it signals the daemon).
+- Dead tunnel daemons are cleaned out of the state file on the next `list` or
+  `start`.
+- Each daemon writes connection errors to `~/.shed/logs/tunnel-<shed>.log`. The
+  file is truncated on each start and is not rotated (it only records errors, so
+  it stays small in normal use).
 
 ## Port Conflicts
 

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -99,6 +99,16 @@ func GetTunnelStatePath() string {
 	return filepath.Join(GetClientConfigDir(), "tunnel-state.json")
 }
 
+// GetTunnelLogDir returns the directory holding background tunnel daemon logs.
+func GetTunnelLogDir() string {
+	return filepath.Join(GetClientConfigDir(), "logs")
+}
+
+// GetTunnelLogPath returns the log path for a shed's background tunnel daemon.
+func GetTunnelLogPath(shedName string) string {
+	return filepath.Join(GetTunnelLogDir(), "tunnel-"+shedName+".log")
+}
+
 // GetSyncConfigPath returns the path to the sync config file.
 func GetSyncConfigPath() string {
 	return filepath.Join(GetClientConfigDir(), "sync.yaml")

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,8 +106,10 @@ func GetTunnelLogDir() string {
 }
 
 // GetTunnelLogPath returns the log path for a shed's background tunnel daemon.
+// shedName is escaped so a name containing path separators can't traverse out
+// of the log directory (the daemon opens this path with O_TRUNC).
 func GetTunnelLogPath(shedName string) string {
-	return filepath.Join(GetTunnelLogDir(), "tunnel-"+shedName+".log")
+	return filepath.Join(GetTunnelLogDir(), "tunnel-"+url.PathEscape(shedName)+".log")
 }
 
 // GetSyncConfigPath returns the path to the sync config file.

--- a/internal/config/client_test.go
+++ b/internal/config/client_test.go
@@ -1,6 +1,20 @@
 package config
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestTunnelLogPaths(t *testing.T) {
+	wantDir := filepath.Join(GetClientConfigDir(), "logs")
+	if got := GetTunnelLogDir(); got != wantDir {
+		t.Errorf("GetTunnelLogDir() = %q, want %q", got, wantDir)
+	}
+	wantPath := filepath.Join(wantDir, "tunnel-myproj.log")
+	if got := GetTunnelLogPath("myproj"); got != wantPath {
+		t.Errorf("GetTunnelLogPath(myproj) = %q, want %q", got, wantPath)
+	}
+}
 
 func TestServerEntryBaseURL(t *testing.T) {
 	tests := []struct {

--- a/internal/tunnels/connect.go
+++ b/internal/tunnels/connect.go
@@ -61,6 +61,9 @@ func (c *ConnectClient) Dial(ctx context.Context, shedName string, port uint16) 
 	req.WriteString("\r\n")
 	if _, err := conn.Write([]byte(req.String())); err != nil {
 		conn.Close()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr // watcher closed conn on cancel; report cancellation, not a write error
+		}
 		return nil, fmt.Errorf("send upgrade request: %w", err)
 	}
 
@@ -69,6 +72,9 @@ func (c *ConnectClient) Dial(ctx context.Context, shedName string, port uint16) 
 	resp, err := http.ReadResponse(reader, nil)
 	if err != nil {
 		conn.Close()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr // watcher closed conn on cancel; report cancellation, not a read error
+		}
 		return nil, fmt.Errorf("read upgrade response: %w", err)
 	}
 

--- a/internal/tunnels/connect.go
+++ b/internal/tunnels/connect.go
@@ -44,6 +44,13 @@ func (c *ConnectClient) Dial(ctx context.Context, shedName string, port uint16) 
 		return nil, err
 	}
 
+	// The upgrade write + http.ReadResponse below don't honor ctx on their own,
+	// so a server that accepts the connection but never sends 101 would block
+	// forever — wedging Tunnel.Stop(). Close the conn if ctx is cancelled during
+	// the handshake.
+	stopWatch := closeConnsOnCancel(ctx, conn)
+	defer stopWatch()
+
 	// Send the HTTP upgrade request (over TLS when c.dial wrapped the conn).
 	path := fmt.Sprintf("/api/sheds/%s/connect/%d", shedName, port)
 	var req strings.Builder
@@ -71,6 +78,15 @@ func (c *ConnectClient) Dial(ctx context.Context, shedName string, port uint16) 
 		}
 		conn.Close()
 		return nil, fmt.Errorf("connect API returned HTTP %d (expected 101)", resp.StatusCode)
+	}
+
+	// Stop the cancel-watcher before handing the conn back so it can't close the
+	// conn we return; if ctx was cancelled mid-handshake, fail instead of
+	// returning a conn the watcher may already have closed.
+	stopWatch()
+	if ctx.Err() != nil {
+		conn.Close()
+		return nil, ctx.Err()
 	}
 
 	return &vmutil.BufferedConn{Conn: conn, Reader: reader}, nil

--- a/internal/tunnels/manager.go
+++ b/internal/tunnels/manager.go
@@ -127,6 +127,17 @@ func (m *Manager) StopAllTunnelsForShed(shedName string) error {
 	return err
 }
 
+// RemoveOwnedTunnel removes a shed's tunnel entry only if it is still owned by
+// the given PID. A background daemon calls this on shutdown (with its own PID)
+// so it never deletes an entry that a --replace swapped in for a newer daemon.
+func (m *Manager) RemoveOwnedTunnel(shedName string, pid int) error {
+	return m.state.Update(func(tunnels map[string]TunnelEntry) {
+		if e, ok := tunnels[shedName]; ok && e.PID == pid {
+			delete(tunnels, shedName)
+		}
+	})
+}
+
 // StopAll stops all tunnels.
 func (m *Manager) StopAll() error {
 	var pids []int

--- a/internal/tunnels/manager.go
+++ b/internal/tunnels/manager.go
@@ -73,47 +73,76 @@ func (m *Manager) StartTunnels(target ConnectTarget, shedName string, ports []Po
 
 // SaveBackground saves the state for a background tunnel daemon.
 func (m *Manager) SaveBackground(shedName, serverName, profile string, pid int, ports []PortMapping) error {
-	m.state.SetTunnel(shedName, TunnelEntry{
-		ShedName:   shedName,
-		Profile:    profile,
-		PID:        pid,
-		Ports:      ports,
-		StartedAt:  time.Now(),
-		ServerName: serverName,
+	return m.state.Update(func(tunnels map[string]TunnelEntry) {
+		tunnels[shedName] = TunnelEntry{
+			ShedName:   shedName,
+			Profile:    profile,
+			PID:        pid,
+			Ports:      ports,
+			StartedAt:  time.Now(),
+			ServerName: serverName,
+		}
 	})
-	return m.state.Save()
 }
 
-// Stop stops a tunnel for a shed by signaling its daemon process.
+// killAndRemove removes a shed's tunnel entry and signals its daemon. The PID
+// is read and the entry deleted inside one locked read-modify-write, so the
+// process we signal is exactly the entry we remove — a concurrent replacement
+// can't leave us killing the old daemon while deleting the new one's state.
+// Returns whether a tunnel was found.
+func (m *Manager) killAndRemove(shedName string) (bool, error) {
+	var pid int
+	found := false
+	if err := m.state.Update(func(tunnels map[string]TunnelEntry) {
+		if e, ok := tunnels[shedName]; ok {
+			pid, found = e.PID, true
+			delete(tunnels, shedName)
+		}
+	}); err != nil {
+		return false, err
+	}
+	if found {
+		_ = m.killProcess(pid)
+	}
+	return found, nil
+}
+
+// Stop stops a tunnel for a shed by signaling its daemon process and removing
+// its state entry. It errors if no tunnel is recorded for the shed.
 func (m *Manager) Stop(shedName string) error {
-	entry, ok := m.state.GetTunnel(shedName)
-	if !ok {
+	found, err := m.killAndRemove(shedName)
+	if err != nil {
+		return err
+	}
+	if !found {
 		return fmt.Errorf("no tunnel found for shed %q", shedName)
 	}
-
-	_ = m.killProcess(entry.PID)
-	m.state.RemoveTunnel(shedName)
-	return m.state.Save()
+	return nil
 }
 
-// StopAllTunnelsForShed stops any tunnel for a specific shed.
+// StopAllTunnelsForShed stops any tunnel for a specific shed, succeeding even
+// when none is running.
 func (m *Manager) StopAllTunnelsForShed(shedName string) error {
-	entry, ok := m.state.GetTunnel(shedName)
-	if !ok {
-		return nil
-	}
-	_ = m.killProcess(entry.PID)
-	m.state.RemoveTunnel(shedName)
-	return m.state.Save()
+	_, err := m.killAndRemove(shedName)
+	return err
 }
 
 // StopAll stops all tunnels.
 func (m *Manager) StopAll() error {
-	for shedName, entry := range m.state.GetAllTunnels() {
-		_ = m.killProcess(entry.PID)
-		m.state.RemoveTunnel(shedName)
+	var pids []int
+	err := m.state.Update(func(tunnels map[string]TunnelEntry) {
+		for shedName, entry := range tunnels {
+			pids = append(pids, entry.PID)
+			delete(tunnels, shedName)
+		}
+	})
+	if err != nil {
+		return err
 	}
-	return m.state.Save()
+	for _, pid := range pids {
+		_ = m.killProcess(pid)
+	}
+	return nil
 }
 
 // CheckHealth checks if a tunnel process is still alive.
@@ -125,19 +154,16 @@ func (m *Manager) CheckHealth(shedName string) (bool, error) {
 	return m.isProcessAlive(entry.PID), nil
 }
 
-// CleanupDeadTunnels removes state entries for dead processes.
+// CleanupDeadTunnels removes state entries for dead processes. It re-reads the
+// state under lock so a concurrently-started tunnel is preserved.
 func (m *Manager) CleanupDeadTunnels() error {
-	changed := false
-	for shedName, entry := range m.state.GetAllTunnels() {
-		if !m.isProcessAlive(entry.PID) {
-			m.state.RemoveTunnel(shedName)
-			changed = true
+	return m.state.Update(func(tunnels map[string]TunnelEntry) {
+		for shedName, entry := range tunnels {
+			if !m.isProcessAlive(entry.PID) {
+				delete(tunnels, shedName)
+			}
 		}
-	}
-	if changed {
-		return m.state.Save()
-	}
-	return nil
+	})
 }
 
 // CheckPortConflict checks if a local port is available.

--- a/internal/tunnels/manager_test.go
+++ b/internal/tunnels/manager_test.go
@@ -2,9 +2,40 @@ package tunnels
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
+
+func TestRemoveOwnedTunnel(t *testing.T) {
+	cfg := &TunnelConfig{Sheds: make(map[string]ShedConfig)}
+	state := &TunnelState{
+		Tunnels: make(map[string]TunnelEntry),
+		path:    filepath.Join(t.TempDir(), "state.json"),
+	}
+	mgr := NewManagerWithConfig(cfg, state)
+
+	// A replacement daemon (PID 222) owns the entry.
+	if err := mgr.SaveBackground("web", "srv", "default", 222, []PortMapping{{Local: 3000, Remote: 3000}}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// A stale daemon (PID 111) must not remove the replacement's entry.
+	if err := mgr.RemoveOwnedTunnel("web", 111); err != nil {
+		t.Fatalf("remove (non-owner): %v", err)
+	}
+	if _, ok := mgr.State().GetTunnel("web"); !ok {
+		t.Error("entry was removed by a non-owner PID")
+	}
+
+	// The owner removes it.
+	if err := mgr.RemoveOwnedTunnel("web", 222); err != nil {
+		t.Fatalf("remove (owner): %v", err)
+	}
+	if _, ok := mgr.State().GetTunnel("web"); ok {
+		t.Error("owner failed to remove its entry")
+	}
+}
 
 func TestCheckPortConflict(t *testing.T) {
 	cfg := &TunnelConfig{

--- a/internal/tunnels/state.go
+++ b/internal/tunnels/state.go
@@ -42,32 +42,16 @@ func LoadTunnelStateFromPath(path string) (*TunnelState, error) {
 	}
 	defer func() { _ = lock.Unlock() }()
 
-	state := &TunnelState{
-		Tunnels: make(map[string]TunnelEntry),
-		path:    path,
-	}
-
-	data, err := os.ReadFile(path)
+	tunnels, err := readTunnels(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return state, nil
-		}
-		return nil, fmt.Errorf("failed to read tunnel state: %w", err)
+		return nil, err
 	}
-
-	if err := json.Unmarshal(data, state); err != nil {
-		return nil, fmt.Errorf("failed to parse tunnel state: %w", err)
-	}
-
-	if state.Tunnels == nil {
-		state.Tunnels = make(map[string]TunnelEntry)
-	}
-
-	state.path = path
-	return state, nil
+	return &TunnelState{Tunnels: tunnels, path: path}, nil
 }
 
-// Save writes the tunnel state to disk.
+// Save writes the in-memory tunnel state to disk, replacing the file's
+// contents. It is not transactional — for concurrent-safe partial mutations
+// (the normal case), use Update instead.
 func (s *TunnelState) Save() error {
 	return s.SaveToPath(s.path)
 }
@@ -81,12 +65,71 @@ func (s *TunnelState) SaveToPath(path string) error {
 	}
 	defer func() { _ = lock.Unlock() }()
 
+	if err := writeTunnels(path, s.Tunnels); err != nil {
+		return err
+	}
+	s.path = path
+	return nil
+}
+
+// Update atomically applies mutate to the on-disk tunnel state under a single
+// lock acquisition (load → mutate → save). Reloading inside the lock prevents a
+// long-lived process (e.g. a background tunnel daemon) from clobbering entries
+// written by other processes since it last loaded — the bug that lets one
+// daemon's shutdown silently delete another shed's tunnel entry. On success the
+// in-memory map is refreshed to the persisted result.
+//
+// mutate runs while the state lock is held; it must only touch the supplied map
+// and must not call other state methods (they would deadlock on the same lock).
+func (s *TunnelState) Update(mutate func(tunnels map[string]TunnelEntry)) error {
+	lock := NewFileLock(s.path)
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("failed to acquire state lock: %w", err)
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	tunnels, err := readTunnels(s.path)
+	if err != nil {
+		return err
+	}
+	mutate(tunnels)
+	if err := writeTunnels(s.path, tunnels); err != nil {
+		return err
+	}
+	s.Tunnels = tunnels
+	return nil
+}
+
+// readTunnels reads and parses the tunnel map from path. The caller must hold
+// the state lock. A missing file yields an empty (non-nil) map.
+func readTunnels(path string) (map[string]TunnelEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]TunnelEntry), nil
+		}
+		return nil, fmt.Errorf("failed to read tunnel state: %w", err)
+	}
+
+	var state TunnelState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("failed to parse tunnel state: %w", err)
+	}
+	if state.Tunnels == nil {
+		state.Tunnels = make(map[string]TunnelEntry)
+	}
+	return state.Tunnels, nil
+}
+
+// writeTunnels atomically writes the tunnel map to path via a temp file +
+// rename. The caller must hold the state lock.
+func writeTunnels(path string, tunnels map[string]TunnelEntry) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("failed to create state directory: %w", err)
 	}
 
-	data, err := json.MarshalIndent(s, "", "  ")
+	data, err := json.MarshalIndent(&TunnelState{Tunnels: tunnels}, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal state: %w", err)
 	}
@@ -95,13 +138,10 @@ func (s *TunnelState) SaveToPath(path string) error {
 	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write state file: %w", err)
 	}
-
 	if err := os.Rename(tmpPath, path); err != nil {
 		os.Remove(tmpPath)
 		return fmt.Errorf("failed to save state file: %w", err)
 	}
-
-	s.path = path
 	return nil
 }
 
@@ -109,16 +149,6 @@ func (s *TunnelState) SaveToPath(path string) error {
 func (s *TunnelState) GetTunnel(shedName string) (TunnelEntry, bool) {
 	entry, ok := s.Tunnels[shedName]
 	return entry, ok
-}
-
-// SetTunnel sets the tunnel entry for a shed.
-func (s *TunnelState) SetTunnel(shedName string, entry TunnelEntry) {
-	s.Tunnels[shedName] = entry
-}
-
-// RemoveTunnel removes the tunnel entry for a shed.
-func (s *TunnelState) RemoveTunnel(shedName string) {
-	delete(s.Tunnels, shedName)
 }
 
 // GetAllTunnels returns all tunnel entries.

--- a/internal/tunnels/state_test.go
+++ b/internal/tunnels/state_test.go
@@ -267,7 +267,10 @@ func TestUpdatePIDGuardedRemoval(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("old-daemon update: %v", err)
 	}
-	loaded, _ := LoadTunnelStateFromPath(path)
+	loaded, err := LoadTunnelStateFromPath(path)
+	if err != nil {
+		t.Fatalf("reload after non-owner update: %v", err)
+	}
 	if e, ok := loaded.GetTunnel("web"); !ok || e.PID != 222 {
 		t.Fatal("replacement entry should survive removal attempt by stale old daemon")
 	}
@@ -280,7 +283,10 @@ func TestUpdatePIDGuardedRemoval(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("owner update: %v", err)
 	}
-	loaded, _ = LoadTunnelStateFromPath(path)
+	loaded, err = LoadTunnelStateFromPath(path)
+	if err != nil {
+		t.Fatalf("reload after owner update: %v", err)
+	}
 	if _, ok := loaded.GetTunnel("web"); ok {
 		t.Fatal("owning daemon should have removed its own entry")
 	}

--- a/internal/tunnels/state_test.go
+++ b/internal/tunnels/state_test.go
@@ -1,8 +1,10 @@
 package tunnels
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -76,18 +78,18 @@ func TestTunnelStateSave(t *testing.T) {
 	statePath := filepath.Join(tmpDir, "state.json")
 
 	state := &TunnelState{
-		Tunnels: make(map[string]TunnelEntry),
-		path:    statePath,
+		Tunnels: map[string]TunnelEntry{
+			"myproj": {
+				ShedName:   "myproj",
+				Profile:    "default",
+				PID:        54321,
+				Ports:      []PortMapping{{Local: 3000, Remote: 3000}},
+				StartedAt:  time.Now(),
+				ServerName: "home",
+			},
+		},
+		path: statePath,
 	}
-
-	state.SetTunnel("myproj", TunnelEntry{
-		ShedName:   "myproj",
-		Profile:    "default",
-		PID:        54321,
-		Ports:      []PortMapping{{Local: 3000, Remote: 3000}},
-		StartedAt:  time.Now(),
-		ServerName: "home",
-	})
 
 	if err := state.Save(); err != nil {
 		t.Fatalf("failed to save state: %v", err)
@@ -111,16 +113,21 @@ func TestTunnelStateSave(t *testing.T) {
 func TestTunnelStateOperations(t *testing.T) {
 	state := &TunnelState{
 		Tunnels: make(map[string]TunnelEntry),
+		path:    filepath.Join(t.TempDir(), "state.json"),
 	}
 
 	// Set tunnel
-	state.SetTunnel("proj1", TunnelEntry{
-		ShedName:  "proj1",
-		Profile:   "default",
-		PID:       1000,
-		Ports:     []PortMapping{{Local: 3000, Remote: 3000}},
-		StartedAt: time.Now(),
-	})
+	if err := state.Update(func(tunnels map[string]TunnelEntry) {
+		tunnels["proj1"] = TunnelEntry{
+			ShedName:  "proj1",
+			Profile:   "default",
+			PID:       1000,
+			Ports:     []PortMapping{{Local: 3000, Remote: 3000}},
+			StartedAt: time.Now(),
+		}
+	}); err != nil {
+		t.Fatalf("update (set): %v", err)
+	}
 
 	// Get tunnel
 	entry, ok := state.GetTunnel("proj1")
@@ -138,10 +145,144 @@ func TestTunnelStateOperations(t *testing.T) {
 	}
 
 	// Remove tunnel
-	state.RemoveTunnel("proj1")
+	if err := state.Update(func(tunnels map[string]TunnelEntry) {
+		delete(tunnels, "proj1")
+	}); err != nil {
+		t.Fatalf("update (delete): %v", err)
+	}
 	_, ok = state.GetTunnel("proj1")
 	if ok {
 		t.Error("tunnel should be removed")
+	}
+}
+
+// TestUpdateNoClobber is the regression guard for the state-clobber bug: a
+// handle that loaded the file while it was empty must not erase entries written
+// by another handle since then. The old separate-lock Save() overwrote the file
+// from a stale in-memory map; Update() reloads inside the lock.
+func TestUpdateNoClobber(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "state.json")
+
+	// Two independent handles over the same file, both loaded while empty
+	// (simulating two background daemons).
+	a, err := LoadTunnelStateFromPath(path)
+	if err != nil {
+		t.Fatalf("load a: %v", err)
+	}
+	b, err := LoadTunnelStateFromPath(path)
+	if err != nil {
+		t.Fatalf("load b: %v", err)
+	}
+
+	if err := a.Update(func(tunnels map[string]TunnelEntry) {
+		tunnels["a"] = TunnelEntry{ShedName: "a", PID: 111}
+	}); err != nil {
+		t.Fatalf("update a: %v", err)
+	}
+	if err := b.Update(func(tunnels map[string]TunnelEntry) {
+		tunnels["b"] = TunnelEntry{ShedName: "b", PID: 222}
+	}); err != nil {
+		t.Fatalf("update b: %v", err)
+	}
+
+	loaded, err := LoadTunnelStateFromPath(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if _, ok := loaded.GetTunnel("a"); !ok {
+		t.Error("entry a was clobbered by b's update")
+	}
+	if _, ok := loaded.GetTunnel("b"); !ok {
+		t.Error("entry b missing")
+	}
+}
+
+// TestUpdateConcurrent hammers Update from many goroutines, each with its own
+// handle (its own flock fd, like separate processes), on distinct keys. All
+// entries must survive.
+func TestUpdateConcurrent(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "state.json")
+
+	const n = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s, err := LoadTunnelStateFromPath(path)
+			if err != nil {
+				errs <- err
+				return
+			}
+			name := fmt.Sprintf("shed-%d", i)
+			if err := s.Update(func(tunnels map[string]TunnelEntry) {
+				tunnels[name] = TunnelEntry{ShedName: name, PID: 1000 + i}
+			}); err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent update failed: %v", err)
+	}
+
+	loaded, err := LoadTunnelStateFromPath(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(loaded.Tunnels) != n {
+		t.Fatalf("expected %d tunnels, got %d", n, len(loaded.Tunnels))
+	}
+}
+
+// TestUpdatePIDGuardedRemoval covers the daemon-shutdown contract: a stale old
+// daemon must delete its entry only if it still owns it, so a --replace that
+// swapped in a new daemon (different PID) is not undone by the old one's SIGTERM.
+func TestUpdatePIDGuardedRemoval(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "state.json")
+	s, err := LoadTunnelStateFromPath(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// Replacement daemon owns "web" with PID 222.
+	if err := s.Update(func(tunnels map[string]TunnelEntry) {
+		tunnels["web"] = TunnelEntry{ShedName: "web", PID: 222}
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Old daemon (PID 111) shutting down must NOT delete the replacement's entry.
+	const oldPID = 111
+	if err := s.Update(func(tunnels map[string]TunnelEntry) {
+		if e, ok := tunnels["web"]; ok && e.PID == oldPID {
+			delete(tunnels, "web")
+		}
+	}); err != nil {
+		t.Fatalf("old-daemon update: %v", err)
+	}
+	loaded, _ := LoadTunnelStateFromPath(path)
+	if e, ok := loaded.GetTunnel("web"); !ok || e.PID != 222 {
+		t.Fatal("replacement entry should survive removal attempt by stale old daemon")
+	}
+
+	// The owning daemon (PID 222) removes its own entry.
+	if err := s.Update(func(tunnels map[string]TunnelEntry) {
+		if e, ok := tunnels["web"]; ok && e.PID == 222 {
+			delete(tunnels, "web")
+		}
+	}); err != nil {
+		t.Fatalf("owner update: %v", err)
+	}
+	loaded, _ = LoadTunnelStateFromPath(path)
+	if _, ok := loaded.GetTunnel("web"); ok {
+		t.Fatal("owning daemon should have removed its own entry")
 	}
 }
 

--- a/internal/tunnels/tunnel.go
+++ b/internal/tunnels/tunnel.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/charliek/shed/internal/vmutil"
 )
@@ -76,16 +77,82 @@ func (t *Tunnel) handleConn(clientConn net.Conn) {
 	}
 	defer vmConn.Close()
 
+	// If Stop() raced this dial and already cancelled, don't start copying.
+	if t.ctx.Err() != nil {
+		return
+	}
+
+	// Stop() only cancels the context; BidirectionalCopy blocks on io.Copy and
+	// never watches it, so without help an idle-but-open connection would wedge
+	// Stop()'s wg.Wait() forever. Close both conns when the tunnel is stopping
+	// so both copies return. net.Conn.Close is idempotent, so the deferred
+	// closes above are safe to run again.
+	defer closeConnsOnCancel(t.ctx, clientConn, vmConn)()
+
 	vmutil.BidirectionalCopy(clientConn, vmConn)
 }
 
-// Stop stops the tunnel, closing the listener and waiting for connections to drain.
+// closeConnsOnCancel closes conns if ctx is cancelled before the returned stop
+// func runs, so a blocking read/write (which doesn't watch the context) is
+// unblocked on teardown. The caller defers stop() to end the watcher once the
+// operation it guards completes.
+//
+// stop is idempotent and synchronous: it returns only after the watcher has
+// exited, and the watcher prefers the stop signal when both fire at once, so
+// once stop() returns the conns are guaranteed safe from this watcher (e.g. a
+// conn handed back by Dial can't be closed out from under the caller).
+func closeConnsOnCancel(ctx context.Context, conns ...net.Conn) (stop func()) {
+	done := make(chan struct{})
+	exited := make(chan struct{})
+	go func() {
+		defer close(exited)
+		select {
+		case <-done:
+			return
+		case <-ctx.Done():
+			// stop() may have raced the cancellation; if so, don't close conns
+			// the caller has already reclaimed.
+			select {
+			case <-done:
+				return
+			default:
+			}
+			for _, c := range conns {
+				_ = c.Close()
+			}
+		}
+	}()
+	var once sync.Once
+	return func() {
+		once.Do(func() { close(done) })
+		<-exited
+	}
+}
+
+// stopDrainTimeout bounds how long Stop() waits for in-flight connections to
+// drain before giving up. Closing the conns (see handleConn) normally unblocks
+// the copies immediately; this is a backstop so a latent edge case can never
+// reintroduce the hang this fix removes.
+const stopDrainTimeout = 5 * time.Second
+
+// Stop stops the tunnel, closing the listener and waiting for connections to
+// drain (bounded by stopDrainTimeout).
 func (t *Tunnel) Stop() {
 	t.cancel()
 	if t.listener != nil {
 		t.listener.Close()
 	}
-	t.wg.Wait()
+
+	done := make(chan struct{})
+	go func() {
+		t.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(stopDrainTimeout):
+		log.Printf("tunnel %d: timed out waiting for connections to drain", t.port.Local)
+	}
 }
 
 // LocalAddr returns the local listener address, or nil if not started.

--- a/internal/tunnels/tunnel_test.go
+++ b/internal/tunnels/tunnel_test.go
@@ -1,0 +1,119 @@
+package tunnels
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// assertStopReturns runs tun.Stop() and fails if it doesn't return promptly —
+// the regression guard for the teardown hang (issue #223).
+func assertStopReturns(t *testing.T, tun *Tunnel) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		tun.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Stop() hung")
+	}
+}
+
+// startTunnel starts a Tunnel against srv on an ephemeral local port and opens a
+// client connection through it (which drives handleConn -> Dial). The client
+// conn is returned for the caller to exercise and is closed via t.Cleanup.
+func startTunnel(t *testing.T, srv *httptest.Server) (*Tunnel, net.Conn) {
+	t.Helper()
+	tun := NewTunnel(NewConnectClient(ConnectTarget{Addr: addrOf(srv)}), "myshed", PortMapping{Local: 0, Remote: 8080})
+	if err := tun.Start(); err != nil {
+		t.Fatalf("start tunnel: %v", err)
+	}
+	c, err := net.Dial("tcp", tun.LocalAddr().String())
+	if err != nil {
+		tun.Stop()
+		t.Fatalf("dial local listener: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return tun, c
+}
+
+// TestTunnelStopUnblocksOpenConnection covers the core hang: an established but
+// idle tunneled connection must not wedge Stop(). Before the fix,
+// BidirectionalCopy blocked on io.Copy and Stop()'s wg.Wait() never returned.
+func TestTunnelStopUnblocksOpenConnection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, _ = conn.Write([]byte("HTTP/1.1 101 Switching Protocols\r\n\r\n"))
+		buf := make([]byte, 64)
+		// Echo one message (proves the pipe is fully wired), then stay idle
+		// until the peer closes (Stop closes the conns).
+		for {
+			n, err := conn.Read(buf)
+			if err != nil {
+				return
+			}
+			if _, err := conn.Write(buf[:n]); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	tun, c := startTunnel(t, srv)
+
+	// A successful round-trip guarantees handleConn is inside BidirectionalCopy
+	// in both directions — exactly the state that used to hang Stop().
+	if _, err := c.Write([]byte("ping")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, 4)
+	if _, err := io.ReadFull(c, got); err != nil {
+		t.Fatalf("round-trip: %v", err)
+	}
+
+	assertStopReturns(t, tun)
+}
+
+// TestTunnelStopUnblocksHangingUpgrade covers the second teardown gap: a backend
+// that accepts the connection but never sends 101 wedges Dial's ReadResponse.
+// The cancelable upgrade in ConnectClient.Dial must let Stop() tear it down.
+func TestTunnelStopUnblocksHangingUpgrade(t *testing.T) {
+	accepted := make(chan struct{})
+	var once sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		once.Do(func() { close(accepted) })
+		// Never reply with 101; block until the client closes.
+		buf := make([]byte, 64)
+		for {
+			if _, err := conn.Read(buf); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	tun, _ := startTunnel(t, srv)
+	select {
+	case <-accepted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("backend never saw the upgrade attempt")
+	}
+
+	assertStopReturns(t, tun)
+}

--- a/internal/tunnels/tunnel_test.go
+++ b/internal/tunnels/tunnel_test.go
@@ -35,9 +35,10 @@ func startTunnel(t *testing.T, srv *httptest.Server) (*Tunnel, net.Conn) {
 	if err := tun.Start(); err != nil {
 		t.Fatalf("start tunnel: %v", err)
 	}
+	// Stop the tunnel even if a later assertion fails, so the goroutines don't leak.
+	t.Cleanup(tun.Stop)
 	c, err := net.Dial("tcp", tun.LocalAddr().String())
 	if err != nil {
-		tun.Stop()
 		t.Fatalf("dial local listener: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Close() })

--- a/tests/integration/fixtures/server.py
+++ b/tests/integration/fixtures/server.py
@@ -442,6 +442,29 @@ class LocalServer:
         resp = json.loads(r.stdout)
         return resp.get("images") or []
 
+    def list_tunnels(self) -> dict:
+        """Return active tunnels keyed by shed name.
+
+        `shed --json tunnels list` emits a bare JSON object mapping shed
+        name -> tunnel entry (see `cmd/shed/tunnels.go:runTunnelsList`).
+        Raises on a failed call so a misconfigured client surfaces loudly;
+        callers assert on the entry's fields (e.g. `pid`). Note: tunnel
+        state is client-side (~/.shed/tunnel-state.json) and not actually
+        per-server, but we key off the same CLI the suite uses everywhere.
+        """
+        r = subprocess.run(
+            ["shed", "--json", "-s", self.name, "tunnels", "list"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if r.returncode != 0:
+            raise AssertionError(
+                f"shed tunnels list failed (exit {r.returncode}) on {self.name}: "
+                f"stdout={r.stdout!r} stderr={r.stderr!r}"
+            )
+        return json.loads(r.stdout or "{}")
+
     # ------------------------------------------------------------------
     # Log handling (overridden in RemoteServer)
     # ------------------------------------------------------------------

--- a/tests/integration/test_tunnels_background.py
+++ b/tests/integration/test_tunnels_background.py
@@ -1,0 +1,113 @@
+"""Background-tunnel detach test for issue #223.
+
+`shed tunnels start -d` is documented to run the tunnel as a detached
+daemon: print success, return the terminal, and keep forwarding in a
+separate process. Before the fix it blocked in the foreground exactly like
+non-background mode. This is the live regression guard for the detach
+behavior — the per-connection copy/teardown logic is unit-tested in
+`internal/tunnels`.
+
+The behavior under test is client-side and backend-independent; the shed is
+only here to give the tunnel a real server + running shed to attach to. One
+create-cycle, parameterized over the available backend like the rest of the
+suite (it skips cleanly when a backend is unreachable).
+"""
+
+import os
+import signal
+import socket
+import subprocess
+import time
+
+# A foreground (un-detached) `start` blocks until killed; a detached one
+# returns as soon as the worker reports readiness (~0.1s observed). The budget
+# is generous against CI variance while staying far below the subprocess
+# timeout, so it cleanly separates "detached" from "blocked".
+DETACH_RETURN_BUDGET_S = 10.0
+
+
+def _free_local_port() -> int:
+    s = socket.socket()
+    try:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+    finally:
+        s.close()
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def test_tunnels_background_detaches(shed_server, test_shed_name):
+    server = shed_server
+    name = test_shed_name
+    server.create(name)
+
+    local_port = _free_local_port()
+    pid = None
+    try:
+        t0 = time.monotonic()
+        r = subprocess.run(
+            ["shed", "-s", server.name, "tunnels", "start", name,
+             "-t", f"{local_port}:22", "-d"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        elapsed = time.monotonic() - t0
+        assert r.returncode == 0, f"tunnels start -d failed: {r.stdout}\n{r.stderr}"
+        # The defining symptom of the bug: -d blocked in the foreground.
+        assert elapsed < DETACH_RETURN_BUDGET_S, (
+            f"tunnels start -d took {elapsed:.1f}s; it did not detach"
+        )
+
+        # The readiness handshake guarantees the worker has bound its listener
+        # and written state before the CLI returned, so these are race-free:
+        # state records a separate, live daemon process (not the already-exited
+        # CLI, not this test).
+        listing = server.list_tunnels()
+        assert name in listing, f"tunnel not listed after start: {listing}"
+        pid = listing[name]["pid"]
+        assert pid != os.getpid()
+        assert _pid_alive(pid), f"daemon pid {pid} not alive after detach"
+
+        # That daemon owns the local listener: connecting to it succeeds even
+        # though the launching CLI has already returned.
+        with socket.create_connection(("127.0.0.1", local_port), timeout=5):
+            pass
+
+        # `tunnels stop` tears the daemon down cleanly.
+        stop = subprocess.run(
+            ["shed", "-s", server.name, "tunnels", "stop", name],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert stop.returncode == 0, f"tunnels stop failed: {stop.stdout}\n{stop.stderr}"
+
+        assert name not in server.list_tunnels()
+        deadline = time.monotonic() + 10.0
+        while _pid_alive(pid) and time.monotonic() < deadline:
+            time.sleep(0.2)
+        assert not _pid_alive(pid), "daemon survived `tunnels stop`"
+    finally:
+        # Best-effort: never leak the daemon, whichever assertion failed —
+        # including the case where `stop` returned 0 but the process lingered.
+        subprocess.run(
+            ["shed", "-s", server.name, "tunnels", "stop", name],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if pid is not None and _pid_alive(pid):
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass


### PR DESCRIPTION
Fixes #223.

## Problem

`shed tunnels start <shed> -t <port> -d` was documented to detach but behaved identically to foreground mode: it started the listeners in the foreground process, saved that PID, and blocked on signal — so the terminal was never returned and closing it killed the tunnel.

Validating the report surfaced **two more defects** in the same teardown path:

- **Ctrl+C / SIGTERM could hang.** `Tunnel.Stop()` waited on the connection waitgroup, but the per-connection goroutines block inside `BidirectionalCopy` (two `io.Copy`s) which nothing unblocked — any open tunneled connection wedged shutdown after "Stopping tunnels...". The HTTP upgrade inside `Dial` had the same problem (a backend that never sends `101` wedged `ReadResponse`).
- **Tunnel state could be clobbered.** State load and save took the file lock separately, so a long-lived daemon's shutdown could overwrite the state file from a stale in-memory map and silently delete *another* shed's entry.

## What changed (5 commits)

1. **fix(tunnels): make tunnel-state writes transactional** — `TunnelState.Update(mutate)` holds the lock across load→mutate→save; manager mutators route through it; PID-guarded removal so a `--replace`d daemon isn't undone by the old one's shutdown.
2. **fix(tunnels): stop tunnels cleanly instead of hanging on teardown** — close active conns on cancel (unblocks `BidirectionalCopy`), make the upgrade handshake cancelable, bound `Stop()` with a 5s backstop, and let a second foreground Ctrl+C force-quit.
3. **feat(tunnels): truly daemonize `shed tunnels start -d`** — parent re-execs with a hidden `--daemon` flag + `Setsid` (new session, no `Pdeathsig` so the child outlives the parent), stdio to a per-shed log; parent/child rendezvous over a pipe (`ExtraFiles` fd 3) so the parent returns only once the tunnel is **listening** (surfacing real startup errors instead of hanging). The worker re-resolves its connect target from config, so the **credentials token never hits the command line**.
4. **test(tunnels): integration coverage for background detach** — one create-cycle test asserting `-d` returns promptly, records a separate live daemon PID, owns the listener, and stops cleanly.
5. **docs(tunnels): correct background-mode docs** — real detachment, the corrected state path (`~/.shed/tunnel-state.json`), the daemon log, and foreground Ctrl+C behavior.

## Verification

- `make check` green; `internal/tunnels` passes under `-race`.
- New unit tests: state clobber/concurrency/PID-guard, teardown (established conn + hung upgrade), `daemonChildArgs`/`parseReadyMessage`/log-path helpers.
- **Live end-to-end on the VZ backend** (built client): `start -d` returns in ~0.1s (was: blocks forever); the daemon is detached (`PPID 1`, session leader) and forwards real traffic (`HELLO-FROM-SHED` read back through the detached daemon); `tunnels stop` tears it down; foreground Ctrl+C exits cleanly.
- Integration test `test_tunnels_background_detaches[vz]` PASSED against a live server.

## Process

The implementation plan was reviewed by **Codex, Kimi K2.6, and CodeRabbit** (`/planning:ask-panel`) before coding — that pass added the state-integrity fix and the cancelable-upgrade requirement, among others. Each commit was then run through `/simplify` (4-agent cleanup) and a `/codex:rescue` code review, with findings folded in (notably a kill/delete atomicity fix in commit 1 and a synchronous-stop race fix in commit 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `tunnels start -d` now launches a detached background daemon, returns once tunnels are listening, and records per-shed logs for later inspection.
* **Bug Fixes**
  * Improved tunnel shutdown so stopping no longer hangs due to open connections or stalled upgrade handshakes.
  * More reliable background tunnel startup/replacement and safer tunnel-state handling.
* **Documentation**
  * Updated CLI and tunnel runtime docs to clearly explain foreground vs. background behavior and management.
* **Tests**
  * Added unit and integration coverage for daemon start/detach and tunnel stop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->