### PR TITLE
fix(agent): Zed Remote-SSH — blocking stdin reads + exec-channel teardown reliability (#222)

### DIFF
--- a/.claude/skills/testing-vm-agent-changes/SKILL.md
+++ b/.claude/skills/testing-vm-agent-changes/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: testing-vm-agent-changes
+description: >
+  Validate changes to the in-VM agent (cmd/shed-agent) on a real VZ/FC VM. Use
+  whenever you edit cmd/shed-agent/ and need to prove the change works on a live
+  VM, or when an integration test exercises agent behavior. CRITICAL: the agent
+  is baked into the rootfs IMAGE, not the host shed-server, so `make
+  test-integration-dev` (which only restarts the dev server) does NOT pick up
+  agent changes — you must rebuild the rootfs into the dev image store. Covers
+  that rebuild loop plus the codesign / build-tools / BuildKit-cache / ref-index
+  gremlins, and running the linux-only agent unit tests via Docker on macOS.
+  Keep this file updated whenever you hit a new rough edge.
+---
+
+# Testing in-VM agent (`cmd/shed-agent`) changes
+
+> Scope: the end-to-end loop below is the **macOS / VZ** parallel-dev setup. The
+> Firecracker remote loop is analogous (`make dev-server-*-fc`, `OUTPUT_DIR`
+> under `/var/lib/shed-dev/...`) — see CLAUDE.md. All commands use `$HOME`/`~`
+> and read repo-relative paths, so nothing is tied to a specific machine; the
+> image **tags** below (`vX.Y.Z`, `golang:1.NN`) are point-in-time examples —
+> resolve the real values from your config / `go.mod` / local `docker images`
+> as noted at each step.
+
+The agent runs **inside** the VM and is shipped **inside the rootfs image**.
+The host `shed-server` is a separate binary. This split is the #1 source of
+"my change didn't take effect" confusion:
+
+> `make test-integration-dev` rebuilds and restarts the dev **server**. It does
+> **NOT** rebuild the rootfs, so it does **NOT** pick up `cmd/shed-agent`
+> changes. You must rebuild the rootfs image and create a fresh shed from it.
+
+## Fast unit tests (do this first, every time)
+
+`cmd/shed-agent/*.go` is `//go:build linux`, so its tests don't run under
+`make test` on macOS. Run them in Docker (native arch on Apple Silicon):
+
+```bash
+docker run --rm -v "$PWD":/src -w /src -e GOFLAGS=-buildvcs=false \
+  golang:1.25 go test -count=1 -race ./cmd/shed-agent/   # match the `go` line in go.mod
+```
+
+Cross-compile + lint locally without running:
+
+```bash
+GOOS=linux GOARCH=arm64 go build -o /dev/null ./cmd/shed-agent   # VZ
+GOOS=linux GOARCH=amd64 go build -o /dev/null ./cmd/shed-agent   # FC
+GOOS=linux golangci-lint run ./cmd/shed-agent/...
+```
+
+## End-to-end on a real VZ VM (the parallel dev server)
+
+Prereqs (see CLAUDE.md "Server-side changes — parallel dev server"): a
+`my-server-dev` entry in `~/.shed/config.yaml` on ports 18080/12222, and the
+dev config `configs/server.dev-parallel.mac.yaml`.
+
+### 1. Build + codesign the host server
+
+```bash
+make build
+codesign --entitlements internal/vz/entitlements.plist -s - ./bin/shed-server
+```
+
+**Gotcha:** `make dev-server-up` and `make test-integration-dev` both depend on
+the `build` target, which rebuilds `bin/shed-server` **unsigned** — clobbering
+your codesign and breaking VZ. So start the dev server **manually** with the
+codesigned binary (don't use `make dev-server-up` after codesigning), and use a
+**local** build-tools image (ghcr pulls are often denied):
+
+```bash
+# <BT_TAG>: any shed-build-tools tag you have locally (see step 2 — ghcr pulls
+# are often denied). The server uses it to mint the per-shed ext4 upper template.
+SHED_BUILD_TOOLS_REF="ghcr.io/charliek/shed-build-tools:<BT_TAG>" \
+  nohup bin/shed-server serve --config configs/server.dev-parallel.mac.yaml \
+  > "$HOME/.shed/dev/server.log" 2>&1 &
+echo $! > "$HOME/.shed/dev/server.pid"
+# readiness:
+for i in $(seq 1 20); do shed -s my-server-dev list >/dev/null 2>&1 && break; sleep 1; done
+```
+
+### 2. Rebuild the rootfs with your agent INTO the dev image store
+
+`OUTPUT_DIR` points the blobs at the dev server's store (the VZ dev `images_dir`
+from your dev config — `~/Library/Application Support/shed-dev/vz` on macOS).
+`SHED_SOURCE_REF` **must equal the dev config's `image_aliases.base` value** so
+`--image base` resolves to *your* build — read the current value out of the
+config rather than copying the tag below verbatim:
+
+```bash
+grep -A3 image_aliases configs/server.dev-parallel.mac.yaml   # → base: ghcr.io/charliek/shed-vz-base:<TAG>
+```
+
+`--build-tools-version` is any `shed-build-tools` tag you have **locally** —
+ghcr pulls are frequently denied, and the exact version need not match your
+source unless your change touches build-tools/erofs:
+
+```bash
+docker images | grep shed-build-tools     # pick a tag that's already pulled
+```
+
+Then build (substitute the `<TAG>`/`<BT_TAG>` you found above):
+
+```bash
+SHED_SOURCE_REF="ghcr.io/charliek/shed-vz-base:<TAG>" \
+OUTPUT_DIR="$HOME/Library/Application Support/shed-dev/vz" \
+  ./scripts/build-vz-rootfs.sh --variant base --build-tools-version <BT_TAG>
+```
+
+### 3. Make the dev server resolve to your new manifest
+
+Two gremlins routinely make the freshly-built agent NOT reach the VM. Always
+**verify** (step 4) before trusting a run.
+
+- **BuildKit caches the agent install layer** (`RUN --mount=type=bind … install
+  /ctx/shed-agent`). A changed binary can be silently reused from cache. If the
+  baked agent is stale, bust it and rebuild:
+  ```bash
+  docker buildx prune -af && docker builder prune -af
+  ```
+- **The ref-index can point at a stale manifest** after an `OUTPUT_DIR` build
+  (the running dev server + repeated builds leave `refs/<hash>.json` pointing at
+  an older digest than the one you just built). Force it to your build, then
+  restart the server:
+  ```bash
+  cd "$HOME/Library/Application Support/shed-dev/vz"
+  REF="ghcr.io/charliek/shed-vz-base:<TAG>"   # the same image_aliases.base value as above
+  REFHASH=$(printf '%s' "$REF" | shasum -a 256 | awk '{print $1}')
+  cat "refs/$REFHASH.json"          # what it points at now
+  # <DIGEST> = your build's manifest digest from its "Built image (sha256:...)" line:
+  printf '{"ref":"%s","digest":"sha256:<DIGEST>"}\n' "$REF" > "refs/$REFHASH.json"
+  # then restart the dev server (kill the PID in ~/.shed/dev/server.pid, relaunch as in step 1)
+  ```
+
+### 4. VERIFY the VM is running YOUR agent (do not skip)
+
+Create a fresh shed and grep the baked binary for a symbol/string only your
+change adds (function names survive in the Go binary):
+
+```bash
+shed -s my-server-dev create dbg --image base
+shed -s my-server-dev exec dbg -- bash -c \
+  "strings /usr/local/bin/shed-agent | grep -c '<your-new-symbol-or-log-string>'"
+# >0 means your agent is baked in; 0 means a stale layer/manifest — go back to step 3.
+```
+
+To extract+inspect the agent from a manifest without booting a VM (useful to
+tell "build baked it" from "resolution is stale"):
+
+```bash
+cd "$HOME/Library/Application Support/shed-dev/vz/blobs/sha256"
+# for each layer of the manifest, find usr/local/bin/shed-agent and strings it
+```
+
+### 5. Run the integration suite against the dev server
+
+```bash
+cd tests/integration
+SHED_VZ_SERVER=my-server-dev SHED_VZ_LOG_PATH="$HOME/.shed/dev/server.log" \
+SHED_VZ_DEV_SERVER=my-server-dev SHED_VZ_DEV_LOG_PATH="$HOME/.shed/dev/server.log" \
+  uv run pytest -v -k vz <test_files...>
+```
+
+`-k vz` skips the FC params (unreachable from a Mac). The in-VM agent log is at
+`shed -s my-server-dev exec <shed> -- sudo journalctl -u shed-agent`.
+
+## Per-iteration loop
+
+Edit agent → unit tests (Docker) → rebuild rootfs (step 2) → if stale, bust
+cache + force ref-index (step 3) → verify (step 4) → integration (step 5).
+Comment-only edits don't change the binary, so they don't need a rebuild.
+
+## When you hit a NEW rough edge
+
+Add it here. This file exists because the agent-in-image split and the
+build/cache/ref-index resolution have several non-obvious traps; capturing each
+one saves the next session an hour.

--- a/.claude/skills/testing-vm-agent-changes/SKILL.md
+++ b/.claude/skills/testing-vm-agent-changes/SKILL.md
@@ -173,4 +173,6 @@ Comment-only edits don't change the binary, so they don't need a rebuild.
 
 Add it here. This file exists because the agent-in-image split and the
 build/cache/ref-index resolution have several non-obvious traps; capturing each
-one saves the next session an hour.
+one saves the next session an hour. The stale-ref-index and BuildKit-cache traps
+in step 3 are tracked for a proper fix in **issue #227** — drop the workarounds
+here once it lands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ The suite is **parameterized over `["vz", "fc"]`** and skips cleanly when a back
 
 **FC live tests require the remote `shed-server` to emit `PhaseTimer` log lines** (added in v0.5.4 via PR #118). Two tests (`test_phase_timer_emitted[fc]`, `test_create_agent_p50[fc]`) skip cleanly with a clear message if the remote is older — the other tests work against any shed-server version. Once the remote upgrades to v0.5.4+, the suite picks up the FC tests automatically with no config change.
 
+> **In-VM agent (`cmd/shed-agent`) changes have an extra trap:** the agent is baked into the rootfs **image**, not the host `shed-server`, so `make test-integration-dev` (which only restarts the dev *server*) does **not** pick up agent changes — you must rebuild the rootfs into the dev image store. The in-repo skill **`.claude/skills/testing-vm-agent-changes`** documents that loop end-to-end (codesign, build-tools/BuildKit-cache/ref-index gremlins, running the linux-only agent unit tests via Docker, and verifying the VM is running *your* agent). Read it before validating an agent change, and **update it whenever you hit a new rough edge**.
+
 #### Server-side changes — parallel dev server
 
 `make test-integration` runs against whatever `shed-server` binary is currently **installed** on the host (brew on Mac, deb on Linux), not the source tree you're editing. A server-side-only change (orchestrator, lifecycle internals, backend handlers with no CLI-visible signature change) can pass `make test-integration` without ever executing the new code path — the installed binary is still the OLD one.

--- a/cmd/shed-agent/exec.go
+++ b/cmd/shed-agent/exec.go
@@ -168,56 +168,23 @@ func runWithPTY(conn net.Conn, cmd *exec.Cmd, rows, cols uint16) {
 	// WaitGroup to ensure output is flushed before sending exit code
 	var outputWg sync.WaitGroup
 
-	stopCh := make(chan struct{})
-
-	// Handle resize messages in background
-	go func() {
-		for {
-			msgType, data, err := readMessageWithTimeout(conn, 500*time.Millisecond)
-			if err != nil {
-				if isTimeout(err) {
-					select {
-					case <-stopCh:
-						return
-					default:
-						continue
-					}
-				}
-				return
+	// Forward client→process messages (stdin data, resize, signals) using
+	// blocking reads. The pump is unblocked and awaited at teardown via
+	// pump.stop() before the exit code is sent.
+	pump := startClientPump(conn, messageHandlers{
+		onData: func(b []byte) {
+			if _, err := ptmx.Write(b); err != nil {
+				log.Printf("Warning: failed to write to PTY: %v", err)
 			}
-
-			switch msgType {
-			case MsgTypeResize:
-				var resize ResizeMessage
-				if err := json.Unmarshal(data, &resize); err != nil {
-					log.Printf("Warning: failed to unmarshal resize message: %v", err)
-				} else if err := pty.Setsize(ptmx, &pty.Winsize{
-					Rows: resize.Rows,
-					Cols: resize.Cols,
-				}); err != nil {
-					log.Printf("Warning: failed to resize PTY: %v", err)
-				}
-			case MsgTypeSignal:
-				var sig SignalMessage
-				if err := json.Unmarshal(data, &sig); err != nil {
-					log.Printf("Warning: failed to unmarshal signal message: %v", err)
-				} else if sig.Signal < 1 || sig.Signal > 64 {
-					log.Printf("Warning: invalid signal number %d", sig.Signal)
-				} else if err := cmd.Process.Signal(syscall.Signal(sig.Signal)); err != nil {
-					log.Printf("Warning: failed to send signal %d: %v", sig.Signal, err)
-				}
-			case MsgTypeStdinEOF:
-				// Ignored in PTY mode — PTY doesn't have a separate stdin pipe
-			default:
-				// Data from stdin
-				if len(data) > 0 {
-					if _, err := ptmx.Write(data); err != nil {
-						log.Printf("Warning: failed to write to PTY: %v", err)
-					}
-				}
+		},
+		onResize: func(rows, cols uint16) {
+			if err := pty.Setsize(ptmx, &pty.Winsize{Rows: rows, Cols: cols}); err != nil {
+				log.Printf("Warning: failed to resize PTY: %v", err)
 			}
-		}
-	}()
+		},
+		onSignal:       signalProcess(cmd),
+		stopOnStdinEOF: false, // a PTY has no separate stdin pipe
+	}, nil)
 
 	// Copy PTY output to connection
 	outputWg.Add(1)
@@ -264,7 +231,11 @@ func runWithPTY(conn net.Conn, cmd *exec.Cmd, rows, cols uint16) {
 	// Wait for output to be flushed before sending exit code
 	outputWg.Wait()
 
-	close(stopCh)
+	// Unblock and await the input pump now that the process has exited, before
+	// sending the exit code. (stop() sets a read deadline, which affects reads
+	// only, so the writeExitCode below is unaffected.)
+	pump.stop()
+
 	if err := writeExitCode(conn, exitCode); err != nil {
 		log.Printf("Warning: failed to write exit code: %v", err)
 	}
@@ -313,49 +284,20 @@ func runWithoutPTY(conn net.Conn, cmd *exec.Cmd) {
 	// WaitGroup to ensure output is flushed before sending exit code
 	var outputWg sync.WaitGroup
 
-	done := make(chan struct{})
-
-	// Copy stdin from connection messages
-	go func() {
-		defer stdin.Close()
-		for {
-			msgType, data, err := readMessageWithTimeout(conn, 500*time.Millisecond)
-			if err != nil {
-				if isTimeout(err) {
-					select {
-					case <-done:
-						return
-					default:
-						continue
-					}
-				}
-				return
+	// Forward client→process stdin using blocking reads. stdin is closed when the
+	// pump returns (the cleanup arg) so the command sees EOF (e.g. `tar xzpf -`
+	// finishes reading); the close is idempotent (cmd.Wait also closes the pipe).
+	// Resize frames are ignored in non-PTY mode because onResize is left nil. The
+	// pump is unblocked and awaited at teardown via pump.stop().
+	pump := startClientPump(conn, messageHandlers{
+		onData: func(b []byte) {
+			if _, err := stdin.Write(b); err != nil {
+				log.Printf("Warning: failed to write to stdin: %v", err)
 			}
-			switch msgType {
-			case MsgTypeSignal:
-				var sig SignalMessage
-				if err := json.Unmarshal(data, &sig); err != nil {
-					log.Printf("Warning: failed to unmarshal signal message: %v", err)
-				} else if sig.Signal < 1 || sig.Signal > 64 {
-					log.Printf("Warning: invalid signal number %d", sig.Signal)
-				} else if err := cmd.Process.Signal(syscall.Signal(sig.Signal)); err != nil {
-					log.Printf("Warning: failed to send signal %d: %v", sig.Signal, err)
-				}
-			case MsgTypeStdinEOF:
-				// Client signaled end of stdin; close the pipe so the
-				// command sees EOF (e.g. tar xzpf - finishes reading).
-				return
-			case MsgTypeResize:
-				// Resize is only meaningful for PTY sessions; ignore in non-PTY mode.
-			default:
-				if len(data) > 0 {
-					if _, err := stdin.Write(data); err != nil {
-						log.Printf("Warning: failed to write to stdin: %v", err)
-					}
-				}
-			}
-		}
-	}()
+		},
+		onSignal:       signalProcess(cmd),
+		stopOnStdinEOF: true,
+	}, func() { _ = stdin.Close() })
 
 	// Mutex to protect concurrent writes to conn from stdout/stderr goroutines
 	var connMu sync.Mutex
@@ -418,7 +360,10 @@ func runWithoutPTY(conn net.Conn, cmd *exec.Cmd) {
 	// Wait for output to be flushed before sending exit code
 	outputWg.Wait()
 
-	close(done)
+	// Unblock and await the input pump now that the process has exited, before
+	// sending the exit code.
+	pump.stop()
+
 	connMu.Lock()
 	err = writeExitCode(conn, exitCode)
 	connMu.Unlock()
@@ -428,21 +373,131 @@ func runWithoutPTY(conn net.Conn, cmd *exec.Cmd) {
 	log.Printf("Command exited with code %d", exitCode)
 }
 
-func readMessageWithTimeout(conn net.Conn, timeout time.Duration) (byte, []byte, error) {
-	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
-		return 0, nil, err
-	}
-	return readMessage(conn)
+// messageHandlers customizes how pumpClientMessages dispatches each frame from
+// the host. Any handler may be nil.
+//
+//   - onData receives stdin payload destined for the process (the stdin pipe or
+//     the PTY master). It logs its own write errors and never stops the pump: a
+//     process that has closed its own stdin may still be running and must keep
+//     receiving forwarded signals. Pump termination is driven solely by
+//     MsgTypeStdinEOF (when stopOnStdinEOF is set), a read error (the host closed
+//     the conn), or the teardown read deadline.
+//   - onResize handles a PTY window-resize request (left nil for the non-PTY path,
+//     where resize frames are ignored).
+//   - onSignal forwards an already-validated signal number to the process.
+//
+// stopOnStdinEOF is true for the non-PTY path (closing the stdin pipe lets the
+// process see EOF) and false for the PTY path (a PTY has no separate stdin pipe,
+// so MsgTypeStdinEOF is ignored).
+type messageHandlers struct {
+	onData         func([]byte)
+	onResize       func(rows, cols uint16)
+	onSignal       func(sig int)
+	stopOnStdinEOF bool
 }
 
-func isTimeout(err error) bool {
-	if err == nil {
-		return false
+// pumpClientMessages reads framed messages from the host and dispatches each to
+// the supplied handlers until the host signals end-of-stdin (non-PTY), the
+// connection errors, or the caller sets a read deadline at teardown.
+//
+// It uses blocking reads with NO per-read deadline. The previous implementation
+// wrapped each read in a 500ms SetReadDeadline poll; when that deadline fired
+// mid-frame, io.ReadFull had already consumed bytes from the stream that
+// ReadMessage then discarded, permanently desynchronizing the framed binary
+// protocol (issue #222: Zed Remote-SSH's raw binary pipe). Blocking reads cannot
+// lose bytes that way.
+//
+// The caller runs this in a goroutine and, after the process exits, unblocks it
+// with conn.SetReadDeadline(time.Now()) and then waits for it to return.
+//
+// INVARIANT: this function only reads from conn and writes to the process. It
+// must never write to conn — otherwise the teardown read deadline racing a
+// concurrent writeExitCode would become a data race on the connection.
+func pumpClientMessages(conn net.Conn, h messageHandlers) {
+	for {
+		msgType, data, err := readMessage(conn)
+		if err != nil {
+			return
+		}
+		switch msgType {
+		case MsgTypeData:
+			if len(data) > 0 && h.onData != nil {
+				h.onData(data)
+			}
+		case MsgTypeResize:
+			var resize ResizeMessage
+			if err := json.Unmarshal(data, &resize); err != nil {
+				log.Printf("Warning: failed to unmarshal resize message: %v", err)
+			} else if h.onResize != nil {
+				h.onResize(resize.Rows, resize.Cols)
+			}
+		case MsgTypeSignal:
+			var sig SignalMessage
+			if err := json.Unmarshal(data, &sig); err != nil {
+				log.Printf("Warning: failed to unmarshal signal message: %v", err)
+			} else if sig.Signal < 1 || sig.Signal > 64 {
+				log.Printf("Warning: invalid signal number %d", sig.Signal)
+			} else if h.onSignal != nil {
+				h.onSignal(sig.Signal)
+			}
+		case MsgTypeStdinEOF:
+			// Client signaled end of stdin. In non-PTY mode this closes the
+			// stdin pipe (via the caller's deferred stdin.Close) so the command
+			// sees EOF; in PTY mode there is no separate stdin pipe, so ignore it.
+			if h.stopOnStdinEOF {
+				return
+			}
+		default:
+			// Unknown/future message type: log and skip rather than writing it
+			// into the child process.
+			log.Printf("Ignoring unknown message type on exec channel: 0x%02x", msgType)
+		}
 	}
-	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-		return true
+}
+
+// signalProcess returns an onSignal handler that forwards a signal number to the
+// process, logging any failure. Shared by the PTY and non-PTY input pumps.
+func signalProcess(cmd *exec.Cmd) func(int) {
+	return func(sig int) {
+		if err := cmd.Process.Signal(syscall.Signal(sig)); err != nil {
+			log.Printf("Warning: failed to send signal %d: %v", sig, err)
+		}
 	}
-	return false
+}
+
+// clientPump runs pumpClientMessages in a goroutine and provides an ordered
+// teardown. stop() sets a read deadline to unblock the pump's blocking read and
+// then waits for the goroutine to exit. The deadline-before-wait ordering is the
+// load-bearing invariant — waiting first would block forever on a pump still in a
+// blocking read — so it is encapsulated here rather than open-coded at each call
+// site.
+type clientPump struct {
+	conn net.Conn
+	wg   sync.WaitGroup
+}
+
+// startClientPump spawns the input pump for conn. If cleanup is non-nil it runs
+// once, after the pump returns and before the goroutine exits (e.g. closing the
+// process stdin pipe so the command sees EOF).
+func startClientPump(conn net.Conn, h messageHandlers, cleanup func()) *clientPump {
+	p := &clientPump{conn: conn}
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		if cleanup != nil {
+			defer cleanup()
+		}
+		pumpClientMessages(conn, h)
+	}()
+	return p
+}
+
+// stop unblocks the pump's blocking read and waits for the goroutine to exit. It
+// should be called once, after the process has exited and the agent no longer
+// needs to read client input.
+func (p *clientPump) stop() {
+	_ = p.conn.SetReadDeadline(time.Now())
+	p.wg.Wait()
 }
 
 // setEnv sets or replaces an environment variable in the given slice.

--- a/cmd/shed-agent/exec.go
+++ b/cmd/shed-agent/exec.go
@@ -19,10 +19,14 @@ import (
 	"github.com/creack/pty"
 )
 
-// connKeepaliveInterval is how often the non-PTY exec path probes the host
-// connection with a zero-length frame to detect a disconnect for commands that
-// otherwise neither read stdin nor write output (see runWithoutPTY).
+// connKeepaliveInterval is how often the exec paths probe the host connection
+// with a zero-length frame to detect a disconnect for commands that otherwise
+// neither read stdin nor write output (see startKeepalive).
 const connKeepaliveInterval = 15 * time.Second
+
+// connKeepaliveWriteTimeout bounds a single keepalive probe write so a stalled
+// connection can't wedge teardown (which waits for the keepalive goroutine).
+const connKeepaliveWriteTimeout = 5 * time.Second
 
 // handleExecConnection handles a connection on the console port.
 func handleExecConnection(conn net.Conn, user *userInfo) {
@@ -180,9 +184,9 @@ func runWithPTY(conn net.Conn, cmd *exec.Cmd, rows, cols uint16) {
 	// so even a perfectly idle PTY session is cleaned up on a lost host.
 	disconnect := onHostDisconnect(cmd)
 
-	// connMu serializes the output copier and the keepalive probe, which both
-	// write to conn.
-	var connMu sync.Mutex
+	// w serializes the output copier and the keepalive probe (both write conn)
+	// and SIGHUPs the command on a write failure.
+	w := &connWriter{conn: conn, disconnect: disconnect}
 
 	// Forward client→process messages (stdin data, resize, signals) using
 	// blocking reads. The pump is unblocked and awaited at teardown via
@@ -198,40 +202,18 @@ func runWithPTY(conn net.Conn, cmd *exec.Cmd, rows, cols uint16) {
 				log.Printf("Warning: failed to resize PTY: %v", err)
 			}
 		},
-		onSignal:       signalProcess(cmd),
-		onDisconnect:   disconnect,
-		stopOnStdinEOF: false, // a PTY has no separate stdin pipe
+		onSignal:     signalProcess(cmd),
+		onDisconnect: disconnect,
+		// onStdinEOF left nil: a PTY has no separate stdin pipe.
 	}, nil)
 
-	// Copy PTY output to connection
+	// Copy PTY output to connection.
 	outputWg.Add(1)
-	go func() {
-		defer outputWg.Done()
-		buf := make([]byte, 4096)
-		for {
-			n, err := ptmx.Read(buf)
-			if err != nil {
-				if err != io.EOF {
-					log.Printf("PTY read error: %v", err)
-				}
-				return
-			}
-			if n > 0 {
-				connMu.Lock()
-				werr := writeData(conn, buf[:n])
-				connMu.Unlock()
-				if werr != nil {
-					log.Printf("Warning: failed to write data to connection: %v", werr)
-					disconnect()
-					return
-				}
-			}
-		}
-	}()
+	go func() { defer outputWg.Done(); copyToConn(w, ptmx, "PTY") }()
 
 	// Probe for a host disconnect even when the PTY session is idle (no output);
-	// stopped after the command exits (see startKeepalive).
-	keepaliveStop := startKeepalive(conn, &connMu, disconnect)
+	// stopped after the command exits.
+	keepaliveStop := startKeepalive(w)
 
 	// Wait for command to exit
 	go func() {
@@ -322,75 +304,40 @@ func runWithoutPTY(conn net.Conn, cmd *exec.Cmd) {
 	// instead of orphaning (and leaking this handler at cmd.Wait below).
 	disconnect := onHostDisconnect(cmd)
 
-	// Forward client→process stdin using blocking reads. stdin is closed when the
-	// pump returns (the cleanup arg) so the command sees EOF (e.g. `tar xzpf -`
-	// finishes reading); the close is idempotent (cmd.Wait also closes the pipe).
-	// Resize frames are ignored in non-PTY mode because onResize is left nil. The
-	// pump is unblocked and awaited at teardown via pump.stop().
+	// Forward client→process stdin using blocking reads. On MsgTypeStdinEOF the
+	// stdin pipe is closed (once) so the command sees EOF (e.g. `tar xzpf -`
+	// finishes reading) — but the pump keeps running so it can still forward
+	// signals and detect a host disconnect via its read error after stdin closes.
+	// The same close runs as the pump's teardown cleanup; sync.Once makes it
+	// idempotent (cmd.Wait also closes the pipe). Resize frames are ignored in
+	// non-PTY mode because onResize is left nil. The pump is unblocked and awaited
+	// at teardown via pump.stop().
+	var closeStdinOnce sync.Once
+	closeStdin := func() { closeStdinOnce.Do(func() { _ = stdin.Close() }) }
 	pump := startClientPump(conn, messageHandlers{
 		onData: func(b []byte) {
 			if _, err := stdin.Write(b); err != nil {
 				log.Printf("Warning: failed to write to stdin: %v", err)
 			}
 		},
-		onSignal:       signalProcess(cmd),
-		onDisconnect:   disconnect,
-		stopOnStdinEOF: true,
-	}, func() { _ = stdin.Close() })
+		onSignal:     signalProcess(cmd),
+		onDisconnect: disconnect,
+		onStdinEOF:   closeStdin,
+	}, closeStdin)
 
-	// Mutex to protect concurrent writes to conn from stdout/stderr goroutines
-	var connMu sync.Mutex
+	// w serializes the stdout/stderr copiers and the keepalive probe (all write
+	// conn) and SIGHUPs the command on a write failure.
+	w := &connWriter{conn: conn, disconnect: disconnect}
 
-	// Copy stdout to connection
-	outputWg.Add(1)
-	go func() {
-		defer outputWg.Done()
-		buf := make([]byte, 4096)
-		for {
-			n, err := stdout.Read(buf)
-			if err != nil {
-				return
-			}
-			if n > 0 {
-				connMu.Lock()
-				err := writeData(conn, buf[:n])
-				connMu.Unlock()
-				if err != nil {
-					log.Printf("Warning: failed to write stdout to connection: %v", err)
-					disconnect()
-					return
-				}
-			}
-		}
-	}()
-
-	// Copy stderr to connection (same stream for now)
-	outputWg.Add(1)
-	go func() {
-		defer outputWg.Done()
-		buf := make([]byte, 4096)
-		for {
-			n, err := stderr.Read(buf)
-			if err != nil {
-				return
-			}
-			if n > 0 {
-				connMu.Lock()
-				err := writeData(conn, buf[:n])
-				connMu.Unlock()
-				if err != nil {
-					log.Printf("Warning: failed to write stderr to connection: %v", err)
-					disconnect()
-					return
-				}
-			}
-		}
-	}()
+	// Copy stdout and stderr to the connection (folded into one stream).
+	outputWg.Add(2)
+	go func() { defer outputWg.Done(); copyToConn(w, stdout, "stdout") }()
+	go func() { defer outputWg.Done(); copyToConn(w, stderr, "stderr") }()
 
 	// Probe for a host disconnect even when the command produces no output and
 	// reads no stdin (see startKeepalive). Stopped after cmd.Wait below so it
 	// keeps probing until the process actually exits.
-	keepaliveStop := startKeepalive(conn, &connMu, disconnect)
+	keepaliveStop := startKeepalive(w)
 
 	// Drain stdout/stderr to EOF BEFORE reaping the process. cmd.Wait closes the
 	// StdoutPipe/StderrPipe read ends, discarding any output still buffered in
@@ -416,10 +363,9 @@ func runWithoutPTY(conn net.Conn, cmd *exec.Cmd) {
 	keepaliveStop()
 	pump.stop()
 
-	// No connMu needed: outputWg.Wait + keepaliveWg.Wait + pump.stop above
-	// guarantee every other conn writer has returned, and the input pump only
-	// ever reads conn, so writeExitCode is the sole remaining writer (matching
-	// the PTY path).
+	// writeExitCode is the sole remaining conn writer: outputWg.Wait +
+	// keepaliveStop above guarantee every other writer (the copiers and the probe
+	// on w) has returned, and the input pump only ever reads conn.
 	if err := writeExitCode(conn, exitCode); err != nil {
 		log.Printf("Warning: failed to write exit code: %v", err)
 	}
@@ -459,16 +405,22 @@ func exitCodeFromWait(err error) int {
 // process see EOF) and false for the PTY path (a PTY has no separate stdin pipe,
 // so MsgTypeStdinEOF is ignored).
 type messageHandlers struct {
-	onData         func([]byte)
-	onResize       func(rows, cols uint16)
-	onSignal       func(sig int)
-	onDisconnect   func()
-	stopOnStdinEOF bool
+	onData       func([]byte)
+	onResize     func(rows, cols uint16)
+	onSignal     func(sig int)
+	onDisconnect func()
+	// onStdinEOF, if set, is called when the host signals end-of-stdin
+	// (MsgTypeStdinEOF) — the non-PTY path closes the stdin pipe here. It does
+	// NOT stop the pump: a command can keep running after stdin closes and must
+	// still receive forwarded signals and have a later host disconnect detected
+	// via the read-error path. PTY mode leaves this nil (no separate stdin pipe).
+	onStdinEOF func()
 }
 
 // pumpClientMessages reads framed messages from the host and dispatches each to
-// the supplied handlers until the host signals end-of-stdin (non-PTY), the
-// connection errors, or the caller sets a read deadline at teardown.
+// the supplied handlers until the connection errors (host disconnect) or the
+// caller sets a read deadline at teardown. End-of-stdin closes the stdin pipe
+// (via onStdinEOF) but does NOT stop the pump.
 //
 // It uses blocking reads with NO per-read deadline. The previous implementation
 // wrapped each read in a 500ms SetReadDeadline poll; when that deadline fired
@@ -518,11 +470,11 @@ func pumpClientMessages(conn net.Conn, h messageHandlers) {
 				h.onSignal(sig.Signal)
 			}
 		case MsgTypeStdinEOF:
-			// Client signaled end of stdin. In non-PTY mode this closes the
-			// stdin pipe (via the caller's deferred stdin.Close) so the command
-			// sees EOF; in PTY mode there is no separate stdin pipe, so ignore it.
-			if h.stopOnStdinEOF {
-				return
+			// Client signaled end of stdin. Non-PTY closes the stdin pipe (so the
+			// command sees EOF) but the pump keeps running for later signals and
+			// disconnect detection; PTY has no separate stdin pipe (onStdinEOF nil).
+			if h.onStdinEOF != nil {
+				h.onStdinEOF()
 			}
 		default:
 			// Unknown/future message type: log and skip rather than writing it
@@ -585,16 +537,74 @@ func onHostDisconnect(cmd *exec.Cmd) func() {
 	}
 }
 
-// startKeepalive periodically probes conn with a zero-length frame so a host
+// connWriter serializes all writes to the host connection (the output copiers
+// and the keepalive probe on both the PTY and non-PTY paths) and fires
+// disconnect() on the first write failure — the host is gone, so the command
+// should be terminated rather than left orphaned.
+type connWriter struct {
+	mu         sync.Mutex
+	conn       net.Conn
+	disconnect func()
+}
+
+// write sends data to the host, firing disconnect on a write error.
+func (w *connWriter) write(data []byte) error {
+	w.mu.Lock()
+	err := writeData(w.conn, data)
+	w.mu.Unlock()
+	if err != nil {
+		w.disconnect()
+	}
+	return err
+}
+
+// writeProbe sends a bounded zero-length keepalive frame. A stalled conn that
+// can't accept even 5 bytes within timeout is treated as a disconnect, so a
+// wedged write can't hang teardown (which waits for the keepalive goroutine).
+func (w *connWriter) writeProbe(timeout time.Duration) error {
+	w.mu.Lock()
+	err := w.conn.SetWriteDeadline(time.Now().Add(timeout))
+	if err == nil {
+		err = writeData(w.conn, nil)
+	}
+	_ = w.conn.SetWriteDeadline(time.Time{}) // clear for other writers
+	w.mu.Unlock()
+	if err != nil {
+		w.disconnect()
+	}
+	return err
+}
+
+// copyToConn copies r to the host connection via w until EOF or a write failure,
+// labeling read/write errors with name. Used for the process stdout/stderr pipes
+// (non-PTY) and the PTY master.
+func copyToConn(w *connWriter, r io.Reader, name string) {
+	buf := make([]byte, 4096)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			if werr := w.write(buf[:n]); werr != nil {
+				log.Printf("Warning: failed to write %s to connection: %v", name, werr)
+				return
+			}
+		}
+		if err != nil {
+			if err != io.EOF {
+				log.Printf("%s read error: %v", name, err)
+			}
+			return
+		}
+	}
+}
+
+// startKeepalive periodically probes w with a zero-length frame so a host
 // disconnect is detected even for a command that produces no output and reads no
 // stdin: the guest's vsock read never delivers EOF on the host's close, and the
 // output-write path only fires for commands that emit something. The host treats
-// a zero-length frame as an empty stdout write — harmless to the byte stream. mu
-// serializes the probe with the path's output writer(s); a failed probe means
-// the host is gone → disconnect(). Returns stop(), which ends the probe and
-// waits for it to exit so it can't write conn concurrently with a later
-// writeExitCode. Used by both the PTY and non-PTY paths.
-func startKeepalive(conn net.Conn, mu *sync.Mutex, disconnect func()) (stop func()) {
+// a zero-length frame as an empty stdout write — harmless to the byte stream.
+// Returns stop(), which ends the probe and waits for it to exit so it can't
+// write conn concurrently with a later writeExitCode. Used by both paths.
+func startKeepalive(w *connWriter) (stop func()) {
 	done := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -607,11 +617,7 @@ func startKeepalive(conn net.Conn, mu *sync.Mutex, disconnect func()) (stop func
 			case <-done:
 				return
 			case <-ticker.C:
-				mu.Lock()
-				err := writeData(conn, nil)
-				mu.Unlock()
-				if err != nil {
-					disconnect()
+				if w.writeProbe(connKeepaliveWriteTimeout) != nil {
 					return
 				}
 			}

--- a/cmd/shed-agent/exec.go
+++ b/cmd/shed-agent/exec.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 	"net"
@@ -17,6 +18,11 @@ import (
 
 	"github.com/creack/pty"
 )
+
+// connKeepaliveInterval is how often the non-PTY exec path probes the host
+// connection with a zero-length frame to detect a disconnect for commands that
+// otherwise neither read stdin nor write output (see runWithoutPTY).
+const connKeepaliveInterval = 15 * time.Second
 
 // handleExecConnection handles a connection on the console port.
 func handleExecConnection(conn net.Conn, user *userInfo) {
@@ -168,6 +174,16 @@ func runWithPTY(conn net.Conn, cmd *exec.Cmd, rows, cols uint16) {
 	// WaitGroup to ensure output is flushed before sending exit code
 	var outputWg sync.WaitGroup
 
+	// On host disconnect, SIGHUP the command's process group (pty.Start put it in
+	// its own session) so it terminates instead of orphaning. Detected via the
+	// output-write path below, the pump's read error, and the keepalive probe —
+	// so even a perfectly idle PTY session is cleaned up on a lost host.
+	disconnect := onHostDisconnect(cmd)
+
+	// connMu serializes the output copier and the keepalive probe, which both
+	// write to conn.
+	var connMu sync.Mutex
+
 	// Forward client→process messages (stdin data, resize, signals) using
 	// blocking reads. The pump is unblocked and awaited at teardown via
 	// pump.stop() before the exit code is sent.
@@ -183,6 +199,7 @@ func runWithPTY(conn net.Conn, cmd *exec.Cmd, rows, cols uint16) {
 			}
 		},
 		onSignal:       signalProcess(cmd),
+		onDisconnect:   disconnect,
 		stopOnStdinEOF: false, // a PTY has no separate stdin pipe
 	}, nil)
 
@@ -200,13 +217,21 @@ func runWithPTY(conn net.Conn, cmd *exec.Cmd, rows, cols uint16) {
 				return
 			}
 			if n > 0 {
-				if err := writeData(conn, buf[:n]); err != nil {
-					log.Printf("Warning: failed to write data to connection: %v", err)
+				connMu.Lock()
+				werr := writeData(conn, buf[:n])
+				connMu.Unlock()
+				if werr != nil {
+					log.Printf("Warning: failed to write data to connection: %v", werr)
+					disconnect()
 					return
 				}
 			}
 		}
 	}()
+
+	// Probe for a host disconnect even when the PTY session is idle (no output);
+	// stopped after the command exits (see startKeepalive).
+	keepaliveStop := startKeepalive(conn, &connMu, disconnect)
 
 	// Wait for command to exit
 	go func() {
@@ -214,22 +239,23 @@ func runWithPTY(conn net.Conn, cmd *exec.Cmd, rows, cols uint16) {
 	}()
 
 	err = <-exitCh
-	exitCode := 0
-	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			exitCode = exitError.ExitCode()
-		} else {
-			exitCode = 1
-		}
-	}
+	exitCode := exitCodeFromWait(err)
 
 	// Close the PTY master to unblock the output goroutine. Without this,
 	// ptmx.Read() can block indefinitely after the process exits because
-	// the PTY master doesn't always deliver EOF promptly on Linux.
+	// the PTY master doesn't always deliver EOF promptly on Linux. This may
+	// discard a small unread tail still buffered in the line discipline — a
+	// truncation-vs-hang tradeoff accepted for interactive PTY sessions. Do NOT
+	// switch this to "drain before close" like the non-PTY path: the master's
+	// lack of a prompt EOF would reintroduce the indefinite hang.
 	ptmx.Close()
 
 	// Wait for output to be flushed before sending exit code
 	outputWg.Wait()
+
+	// Stop the keepalive (it probed until the command exited) so it can't write
+	// conn concurrently with writeExitCode below.
+	keepaliveStop()
 
 	// Unblock and await the input pump now that the process has exited, before
 	// sending the exit code. (stop() sets a read deadline, which affects reads
@@ -272,6 +298,14 @@ func runWithoutPTY(conn net.Conn, cmd *exec.Cmd) {
 		return
 	}
 
+	// Run the command in its own process group so a host disconnect can SIGHUP
+	// the whole tree (the command plus anything it spawned) instead of orphaning
+	// it. Any Credential set by the caller (for the shed user) is preserved.
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+
 	// Start command
 	if err := cmd.Start(); err != nil {
 		log.Printf("Failed to start command: %v", err)
@@ -283,6 +317,10 @@ func runWithoutPTY(conn net.Conn, cmd *exec.Cmd) {
 
 	// WaitGroup to ensure output is flushed before sending exit code
 	var outputWg sync.WaitGroup
+
+	// On host disconnect, SIGHUP the command's process group so it terminates
+	// instead of orphaning (and leaking this handler at cmd.Wait below).
+	disconnect := onHostDisconnect(cmd)
 
 	// Forward client→process stdin using blocking reads. stdin is closed when the
 	// pump returns (the cleanup arg) so the command sees EOF (e.g. `tar xzpf -`
@@ -296,6 +334,7 @@ func runWithoutPTY(conn net.Conn, cmd *exec.Cmd) {
 			}
 		},
 		onSignal:       signalProcess(cmd),
+		onDisconnect:   disconnect,
 		stopOnStdinEOF: true,
 	}, func() { _ = stdin.Close() })
 
@@ -318,6 +357,7 @@ func runWithoutPTY(conn net.Conn, cmd *exec.Cmd) {
 				connMu.Unlock()
 				if err != nil {
 					log.Printf("Warning: failed to write stdout to connection: %v", err)
+					disconnect()
 					return
 				}
 			}
@@ -340,37 +380,62 @@ func runWithoutPTY(conn net.Conn, cmd *exec.Cmd) {
 				connMu.Unlock()
 				if err != nil {
 					log.Printf("Warning: failed to write stderr to connection: %v", err)
+					disconnect()
 					return
 				}
 			}
 		}
 	}()
 
-	// Wait for command
-	err = cmd.Wait()
-	exitCode := 0
-	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			exitCode = exitError.ExitCode()
-		} else {
-			exitCode = 1
-		}
-	}
+	// Probe for a host disconnect even when the command produces no output and
+	// reads no stdin (see startKeepalive). Stopped after cmd.Wait below so it
+	// keeps probing until the process actually exits.
+	keepaliveStop := startKeepalive(conn, &connMu, disconnect)
 
-	// Wait for output to be flushed before sending exit code
+	// Drain stdout/stderr to EOF BEFORE reaping the process. cmd.Wait closes the
+	// StdoutPipe/StderrPipe read ends, discarding any output still buffered in
+	// the OS pipe; calling it before the copy goroutines finish truncates large
+	// outputs under back-pressure (the pipes hit EOF on their own when the
+	// process exits and closes its write ends). Per the os/exec StdoutPipe docs:
+	// "It is thus incorrect to call Wait before all reads from the pipe have
+	// completed."
 	outputWg.Wait()
 
-	// Unblock and await the input pump now that the process has exited, before
-	// sending the exit code.
+	// Reap the process. The keepalive keeps probing the conn until the process
+	// actually EXITS — not merely until output drains — so a disconnect is still
+	// caught for a command that closed its own stdout/stderr but kept running
+	// (e.g. `exec >/dev/null 2>&1; sleep 600`), where outputWg.Wait returns early.
+	// (For commands that hold their output pipes open, outputWg.Wait already
+	// blocks until exit.)
+	err = cmd.Wait()
+	exitCode := exitCodeFromWait(err)
+
+	// Now that the process has exited, stop the keepalive and the input pump,
+	// waiting for the keepalive to return, so neither can write conn concurrently
+	// with writeExitCode below.
+	keepaliveStop()
 	pump.stop()
 
-	connMu.Lock()
-	err = writeExitCode(conn, exitCode)
-	connMu.Unlock()
-	if err != nil {
+	// No connMu needed: outputWg.Wait + keepaliveWg.Wait + pump.stop above
+	// guarantee every other conn writer has returned, and the input pump only
+	// ever reads conn, so writeExitCode is the sole remaining writer (matching
+	// the PTY path).
+	if err := writeExitCode(conn, exitCode); err != nil {
 		log.Printf("Warning: failed to write exit code: %v", err)
 	}
 	log.Printf("Command exited with code %d", exitCode)
+}
+
+// exitCodeFromWait maps a cmd.Wait() error to a process exit code: 0 for nil,
+// the process's real code for an *exec.ExitError, and 1 for any other failure.
+func exitCodeFromWait(err error) int {
+	if err == nil {
+		return 0
+	}
+	if exitError, ok := err.(*exec.ExitError); ok {
+		return exitError.ExitCode()
+	}
+	return 1
 }
 
 // messageHandlers customizes how pumpClientMessages dispatches each frame from
@@ -385,6 +450,10 @@ func runWithoutPTY(conn net.Conn, cmd *exec.Cmd) {
 //   - onResize handles a PTY window-resize request (left nil for the non-PTY path,
 //     where resize frames are ignored).
 //   - onSignal forwards an already-validated signal number to the process.
+//   - onDisconnect fires once when the read loop ends because the host closed the
+//     connection (a non-timeout read error), so the caller can terminate the
+//     command rather than orphaning it. It is NOT called for the teardown read
+//     deadline (a timeout) the caller sets after the process has already exited.
 //
 // stopOnStdinEOF is true for the non-PTY path (closing the stdin pipe lets the
 // process see EOF) and false for the PTY path (a PTY has no separate stdin pipe,
@@ -393,6 +462,7 @@ type messageHandlers struct {
 	onData         func([]byte)
 	onResize       func(rows, cols uint16)
 	onSignal       func(sig int)
+	onDisconnect   func()
 	stopOnStdinEOF bool
 }
 
@@ -417,6 +487,13 @@ func pumpClientMessages(conn net.Conn, h messageHandlers) {
 	for {
 		msgType, data, err := readMessage(conn)
 		if err != nil {
+			// A non-timeout read error means the host closed the connection
+			// mid-session. The teardown path (clientPump.stop) instead sets a
+			// read DEADLINE, which surfaces as a timeout and must NOT be treated
+			// as a disconnect — the process has already exited in that case.
+			if h.onDisconnect != nil && !isTimeoutError(err) {
+				h.onDisconnect()
+			}
 			return
 		}
 		switch msgType {
@@ -462,6 +539,87 @@ func signalProcess(cmd *exec.Cmd) func(int) {
 		if err := cmd.Process.Signal(syscall.Signal(sig)); err != nil {
 			log.Printf("Warning: failed to send signal %d: %v", sig, err)
 		}
+	}
+}
+
+// isTimeoutError reports whether err is a deadline timeout (as opposed to a
+// connection-closed or other read error). Used to distinguish the teardown read
+// deadline from a host disconnect.
+func isTimeoutError(err error) bool {
+	var nerr net.Error
+	return errors.As(err, &nerr) && nerr.Timeout()
+}
+
+// terminateGroup sends sig to the command's entire process group. The child runs
+// in its own process group (Setpgid on the non-PTY path; Setsid via pty.Start on
+// the PTY path), so the negative PID reaches the command and everything it
+// spawned. No-op if the process never started.
+func terminateGroup(cmd *exec.Cmd, sig syscall.Signal) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, sig)
+}
+
+// onHostDisconnect returns a func that, once, SIGHUPs the command's process
+// group so a host disconnect terminates the command (and its children) instead
+// of orphaning it and leaking this handler's goroutine — matching standard SSH
+// "connection hung up" semantics. Use tmux/nohup to intentionally survive a
+// disconnect.
+//
+// Callers stop the disconnect sources (pump, keepalive) immediately after
+// cmd.Wait, so a call after reap is a tiny race rather than fully safe:
+// kill(-pid) on a freed process group is normally a no-op (ESRCH), but in the
+// microscopic window before those sources stop, a reused PID that became a group
+// leader could in theory be signaled. The window is negligible in practice.
+func onHostDisconnect(cmd *exec.Cmd) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			if cmd.Process == nil {
+				return
+			}
+			log.Printf("Host disconnected; sending SIGHUP to command group (pid %d)", cmd.Process.Pid)
+			terminateGroup(cmd, syscall.SIGHUP)
+		})
+	}
+}
+
+// startKeepalive periodically probes conn with a zero-length frame so a host
+// disconnect is detected even for a command that produces no output and reads no
+// stdin: the guest's vsock read never delivers EOF on the host's close, and the
+// output-write path only fires for commands that emit something. The host treats
+// a zero-length frame as an empty stdout write — harmless to the byte stream. mu
+// serializes the probe with the path's output writer(s); a failed probe means
+// the host is gone → disconnect(). Returns stop(), which ends the probe and
+// waits for it to exit so it can't write conn concurrently with a later
+// writeExitCode. Used by both the PTY and non-PTY paths.
+func startKeepalive(conn net.Conn, mu *sync.Mutex, disconnect func()) (stop func()) {
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(connKeepaliveInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				mu.Lock()
+				err := writeData(conn, nil)
+				mu.Unlock()
+				if err != nil {
+					disconnect()
+					return
+				}
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		wg.Wait()
 	}
 }
 

--- a/cmd/shed-agent/exec_test.go
+++ b/cmd/shed-agent/exec_test.go
@@ -261,4 +261,34 @@ func TestPumpClientMessages(t *testing.T) {
 			t.Fatal("unknown message type was routed to onData")
 		}
 	})
+
+	// Host disconnect (the peer closes the connection) fires onDisconnect so the
+	// caller can terminate the command instead of orphaning it.
+	t.Run("onDisconnectOnConnClose", func(t *testing.T) {
+		called := make(chan struct{}, 1)
+		client, stop := startTestPump(t, messageHandlers{
+			onDisconnect: func() { called <- struct{}{} },
+		})
+		_ = client.Close() // peer closes → non-timeout read error (io.EOF)
+		select {
+		case <-called:
+		case <-time.After(2 * time.Second):
+			t.Fatal("onDisconnect was not called when the host closed the connection")
+		}
+		stop()
+	})
+
+	// The teardown read deadline (a timeout) must NOT be treated as a disconnect:
+	// the process has already exited and the command must not be re-signaled.
+	// stop() drives the real clientPump teardown (SetReadDeadline now).
+	t.Run("noDisconnectOnTeardownDeadline", func(t *testing.T) {
+		disconnected := false
+		_, stop := startTestPump(t, messageHandlers{
+			onDisconnect: func() { disconnected = true },
+		})
+		stop() // teardown deadline → timeout, not a disconnect
+		if disconnected {
+			t.Fatal("onDisconnect fired on the teardown read deadline (should only fire on host close)")
+		}
+	})
 }

--- a/cmd/shed-agent/exec_test.go
+++ b/cmd/shed-agent/exec_test.go
@@ -1,0 +1,264 @@
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+)
+
+// mustJSON marshals v or fails the test.
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// send writes a framed message to c, failing the test on error. It sets a write
+// deadline so that a regression which makes the pump stop reading produces a
+// clean failure instead of hanging the test until the package timeout
+// (net.Pipe is synchronous: a write blocks until the pump reads).
+func send(t *testing.T, c net.Conn, msgType byte, data []byte) {
+	t.Helper()
+	_ = c.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if err := writeMessage(c, msgType, data); err != nil {
+		t.Fatalf("write 0x%02x: %v", msgType, err)
+	}
+}
+
+// startTestPump runs the production input pump over a net.Pipe and returns the
+// client end (the test writes framed messages into it) plus a stop() that drives
+// the real teardown (clientPump.stop) and closes the pipe. net.Pipe is
+// synchronous and supports deadlines (Go 1.10+), which is what the teardown
+// relies on.
+func startTestPump(t *testing.T, h messageHandlers) (client net.Conn, stop func()) {
+	t.Helper()
+	c, s := net.Pipe()
+	// Fail fast (rather than hang to the package timeout) if a regression makes
+	// the pump stop reading while a test is still writing raw frames into c.
+	_ = c.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	pump := startClientPump(s, h, nil)
+	return c, func() {
+		pump.stop()
+		_ = c.Close()
+		_ = s.Close()
+	}
+}
+
+func TestPumpClientMessages(t *testing.T) {
+	// Fidelity guard: a single frame whose header and payload are delivered
+	// across several separate writes must be reassembled and handed to onData
+	// complete and in order. This proves the blocking reader reassembles a split
+	// frame correctly; the timing-specific #222 regression (losing bytes when a
+	// per-read deadline fires mid-frame) is covered by slowPayloadNotTimedOut
+	// below and by the one-time pre-fix demo recorded in the PR.
+	t.Run("splitFrameDeliveredIntact", func(t *testing.T) {
+		var got []byte
+		client, stop := startTestPump(t, messageHandlers{
+			onData:         func(b []byte) { got = append(got, b...) },
+			stopOnStdinEOF: true,
+		})
+
+		payload := make([]byte, 9000) // larger than a single pipe read chunk
+		for i := range payload {
+			payload[i] = byte(i % 251)
+		}
+		hdr := make([]byte, 5)
+		hdr[0] = MsgTypeData
+		binary.BigEndian.PutUint32(hdr[1:], uint32(len(payload)))
+
+		// Deliver the frame in pieces: header, then the payload split across two
+		// writes, so the agent's io.ReadFull must reassemble across reads.
+		if _, err := client.Write(hdr); err != nil {
+			t.Fatalf("write header: %v", err)
+		}
+		if _, err := client.Write(payload[:4000]); err != nil {
+			t.Fatalf("write payload part 1: %v", err)
+		}
+		if _, err := client.Write(payload[4000:]); err != nil {
+			t.Fatalf("write payload part 2: %v", err)
+		}
+		send(t, client, MsgTypeStdinEOF, nil) // stop the pump
+		stop()                                // wg.Wait inside establishes happens-before for got
+
+		if !bytes.Equal(got, payload) {
+			t.Fatalf("payload corrupted/lost: got %d bytes, want %d", len(got), len(payload))
+		}
+	})
+
+	// Timing regression guard tied to #222: the input pump must NOT impose a
+	// per-read deadline. A frame whose payload arrives after a pause longer than
+	// the removed 500ms poll interval must still be delivered intact. A
+	// regression to deadline-based polling would time out mid-frame and discard
+	// the bytes consumed so far (the pre-fix behavior, demonstrated against the
+	// old code in the PR). This is the only intentionally slow subtest (~600ms).
+	t.Run("slowPayloadNotTimedOut", func(t *testing.T) {
+		var got []byte
+		client, stop := startTestPump(t, messageHandlers{
+			onData:         func(b []byte) { got = append(got, b...) },
+			stopOnStdinEOF: true,
+		})
+		payload := []byte("payload-after-a-long-pause")
+		hdr := make([]byte, 5)
+		hdr[0] = MsgTypeData
+		binary.BigEndian.PutUint32(hdr[1:], uint32(len(payload)))
+
+		if _, err := client.Write(hdr); err != nil {
+			t.Fatalf("write header: %v", err)
+		}
+		// Pause longer than the removed 500ms poll deadline before the payload.
+		// The blocking pump waits; a deadline-polling regression would not.
+		time.Sleep(600 * time.Millisecond)
+		if _, err := client.Write(payload); err != nil {
+			t.Fatalf("write payload: %v", err)
+		}
+		send(t, client, MsgTypeStdinEOF, nil)
+		stop()
+
+		if string(got) != string(payload) {
+			t.Fatalf("payload lost across pause: got %q want %q", got, payload)
+		}
+	})
+
+	// After the process exits the caller's pump.stop() sets a read deadline; the
+	// blocked pump must return promptly. Proves the teardown contract is
+	// deterministic (and exercises the real clientPump.stop path).
+	t.Run("teardownDeadlineUnblocks", func(t *testing.T) {
+		c, s := net.Pipe()
+		defer c.Close()
+		defer s.Close()
+		pump := startClientPump(s, messageHandlers{}, nil) // blocks: nothing is ever written
+		done := make(chan struct{})
+		go func() { defer close(done); pump.stop() }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("pump.stop did not return (SetReadDeadline failed to unblock the blocking read)")
+		}
+	})
+
+	// Non-PTY semantics: MsgTypeStdinEOF stops the pump on its own. The cleanup
+	// callback fires when the pump returns, so closing it signals "stopped".
+	t.Run("stdinEOFStopsNonPTY", func(t *testing.T) {
+		c, s := net.Pipe()
+		defer c.Close()
+		defer s.Close()
+		done := make(chan struct{})
+		startClientPump(s, messageHandlers{stopOnStdinEOF: true}, func() { close(done) })
+		send(t, c, MsgTypeStdinEOF, nil)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("pump did not stop on MsgTypeStdinEOF")
+		}
+	})
+
+	// PTY semantics: MsgTypeStdinEOF is ignored (no separate stdin pipe), so the
+	// pump keeps running and still delivers later data frames.
+	t.Run("stdinEOFIgnoredPTY", func(t *testing.T) {
+		var got []byte
+		client, stop := startTestPump(t, messageHandlers{
+			onData:         func(b []byte) { got = append(got, b...) },
+			stopOnStdinEOF: false,
+		})
+		send(t, client, MsgTypeStdinEOF, nil)
+		send(t, client, MsgTypeData, []byte("after-eof"))
+		stop()
+		if string(got) != "after-eof" {
+			t.Fatalf("expected data delivered after ignored StdinEOF, got %q", got)
+		}
+	})
+
+	// onData failing/continuing must NOT stop the pump: a process that closed its
+	// own stdin can still be running and must keep receiving forwarded signals.
+	// This pins the resolved review contradiction (log-and-continue, not stop).
+	t.Run("dataFrameDoesNotStopSignalForwarding", func(t *testing.T) {
+		sigCh := make(chan int, 4)
+		client, stop := startTestPump(t, messageHandlers{
+			onData:         func(b []byte) { /* simulate a process that ignores stdin */ },
+			onSignal:       func(sig int) { sigCh <- sig },
+			stopOnStdinEOF: true,
+		})
+		send(t, client, MsgTypeData, []byte("ignored"))
+		send(t, client, MsgTypeSignal, mustJSON(t, SignalMessage{Signal: 2}))
+		send(t, client, MsgTypeStdinEOF, nil)
+		stop()
+		close(sigCh)
+		var sigs []int
+		for s := range sigCh {
+			sigs = append(sigs, s)
+		}
+		if len(sigs) != 1 || sigs[0] != 2 {
+			t.Fatalf("expected signal 2 forwarded after data frame, got %v", sigs)
+		}
+	})
+
+	// Signal dispatch: valid numbers reach onSignal; out-of-range numbers are
+	// logged and dropped (never forwarded).
+	t.Run("signalDispatchAndValidation", func(t *testing.T) {
+		sigCh := make(chan int, 8)
+		client, stop := startTestPump(t, messageHandlers{
+			onSignal:       func(sig int) { sigCh <- sig },
+			stopOnStdinEOF: true,
+		})
+		for _, n := range []int{15, 0, 65, 9} { // 0 and 65 are invalid
+			send(t, client, MsgTypeSignal, mustJSON(t, SignalMessage{Signal: n}))
+		}
+		send(t, client, MsgTypeStdinEOF, nil)
+		stop()
+		close(sigCh)
+		var sigs []int
+		for s := range sigCh {
+			sigs = append(sigs, s)
+		}
+		want := []int{15, 9}
+		if len(sigs) != len(want) || sigs[0] != want[0] || sigs[1] != want[1] {
+			t.Fatalf("expected only valid signals %v forwarded, got %v", want, sigs)
+		}
+	})
+
+	// Resize dispatch (PTY path).
+	t.Run("resizeDispatch", func(t *testing.T) {
+		type size struct{ rows, cols uint16 }
+		szCh := make(chan size, 2)
+		client, stop := startTestPump(t, messageHandlers{
+			onResize:       func(rows, cols uint16) { szCh <- size{rows, cols} },
+			stopOnStdinEOF: true,
+		})
+		send(t, client, MsgTypeResize, mustJSON(t, ResizeMessage{Rows: 40, Cols: 120}))
+		send(t, client, MsgTypeStdinEOF, nil)
+		stop()
+		select {
+		case got := <-szCh:
+			if got.rows != 40 || got.cols != 120 {
+				t.Fatalf("resize = %dx%d, want 40x120", got.rows, got.cols)
+			}
+		default:
+			t.Fatal("onResize was not called")
+		}
+	})
+
+	// Unknown/future message types are logged and skipped — never written into
+	// the child via onData.
+	t.Run("unknownTypeIgnored", func(t *testing.T) {
+		dataCalled := false
+		client, stop := startTestPump(t, messageHandlers{
+			onData:         func(b []byte) { dataCalled = true },
+			stopOnStdinEOF: true,
+		})
+		send(t, client, 0x7F, []byte("mystery"))
+		send(t, client, MsgTypeStdinEOF, nil)
+		stop()
+		if dataCalled {
+			t.Fatal("unknown message type was routed to onData")
+		}
+	})
+}

--- a/cmd/shed-agent/exec_test.go
+++ b/cmd/shed-agent/exec_test.go
@@ -38,13 +38,11 @@ func send(t *testing.T, c net.Conn, msgType byte, data []byte) {
 // client end (the test writes framed messages into it) plus a stop() that drives
 // the real teardown (clientPump.stop) and closes the pipe. net.Pipe is
 // synchronous and supports deadlines (Go 1.10+), which is what the teardown
-// relies on.
+// relies on. stop()'s wg.Wait establishes happens-before for reading whatever
+// the handlers recorded.
 func startTestPump(t *testing.T, h messageHandlers) (client net.Conn, stop func()) {
 	t.Helper()
 	c, s := net.Pipe()
-	// Fail fast (rather than hang to the package timeout) if a regression makes
-	// the pump stop reading while a test is still writing raw frames into c.
-	_ = c.SetWriteDeadline(time.Now().Add(5 * time.Second))
 	pump := startClientPump(s, h, nil)
 	return c, func() {
 		pump.stop()
@@ -63,8 +61,7 @@ func TestPumpClientMessages(t *testing.T) {
 	t.Run("splitFrameDeliveredIntact", func(t *testing.T) {
 		var got []byte
 		client, stop := startTestPump(t, messageHandlers{
-			onData:         func(b []byte) { got = append(got, b...) },
-			stopOnStdinEOF: true,
+			onData: func(b []byte) { got = append(got, b...) },
 		})
 
 		payload := make([]byte, 9000) // larger than a single pipe read chunk
@@ -86,8 +83,7 @@ func TestPumpClientMessages(t *testing.T) {
 		if _, err := client.Write(payload[4000:]); err != nil {
 			t.Fatalf("write payload part 2: %v", err)
 		}
-		send(t, client, MsgTypeStdinEOF, nil) // stop the pump
-		stop()                                // wg.Wait inside establishes happens-before for got
+		stop() // wg.Wait inside establishes happens-before for got
 
 		if !bytes.Equal(got, payload) {
 			t.Fatalf("payload corrupted/lost: got %d bytes, want %d", len(got), len(payload))
@@ -98,13 +94,11 @@ func TestPumpClientMessages(t *testing.T) {
 	// per-read deadline. A frame whose payload arrives after a pause longer than
 	// the removed 500ms poll interval must still be delivered intact. A
 	// regression to deadline-based polling would time out mid-frame and discard
-	// the bytes consumed so far (the pre-fix behavior, demonstrated against the
-	// old code in the PR). This is the only intentionally slow subtest (~600ms).
+	// the bytes consumed so far. This is the only intentionally slow subtest.
 	t.Run("slowPayloadNotTimedOut", func(t *testing.T) {
 		var got []byte
 		client, stop := startTestPump(t, messageHandlers{
-			onData:         func(b []byte) { got = append(got, b...) },
-			stopOnStdinEOF: true,
+			onData: func(b []byte) { got = append(got, b...) },
 		})
 		payload := []byte("payload-after-a-long-pause")
 		hdr := make([]byte, 5)
@@ -120,7 +114,6 @@ func TestPumpClientMessages(t *testing.T) {
 		if _, err := client.Write(payload); err != nil {
 			t.Fatalf("write payload: %v", err)
 		}
-		send(t, client, MsgTypeStdinEOF, nil)
 		stop()
 
 		if string(got) != string(payload) {
@@ -145,29 +138,39 @@ func TestPumpClientMessages(t *testing.T) {
 		}
 	})
 
-	// Non-PTY semantics: MsgTypeStdinEOF stops the pump on its own. The cleanup
-	// callback fires when the pump returns, so closing it signals "stopped".
-	t.Run("stdinEOFStopsNonPTY", func(t *testing.T) {
-		c, s := net.Pipe()
-		defer c.Close()
-		defer s.Close()
-		done := make(chan struct{})
-		startClientPump(s, messageHandlers{stopOnStdinEOF: true}, func() { close(done) })
-		send(t, c, MsgTypeStdinEOF, nil)
+	// MsgTypeStdinEOF closes stdin (fires onStdinEOF) but does NOT stop the pump:
+	// a command can keep running after stdin closes and must still receive later
+	// signal frames. Pins the resolved review finding (close-once, keep pumping).
+	t.Run("stdinEOFClosesStdinKeepsPumping", func(t *testing.T) {
+		eofCount := 0
+		sigCh := make(chan int, 2)
+		client, stop := startTestPump(t, messageHandlers{
+			onStdinEOF: func() { eofCount++ },
+			onSignal:   func(sig int) { sigCh <- sig },
+		})
+		send(t, client, MsgTypeStdinEOF, nil)
+		// Pump must still be alive to forward this signal after stdin EOF.
+		send(t, client, MsgTypeSignal, mustJSON(t, SignalMessage{Signal: 2}))
+		stop()
+		if eofCount != 1 {
+			t.Fatalf("onStdinEOF fired %d times, want 1", eofCount)
+		}
 		select {
-		case <-done:
-		case <-time.After(2 * time.Second):
-			t.Fatal("pump did not stop on MsgTypeStdinEOF")
+		case got := <-sigCh:
+			if got != 2 {
+				t.Fatalf("signal after stdin EOF = %d, want 2", got)
+			}
+		default:
+			t.Fatal("signal after stdin EOF was not forwarded (pump stopped too early)")
 		}
 	})
 
-	// PTY semantics: MsgTypeStdinEOF is ignored (no separate stdin pipe), so the
-	// pump keeps running and still delivers later data frames.
+	// PTY semantics: onStdinEOF is nil, so MsgTypeStdinEOF is a no-op and the pump
+	// keeps delivering later data frames.
 	t.Run("stdinEOFIgnoredPTY", func(t *testing.T) {
 		var got []byte
 		client, stop := startTestPump(t, messageHandlers{
-			onData:         func(b []byte) { got = append(got, b...) },
-			stopOnStdinEOF: false,
+			onData: func(b []byte) { got = append(got, b...) },
 		})
 		send(t, client, MsgTypeStdinEOF, nil)
 		send(t, client, MsgTypeData, []byte("after-eof"))
@@ -179,17 +182,14 @@ func TestPumpClientMessages(t *testing.T) {
 
 	// onData failing/continuing must NOT stop the pump: a process that closed its
 	// own stdin can still be running and must keep receiving forwarded signals.
-	// This pins the resolved review contradiction (log-and-continue, not stop).
 	t.Run("dataFrameDoesNotStopSignalForwarding", func(t *testing.T) {
 		sigCh := make(chan int, 4)
 		client, stop := startTestPump(t, messageHandlers{
-			onData:         func(b []byte) { /* simulate a process that ignores stdin */ },
-			onSignal:       func(sig int) { sigCh <- sig },
-			stopOnStdinEOF: true,
+			onData:   func(b []byte) { /* simulate a process that ignores stdin */ },
+			onSignal: func(sig int) { sigCh <- sig },
 		})
 		send(t, client, MsgTypeData, []byte("ignored"))
 		send(t, client, MsgTypeSignal, mustJSON(t, SignalMessage{Signal: 2}))
-		send(t, client, MsgTypeStdinEOF, nil)
 		stop()
 		close(sigCh)
 		var sigs []int
@@ -206,13 +206,11 @@ func TestPumpClientMessages(t *testing.T) {
 	t.Run("signalDispatchAndValidation", func(t *testing.T) {
 		sigCh := make(chan int, 8)
 		client, stop := startTestPump(t, messageHandlers{
-			onSignal:       func(sig int) { sigCh <- sig },
-			stopOnStdinEOF: true,
+			onSignal: func(sig int) { sigCh <- sig },
 		})
 		for _, n := range []int{15, 0, 65, 9} { // 0 and 65 are invalid
 			send(t, client, MsgTypeSignal, mustJSON(t, SignalMessage{Signal: n}))
 		}
-		send(t, client, MsgTypeStdinEOF, nil)
 		stop()
 		close(sigCh)
 		var sigs []int
@@ -230,11 +228,9 @@ func TestPumpClientMessages(t *testing.T) {
 		type size struct{ rows, cols uint16 }
 		szCh := make(chan size, 2)
 		client, stop := startTestPump(t, messageHandlers{
-			onResize:       func(rows, cols uint16) { szCh <- size{rows, cols} },
-			stopOnStdinEOF: true,
+			onResize: func(rows, cols uint16) { szCh <- size{rows, cols} },
 		})
 		send(t, client, MsgTypeResize, mustJSON(t, ResizeMessage{Rows: 40, Cols: 120}))
-		send(t, client, MsgTypeStdinEOF, nil)
 		stop()
 		select {
 		case got := <-szCh:
@@ -251,11 +247,9 @@ func TestPumpClientMessages(t *testing.T) {
 	t.Run("unknownTypeIgnored", func(t *testing.T) {
 		dataCalled := false
 		client, stop := startTestPump(t, messageHandlers{
-			onData:         func(b []byte) { dataCalled = true },
-			stopOnStdinEOF: true,
+			onData: func(b []byte) { dataCalled = true },
 		})
 		send(t, client, 0x7F, []byte("mystery"))
-		send(t, client, MsgTypeStdinEOF, nil)
 		stop()
 		if dataCalled {
 			t.Fatal("unknown message type was routed to onData")

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -791,6 +791,17 @@ This is the same model Docker, devcontainers, Codespaces, and Coder follow on th
 
 **Raw SSH gets the full shell.** If you connect with raw `ssh shed-name 'cmd | pipe'` (the path Zed Remote-SSH, VS Code Remote-SSH, JetBrains Gateway, and `rsync` take), the SSH server runs your command string through `bash -lc <raw>` — so the pipe runs as a shell pipeline on the shed, exactly like a normal dev VM. The `shed exec` CLI is the path that preserves argv literally; raw SSH is the path that runs a shell.
 
+**Disconnect behavior.** When the connection drops (you Ctrl-C the client, the network drops, your laptop sleeps), the command is terminated — the agent sends `SIGHUP` to the command's process group, matching standard SSH/terminal "connection hung up" semantics. To keep a long task running across disconnects, detach it from the session with **`tmux`** (baked into the shed image) or **`nohup`**:
+
+```bash
+# Survives a disconnect — runs in a detached tmux session
+shed exec codelens -- tmux new-session -d -s build './build.sh'
+# …or with nohup
+shed exec codelens -- bash -c 'nohup ./build.sh >build.log 2>&1 &'
+```
+
+These detach the work into its own session/process group, so the `SIGHUP` to the foreground command never reaches it. Reattach later with `shed attach codelens --session build` (tmux) or just re-read the log.
+
 **Examples:**
 
 ```bash

--- a/tests/integration/fixtures/server.py
+++ b/tests/integration/fixtures/server.py
@@ -299,36 +299,74 @@ class LocalServer:
         Gateway take. The `shed exec` CLI path is covered by
         `exec(...)` above; use *this* helper when you want to assert
         that shell metacharacters in the raw command actually fire on
-        the server side.
+        the server side. Connection params are resolved by `ssh_argv`.
+        """
+        return subprocess.run(
+            self.ssh_argv(name, raw_command),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
 
-        Resolves connection params (host, SSH port, known-hosts file)
-        via `shed --json server list` so we line up with whatever the
-        CLI would have used. Uses `~/.shed/known_hosts` with
-        StrictHostKeyChecking=yes when it exists (the file the CLI
-        populates at create-time); falls back to
-        StrictHostKeyChecking=no for fresh test environments. The
-        integration suite only ever talks to known-good test sheds, so
-        the fallback is safe.
+    def ssh_argv(self, name: str, raw_command: str) -> list[str]:
+        """Build the raw `ssh` argv for `name`'s shed running `raw_command`.
+
+        Shared by `ssh_exec` (text) and `ssh_exec_binary` (bytes), and
+        exposed so a test that drives the channel directly lines up with
+        the same connection params the CLI would have used.
+
+        Resolves connection params (host, SSH port, known-hosts file) via
+        the server entry (`_ssh_connect_params`). Uses `~/.shed/known_hosts`
+        with StrictHostKeyChecking=yes when it exists (the file the CLI
+        populates at create-time); falls back to StrictHostKeyChecking=no
+        for fresh test environments. The integration suite only ever talks
+        to known-good test sheds, so the fallback is safe.
+
+        Passes `-T` to force the non-PTY exec path regardless of the
+        client's `RequestTTY` config. These helpers drive `ssh host cmd`,
+        which is the channel shape Zed/VS Code/rsync use and the one issue
+        #222 concerns; a stray PTY would apply line-discipline translation
+        and corrupt a binary round-trip.
         """
         host, port, known_hosts = self._ssh_connect_params()
-        ssh_argv = [
+        argv = [
             "ssh",
+            "-T",
             "-p", str(port),
             "-o", "BatchMode=yes",
             "-o", "ConnectTimeout=5",
         ]
         if known_hosts is not None:
-            ssh_argv += [
+            argv += [
                 "-o", f"UserKnownHostsFile={known_hosts}",
                 "-o", "StrictHostKeyChecking=yes",
             ]
         else:
-            ssh_argv += ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null"]
-        ssh_argv += [f"{name}@{host}", raw_command]
+            argv += ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null"]
+        argv += [f"{name}@{host}", raw_command]
+        return argv
+
+    def ssh_exec_binary(
+        self,
+        name: str,
+        raw_command: str,
+        input: bytes,
+        timeout: int = 60,
+    ) -> "subprocess.CompletedProcess[bytes]":
+        """Like `ssh_exec`, but pipes binary `input` to the remote command
+        and captures raw stdout BYTES (no text-mode newline translation).
+
+        This drives the non-PTY exec channel as an 8-bit-clean binary pipe
+        — the channel shape Zed Remote-SSH uses — so a test can assert
+        byte-perfect round-trips through the agent's framed protocol
+        (issue #222). `subprocess.run(input=...)` uses `communicate()`
+        under the hood, so it writes stdin, drains stdout/stderr, and
+        closes cleanly without deadlock; `timeout` bounds the whole call.
+        """
         return subprocess.run(
-            ssh_argv,
+            self.ssh_argv(name, raw_command),
+            input=input,
             capture_output=True,
-            text=True,
             timeout=timeout,
         )
 

--- a/tests/integration/fixtures/server.py
+++ b/tests/integration/fixtures/server.py
@@ -308,7 +308,7 @@ class LocalServer:
             timeout=timeout,
         )
 
-    def ssh_argv(self, name: str, raw_command: str) -> list[str]:
+    def ssh_argv(self, name: str, raw_command: str, pty: bool = False) -> list[str]:
         """Build the raw `ssh` argv for `name`'s shed running `raw_command`.
 
         Shared by `ssh_exec` (text) and `ssh_exec_binary` (bytes), and
@@ -322,16 +322,16 @@ class LocalServer:
         for fresh test environments. The integration suite only ever talks
         to known-good test sheds, so the fallback is safe.
 
-        Passes `-T` to force the non-PTY exec path regardless of the
-        client's `RequestTTY` config. These helpers drive `ssh host cmd`,
-        which is the channel shape Zed/VS Code/rsync use and the one issue
-        #222 concerns; a stray PTY would apply line-discipline translation
-        and corrupt a binary round-trip.
+        Forces the channel type regardless of the client's `RequestTTY`
+        config: `-T` (default) drives the non-PTY exec path — the channel
+        shape Zed/VS Code/rsync use and the one issue #222 concerns (a stray
+        PTY would line-discipline-mangle a binary round-trip) — while
+        `pty=True` passes `-tt` to force the interactive PTY path.
         """
         host, port, known_hosts = self._ssh_connect_params()
         argv = [
             "ssh",
-            "-T",
+            "-tt" if pty else "-T",
             "-p", str(port),
             "-o", "BatchMode=yes",
             "-o", "ConnectTimeout=5",

--- a/tests/integration/test_exec_disconnect.py
+++ b/tests/integration/test_exec_disconnect.py
@@ -1,0 +1,88 @@
+"""Host-disconnect cleanup for the SSH exec channel (issue #222 follow-on).
+
+When the host disconnects mid-command, the in-VM agent must terminate the
+command — it SIGHUPs the command's process group — rather than orphaning it.
+This matches standard SSH "connection hung up" semantics (use tmux/nohup to
+intentionally survive a disconnect). Before the fix, a disconnected command kept
+running and the agent leaked the handler goroutine waiting on it.
+
+A silent command (no stdin, no output) can't be detected via an I/O error on the
+channel — the guest's vsock read does not deliver EOF on the host's close — so
+the agent probes the connection with a periodic keepalive; a failed probe is the
+disconnect signal. This is exercised on BOTH the non-PTY exec path and the PTY
+path (an idle interactive session whose host sleeps/drops is the canonical
+orphan case).
+
+Parameterized over ["vz", "fc"] (the backend) and ["nopty", "pty"] (the channel).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+
+import pytest
+
+
+@pytest.mark.parametrize("pty", [False, True], ids=["nopty", "pty"])
+def test_disconnect_terminates_command(shed_server, test_shed_name, pty):
+    """Killing the SSH client mid-command terminates the remote process.
+
+    Runs a long silent `sleep` over the exec channel, records its PID (via a
+    file the command writes), kills the SSH client to simulate a disconnect,
+    then polls `/proc/<pid>` from a fresh exec until the process is gone. The
+    silent command forces detection through the agent's keepalive probe rather
+    than an I/O error, on both the non-PTY and PTY paths.
+    """
+    shed_server.create(test_shed_name, image="base")
+
+    label = "pty" if pty else "nopty"
+    pid_file = f"/tmp/shed-disconnect-{label}.pid"
+    # `exec sleep` replaces the shell, so $$ (recorded before exec) is the
+    # sleep's PID. The command holds the channel open until we disconnect.
+    raw = f"echo $$ > {pid_file}; exec sleep 600"
+    argv = shed_server.ssh_argv(test_shed_name, raw, pty=pty)
+
+    # `with` closes the stdin/stdout/stderr pipes and reaps the client on exit
+    # (avoids ResourceWarnings that the suite escalates to failures).
+    with subprocess.Popen(
+        argv,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ) as proc:
+        # Poll (from a fresh exec) for the PID the command records — robust to
+        # PTY echo/control bytes that would complicate parsing the channel.
+        pid = None
+        for _ in range(30):
+            r = shed_server.exec(test_shed_name, ["cat", pid_file])
+            if r.returncode == 0 and r.stdout.strip().isdigit():
+                pid = r.stdout.strip()
+                break
+            time.sleep(0.5)
+        assert pid, f"command did not start on the {label} channel"
+
+        r = shed_server.exec(test_shed_name, ["test", "-d", f"/proc/{pid}"])
+        assert r.returncode == 0, f"probe process {pid} not alive before disconnect"
+
+        # Simulate a host disconnect: kill the SSH client hard.
+        proc.kill()
+
+    # The disconnect should propagate to the agent, which SIGHUPs the command's
+    # process group. A silent command is detected via the agent's keepalive
+    # probe, so allow comfortably more than one keepalive interval. Poll until
+    # /proc/<pid> disappears.
+    deadline = time.time() + 40
+    alive = True
+    while time.time() < deadline:
+        r = shed_server.exec(test_shed_name, ["test", "-d", f"/proc/{pid}"])
+        if r.returncode != 0:
+            alive = False
+            break
+        time.sleep(1)
+
+    assert not alive, (
+        f"command (pid {pid}) survived the host disconnect on the {label} channel "
+        f"— the agent did not terminate the process group, orphaning it and "
+        f"leaking the handler goroutine"
+    )

--- a/tests/integration/test_exec_disconnect.py
+++ b/tests/integration/test_exec_disconnect.py
@@ -37,7 +37,10 @@ def test_disconnect_terminates_command(shed_server, test_shed_name, pty):
     shed_server.create(test_shed_name, image="base")
 
     label = "pty" if pty else "nopty"
-    pid_file = f"/tmp/shed-disconnect-{label}.pid"
+    # Unique per shed + mode so a run can never read a stale PID file (the shed
+    # is fresh per test, but this is cheap insurance against future test reuse).
+    pid_file = f"/tmp/shed-disconnect-{test_shed_name}-{label}.pid"
+    shed_server.exec(test_shed_name, ["rm", "-f", pid_file])  # clear any stale file
     # `exec sleep` replaces the shell, so $$ (recorded before exec) is the
     # sleep's PID. The command holds the channel open until we disconnect.
     raw = f"echo $$ > {pid_file}; exec sleep 600"

--- a/tests/integration/test_zed_binary_channel.py
+++ b/tests/integration/test_zed_binary_channel.py
@@ -1,0 +1,79 @@
+"""Binary-fidelity tests for the non-PTY SSH exec channel (issue #222).
+
+Zed Remote-SSH runs a long-running proxy over a *non-PTY* exec channel and
+uses its stdin/stdout as a raw, length-prefixed binary pipe. A regression in
+the agent's stdin forwarding (`cmd/shed-agent/exec.go`) once desynchronized
+that framed protocol — a 500ms `SetReadDeadline` poll could fire mid-frame,
+consume bytes that `ReadMessage` then discarded, and permanently offset the
+stream — so Zed connections failed with "stdin read failed: unexpected end of
+file". VS Code was unaffected because its primary data channel uses
+`direct-tcpip` raw `io.Copy`, not the framed agent protocol.
+
+These tests pump binary data through `ssh <shed> -- cat` (no PTY) and assert a
+byte-perfect round-trip, exercising the real wire path host framing → vsock →
+agent pump → process and back.
+
+Scope note: the **deterministic** mid-frame-desync reproducer is the Go unit
+test `TestPumpClientMessages` (cmd/shed-agent/exec_test.go), which can force a
+read deadline mid-frame. These live tests are the complementary fidelity guard:
+they confirm the real non-PTY binary channel carries data intact and stays in
+sync end-to-end. Parameterized over `["vz", "fc"]` like the rest of the suite.
+"""
+
+from __future__ import annotations
+
+import random
+
+
+def test_binary_roundtrip_fidelity(shed_server, test_shed_name):
+    """4 MB of binary data piped through `cat` returns byte-identical.
+
+    The agent reads the SSH stdin stream as framed `MsgTypeData` messages and
+    writes them to the process; `cat` echoes them back. Several MB streamed
+    continuously crosses ~1000 frames — if the agent's framed reader lost or
+    misaligned bytes, the echo would not match.
+    """
+    shed_server.create(test_shed_name, image="base")
+
+    # Deterministic (seeded) random payload so a failure is reproducible. Random
+    # bytes include every value 0x00..0xFF, so control bytes and high-bit bytes
+    # all traverse the 8-bit-clean channel.
+    payload = random.Random(0xC0FFEE).randbytes(4 * 1024 * 1024)
+
+    r = shed_server.ssh_exec_binary(test_shed_name, "cat", input=payload, timeout=120)
+    assert r.returncode == 0, (
+        f"ssh -- cat exited {r.returncode}; stderr={r.stderr[:200]!r}"
+    )
+    assert len(r.stdout) == len(payload), (
+        f"length mismatch: got {len(r.stdout)} bytes, sent {len(payload)} — "
+        f"the binary stream was truncated or desynchronized"
+    )
+    assert r.stdout == payload, (
+        "binary round-trip corrupted: the echoed bytes differ from what was "
+        "sent, indicating the agent's framed stdin reader lost or misaligned "
+        "bytes (issue #222 regression)"
+    )
+
+
+def test_binary_roundtrip_all_byte_values(shed_server, test_shed_name):
+    """A payload covering every byte value 0x00..0xFF round-trips intact.
+
+    Explicitly includes the protocol's own control-frame type bytes (0x05
+    `MsgTypeData`, 0x06 `MsgTypeStdinEOF`) and NUL as ordinary payload data, to
+    prove the channel is a transparent 8-bit pipe and never reinterprets
+    payload bytes as framing.
+    """
+    shed_server.create(test_shed_name, image="base")
+
+    # Tile 0x00..0xFF so the payload is exhaustive over byte values and large
+    # enough to span many frames.
+    payload = bytes(range(256)) * 4096  # 1 MiB
+
+    r = shed_server.ssh_exec_binary(test_shed_name, "cat", input=payload, timeout=60)
+    assert r.returncode == 0, (
+        f"ssh -- cat exited {r.returncode}; stderr={r.stderr[:200]!r}"
+    )
+    assert r.stdout == payload, (
+        f"binary round-trip corrupted across the full byte range: "
+        f"got {len(r.stdout)} bytes, sent {len(payload)}"
+    )


### PR DESCRIPTION
Fixes #222 — Zed Remote-SSH cannot connect to a shed.

## Root cause

Zed runs a long-running proxy over a **non-PTY** SSH exec channel and uses its stdin/stdout as a raw, length-prefixed binary protobuf pipe. The in-VM agent forwarded that stream into the process with a 500 ms `SetReadDeadline` *polling* read (`readMessageWithTimeout` → `io.ReadFull`). When the deadline fired **mid-frame**, `io.ReadFull` had already consumed N bytes that `ReadMessage` then discarded on the timeout error; the caller treated the timeout as "continue" and re-framed from a misaligned offset — **permanently desynchronizing the framed binary protocol**. The agent then read garbage, closed the process's stdin, and Zed reported `stdin read failed: unexpected end of file`. VS Code is unaffected because its data channel uses `direct-tcpip` raw `io.Copy`, not the framed agent protocol.

## What changed

Three reliability fixes to the in-VM agent's exec channel (`cmd/shed-agent/exec.go`), shared by VZ and Firecracker:

1. **Stdin desync (the #222 blocker)** — replace the 500 ms deadline polling with **blocking reads** (`pumpClientMessages`), so a deadline can never fire mid-frame. A `clientPump` handle owns the goroutine and an ordered teardown (`SetReadDeadline(now)` → wait → `writeExitCode`). Dispatch is on the explicit `MsgTypeData` case; unknown types are logged and ignored.

2. **Output truncation** (surfaced by the new 4 MB binary test) — `runWithoutPTY` called `cmd.Wait()` before draining the stdout/stderr copy goroutines, but `cmd.Wait` closes the `StdoutPipe`/`StderrPipe` read ends and discards still-buffered output, truncating large outputs under back-pressure (a 4 MB `cat` round-trip lost ~36 KB). Drain to EOF **before** reaping (the `os/exec` `StdoutPipe` contract). Zed needs reliable *bidirectional* transport, so this matters for it too.

3. **Host-disconnect cleanup** — previously a disconnected command kept running **orphaned** and the agent leaked the handler goroutine blocked on `cmd.Wait`. Now the command runs in its own process group (`Setpgid`; PTY uses `Setsid` via `pty.Start`) and a disconnect **SIGHUPs the group**, matching standard SSH "connection hung up" semantics. Detected on three signals — the pump's read error, an output-write error, and a periodic **keepalive probe** (a zero-length frame the host treats as an empty stdout write) that covers commands which neither read stdin nor write output. The keepalive runs on **both** the PTY and non-PTY paths, so an idle interactive session whose host sleeps/drops is cleaned up too.

### Behavior change

Disconnecting a bare `shed exec`/ssh command now **terminates** it (it was silently orphaned before — a leak). This matches OpenSSH/Docker/Codespaces. Use **tmux** (baked into the image) or **nohup** to survive a disconnect — they detach into their own session, so the SIGHUP never reaches them. Documented in `docs/reference/cli.md`.

## Evidence

A one-time RED/GREEN check against the pre-fix code (a frame whose payload straddles a >500 ms gap):

```
OLD polling reader: delivered 0/9000 payload bytes, intact=false
NEW blocking pump : delivered 9000/9000 payload bytes, intact=true
```

## Tests

- **Unit** (`cmd/shed-agent/exec_test.go`, `-race`): split-frame byte-fidelity, a >500 ms-gap timing-regression guard, deterministic teardown, StdinEOF stop (non-PTY) vs ignore (PTY), signal-forwarding-survives-stdin-write-error, signal/resize/unknown-type dispatch, and disconnect-vs-teardown-deadline classification.
- **Integration** (opt-in live suite): `test_zed_binary_channel.py` (4 MB + all-byte-values binary round-trip) and `test_exec_disconnect.py` (silent `sleep` killed on disconnect, parameterized over the **PTY and non-PTY** channels).

**Validated end-to-end on a real VZ VM** (dev server, rebuilt rootfs): 4 MB binary round-trip byte-perfect; streaming, silent, and PTY disconnects all terminate the command within the expected window; tmux-detached work survives; `exec_shell` + `smoke` suites green (19/19 vz). `make check` passes.

## Plan review

Plan was reviewed by Codex, Kimi K2.6, and CodeRabbit (`/planning:ask-panel`); each commit went through `/simplify` (4 cleanup agents) and `/codex:rescue` (correctness). Codex's two blocking findings on the teardown (keepalive stop ordering for closed-output commands; comment overstating post-reap kill safety) are addressed.

CodeRabbit's two Major findings on the PR are addressed in `refactor(agent): address review …`: (1) the input pump now stays alive after `MsgTypeStdinEOF` (closing stdin once) so signal forwarding + read-error disconnect detection survive stdin close; (2) the keepalive probe write is bounded by a deadline so a stalled conn can't hang teardown. Re-validated end-to-end.

## Also included

- **Testing skill** (`.claude/skills/testing-vm-agent-changes`) + a CLAUDE.md pointer — the agent is baked into the rootfs *image*, not the host server, so `make test-integration-dev` doesn't pick up agent changes. The skill documents the rebuild-rootfs-into-dev-store loop and the codesign / build-tools / BuildKit-cache / ref-index gremlins this PR hit.

## Follow-ups

- ~~Unify the per-path conn writers (`connWriter`/`copyToConn`)~~ — **done in this PR** after the review feedback (collapses the duplicated stdout/stderr/PTY copy loops + keepalive probe into one shared guarded writer).
- Dev-tooling: the `OUTPUT_DIR` build can leave the ref-index pointing at a stale manifest, and BuildKit can cache a stale agent layer — **tracked in #227** (worked around here + captured in the testing skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
