### PR TITLE
fix(image+build): dev-image build resolution + agent cache-bust (#227)

### DIFF
--- a/.claude/skills/testing-vm-agent-changes/SKILL.md
+++ b/.claude/skills/testing-vm-agent-changes/SKILL.md
@@ -106,30 +106,26 @@ OUTPUT_DIR="$HOME/Library/Application Support/shed-dev/vz" \
   ./scripts/build-vz-rootfs.sh --variant base --build-tools-version <BT_TAG>
 ```
 
-### 3. Make the dev server resolve to your new manifest
+### 3. Resolution is automatic (since #227)
 
-Two gremlins routinely make the freshly-built agent NOT reach the VM. Always
-**verify** (step 4) before trusting a run.
+The rebuild "just works" now — **no `docker buildx prune`, no hand-edited
+`refs/<hash>.json`.** Two mechanisms make it reliable (both fixed the gremlins
+that used to live here):
 
-- **BuildKit caches the agent install layer** (`RUN --mount=type=bind … install
-  /ctx/shed-agent`). A changed binary can be silently reused from cache. If the
-  baked agent is stale, bust it and rebuild:
-  ```bash
-  docker buildx prune -af && docker builder prune -af
-  ```
-- **The ref-index can point at a stale manifest** after an `OUTPUT_DIR` build
-  (the running dev server + repeated builds leave `refs/<hash>.json` pointing at
-  an older digest than the one you just built). Force it to your build, then
-  restart the server:
-  ```bash
-  cd "$HOME/Library/Application Support/shed-dev/vz"
-  REF="ghcr.io/charliek/shed-vz-base:<TAG>"   # the same image_aliases.base value as above
-  REFHASH=$(printf '%s' "$REF" | shasum -a 256 | awk '{print $1}')
-  cat "refs/$REFHASH.json"          # what it points at now
-  # <DIGEST> = your build's manifest digest from its "Built image (sha256:...)" line:
-  printf '{"ref":"%s","digest":"sha256:<DIGEST>"}\n' "$REF" > "refs/$REFHASH.json"
-  # then restart the dev server (kill the PID in ~/.shed/dev/server.pid, relaunch as in step 1)
-  ```
+- **The install layer busts on content change.** `build-vz-rootfs.sh` computes a
+  content hash of the build context and passes `--build-arg SHED_INSTALL_SHA=…`,
+  which the Dockerfile's bind-mount install RUN references. A changed agent
+  re-runs that layer — the build log prints `SHED_INSTALL_SHA=<hash>` and the
+  step is **not** `CACHED` — while the expensive apt layer stays cached. An
+  unchanged agent leaves the install layer `CACHED`.
+- **The ref-index is written by the build.** `shed image build` records
+  `refs/<sha256(source-ref)>.json` → the new manifest digest, so
+  `shed create --image base` resolves your build immediately. `SHED_SOURCE_REF`
+  (step 2) **must** equal the dev config's `image_aliases.base` so the build
+  writes the ref create reads. The dev server reads the ref-index per-create, so
+  no restart is needed.
+
+Still **verify** (step 4) before trusting a run — it's cheap insurance.
 
 ### 4. VERIFY the VM is running YOUR agent (do not skip)
 
@@ -140,7 +136,9 @@ change adds (function names survive in the Go binary):
 shed -s my-server-dev create dbg --image base
 shed -s my-server-dev exec dbg -- bash -c \
   "strings /usr/local/bin/shed-agent | grep -c '<your-new-symbol-or-log-string>'"
-# >0 means your agent is baked in; 0 means a stale layer/manifest — go back to step 3.
+# >0 means your agent is baked in; 0 means a stale layer/manifest — check the
+# build log shows the install RUN ran (`SHED_INSTALL_SHA=…`, not `CACHED`) and
+# that SHED_SOURCE_REF (step 2) matched the dev config's image_aliases.base.
 ```
 
 To extract+inspect the agent from a manifest without booting a VM (useful to
@@ -165,14 +163,13 @@ SHED_VZ_DEV_SERVER=my-server-dev SHED_VZ_DEV_LOG_PATH="$HOME/.shed/dev/server.lo
 
 ## Per-iteration loop
 
-Edit agent → unit tests (Docker) → rebuild rootfs (step 2) → if stale, bust
-cache + force ref-index (step 3) → verify (step 4) → integration (step 5).
-Comment-only edits don't change the binary, so they don't need a rebuild.
+Edit agent → unit tests (Docker) → rebuild rootfs (step 2) → verify (step 4) →
+integration (step 5). Comment-only edits don't change the binary, so they don't
+need a rebuild.
 
 ## When you hit a NEW rough edge
 
-Add it here. This file exists because the agent-in-image split and the
-build/cache/ref-index resolution have several non-obvious traps; capturing each
-one saves the next session an hour. The stale-ref-index and BuildKit-cache traps
-in step 3 are tracked for a proper fix in **issue #227** — drop the workarounds
-here once it lands.
+Add it here. This file exists because the agent-in-image split has non-obvious
+traps; capturing each one saves the next session an hour. (The stale-ref-index
+and BuildKit-cache traps that used to live in step 3 were fixed in **#227** —
+the rebuild now busts the install layer and writes the ref-index on its own.)

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -168,6 +168,12 @@ jobs:
           # the remote server's resolveImage cache-hit check matches
           # on subsequent `shed create` pulls.
           mkdir -p /tmp/oci-store-vz
+          # SHED_INSTALL_SHA busts BuildKit's content-blind bind-mount cache
+          # when the staged agent/service files change (#227). Belt-and-
+          # suspenders on a cold CI runner, but keeps the published layer's
+          # cache key honest and matters if a shared buildx cache is enabled.
+          install_sha="$(./scripts/install-input-sha.sh vz/)"
+          echo "SHED_INSTALL_SHA=${install_sha}"
           for variant in base extensions full; do
             echo "=== building shed-vz-${variant} ==="
             ./bin/shed image build \
@@ -177,6 +183,7 @@ jobs:
               --source-ref "ghcr.io/charliek/shed-vz-${variant}:${{ steps.version.outputs.tag }}" \
               --initramfs /tmp/shed-initrd-vz.img \
               --output-dir /tmp/oci-store-vz \
+              --build-arg "SHED_INSTALL_SHA=${install_sha}" \
               -f vz/Dockerfile \
               vz/
           done
@@ -277,8 +284,11 @@ jobs:
 
       - name: Build OCI images (base, extensions, full)
         run: |
-          # See VZ job for rationale on --platform and --source-ref.
+          # See VZ job for rationale on --platform, --source-ref, and
+          # SHED_INSTALL_SHA (#227 bind-mount cache-bust).
           mkdir -p /tmp/oci-store-fc
+          install_sha="$(./scripts/install-input-sha.sh firecracker/)"
+          echo "SHED_INSTALL_SHA=${install_sha}"
           for variant in base extensions full; do
             echo "=== building shed-fc-${variant} ==="
             ./bin/shed image build \
@@ -288,6 +298,7 @@ jobs:
               --source-ref "ghcr.io/charliek/shed-fc-${variant}:${{ steps.version.outputs.tag }}" \
               --initramfs /tmp/shed-initrd-fc.img \
               --output-dir /tmp/oci-store-fc \
+              --build-arg "SHED_INSTALL_SHA=${install_sha}" \
               -f firecracker/Dockerfile \
               firecracker/
           done

--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -78,6 +78,7 @@ var (
 	imageBuildForce        bool
 	imageBuildOCIArchive   string
 	imageBuildToolsVersion string
+	imageBuildArgs         []string
 
 	imageDeleteForce  bool
 	imagePruneForce   bool
@@ -209,6 +210,13 @@ func init() {
 	// Override with `dev` (or any other tag) when iterating on the
 	// build-tools image locally — see docs/reference/build-tools.md.
 	imageBuildCmd.Flags().StringVar(&imageBuildToolsVersion, "build-tools-version", "", "Override the shed-build-tools image tag used to mint the rootfs erofs (default: matches the shed CLI version; pass 'dev' for a locally-built shed-build-tools:dev image)")
+	// --build-arg passes a build-time variable through to `docker buildx
+	// build` (repeatable, KEY=VALUE). The rootfs build scripts use it to
+	// inject SHED_INSTALL_SHA — a content hash of the agent/service files —
+	// so a changed binary busts BuildKit's bind-mount stat cache, which
+	// otherwise keys on (path, size, mtime) and can silently bake a stale
+	// agent (#227). Dockerfile-build only; rejected with --from-oci-archive.
+	imageBuildCmd.Flags().StringArrayVar(&imageBuildArgs, "build-arg", nil, "Pass a build-time variable to docker buildx (repeatable, KEY=VALUE)")
 	_ = imageBuildCmd.MarkFlagRequired("name")
 
 	imageDeleteCmd.Flags().BoolVar(&imageDeleteForce, "force", false, "Skip confirmation prompt")
@@ -363,6 +371,9 @@ func runImageBuildFromOCIArchive(ctx context.Context, outputDir, prefix, platfor
 	if imageBuildForce {
 		return fmt.Errorf("--force is incompatible with --from-oci-archive (no base-image validation runs without a Dockerfile)")
 	}
+	if len(imageBuildArgs) > 0 {
+		return fmt.Errorf("--build-arg is incompatible with --from-oci-archive (the OCI archive is already built; no docker buildx runs)")
+	}
 	if _, err := os.Stat(imageBuildOCIArchive); err != nil {
 		return fmt.Errorf("--from-oci-archive %s: %w", imageBuildOCIArchive, err)
 	}
@@ -385,7 +396,36 @@ func runImageBuildFromOCIArchive(ctx context.Context, outputDir, prefix, platfor
 	return nil
 }
 
+// buildxBuildArgs assembles the `docker buildx build` argv. Extracted as a
+// pure function so the flag wiring — in particular the repeatable --build-arg
+// passthrough and the invariant that the build context is always the final
+// argument — is unit-testable without invoking docker. Each buildArgs element
+// is a KEY=VALUE string forwarded verbatim as `--build-arg KEY=VALUE`.
+func buildxBuildArgs(platform, ociTarPath, dockerfile, target, buildContext string, buildArgs []string) []string {
+	argv := []string{
+		"buildx", "build", "--platform", platform,
+		"--output", "type=oci,dest=" + ociTarPath,
+		"-f", dockerfile,
+	}
+	if target != "" {
+		argv = append(argv, "--target", target)
+	}
+	for _, ba := range buildArgs {
+		argv = append(argv, "--build-arg", ba)
+	}
+	// Context must be last — buildx treats the final positional arg as the
+	// build context.
+	argv = append(argv, buildContext)
+	return argv
+}
+
 func runImageBuildFromDockerfile(ctx context.Context, args []string, outputDir, prefix, platform string, extractKernel, needsInitrd bool) error {
+	for _, ba := range imageBuildArgs {
+		if strings.TrimSpace(ba) == "" {
+			return fmt.Errorf("--build-arg requires a non-empty KEY=VALUE")
+		}
+	}
+
 	buildContext := "."
 	if len(args) > 0 {
 		buildContext = args[0]
@@ -437,16 +477,7 @@ func runImageBuildFromDockerfile(ctx context.Context, args []string, outputDir, 
 	defer os.Remove(ociTarPath)
 
 	fmt.Printf("Building Docker image %s (OCI output → %s)...\n", dockerTag, ociTarPath)
-	buildArgs := []string{
-		"buildx", "build", "--platform", platform,
-		"--output", "type=oci,dest=" + ociTarPath,
-		"-f", dockerfile,
-	}
-	if imageBuildTarget != "" {
-		buildArgs = append(buildArgs, "--target", imageBuildTarget)
-	}
-	buildArgs = append(buildArgs, buildContext)
-
+	buildArgs := buildxBuildArgs(platform, ociTarPath, dockerfile, imageBuildTarget, buildContext, imageBuildArgs)
 	buildCmd := exec.CommandContext(ctx, "docker", buildArgs...)
 	buildCmd.Stdout = os.Stdout
 	buildCmd.Stderr = os.Stderr

--- a/cmd/shed/image.go
+++ b/cmd/shed/image.go
@@ -381,7 +381,7 @@ func runImageBuildFromOCIArchive(ctx context.Context, outputDir, prefix, platfor
 	if err != nil {
 		return err
 	}
-	finishImageBuild(outputDir, sourceRef, digest)
+	finishImageBuild(digest)
 	return nil
 }
 
@@ -459,20 +459,23 @@ func runImageBuildFromDockerfile(ctx context.Context, args []string, outputDir, 
 	if err != nil {
 		return err
 	}
-	finishImageBuild(outputDir, sourceRef, digest)
+	finishImageBuild(digest)
 	return nil
 }
 
 // convertAndInstall runs the OCI Convert flow against `imagesDir`,
 // which writes the manifest+config+layer+kernel+initrd blobs into the
-// OCI layout and materializes a derived ext4 in the cache, then
-// advances the imageBuildName tag to the new manifest digest.
+// OCI layout and materializes a derived ext4 in the cache, then records
+// the result via recordBuiltImage — advancing both the imageBuildName
+// tag AND the ref-index entry for sourceRef.
 //
 // sourceRef is recorded verbatim in the manifest's io.shed.source-ref
 // annotation; pass the final registry ref here when this image will be
 // pushed, otherwise the server's resolveImage cache check (which
 // compares `manifest.ShedSourceRef() == cfg.ref`) will miss on every
-// subsequent pull. Returns the manifest digest.
+// subsequent pull. It is also the key under which the ref-index is
+// written, so `shed create --image <sourceRef>` resolves to this build
+// (#227). Returns the manifest digest.
 func convertAndInstall(ctx context.Context, sourceRef, ociArchivePath, imagesDir, platform string, extractKernel, needsInitrd bool) (string, error) {
 	if err := vmimage.ValidateImageName(imageBuildName); err != nil {
 		return "", fmt.Errorf("invalid image name %q: %w", imageBuildName, err)
@@ -493,16 +496,44 @@ func convertAndInstall(ctx context.Context, sourceRef, ociArchivePath, imagesDir
 	if err != nil {
 		return "", fmt.Errorf("conversion failed: %w", err)
 	}
-	if err := vmimage.SetTag(imagesDir, imageBuildName, result.ManifestDigest); err != nil {
-		return "", fmt.Errorf("advancing tag %q: %w", imageBuildName, err)
+	if err := recordBuiltImage(imagesDir, imageBuildName, sourceRef, result.ManifestDigest); err != nil {
+		return "", err
 	}
 	return result.ManifestDigest, nil
 }
 
-// finishImageBuild prints success output. Tag advancement happens inside
-// convertAndInstall.
-func finishImageBuild(_ /*outputDir*/, sourceRef, digest string) {
-	_ = sourceRef
+// recordBuiltImage records a freshly converted image so `shed create --image
+// <ref>` — which resolves through the ref-index (RefIndexGet) — sees this
+// manifest instead of a stale digest left by an earlier pull. The build path
+// previously wrote only the cosmetic tag, so a `--source-ref` build was
+// invisible to create (#227).
+//
+// The ref-index is committed BEFORE the cosmetic tag deliberately: it is the
+// load-bearing resolution artifact, so if the tag write fails afterward, create
+// still resolves correctly and only the cosmetic label lags — strictly better
+// than the reverse, where a failed ref-index write would leave create broken
+// while the tag had already advanced. RefIndexPut is the documented "final
+// commit" step and is safe here: Convert has already made the manifest, blobs,
+// and index.json durable by the time this is called.
+//
+// Unlike the pull-path callers (manager.go EnsureImage/PullImage), which log and
+// continue on a RefIndexPut error, this hard-errors: an explicit local build
+// that silently failed to record the ref-index is exactly the staleness #227
+// fixes, and must be visible. Both writes overwrite unconditionally, so the
+// partial state a hard error leaves is idempotent and clears on retry.
+func recordBuiltImage(imagesDir, name, sourceRef, digest string) error {
+	if err := vmimage.RefIndexPut(imagesDir, sourceRef, digest); err != nil {
+		return fmt.Errorf("recording ref-index entry for %q: %w", sourceRef, err)
+	}
+	if err := vmimage.SetTag(imagesDir, name, digest); err != nil {
+		return fmt.Errorf("advancing tag %q: %w", name, err)
+	}
+	return nil
+}
+
+// finishImageBuild prints success output. Tag + ref-index advancement happens
+// inside convertAndInstall via recordBuiltImage.
+func finishImageBuild(digest string) {
 	printSuccess("Built image %q (%s)", imageBuildName, vmimage.ShortDigest(digest))
 	fmt.Printf("\nUse it with: shed create mydev --image %s\n", imageBuildName)
 }

--- a/cmd/shed/image_test.go
+++ b/cmd/shed/image_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/charliek/shed/internal/config"
@@ -127,5 +130,51 @@ func TestImageBackendContextForHost(t *testing.T) {
 				t.Errorf("NeedsInitrd = %v, want %v", bc.NeedsInitrd, tt.wantInitrd)
 			}
 		})
+	}
+}
+
+// TestRecordBuiltImage is the #227 regression guard: a local `shed image build`
+// must populate the ref-index (not just the cosmetic tag), so a subsequent
+// `shed create --image <sourceRef>` — which resolves through RefIndexGet — sees
+// the freshly built manifest instead of a stale digest left by an earlier pull.
+// Before the fix, convertAndInstall called SetTag only, so the build was
+// invisible to create and the dev loop required a hand-edited refs/<hash>.json.
+func TestRecordBuiltImage(t *testing.T) {
+	imagesDir := t.TempDir()
+	const sourceRef = "ghcr.io/charliek/shed-vz-base:v9.9.9"
+	// recordBuiltImage doesn't hash blob bytes; RefIndexGet only requires the
+	// referenced blob to exist on disk, so stand in a dummy blob at the path for
+	// an arbitrary valid-hex digest.
+	digest := "sha256:" + strings.Repeat("a", 64)
+	blobPath, err := vmimage.BlobPath(imagesDir, digest)
+	if err != nil {
+		t.Fatalf("BlobPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(blobPath), 0o755); err != nil {
+		t.Fatalf("mkdir blobs: %v", err)
+	}
+	if err := os.WriteFile(blobPath, []byte("manifest"), 0o644); err != nil {
+		t.Fatalf("write blob: %v", err)
+	}
+
+	if err := recordBuiltImage(imagesDir, "base", sourceRef, digest); err != nil {
+		t.Fatalf("recordBuiltImage: %v", err)
+	}
+
+	got, ok := vmimage.RefIndexGet(imagesDir, sourceRef)
+	if !ok {
+		t.Fatal("RefIndexGet missed after recordBuiltImage — build did not write the ref-index (#227)")
+	}
+	if got != digest {
+		t.Errorf("RefIndexGet = %q, want %q", got, digest)
+	}
+
+	// The cosmetic tag must still advance (pre-existing behavior preserved).
+	tag, err := vmimage.GetTag(imagesDir, "base")
+	if err != nil {
+		t.Fatalf("GetTag: %v", err)
+	}
+	if tag.Digest != digest {
+		t.Errorf("tag digest = %q, want %q", tag.Digest, digest)
 	}
 }

--- a/cmd/shed/image_test.go
+++ b/cmd/shed/image_test.go
@@ -178,3 +178,60 @@ func TestRecordBuiltImage(t *testing.T) {
 		t.Errorf("tag digest = %q, want %q", tag.Digest, digest)
 	}
 }
+
+// TestBuildxBuildArgs locks in the `docker buildx build` argv assembly — most
+// importantly the #227 --build-arg passthrough (used to inject SHED_INSTALL_SHA)
+// and the invariant that the build context is the LAST positional arg, which
+// buildx requires.
+func TestBuildxBuildArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    string
+		buildArgs []string
+		want      []string
+	}{
+		{
+			name:      "no target, no build-args",
+			target:    "",
+			buildArgs: nil,
+			want: []string{
+				"buildx", "build", "--platform", "linux/arm64",
+				"--output", "type=oci,dest=/tmp/out.tar",
+				"-f", "vz/Dockerfile",
+				"ctx",
+			},
+		},
+		{
+			name:      "target + multiple build-args, context stays last",
+			target:    "shed-vz-base",
+			buildArgs: []string{"SHED_INSTALL_SHA=abc123", "FOO=bar"},
+			want: []string{
+				"buildx", "build", "--platform", "linux/arm64",
+				"--output", "type=oci,dest=/tmp/out.tar",
+				"-f", "vz/Dockerfile",
+				"--target", "shed-vz-base",
+				"--build-arg", "SHED_INSTALL_SHA=abc123",
+				"--build-arg", "FOO=bar",
+				"ctx",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildxBuildArgs("linux/arm64", "/tmp/out.tar", "vz/Dockerfile", tt.target, "ctx", tt.buildArgs)
+			if len(got) != len(tt.want) {
+				t.Fatalf("argv = %v (len %d), want %v (len %d)", got, len(got), tt.want, len(tt.want))
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("argv[%d] = %q, want %q (full: %v)", i, got[i], tt.want[i], got)
+				}
+			}
+			// The build context must always be the final element.
+			if got[len(got)-1] != "ctx" {
+				t.Errorf("build context not last: %v", got)
+			}
+		})
+	}
+}

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -268,13 +268,12 @@ OUTPUT_DIR="$HOME/Library/Application Support/shed-dev/vz" \
 OUTPUT_DIR="$HOME/Library/Application Support/shed-dev/vz" \
   ./scripts/build-vz-rootfs.sh --variant base --build-tools-version dev
 
-# Note on shed-extensions changes: the build-vz-rootfs.sh script
-# does NOT pass --shed-ext-version through to the docker build
-# (its `--shed-ext-version` flag is informational only, per
-# scripts/build-vz-rootfs.sh:201-211). To validate a shed-extensions
-# bump, edit `ARG SHED_EXT_VERSION` in `vz/Dockerfile` directly
-# before running the script, or invoke `docker buildx build
-# --build-arg SHED_EXT_VERSION=<tag> ...` manually.
+# Note on shed-extensions changes: pass --shed-ext-version <tag> to
+# the build script to validate a shed-extensions bump. It forwards the
+# pin to the Dockerfile's `ARG SHED_EXT_VERSION` via `shed image build
+# --build-arg` (#227), so no manual Dockerfile edit is needed:
+OUTPUT_DIR="$HOME/Library/Application Support/shed-dev/vz" \
+  ./scripts/build-vz-rootfs.sh --variant extensions --shed-ext-version <tag>
 
 # 2. Restart the dev server (it picks up the new blobs automatically
 #    — the OCI store is content-addressed so a `shed image ls` will

--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -113,12 +113,24 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
+# SHED_INSTALL_SHA is a content hash of the files installed by the bind-mount
+# RUN below (shed-agent + shed-firstboot + the .service/.sh/.json staged from
+# the context). BuildKit's bind-mount cache keys on (path, size, mtime), NOT
+# content, so a rebuilt binary that collides on size+mtime would otherwise be
+# silently reused from cache — baking a stale agent (#227). Referencing the ARG
+# in the RUN makes a changed hash bust this layer. Declared AFTER the apt layer
+# so it never invalidates the expensive package install. The build scripts pass
+# the real value; `unknown` is the cache-busting-disabled default for ad-hoc
+# `docker build` invocations.
+ARG SHED_INSTALL_SHA=unknown
+
 # Layer 2: stage shed-built binaries + service files from the build
 # context via a bind mount so we get a single layer for the placements
 # + chmods + configs (instead of 1 layer per COPY). daemon.json is
 # staged but placed by the `full` stage where docker is actually
 # installed.
 RUN --mount=type=bind,source=.,target=/ctx \
+    echo "SHED_INSTALL_SHA=${SHED_INSTALL_SHA}" && \
     install -m 0755 /ctx/shed-agent       /usr/local/bin/shed-agent && \
     install -m 0755 /ctx/shed-firstboot   /usr/local/bin/shed-firstboot && \
     install -m 0755 /ctx/network-setup.sh /usr/local/bin/network-setup.sh && \

--- a/scripts/build-firecracker-rootfs.sh
+++ b/scripts/build-firecracker-rootfs.sh
@@ -181,14 +181,37 @@ build_variant() {
         extra_args+=(--build-tools-version "$BUILD_TOOLS_VERSION")
     fi
 
+    # The ref-index resolves `shed create --image <ref>` to a manifest, so the
+    # built image MUST be recorded under the ref the server is configured for.
+    # Honor SHED_SOURCE_REF (parallel-dev points it at image_aliases.base);
+    # otherwise derive the release ref from `shed version`. Without this the FC
+    # build records `shed-fc-<variant>:latest`, which `--image base` can't
+    # resolve (mirrors build-vz-rootfs.sh).
+    local source_ref
+    if [ -n "${SHED_SOURCE_REF:-}" ]; then
+        source_ref="$SHED_SOURCE_REF"
+    else
+        local version
+        version="$("$PROJECT_ROOT/bin/shed" version 2>/dev/null | awk '{print $2}')"
+        version="${version:-dev}"
+        source_ref="ghcr.io/charliek/shed-fc-${variant}:${version}"
+    fi
+
     "$PROJECT_ROOT/bin/shed" image build \
         --target "$docker_target" \
         -n "$variant" \
         --initramfs "$SHED_INITRD" \
         --output-dir "$OUTPUT_DIR" \
+        --source-ref "$source_ref" \
         -f "$FIRECRACKER_DIR/Dockerfile" \
         "${extra_args[@]}" \
-        "$FIRECRACKER_DIR"
+        "$FIRECRACKER_DIR" || return $?
+
+    # Helpful pointer so server config can be aligned. Important: if
+    # server.yaml's images.<variant> doesn't match this source-ref,
+    # `shed create --image <variant>` will fall through to a registry
+    # pull and OVERWRITE this manifest. (Mirrors build-vz-rootfs.sh.)
+    echo "Tip: ensure ~/.config/shed/server.yaml has 'images.${variant}: $source_ref'"
 }
 
 # Main execution

--- a/scripts/build-firecracker-rootfs.sh
+++ b/scripts/build-firecracker-rootfs.sh
@@ -180,6 +180,17 @@ build_variant() {
     if [ -n "$BUILD_TOOLS_VERSION" ]; then
         extra_args+=(--build-tools-version "$BUILD_TOOLS_VERSION")
     fi
+    if [ -n "$SHED_EXT_VERSION" ]; then
+        # Forward the shed-extensions pin to the Dockerfile's top-level
+        # ARG SHED_EXT_VERSION (used by the extensions/full variants) via
+        # the now-supported --build-arg passthrough on `shed image build`.
+        extra_args+=(--build-arg "SHED_EXT_VERSION=$SHED_EXT_VERSION")
+    fi
+
+    # SHED_INSTALL_SHA busts BuildKit's bind-mount stat cache when the staged
+    # agent/service files change (see firecracker/Dockerfile + #227). Computed
+    # once into $INSTALL_SHA after build_prereqs staged the inputs (below).
+    extra_args+=(--build-arg "SHED_INSTALL_SHA=$INSTALL_SHA")
 
     # The ref-index resolves `shed create --image <ref>` to a manifest, so the
     # built image MUST be recorded under the ref the server is configured for.
@@ -222,6 +233,13 @@ echo "Output directory: $OUTPUT_DIR"
 # Build host prerequisites + shared shed-overlay initramfs once.
 build_prereqs
 build_shed_initrd
+
+# Content hash of the build context, computed ONCE after build_prereqs staged
+# the agent/service binaries. Injected as --build-arg SHED_INSTALL_SHA per
+# variant to bust BuildKit's content-blind bind-mount cache (#227). Identical
+# across variants (the base stage installs them), so compute it here.
+INSTALL_SHA="$("$SCRIPT_DIR/install-input-sha.sh" "$FIRECRACKER_DIR")"
+echo "Install-SHA: $INSTALL_SHA"
 
 if [ "$BUILD_ALL" = true ]; then
     echo ""

--- a/scripts/build-vz-rootfs.sh
+++ b/scripts/build-vz-rootfs.sh
@@ -199,17 +199,16 @@ build_variant() {
         extra_args+=(--build-tools-version "$BUILD_TOOLS_VERSION")
     fi
     if [ -n "$SHED_EXT_VERSION" ]; then
-        # shed image build passes --build-arg through to buildx via the
-        # builder. Encode as KEY=VALUE so the existing flag plumbing
-        # forwards verbatim.
-        echo "Note: SHED_EXT_VERSION=$SHED_EXT_VERSION (forward via docker build cache)"
-        # The Dockerfile reads SHED_EXT_VERSION from ARG; passing via
-        # `DOCKER_BUILDKIT_ARGS` keeps the shell invocation simple.
-        export BUILDX_BUILDER="${BUILDX_BUILDER:-default}"
-        # No direct --build-arg pass-through on shed image build yet;
-        # operators who pin shed-ext should edit the ARG line in
-        # vz/Dockerfile or run docker buildx manually before this step.
+        # Forward the shed-extensions pin to the Dockerfile's top-level
+        # ARG SHED_EXT_VERSION (used by the extensions/full variants) via
+        # the now-supported --build-arg passthrough on `shed image build`.
+        extra_args+=(--build-arg "SHED_EXT_VERSION=$SHED_EXT_VERSION")
     fi
+
+    # SHED_INSTALL_SHA busts BuildKit's bind-mount stat cache when the staged
+    # agent/service files change (see vz/Dockerfile + #227). Computed once into
+    # $INSTALL_SHA after build_prereqs staged the inputs (below the loop).
+    extra_args+=(--build-arg "SHED_INSTALL_SHA=$INSTALL_SHA")
 
     # Bake the source-ref to match the server config's `images.<variant>`
     # entry so server-side resolveCachedTag finds our locally-built
@@ -257,6 +256,13 @@ echo "Output directory: $OUTPUT_DIR"
 # Build host prerequisites + shared shed-overlay initramfs once.
 build_prereqs
 build_shed_initrd
+
+# Content hash of the build context, computed ONCE after build_prereqs staged
+# the agent/service binaries. Injected as --build-arg SHED_INSTALL_SHA per
+# variant to bust BuildKit's content-blind bind-mount cache (#227). Identical
+# across variants (the base stage installs them), so compute it here.
+INSTALL_SHA="$("$SCRIPT_DIR/install-input-sha.sh" "$VZ_DIR")"
+echo "Install-SHA: $INSTALL_SHA"
 
 if [ "$BUILD_ALL" = true ]; then
     echo ""

--- a/scripts/build-vz-rootfs.sh
+++ b/scripts/build-vz-rootfs.sh
@@ -227,9 +227,7 @@ build_variant() {
     else
         local version
         version="$("$PROJECT_ROOT/bin/shed" version 2>/dev/null | awk '{print $2}')"
-        if [ -z "$version" ] || [ "$version" = "dev" ]; then
-            version="dev"
-        fi
+        version="${version:-dev}"
         source_ref="ghcr.io/charliek/shed-vz-${variant}:${version}"
     fi
     echo "Source-ref: $source_ref"

--- a/scripts/install-input-sha.sh
+++ b/scripts/install-input-sha.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# install-input-sha.sh <context-dir>
+#
+# Prints a stable content hash of a docker build context, for injection as
+# `--build-arg SHED_INSTALL_SHA=...`. BuildKit's `RUN --mount=type=bind` and
+# `COPY` cache keys use a per-file stat cache keyed on (path, size, mtime) — NOT
+# content — so a rebuilt binary that collides on size+mtime is silently reused
+# from cache, baking a STALE file (#227). Referencing this hash inside the
+# install RUN makes a real content change bust that layer's cache key.
+#
+# It hashes the WHOLE context (every file except the Dockerfile itself, whose
+# text BuildKit already folds into each layer's key) rather than a hand-listed
+# subset. That is deliberate: the context is exactly the surface those
+# cache-vulnerable bind/COPY instructions expose, so the hash can never drift
+# out of sync with what they consume — adding a staged file to the Dockerfile
+# needs no change here. The output is order-independent (digests are sorted) and
+# content-only, so it is stable across checkouts and reruns.
+#
+# Single source of truth: the rootfs build scripts, the publish CI workflow, and
+# publish-images-local.sh all call this rather than re-deriving the hash.
+set -euo pipefail
+
+dir="${1:?usage: install-input-sha.sh <context-dir>}"
+[ -d "$dir" ] || { echo "install-input-sha.sh: not a directory: $dir" >&2; exit 1; }
+
+# Portable SHA-256: GNU coreutils sha256sum (Linux) or BSD/macOS shasum -a 256.
+# Word-split intentionally so "shasum -a 256" expands to argv (SC2086).
+if command -v sha256sum >/dev/null 2>&1; then
+    SHA_CMD="sha256sum"
+else
+    SHA_CMD="shasum -a 256"
+fi
+
+# Run from inside the context so the paths in the hash are relative — stable
+# across checkout locations, and so the hash binds path→content (a digest list
+# alone would miss two files swapping contents).
+cd "$dir" || exit 1
+
+# Guard against an empty context: with no input and no -r, xargs would hand the
+# sha tool an empty arg list and hang reading stdin.
+if [ "$(find . -type f ! -name Dockerfile | wc -l)" -eq 0 ]; then
+    echo "install-input-sha.sh: no files in context $dir" >&2
+    exit 1
+fi
+
+# Hash each file ($SHA_CMD emits "<digest>  <relpath>", binding path to
+# content), sort the lines for order-independence, then reduce to one digest.
+# shellcheck disable=SC2086
+find . -type f ! -name Dockerfile -print0 \
+    | xargs -0 $SHA_CMD \
+    | LC_ALL=C sort \
+    | $SHA_CMD \
+    | awk '{print $1}'

--- a/scripts/publish-images-local.sh
+++ b/scripts/publish-images-local.sh
@@ -231,6 +231,12 @@ rm -rf "${STORE_DIR}"
 mkdir -p "${STORE_DIR}"
 write_server_yaml "${SERVER_CFG}" "${STORE_DIR}"
 
+# SHED_INSTALL_SHA busts BuildKit's content-blind bind-mount cache when the
+# staged agent/service files change (#227). The base stage installs them, so
+# the value is identical across variants — compute once.
+install_sha="$("${WORK_DIR}/scripts/install-input-sha.sh" "${WORK_DIR}/${BACKEND_DIR}/")"
+log "install-sha=${install_sha}"
+
 for variant in ${VARIANTS}; do
   target="${BACKEND_PREFIX}-${variant}"
   source_ref="${REGISTRY_HOST}/charliek/${target}:${VERSION}"
@@ -243,6 +249,7 @@ for variant in ${VARIANTS}; do
     -n "${variant}" \
     --initramfs "${INITRAMFS}" \
     --output-dir "${STORE_DIR}" \
+    --build-arg "SHED_INSTALL_SHA=${install_sha}" \
     -f "${WORK_DIR}/${BACKEND_DIR}/Dockerfile" \
     "${WORK_DIR}/${BACKEND_DIR}/"
 

--- a/scripts/release-validation.sh
+++ b/scripts/release-validation.sh
@@ -169,11 +169,16 @@ docker run -d --rm --name "${REGISTRY_NAME}" -p "${REGISTRY_PORT}:5000" registry
 # Build + push each variant on Mac                                     #
 # -------------------------------------------------------------------- #
 if [[ "${SKIP_BUILDS}" != "1" ]]; then
+    # Content hash of the build context so a changed agent busts BuildKit's
+    # bind-mount cache (#227); without it this pre-release gate could validate
+    # a stale-cached agent. Same value across variants.
+    vz_install_sha="$("${REPO_ROOT}/scripts/install-input-sha.sh" "${REPO_ROOT}/vz")"
     for variant in "${VARIANTS[@]}"; do
         step "Build shed-vz-${variant}"
         docker buildx build --platform linux/arm64 \
             --target "shed-vz-${variant}" \
             -t "${LOCAL_REGISTRY}/shed-vz-${variant}:test" \
+            --build-arg "SHED_INSTALL_SHA=${vz_install_sha}" \
             --load -f "${REPO_ROOT}/vz/Dockerfile" "${REPO_ROOT}/vz" \
             && ok "build shed-vz-${variant}" \
             || { fail "build shed-vz-${variant}"; continue; }
@@ -246,7 +251,7 @@ if [[ "${SKIP_REMOTE}" != "1" ]]; then
     if [[ "${SKIP_BUILDS}" != "1" ]]; then
         for variant in "${VARIANTS[@]}"; do
             step "Build shed-fc-${variant} on mini2"
-            run_remote "cd /tmp/shed-validation && docker buildx build --platform linux/amd64 --target shed-fc-${variant} -t ${LOCAL_REGISTRY}/shed-fc-${variant}:test --load -f firecracker/Dockerfile firecracker" \
+            run_remote "cd /tmp/shed-validation && docker buildx build --platform linux/amd64 --target shed-fc-${variant} -t ${LOCAL_REGISTRY}/shed-fc-${variant}:test --build-arg SHED_INSTALL_SHA=\$(./scripts/install-input-sha.sh firecracker) --load -f firecracker/Dockerfile firecracker" \
                 && ok "build shed-fc-${variant}" \
                 || { fail "build shed-fc-${variant}"; continue; }
             run_remote "docker push ${LOCAL_REGISTRY}/shed-fc-${variant}:test >/dev/null" \

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -102,12 +102,24 @@ RUN apt-get update \
        || { echo "ERROR: /lib/modules/${LINUX_IMAGE_VERSION}-generic not present after install — LINUX_IMAGE_VERSION ARG is wrong" >&2; exit 1; } \
     && rm -rf /var/lib/apt/lists/*
 
+# SHED_INSTALL_SHA is a content hash of the files installed by the bind-mount
+# RUN below (shed-agent + shed-firstboot + the .service/.sh/.json staged from
+# the context). BuildKit's bind-mount cache keys on (path, size, mtime), NOT
+# content, so a rebuilt binary that collides on size+mtime would otherwise be
+# silently reused from cache — baking a stale agent (#227). Referencing the ARG
+# in the RUN makes a changed hash bust this layer. Declared AFTER the apt layer
+# so it never invalidates the expensive package install. The build scripts pass
+# the real value; `unknown` is the cache-busting-disabled default for ad-hoc
+# `docker build` invocations.
+ARG SHED_INSTALL_SHA=unknown
+
 # Layer 2: stage shed-built binaries + service files from the build
 # context via a bind mount so we get a single layer for the placements
 # + chmods + configs (instead of 1 layer per COPY). daemon.json is
 # staged but placed by the `full` stage where docker is actually
 # installed.
 RUN --mount=type=bind,source=.,target=/ctx \
+    echo "SHED_INSTALL_SHA=${SHED_INSTALL_SHA}" && \
     install -m 0755 /ctx/shed-agent       /usr/local/bin/shed-agent && \
     install -m 0755 /ctx/shed-firstboot   /usr/local/bin/shed-firstboot && \
     install -m 0755 /ctx/network-setup.sh /usr/local/bin/network-setup.sh && \


### PR DESCRIPTION
## What & why

Closes #227 — the two dev-tooling bugs that forced manual workarounds in the in-VM-agent rebuild loop. Both made a freshly built agent fail to reach the VM, and both were papered over by hand in `.claude/skills/testing-vm-agent-changes`.

### Bug 1 — `shed image build` never wrote the ref-index

`shed create --image <ref>` resolves through the ref-index (`RefIndexGet`), but the build path only advanced the cosmetic tag after `Convert` — it never called `RefIndexPut`. So a freshly built image was invisible to `create`, which resolved a stale digest from an earlier pull. The dev loop had to hand-edit `refs/<sha256(ref)>.json`.

**Fix:** `convertAndInstall` now calls a small `recordBuiltImage` helper that commits the **ref-index first, then the cosmetic tag** — the ref-index is the load-bearing resolution artifact, so a partial failure leaves `create` working with only the label lagging. It hard-errors (unlike the pull-path callers that log-and-continue) because a local build has no registry to self-heal from. Also wired `--source-ref` into `build-firecracker-rootfs.sh` (it was missing, so FC builds recorded `shed-fc-<variant>:latest`, which `--image base` can't resolve).

### Bug 2 — BuildKit baked a stale agent from cache

BuildKit's `RUN --mount=type=bind` (and `COPY`) cache key uses a per-file stat cache keyed on `(path, size, mtime)`, **not** content. A rebuilt `shed-agent` that collided on size+mtime was silently reused from cache, baking a stale binary — the dev loop had to `docker buildx prune -af`.

**Fix:** inject `SHED_INSTALL_SHA`, a content hash of the build context, as a `--build-arg` referenced inside the install RUN so a real content change busts **only** that layer (the `ARG` is declared after the apt RUN, so the expensive package layer cache is preserved). A new repeatable `--build-arg KEY=VALUE` flag on `shed image build` carries it (pure, unit-tested `buildxBuildArgs` assembly; rejected with `--from-oci-archive`).

The hash is produced by a single shared `scripts/install-input-sha.sh` that hashes the **whole context** (binding relative-path→content) rather than a hand-maintained file list — so it can never drift out of sync with what the cache-vulnerable bind/COPY instructions consume. Every live build path passes it: both rootfs scripts (computed once after staging), the publish CI jobs, `publish-images-local.sh`, and the `release-validation` pre-release gate. The vestigial `publish-{vz,fc}-images.sh` are intentionally untouched.

**Bonus:** the generic `--build-arg` also fixes a latent no-op — `--shed-ext-version` was parsed but never forwarded; it now reaches the Dockerfile's `ARG SHED_EXT_VERSION`.

## Review process

Each commit went through `/simplify` (4 parallel cleanup agents) then a correctness pass. Codex was rate-limited mid-flow, so the correctness pass used `cursor:cursor-rescue` as the fallback. Findings that shaped the final code:

- **Ref-index-before-tag ordering** (codex) — better partial-failure mode.
- **Shared `install-input-sha.sh` + whole-context hash** (simplify panel: reuse/simplification/altitude all converged) — the 7-file list was duplicated across 5 sites, and forgetting one reintroduces the exact stale-bake bug; the whole-context hash is drift-proof *and* simpler.
- **Path-sensitive, portable hash** (cursor) — bind relative-path→content so swapping two files' contents still busts; relative paths keep it stable across checkout locations.
- **`release-validation.sh` coverage** (cursor) — the live pre-release gate built the production Dockerfiles directly without the cache-bust.

## E2E validation (dev server, VZ)

Proved the full loop works with **no `docker buildx prune` and no manual ref-index edit**:

1. Build 1 (cache-warming) → `recordBuiltImage` advanced the ref-index from the stale baseline to the freshly built digest automatically.
2. Added a marker to the agent → Build 2 (no prune): the install RUN **re-ran** (`SHED_INSTALL_SHA` changed) while the apt layer stayed `CACHED`; the ref-index auto-advanced; `shed create --image base` booted the **marked** agent (`strings | grep` = 1).
3. Build 3 (no change): install RUN `CACHED` — the fix doesn't over-bust.

The marker was a temporary probe and is reverted.

## Test plan

- `make test` — all unit tests pass (adds `TestRecordBuiltImage` for the ref-index guard and `TestBuildxBuildArgs` for the `--build-arg`/context-last invariant).
- `make lint` — 0 issues. `gofmt` clean.
- `scripts/install-input-sha.sh` exercised for stability, Dockerfile-exclusion, change/drift/swap sensitivity, cross-checkout portability, and the empty-context guard.
- E2E on the VZ dev server as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoHk27xjf1khfuijtcru6u


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image builds now automatically pick up staged changes, reducing the need for manual cache clearing or server restarts.
  * Build commands can now pass extra build arguments for more flexible image creation.

* **Bug Fixes**
  * Improved image rebuild reliability so updated content is reflected immediately in generated images.
  * Local image builds now update the correct image reference and tag more consistently.

* **Documentation**
  * Updated build and testing guides with the latest workflows and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->