### PR TITLE
chore(images): bump baked shed-extensions to v0.4.9

### DIFF
--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -24,7 +24,7 @@
 
 # Bump this when shed-extensions releases a new version.
 # The extensions and full variants pull binaries from this tag.
-ARG SHED_EXT_VERSION=v0.4.7
+ARG SHED_EXT_VERSION=v0.4.9
 FROM ghcr.io/charliek/shed-extensions:${SHED_EXT_VERSION} AS shed-extensions
 
 # Note: the shed initramfs (overlay-on-the-guest init) is built from

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -24,7 +24,7 @@
 
 # Bump this when shed-extensions releases a new version.
 # The extensions and full variants pull binaries from this tag.
-ARG SHED_EXT_VERSION=v0.4.7
+ARG SHED_EXT_VERSION=v0.4.9
 FROM ghcr.io/charliek/shed-extensions:${SHED_EXT_VERSION} AS shed-extensions
 
 # Note: the shed initramfs (overlay-on-the-guest init) is built from


### PR DESCRIPTION
## What

Bump the baked `shed-extensions` pin (`ARG SHED_EXT_VERSION`) from **v0.4.7 → v0.4.9** in both `vz/Dockerfile` and `firecracker/Dockerfile`, so the `extensions`/`full` variants layer the latest published guest binaries. v0.4.9 is the current shed-extensions release (2026-06-30); its multi-arch ghcr image carries both linux/arm64 (VZ) and linux/amd64 (FC).

## Validation

The PR CI doesn't build the rootfs (only the release workflow does), so this was validated locally first:

- `docker manifest inspect ghcr.io/charliek/shed-extensions:v0.4.9` → multi-arch index with linux/arm64 + linux/amd64.
- Built the VZ `extensions` variant against the bumped default: `COPY --from=ghcr.io/charliek/shed-extensions:v0.4.9` resolved (`@sha256:a3520ea4…`), all four ext binaries installed (`shed-ext-ssh-agent`, `shed-ext-aws-credentials`, `docker-credential-shed`, `shed-ext-rc`), and the image built clean.

Cut as a standalone bump ahead of the v0.7.6 patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoHk27xjf1khfuijtcru6u


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled extension base image version used by Firecracker and VZ builds.
  * This brings both container builds to the latest available extension release, which may include compatibility and stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->