### PR TITLE
fix(agent): separate exec stderr from stdout on the non-PTY channel (Zed Remote-SSH)

### DIFF
--- a/cmd/shed-agent/exec.go
+++ b/cmd/shed-agent/exec.go
@@ -207,9 +207,11 @@ func runWithPTY(conn net.Conn, cmd *exec.Cmd, rows, cols uint16) {
 		// onStdinEOF left nil: a PTY has no separate stdin pipe.
 	}, nil)
 
-	// Copy PTY output to connection.
+	// Copy PTY output to connection. A pty master is a single stream (stdout and
+	// stderr are merged by the terminal), so it is always MsgTypeData — matching
+	// standard SSH PTY semantics.
 	outputWg.Add(1)
-	go func() { defer outputWg.Done(); copyToConn(w, ptmx, "PTY") }()
+	go func() { defer outputWg.Done(); copyToConn(w, ptmx, "PTY", MsgTypeData) }()
 
 	// Probe for a host disconnect even when the PTY session is idle (no output);
 	// stopped after the command exits.
@@ -329,10 +331,17 @@ func runWithoutPTY(conn net.Conn, cmd *exec.Cmd) {
 	// conn) and SIGHUPs the command on a write failure.
 	w := &connWriter{conn: conn, disconnect: disconnect}
 
-	// Copy stdout and stderr to the connection (folded into one stream).
+	// Copy stdout and stderr to the connection as SEPARATE framed streams (stdout
+	// MsgTypeData, stderr MsgTypeStderr; see MsgTypeStderr): folding them would
+	// inject stderr into a binary stdout protocol like Zed or SFTP. The host
+	// demuxes them back onto the SSH channel's stdout and extended-data stderr;
+	// connWriter serializes both copiers so each frame is written whole. Ordering
+	// WITHIN each stream is preserved; relative ordering BETWEEN stdout and stderr
+	// is best-effort (two OS pipes, two goroutines) — same as real SSH's separate
+	// stdout/stderr channels, not a protocol guarantee.
 	outputWg.Add(2)
-	go func() { defer outputWg.Done(); copyToConn(w, stdout, "stdout") }()
-	go func() { defer outputWg.Done(); copyToConn(w, stderr, "stderr") }()
+	go func() { defer outputWg.Done(); copyToConn(w, stdout, "stdout", MsgTypeData) }()
+	go func() { defer outputWg.Done(); copyToConn(w, stderr, "stderr", MsgTypeStderr) }()
 
 	// Probe for a host disconnect even when the command produces no output and
 	// reads no stdin (see startKeepalive). Stopped after cmd.Wait below so it
@@ -547,10 +556,11 @@ type connWriter struct {
 	disconnect func()
 }
 
-// write sends data to the host, firing disconnect on a write error.
-func (w *connWriter) write(data []byte) error {
+// write sends a framed message of the given type to the host, firing disconnect
+// on a write error.
+func (w *connWriter) write(msgType byte, data []byte) error {
 	w.mu.Lock()
-	err := writeData(w.conn, data)
+	err := writeMessage(w.conn, msgType, data)
 	w.mu.Unlock()
 	if err != nil {
 		w.disconnect()
@@ -576,14 +586,15 @@ func (w *connWriter) writeProbe(timeout time.Duration) error {
 }
 
 // copyToConn copies r to the host connection via w until EOF or a write failure,
-// labeling read/write errors with name. Used for the process stdout/stderr pipes
-// (non-PTY) and the PTY master.
-func copyToConn(w *connWriter, r io.Reader, name string) {
+// framing each chunk as msgType and labeling read/write errors with name. Used
+// for the process stdout pipe (MsgTypeData) and stderr pipe (MsgTypeStderr) on
+// the non-PTY path, and the PTY master (MsgTypeData, merged).
+func copyToConn(w *connWriter, r io.Reader, name string, msgType byte) {
 	buf := make([]byte, 4096)
 	for {
 		n, err := r.Read(buf)
 		if n > 0 {
-			if werr := w.write(buf[:n]); werr != nil {
+			if werr := w.write(msgType, buf[:n]); werr != nil {
 				log.Printf("Warning: failed to write %s to connection: %v", name, werr)
 				return
 			}

--- a/cmd/shed-agent/exec_test.go
+++ b/cmd/shed-agent/exec_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"net"
+	"os/exec"
+	"sync"
 	"testing"
 	"time"
 )
@@ -285,4 +287,103 @@ func TestPumpClientMessages(t *testing.T) {
 			t.Fatal("onDisconnect fired on the teardown read deadline (should only fire on host close)")
 		}
 	})
+}
+
+// readOutputFrames reads framed output messages from c, folding MsgTypeData into
+// gotData and MsgTypeStderr into gotStderr, until the exit-code frame (or a read
+// error/EOF for callers that close the conn without one). Unexpected non-output
+// frame types fail the test.
+func readOutputFrames(t *testing.T, c net.Conn) (gotData, gotStderr []byte) {
+	t.Helper()
+	var data, stderr bytes.Buffer
+	for {
+		_ = c.SetReadDeadline(time.Now().Add(10 * time.Second))
+		mt, payload, err := readMessage(c)
+		if err != nil {
+			break
+		}
+		switch mt {
+		case MsgTypeData:
+			data.Write(payload)
+		case MsgTypeStderr:
+			stderr.Write(payload)
+		case MsgTypeExitCode:
+			return data.Bytes(), stderr.Bytes()
+		default:
+			t.Errorf("unexpected frame type 0x%02x on output channel", mt)
+		}
+	}
+	return data.Bytes(), stderr.Bytes()
+}
+
+// TestCopyToConnTagsStreams is the deterministic guard: the shared output copier
+// frames stdout chunks as MsgTypeData and stderr chunks as MsgTypeStderr, and no
+// stderr byte ever lands in a MsgTypeData frame. This is the separation that
+// keeps a binary stdout protocol (Zed Remote-SSH, SFTP) uncorrupted by
+// interleaved stderr (issue #222 follow-on). It drives the writer directly (no
+// process), so it can't flake on scheduling and asserts by frame type, not order.
+func TestCopyToConnTagsStreams(t *testing.T) {
+	c, s := net.Pipe()
+	defer c.Close()
+
+	w := &connWriter{conn: s, disconnect: func() {}}
+	stdoutPayload := []byte("stdout-bytes-0123456789")
+	stderrPayload := []byte("STDERR-bytes-abcdefghij")
+
+	// Two concurrent copiers serialized by connWriter, exactly like runWithoutPTY.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); copyToConn(w, bytes.NewReader(stdoutPayload), "stdout", MsgTypeData) }()
+	go func() { defer wg.Done(); copyToConn(w, bytes.NewReader(stderrPayload), "stderr", MsgTypeStderr) }()
+	go func() { wg.Wait(); _ = s.Close() }()
+
+	gotData, gotStderr := readOutputFrames(t, c)
+	if !bytes.Equal(gotData, stdoutPayload) {
+		t.Errorf("MsgTypeData stream = %q, want %q", gotData, stdoutPayload)
+	}
+	if !bytes.Equal(gotStderr, stderrPayload) {
+		t.Errorf("MsgTypeStderr stream = %q, want %q", gotStderr, stderrPayload)
+	}
+	if bytes.Contains(gotData, stderrPayload) {
+		t.Error("stderr bytes leaked into the MsgTypeData (stdout) stream — fold regression")
+	}
+}
+
+// TestRunWithoutPTYSeparatesStderr drives the real non-PTY handler with a command
+// that writes to both streams and asserts stdout arrives as MsgTypeData and
+// stderr as MsgTypeStderr — asserted by frame TYPE (not interleave order), read
+// until the exit-code frame.
+func TestRunWithoutPTYSeparatesStderr(t *testing.T) {
+	c, s := net.Pipe()
+	defer c.Close()
+
+	cmd := exec.Command("sh", "-c", "printf OUT; printf ERR 1>&2")
+	go runWithoutPTY(s, cmd)
+
+	gotData, gotStderr := readOutputFrames(t, c)
+	if string(gotData) != "OUT" {
+		t.Errorf("stdout (MsgTypeData) = %q, want %q", gotData, "OUT")
+	}
+	if string(gotStderr) != "ERR" {
+		t.Errorf("stderr (MsgTypeStderr) = %q, want %q", gotStderr, "ERR")
+	}
+	if bytes.Contains(gotData, []byte("ERR")) {
+		t.Error("stderr leaked into the stdout stream (fold regression)")
+	}
+}
+
+// TestRunWithPTYNoStderrFrames asserts the PTY path never emits a MsgTypeStderr
+// frame: a pty master is a single merged stream (stdout+stderr), correctly framed
+// as MsgTypeData. Exact PTY text is intentionally not asserted (the path may drop
+// a small tail on close).
+func TestRunWithPTYNoStderrFrames(t *testing.T) {
+	c, s := net.Pipe()
+	defer c.Close()
+
+	cmd := exec.Command("sh", "-c", "printf OUT; printf ERR 1>&2")
+	go runWithPTY(s, cmd, 24, 80)
+
+	if _, gotStderr := readOutputFrames(t, c); len(gotStderr) > 0 {
+		t.Fatalf("PTY path emitted %d MsgTypeStderr byte(s); PTY output must be a single merged MsgTypeData stream", len(gotStderr))
+	}
 }

--- a/cmd/shed-agent/protocol.go
+++ b/cmd/shed-agent/protocol.go
@@ -18,6 +18,7 @@ const (
 	MsgTypeExitCode      = agentproto.MsgTypeExitCode
 	MsgTypeData          = agentproto.MsgTypeData
 	MsgTypeStdinEOF      = agentproto.MsgTypeStdinEOF
+	MsgTypeStderr        = agentproto.MsgTypeStderr
 	MsgTypePluginMessage = agentproto.MsgTypePluginMessage
 )
 

--- a/cmd/shed/rc.go
+++ b/cmd/shed/rc.go
@@ -105,8 +105,9 @@ func baseSSHArgs(shedName string, entry *config.ServerEntry, extraOpts ...string
 // "shed-ext-rc","list" need no quoting.
 func sshCaptureArgs(shedName string, entry *config.ServerEntry, remoteArgv ...string) []string {
 	// -T disables PTY allocation so ssh doesn't print "Pseudo-terminal will not be
-	// allocated…" to our captured stderr (the shed's sshd folds the remote command's
-	// stderr into the stdout channel, so command diagnostics arrive on stdout anyway).
+	// allocated…" to our captured stderr, and so the non-PTY exec channel keeps the
+	// remote command's stdout and stderr on their own SSH streams (guest-binary
+	// diagnostics arrive on stderr; see the fallback in rcListOverSSH).
 	args := baseSSHArgs(shedName, entry, "-T", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10")
 	args = append(args, "--")
 	return append(args, remoteArgv...)
@@ -222,9 +223,10 @@ func sshShell(ctx context.Context, shedName string, entry *config.ServerEntry, s
 	cmd.Stdout = &out
 	cmd.Stderr = &errb
 	if err := cmd.Run(); err != nil {
-		// The shed's sshd folds the remote command's stderr into stdout, so prefer
-		// stderr but fall back to stdout for the diagnostic (e.g. a guest binary's
-		// "flag provided but not defined: …" arrives on stdout).
+		// Prefer stderr for the diagnostic (e.g. a guest binary's "flag provided but
+		// not defined: …"), falling back to stdout. The non-PTY exec channel now
+		// keeps stderr on its own stream, but older baked agents still fold it into
+		// stdout, so the fallback covers both.
 		detail := strings.TrimSpace(errb.String())
 		if detail == "" {
 			detail = strings.TrimSpace(out.String())

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -791,6 +791,8 @@ This is the same model Docker, devcontainers, Codespaces, and Coder follow on th
 
 **Raw SSH gets the full shell.** If you connect with raw `ssh shed-name 'cmd | pipe'` (the path Zed Remote-SSH, VS Code Remote-SSH, JetBrains Gateway, and `rsync` take), the SSH server runs your command string through `bash -lc <raw>` — so the pipe runs as a shell pipeline on the shed, exactly like a normal dev VM. The `shed exec` CLI is the path that preserves argv literally; raw SSH is the path that runs a shell.
 
+**stdout and stderr.** On a **non-PTY** channel (raw `ssh -T`, Zed Remote-SSH, SFTP/`scp`, `rsync`), the command's stdout and stderr are delivered on **separate** SSH streams, matching OpenSSH — so a binary stdout protocol (Zed's length-prefixed pipe, the SFTP subsystem) is never corrupted by diagnostics written to stderr. On an **interactive PTY** channel — an interactive login, `shed console`, and the `shed exec` CLI (which always passes `ssh -t`, so OpenSSH allocates a PTY whenever your stdin is a terminal) — stdout and stderr are **merged** into the single terminal stream, exactly as a real terminal does. To capture them separately from a script, use raw `ssh -T shed-name 'cmd'`.
+
 **Disconnect behavior.** When the connection drops (you Ctrl-C the client, the network drops, your laptop sleeps), the command is terminated — the agent sends `SIGHUP` to the command's process group, matching standard SSH/terminal "connection hung up" semantics. To keep a long task running across disconnects, detach it from the session with **`tmux`** (baked into the shed image) or **`nohup`**:
 
 ```bash

--- a/internal/agentproto/messages.go
+++ b/internal/agentproto/messages.go
@@ -15,7 +15,15 @@ func WriteExitCode(w io.Writer, code int) error {
 	return WriteMessage(w, MsgTypeExitCode, data)
 }
 
-// WriteData sends a data frame (stdout/stderr output).
+// WriteData sends a stdout data frame (agent→host: process stdout on the non-PTY
+// channel, or merged output on the PTY channel; host→agent: stdin).
 func WriteData(w io.Writer, data []byte) error {
 	return WriteMessage(w, MsgTypeData, data)
+}
+
+// WriteStderr sends a process-stderr data frame (agent→host, non-PTY channel).
+// Kept distinct from WriteData so the host can route it to a separate stderr
+// stream instead of folding it into a binary stdout protocol (see MsgTypeStderr).
+func WriteStderr(w io.Writer, data []byte) error {
+	return WriteMessage(w, MsgTypeStderr, data)
 }

--- a/internal/agentproto/protocol.go
+++ b/internal/agentproto/protocol.go
@@ -17,8 +17,13 @@ const (
 	MsgTypeResize      byte = 0x02
 	MsgTypeSignal      byte = 0x03
 	MsgTypeExitCode    byte = 0x04
-	MsgTypeData        byte = 0x05
+	MsgTypeData        byte = 0x05 // agent→host: process stdout (non-PTY) or merged PTY output; host→agent: stdin
 	MsgTypeStdinEOF    byte = 0x06
+	// MsgTypeStderr carries non-PTY process stderr, framed separately from stdout
+	// (MsgTypeData) so a binary stdout protocol — Zed Remote-SSH, SFTP — is not
+	// corrupted by interleaved diagnostics. PTY output stays merged on MsgTypeData
+	// (a pty master is a single stream).
+	MsgTypeStderr byte = 0x07
 
 	MsgTypePluginMessage byte = 0x20 // Bidirectional: plugin envelope (JSON)
 )

--- a/internal/agentproto/protocol_test.go
+++ b/internal/agentproto/protocol_test.go
@@ -146,6 +146,7 @@ func TestReadWriteRoundTrip(t *testing.T) {
 	}{
 		{"empty plugin message", MsgTypePluginMessage, nil},
 		{"data message", MsgTypeData, []byte("some output data")},
+		{"stderr message", MsgTypeStderr, []byte("some error output")},
 		{"exec request", MsgTypeExecRequest, []byte(`{"cmd":["ls","-la"]}`)},
 		{"exit code", MsgTypeExitCode, []byte(`{"code":0}`)},
 		{"resize", MsgTypeResize, []byte(`{"rows":24,"cols":80}`)},
@@ -214,6 +215,8 @@ func TestMessageTypes(t *testing.T) {
 		MsgTypeSignal,
 		MsgTypeExitCode,
 		MsgTypeData,
+		MsgTypeStdinEOF,
+		MsgTypeStderr,
 		MsgTypePluginMessage,
 	}
 
@@ -223,5 +226,11 @@ func TestMessageTypes(t *testing.T) {
 			t.Errorf("duplicate message type: %#x", msgType)
 		}
 		seen[msgType] = true
+	}
+
+	// Pin the stderr frame type's wire value: hosts and agents at different
+	// versions must agree on 0x07, so it must never be renumbered.
+	if MsgTypeStderr != 0x07 {
+		t.Errorf("MsgTypeStderr = %#x, want 0x07 (wire-compatibility constant)", MsgTypeStderr)
 	}
 }

--- a/internal/vmutil/agent.go
+++ b/internal/vmutil/agent.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"sync"
 	"time"
 
@@ -256,13 +257,33 @@ func (c *AgentClient) Exec(ctx context.Context, opts backend.ExecOptions) error 
 					done <- nil
 				}
 				return
-			default:
+			case agentproto.MsgTypeData:
 				if opts.Stdout != nil {
 					if _, err := opts.Stdout.Write(data); err != nil {
 						done <- err
 						return
 					}
 				}
+			case agentproto.MsgTypeStderr:
+				// Route process stderr to its own writer. When the caller didn't
+				// set Stderr, fold into Stdout to preserve the combined-output
+				// behavior internal callers (e.g. ListSessions) rely on.
+				w := opts.Stderr
+				if w == nil {
+					w = opts.Stdout
+				}
+				if w != nil {
+					if _, err := w.Write(data); err != nil {
+						done <- err
+						return
+					}
+				}
+			default:
+				// Don't write unknown frames to stdout — this channel may carry a
+				// binary stdout protocol (Zed, SFTP), and injecting unexpected bytes
+				// is the corruption MsgTypeStderr separation fixes. Log for parity
+				// with the agent-side pump's unknown-frame handling.
+				log.Printf("Ignoring unknown message type on exec output channel: 0x%02x", msgType)
 			}
 		}
 	}()

--- a/internal/vmutil/agent_test.go
+++ b/internal/vmutil/agent_test.go
@@ -615,3 +615,69 @@ func TestExecWorkingDir(t *testing.T) {
 		t.Errorf("custom WorkingDir = %q, want %q", receivedReq.WorkingDir, "/tmp")
 	}
 }
+
+// routingHandler (server side) emits a stdout frame, a stderr frame, an
+// unknown/future frame type, another stdout frame, then exit 0. Used to assert
+// AgentClient.Exec's output demux routes MsgTypeData→Stdout, MsgTypeStderr→Stderr,
+// and ignores unknown frames (rather than dumping them onto the stdout stream,
+// which would re-open the issue #222 binary-stdout corruption).
+func routingHandler(conn net.Conn) {
+	defer conn.Close()
+	if mt, _, err := agentproto.ReadMessage(conn); err != nil || mt != agentproto.MsgTypeExecRequest {
+		return
+	}
+	agentproto.ReadMessage(conn) // stdin EOF
+	agentproto.WriteData(conn, []byte("out-1"))
+	agentproto.WriteStderr(conn, []byte("err-1"))
+	agentproto.WriteMessage(conn, 0x08, []byte("UNKNOWN")) // unknown/future type: host must ignore
+	agentproto.WriteData(conn, []byte("out-2"))
+	agentproto.WriteExitCode(conn, 0)
+}
+
+// TestExecRoutesStderrSeparately: with distinct Stdout/Stderr writers, stdout
+// frames land on Stdout, stderr frames on Stderr, and an unknown frame is ignored.
+func TestExecRoutesStderrSeparately(t *testing.T) {
+	client := NewAgentClient(&pipeDialer{handler: routingHandler}, 1024, 1026)
+
+	var stdout, stderr strings.Builder
+	opts := backend.ExecOptions{
+		Cmd:    []string{"cmd"},
+		Stdout: NopWriteCloser(&stdout),
+		Stderr: NopWriteCloser(&stderr),
+	}
+	if err := client.Exec(context.Background(), opts); err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+	if stdout.String() != "out-1out-2" {
+		t.Errorf("stdout = %q, want %q", stdout.String(), "out-1out-2")
+	}
+	if stderr.String() != "err-1" {
+		t.Errorf("stderr = %q, want %q", stderr.String(), "err-1")
+	}
+	if strings.Contains(stdout.String(), "err-1") {
+		t.Error("stderr leaked into stdout (fold regression)")
+	}
+	if strings.Contains(stdout.String(), "UNKNOWN") || strings.Contains(stderr.String(), "UNKNOWN") {
+		t.Error("unknown frame type must be ignored, not written to stdout/stderr")
+	}
+}
+
+// TestExecFoldsStderrWhenNilStderr: back-compat for callers that set only Stdout
+// (e.g. ListSessions) — stderr folds into Stdout so combined output is preserved.
+func TestExecFoldsStderrWhenNilStderr(t *testing.T) {
+	client := NewAgentClient(&pipeDialer{handler: routingHandler}, 1024, 1026)
+
+	var stdout strings.Builder
+	opts := backend.ExecOptions{
+		Cmd:    []string{"cmd"},
+		Stdout: NopWriteCloser(&stdout),
+		// Stderr nil → fold into Stdout.
+	}
+	if err := client.Exec(context.Background(), opts); err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+	// Frames arrive in order out-1, err-1(folded), out-2 (unknown ignored).
+	if stdout.String() != "out-1err-1out-2" {
+		t.Errorf("folded stdout = %q, want %q", stdout.String(), "out-1err-1out-2")
+	}
+}

--- a/tests/integration/test_exec_stderr.py
+++ b/tests/integration/test_exec_stderr.py
@@ -1,0 +1,58 @@
+"""Non-PTY exec stderr/stdout separation (issue #222 follow-on).
+
+Zed Remote-SSH, SFTP, and any raw `ssh -T` client read the exec channel's stdout
+and stderr as SEPARATE streams. The in-VM agent used to fold the remote process's
+stderr into stdout (a single MsgTypeData stream), which injected diagnostic/log
+output into a binary stdout protocol — corrupting Zed's length-prefixed protobuf
+pipe so its readiness handshake never parsed ("client did not become ready within
+the timeout"). The agent now frames stderr as its own MsgTypeStderr and the host
+demuxes it onto the SSH channel's extended-data stderr.
+
+These live tests drive the real wire path (host framing → vsock → agent copiers →
+process and back). They assert on raw `ssh -T` (the channel shape Zed/SFTP/rsync
+use), NOT the `shed exec` CLI, which requests a PTY (`ssh -t`, allocated when
+stdin is a terminal) that merges the two streams into one.
+
+Parameterized over ["vz", "fc"] like the rest of the suite.
+
+NOTE: the agent is baked into the rootfs IMAGE, so these assert the NEW agent —
+they pass only against an image rebuilt with the stderr-separation change (a bare
+`make test-integration-dev`, which restarts only the dev *server*, runs the old
+baked agent and will fail here until the rootfs is rebuilt).
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def test_nopty_stderr_separated(shed_server, test_shed_name):
+    """A non-PTY command's stdout and stderr arrive on their own SSH streams."""
+    shed_server.create(test_shed_name, image="base")
+
+    r = shed_server.ssh_exec(test_shed_name, "echo OUT; echo ERR 1>&2")
+    assert r.returncode == 0, f"exit={r.returncode} stderr={r.stderr!r}"
+    assert "OUT" in r.stdout, f"stdout missing OUT: stdout={r.stdout!r}"
+    assert "ERR" not in r.stdout, (
+        f"stderr leaked into stdout (fold regression): stdout={r.stdout!r}"
+    )
+    assert "ERR" in r.stderr, f"stderr missing ERR: stderr={r.stderr!r}"
+    assert "OUT" not in r.stderr, f"stdout leaked into stderr: stderr={r.stderr!r}"
+
+
+def test_pty_merges_streams(shed_server, test_shed_name):
+    """The PTY channel is a single stream: stderr merges onto stdout (correct).
+
+    A pty master merges stdout and stderr the way any terminal does, so the agent
+    keeps the PTY path on one MsgTypeData stream. This locks that intended
+    behavior so a future change can't accidentally split a PTY session.
+    """
+    shed_server.create(test_shed_name, image="base")
+
+    argv = shed_server.ssh_argv(test_shed_name, "echo OUT; echo ERR 1>&2", pty=True)
+    r = subprocess.run(argv, capture_output=True, text=True, timeout=60)
+    # Over a PTY both lines land on the client's stdout (the tty stream).
+    assert "OUT" in r.stdout, f"PTY stdout missing OUT: stdout={r.stdout!r}"
+    assert "ERR" in r.stdout, (
+        f"PTY must merge stderr onto stdout: stdout={r.stdout!r} stderr={r.stderr!r}"
+    )

--- a/tests/integration/test_zed_binary_channel.py
+++ b/tests/integration/test_zed_binary_channel.py
@@ -77,3 +77,43 @@ def test_binary_roundtrip_all_byte_values(shed_server, test_shed_name):
         f"binary round-trip corrupted across the full byte range: "
         f"got {len(r.stdout)} bytes, sent {len(payload)}"
     )
+
+
+def test_binary_stdout_survives_stderr(shed_server, test_shed_name):
+    """Binary stdout stays byte-perfect when the command also writes to stderr.
+
+    This is the Zed Remote-SSH failure shape: the remote process speaks a binary
+    protocol on stdout (Zed's length-prefixed protobuf) and also emits diagnostic
+    text on stderr (the zed-remote-server's JSON logs). The agent used to FOLD
+    stderr into stdout, injecting those log bytes into the binary stream and
+    desyncing Zed's framing (readiness timed out). With stderr on its own
+    MsgTypeStderr frame, stdout must be byte-identical to the input and the stderr
+    text must arrive on the separate stderr channel. (The command writes stderr
+    before and after the `cat`, not strictly interleaved with stdout, which is
+    still sufficient to catch the fold — any folded byte corrupts stdout.)
+
+    Like test_exec_stderr.py, this asserts the NEW baked agent: run against a
+    rootfs rebuilt with the stderr-separation change, not a bare
+    `make test-integration-dev` (which restarts only the dev server).
+    """
+    shed_server.create(test_shed_name, image="base")
+
+    # Every byte value (incl. '{' 0x7b, the byte Zed misreads as a length) so a
+    # single folded stderr byte would both corrupt and lengthen stdout.
+    payload = bytes(range(256)) * 4096  # 1 MiB
+    # Emit stderr diagnostics around the binary echo; the old folding agent would
+    # have spliced these bytes into stdout.
+    cmd = "printf 'log-before\\n' >&2; cat; printf 'log-after\\n' >&2"
+
+    r = shed_server.ssh_exec_binary(test_shed_name, cmd, input=payload, timeout=60)
+    assert r.returncode == 0, f"exit={r.returncode} stderr={r.stderr[:200]!r}"
+    assert r.stdout == payload, (
+        f"binary stdout corrupted by concurrent stderr (fold regression): "
+        f"got {len(r.stdout)} bytes, sent {len(payload)}"
+    )
+    assert b"log-before" in r.stderr and b"log-after" in r.stderr, (
+        f"stderr diagnostics missing from the stderr channel: {r.stderr[:200]!r}"
+    )
+    # (No need to also assert the log markers are absent from stdout: the exact
+    # `stdout == payload` check above already proves stdout is byte-identical to
+    # the monotonic-mod-256 input, which cannot contain those substrings.)


### PR DESCRIPTION
Fixes Zed Remote-SSH failing to connect to a shed. Follow-on to #222 / #225.

## Root cause

PR #225 fixed the stdin desync — a real bug — but the Zed symptom ("client did not become ready within the timeout" at 60 s) had a **second, independent cause**.

Zed runs `zed-remote-server proxy` over a **non-PTY** SSH exec channel and reads **two strictly separate streams** from it:
- **stdout** → length-prefixed protobuf RPC frames; the `RemoteStarted` readiness envelope must be byte-clean.
- **stderr** → newline-delimited JSON `LogRecord` log lines.

shed's in-VM agent **folded the process's stdout and stderr into one `MsgTypeData` stream** (`cmd/shed-agent/exec.go`), and the host wrote every non-exit frame to `opts.Stdout`. So the zed-remote-server's startup **log lines** (emitted on stderr) were injected into Zed's binary protobuf **stdout** pipe — Zed read `{"le` as a u32 length, desynced framing, never parsed `RemoteStarted`, and timed out. VS Code is immune (its data channel is `direct-tcpip`, not exec-stdout). SFTP/scp (also binary-over-stdout) had the same latent corruption risk.

## Fix — give the non-PTY exec path a real stderr stream (matches OpenSSH)

The host was already wired for this: `sshd/session.go` feeds `opts.Stderr` to the SSH channel's extended-data stderr; it was simply never fed. Three additive changes:

1. **agentproto**: add `MsgTypeStderr` (0x07) + `WriteStderr`.
2. **shed-agent `runWithoutPTY`**: frame stdout as `MsgTypeData`, stderr as `MsgTypeStderr` (threaded through `connWriter.write`/`copyToConn`). The **PTY path stays merged** on `MsgTypeData` — a pty master is a single stream. The keepalive probe stays a zero-length `MsgTypeData` frame.
3. **`AgentClient.Exec`**: route `MsgTypeStderr` → `opts.Stderr` (fold into `opts.Stdout` when `Stderr` is nil, preserving combined-output callers like `ListSessions`), `MsgTypeData` → `opts.Stdout`, and **log + ignore** unknown frame types rather than dumping them onto the (possibly binary) stdout stream.

`cmd/shed/rc.go` already captured stdout/stderr separately with a stderr-preferred fallback, so it benefits; its stale "folds stderr into stdout" comments are updated.

## Version skew (degrades safely)

| Host (server) | Agent (image) | Result |
|---|---|---|
| new | old | old agent folds → host routes `MsgTypeData`→Stdout = today's behavior |
| old | new | old host's `default`→Stdout folds the 0x07 payload = today's behavior |
| **new** | **new** | **separated → Zed works** |

The agent is baked into the **rootfs image**, so a `shed-server` upgrade alone does not fix running sheds — the **vz + firecracker images must be rebuilt** with the new agent (bump the baked `default_image`), and **existing sheds need recreation**.

## Evidence (validated end-to-end on a real VZ VM)

Against a dev server (new host routing) + a shed booted from a rebuilt image (new agent):

- **Wire-level:** `ssh -T <shed> 'echo OUT; echo ERR >&2' 2>/dev/null` returns only `OUT` (the old agent returned both). `1>/dev/null` returns only `ERR`.
- **Real `zed-remote-server proxy` handshake:** the proxy's stdout is now **clean binary frames** (`{"level` on stdout: **False**); the JSON logs land on **stderr** (2266 bytes of `{"level":3,…"starting up"…}`). On the old agent those JSON bytes were on stdout, corrupting the protobuf stream.
- **Real Zed Remote-SSH connects** against the rebuilt-agent shed. 
- **Integration suite: 5/5 vz pass**, including the Zed-shaped binary-stdout-survives-stderr guard.

## Tests

- **Unit** (`-race`; agent tests via Docker on macOS): agentproto round-trip + 0x07 wire-value pin; deterministic `copyToConn` stream-tagging guard; real `runWithoutPTY` separation (asserted by frame type); PTY path emits no `MsgTypeStderr`; host `Exec` routing — separate writers, nil-`Stderr` fold, unknown-frame ignored.
- **Integration** (opt-in live suite, parameterized vz/fc): `test_exec_stderr.py` (non-PTY separation + PTY-merge lock); `test_zed_binary_channel.py::test_binary_stdout_survives_stderr` (1 MiB all-byte-values stdout stays byte-perfect while the command writes stderr). These assert the **new baked agent** — run against a rebuilt rootfs, not a bare `make test-integration-dev`.

## Review

Plan reviewed by `/planning:ask-panel` (Codex + CodeRabbit; Kimi unavailable). Each commit went through `/simplify` (4 cleanup agents) and `/codex:rescue` (correctness) — both returned "correct for merge"; the surfaced nits (host `default` should log unknown frames; `-t` PTY-allocation accuracy in docs; redundant assertion) are addressed.

## Out of scope (pre-existing)

`TestNotifyConnResetsBackoffAfterConnection` (`notify_test.go`) has a data race present on `main`, unrelated to this change (only trips under `-race`, which `make check` doesn't run). Left for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate handling for stdout and stderr in non-PTY command sessions, while keeping PTY output merged into one terminal stream.
  * Improved client behavior so stderr is routed distinctly when available, with backward-compatible fallback when it isn’t.

* **Bug Fixes**
  * Prevented stderr output from interfering with binary or framed stdout data in non-PTY sessions.
  * Preserved output ordering within each stream and ignored unexpected frame types more safely.

* **Documentation**
  * Clarified exec and SSH stream behavior in the CLI reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->