### PR TITLE
fix(delete): fast destroy path + SSE progress streaming (#232)

### DIFF
--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -594,20 +594,43 @@ func (c *APIClient) DeleteShedWithProgress(name string, onProgress func(backend.
 	ctx, cancel := context.WithTimeout(context.Background(), c.createTimeout)
 	defer cancel()
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/api/sheds/"+name, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-	httpReq.Header.Set("Accept", "text/event-stream")
-	c.setAuth(httpReq)
-
+	// The streaming client (no client-level timeout, context deadline only)
+	// bypasses doRequest, so replicate its send + 401-refresh here. Rebuilding
+	// per send is fine — a DELETE has no body. Delete, unlike create, has no
+	// GetInfo pre-flight to refresh a stale bootstrap token, so this is the only
+	// place a mid-session token expiry gets re-minted.
 	client := c.newHTTPClient(0)
-	resp, err := client.Do(httpReq)
-	if err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("request timed out after %v (use --timeout to increase)", c.createTimeout)
+	send := func() (*http.Response, error) {
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/api/sheds/"+name, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
 		}
-		return fmt.Errorf("failed to connect to server: %w", err)
+		httpReq.Header.Set("Accept", "text/event-stream")
+		c.setAuth(httpReq)
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				return nil, fmt.Errorf("request timed out after %v (use --timeout to increase)", c.createTimeout)
+			}
+			return nil, fmt.Errorf("failed to connect to server: %w", err)
+		}
+		return resp, nil
+	}
+
+	resp, err := send()
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode == http.StatusUnauthorized && c.refreshFn != nil {
+		_ = resp.Body.Close()
+		tok, rerr := c.refreshFn()
+		if rerr != nil {
+			return fmt.Errorf("re-authenticating after 401: %w", rerr)
+		}
+		c.token = tok
+		if resp, err = send(); err != nil {
+			return err
+		}
 	}
 	defer resp.Body.Close()
 

--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -585,9 +585,49 @@ func (c *APIClient) EgressProfileDelete(name string) error {
 	return c.doRequest(http.MethodDelete, "/api/egress/profiles/"+name, nil, nil)
 }
 
-// DeleteShed deletes a shed.
-func (c *APIClient) DeleteShed(name string) error {
-	return c.doRequest(http.MethodDelete, "/api/sheds/"+name, nil, nil, http.StatusNoContent, http.StatusOK)
+// DeleteShedWithProgress deletes a shed and streams teardown progress via SSE.
+// It uses no client-level timeout (context deadline only, like create), so an
+// active event stream never trips the 30s quick-op timeout while a delete runs.
+// It falls back cleanly to a plain delete when the server predates delete-SSE: a
+// 204 No Content means the delete succeeded and there is no stream to read.
+func (c *APIClient) DeleteShedWithProgress(name string, onProgress func(backend.ProgressEvent)) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.createTimeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/api/sheds/"+name, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Accept", "text/event-stream")
+	c.setAuth(httpReq)
+
+	client := c.newHTTPClient(0)
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("request timed out after %v (use --timeout to increase)", c.createTimeout)
+		}
+		return fmt.Errorf("failed to connect to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Old server (no delete-SSE) returns a plain 204 — the delete succeeded and
+	// there is no stream to read.
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return c.parseError(resp)
+	}
+	// A 200 without the SSE content type is a non-streaming responder (an old or
+	// proxied plain delete that the pre-SSE client also accepted) — the delete
+	// succeeded; don't feed a non-SSE body to the stream reader. Otherwise read
+	// the SSE stream, ignoring the benign terminal "complete" payload.
+	if !strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+		return nil
+	}
+	_, err = c.readSSEStream(resp.Body, onProgress)
+	return err
 }
 
 // StartShed starts a stopped shed.

--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -586,12 +586,8 @@ func (c *APIClient) EgressProfileDelete(name string) error {
 }
 
 // DeleteShed deletes a shed.
-func (c *APIClient) DeleteShed(name string, keepVolume bool) error {
-	path := "/api/sheds/" + name
-	if keepVolume {
-		path += "?keep_volume=true"
-	}
-	return c.doRequest(http.MethodDelete, path, nil, nil, http.StatusNoContent, http.StatusOK)
+func (c *APIClient) DeleteShed(name string) error {
+	return c.doRequest(http.MethodDelete, "/api/sheds/"+name, nil, nil, http.StatusNoContent, http.StatusOK)
 }
 
 // StartShed starts a stopped shed.

--- a/cmd/shed/delete_test.go
+++ b/cmd/shed/delete_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/charliek/shed/internal/backend"
+)
+
+// TestDeleteShedWithProgress covers the three response shapes the delete client
+// must handle (#232): a streamed SSE delete, the plain-204 fallback for a server
+// that predates delete-SSE, and a terminal SSE error event.
+func TestDeleteShedWithProgress(t *testing.T) {
+	t.Run("streams SSE progress then completes", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Accept"); got != "text/event-stream" {
+				t.Errorf("Accept = %q, want text/event-stream", got)
+			}
+			if r.Method != http.MethodDelete {
+				t.Errorf("method = %q, want DELETE", r.Method)
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "event: progress\ndata: {\"message\":\"Terminating virtual machine...\"}\n\n")
+			fmt.Fprint(w, "event: complete\ndata: {\"name\":\"myshed\"}\n\n")
+		}))
+		defer srv.Close()
+
+		c := newAPIClient(srv.URL, "", "", DefaultTimeout)
+		var msgs []string
+		if err := c.DeleteShedWithProgress("myshed", func(e backend.ProgressEvent) {
+			msgs = append(msgs, e.Message)
+		}); err != nil {
+			t.Fatalf("DeleteShedWithProgress: %v", err)
+		}
+		if len(msgs) != 1 || msgs[0] != "Terminating virtual machine..." {
+			t.Errorf("progress messages = %v, want one 'Terminating virtual machine...'", msgs)
+		}
+	})
+
+	t.Run("falls back to 204 without reading a stream (old server)", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// Old server ignores Accept and returns a plain 204 with no body.
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer srv.Close()
+
+		c := newAPIClient(srv.URL, "", "", DefaultTimeout)
+		called := false
+		if err := c.DeleteShedWithProgress("myshed", func(backend.ProgressEvent) { called = true }); err != nil {
+			t.Fatalf("expected 204 to be treated as success, got: %v", err)
+		}
+		if called {
+			t.Error("onProgress must not be called on a 204 fallback")
+		}
+	})
+
+	t.Run("surfaces a terminal SSE error event", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "event: error\ndata: {\"error\":{\"code\":\"SHED_NOT_FOUND\",\"message\":\"shed not found\"}}\n\n")
+		}))
+		defer srv.Close()
+
+		c := newAPIClient(srv.URL, "", "", DefaultTimeout)
+		if err := c.DeleteShedWithProgress("ghost", func(backend.ProgressEvent) {}); err == nil {
+			t.Fatal("expected an error from a terminal SSE error event")
+		}
+	})
+
+	t.Run("treats a non-SSE 200 as success (old/proxied plain delete)", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// 200 without a text/event-stream content type — must not be fed to
+			// the SSE reader (which would error on EOF); the delete succeeded.
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		c := newAPIClient(srv.URL, "", "", DefaultTimeout)
+		if err := c.DeleteShedWithProgress("myshed", func(backend.ProgressEvent) {}); err != nil {
+			t.Fatalf("expected non-SSE 200 to be treated as success, got: %v", err)
+		}
+	})
+}

--- a/cmd/shed/shed.go
+++ b/cmd/shed/shed.go
@@ -701,9 +701,16 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	// Stop any associated tunnels first
 	stopTunnelsForShed(name)
 
-	client := NewAPIClientFromEntry(entry, DefaultTimeout)
-	if err := client.DeleteShed(name); err != nil {
-		return fmt.Errorf("failed to delete shed: %w", err)
+	// Delete streams teardown progress via SSE; use the configured create
+	// timeout (not the 30s quick-op default) so a slow teardown isn't cut off,
+	// and stream phases through the shared renderer (plain lines under --json /
+	// non-TTY / old server).
+	client := NewAPIClientFromEntry(entry, clientConfig.GetCreateTimeout())
+	onProgress, finish, _ := progressSink(jsonFlag)
+	delErr := client.DeleteShedWithProgress(name, onProgress)
+	finish()
+	if delErr != nil {
+		return fmt.Errorf("failed to delete shed: %w", delErr)
 	}
 
 	// Remove from cache

--- a/cmd/shed/shed.go
+++ b/cmd/shed/shed.go
@@ -81,7 +81,6 @@ var (
 	createUpperSize    string
 	startTimeout       time.Duration
 	listAll            bool
-	deleteKeep         bool
 	deleteForce        bool
 )
 
@@ -105,7 +104,6 @@ func init() {
 
 	listCmd.Flags().BoolVarP(&listAll, "all", "a", false, "List sheds from all servers")
 
-	deleteCmd.Flags().BoolVar(&deleteKeep, "keep-volume", false, "Keep the data volume")
 	deleteCmd.Flags().BoolVarP(&deleteForce, "force", "f", false, "Delete without confirmation")
 
 	rootCmd.AddCommand(createCmd)
@@ -693,11 +691,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 	// Confirm deletion unless --force
 	if !deleteForce {
-		prompt := fmt.Sprintf("Delete shed %q on %s? ", name, serverName)
-		if !deleteKeep {
-			prompt += "This will also delete the data volume. "
-		}
-		prompt += "[y/N] "
+		prompt := fmt.Sprintf("Delete shed %q on %s? This will also delete the data volume. [y/N] ", name, serverName)
 		if !confirmAction(prompt) {
 			fmt.Println("Cancelled.")
 			return nil
@@ -708,7 +702,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	stopTunnelsForShed(name)
 
 	client := NewAPIClientFromEntry(entry, DefaultTimeout)
-	if err := client.DeleteShed(name, deleteKeep); err != nil {
+	if err := client.DeleteShed(name); err != nil {
 		return fmt.Errorf("failed to delete shed: %w", err)
 	}
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -210,7 +210,12 @@ shed stop <name>
 
 ### shed delete
 
-Deletes a shed.
+Deletes a shed. This is a **destroy** operation (like `docker rm -f`): a running
+shed is terminated immediately (SIGKILL — the guest `hooks.shutdown` is **not**
+run) and its writable volume is always discarded. Use [`shed stop`](#shed-stop)
+for a graceful shutdown that keeps the shed restartable. Directories mounted with
+`--local-dir`/`--add-dir` are host data and are preserved (their unsynced guest
+writes are flushed before the shed is killed).
 
 ```bash
 shed delete <name> [flags]
@@ -218,7 +223,6 @@ shed delete <name> [flags]
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--keep-volume` | | `false` | Keep the data volume |
 | `--force` | `-f` | `false` | Skip confirmation |
 
 **Note:** When using `--json`, the `--force` flag is required (interactive confirmation is not supported in JSON mode).

--- a/docs/reference/fc-operations.md
+++ b/docs/reference/fc-operations.md
@@ -274,7 +274,7 @@ lower image is read-only and shared:
 # Stop, snapshot if you need to keep state, then recreate with a bigger upper
 shed stop myproject
 shed snapshot create myproject pre-resize
-shed delete myproject --keep-volume
+shed delete myproject
 shed create myproject --from-snapshot pre-resize --upper-size 20G
 ```
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -210,6 +210,26 @@ func newProgressSink(r *http.Request, ch chan<- backend.ProgressEvent) backend.P
 
 // handleCreateShedSSE streams create progress as Server-Sent Events.
 func (s *Server) handleCreateShedSSE(w http.ResponseWriter, r *http.Request, req config.CreateShedRequest) {
+	s.streamSSE(w, r, r.Context(), s.createTimer(req), func(ctx context.Context) (any, error) {
+		shed, err := s.backend.CreateShed(ctx, req)
+		if err != nil {
+			log.Printf("CreateShed failed for %q (backend=%s): %v", req.Name, req.Backend, err)
+		}
+		return shed, err
+	})
+}
+
+// streamSSE runs a backend operation while streaming its progress to the client
+// as Server-Sent Events. It owns the flusher/header preamble, the pump+drain
+// loop (a select rather than closing the channel, which would race sends), and
+// the terminal complete/error event. baseCtx is the context work runs under —
+// create/pull pass r.Context(); delete passes a cancellation-detached one so a
+// client disconnect can't strand a half-torn-down shed. The progress sink is
+// always tied to the request, so a disconnected client simply stops receiving
+// events. work returns the payload for the terminal "complete" event (ignored
+// on error). (handlePullImageSSE predates this and still inlines the same
+// shape; it can adopt this helper too.)
+func (s *Server) streamSSE(w http.ResponseWriter, r *http.Request, baseCtx context.Context, timer *backend.PhaseTimer, work func(ctx context.Context) (any, error)) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		writeError(w, http.StatusInternalServerError, config.ErrBackendError, "streaming not supported")
@@ -221,31 +241,26 @@ func (s *Server) handleCreateShedSSE(w http.ResponseWriter, r *http.Request, req
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
-	timer := s.createTimer(req)
 	events := make(chan backend.ProgressEvent, sseProgressBuffer)
 	sseFn := newProgressSink(r, events)
 
-	// Tee the progress stream: the timer records per-phase durations
-	// server-side (logged below), while sseFn forwards the human-readable
-	// messages to the streaming client. Timing never goes on the wire.
-	ctx := backend.ContextWithProgress(r.Context(), backend.TeeProgress(timer.Track, sseFn))
+	// Tee the progress stream: the timer records per-phase durations server-side
+	// (logged below); sseFn forwards the human-readable messages to the client.
+	// Timing never goes on the wire.
+	ctx := backend.ContextWithProgress(baseCtx, backend.TeeProgress(timer.Track, sseFn))
 
-	type createResult struct {
-		shed *config.Shed
-		err  error
+	type result struct {
+		payload any
+		err     error
 	}
-	done := make(chan createResult, 1)
-
+	done := make(chan result, 1)
 	go func() {
-		shed, err := s.backend.CreateShed(ctx, req)
-		done <- createResult{shed, err}
+		payload, err := work(ctx)
+		done <- result{payload, err}
 	}()
 
-	// Stream progress events until creation completes.
-	// Uses select to avoid closing the events channel (which would race with sends).
-	var res createResult
-	streaming := true
-	for streaming {
+	var res result
+	for streaming := true; streaming; {
 		select {
 		case event := <-events:
 			writeSSEEvent(w, "progress", event)
@@ -255,7 +270,7 @@ func (s *Server) handleCreateShedSSE(w http.ResponseWriter, r *http.Request, req
 		}
 	}
 
-	// Drain any remaining buffered progress events
+	// Drain any remaining buffered progress events.
 drain:
 	for {
 		select {
@@ -270,11 +285,10 @@ drain:
 	log.Printf("timing: %s", timer.Finish(res.err))
 
 	if res.err != nil {
-		log.Printf("CreateShed failed for %q (backend=%s): %v", req.Name, req.Backend, res.err)
 		_, errCode, msg := mapBackendError(res.err)
 		writeSSEEvent(w, "error", config.NewAPIError(errCode, msg))
 	} else {
-		writeSSEEvent(w, "complete", res.shed)
+		writeSSEEvent(w, "complete", res.payload)
 	}
 	flusher.Flush()
 }
@@ -437,13 +451,50 @@ func (s *Server) handleEgressOff(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDeleteShed(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 
-	if err := s.backend.DeleteShed(r.Context(), name); err != nil {
+	// Stream teardown progress via SSE if the client requests it.
+	if strings.Contains(r.Header.Get("Accept"), "text/event-stream") {
+		s.handleDeleteShedSSE(w, r, name)
+		return
+	}
+
+	timer := s.deleteTimer(name)
+	ctx := backend.ContextWithProgress(r.Context(), timer.Track)
+	err := s.backend.DeleteShed(ctx, name)
+	log.Printf("timing: %s", timer.Finish(err))
+	if err != nil {
 		code, errCode, msg := mapBackendError(err)
 		writeError(w, code, errCode, msg)
 		return
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// deleteTimer returns a PhaseTimer labelled for a DeleteShed operation. Like
+// createTimer it's installed for every delete (SSE or not) so the per-phase
+// breakdown lands in the server log regardless of streaming.
+func (s *Server) deleteTimer(name string) *backend.PhaseTimer {
+	return backend.NewPhaseTimer(
+		fmt.Sprintf("delete name=%s backend=%s", name, s.backend.Type()), nil)
+}
+
+// handleDeleteShedSSE streams delete/teardown progress as Server-Sent Events.
+func (s *Server) handleDeleteShedSSE(w http.ResponseWriter, r *http.Request, name string) {
+	// Detach the teardown from client cancellation: once delete starts
+	// destroying resources, a client disconnect (or its request timeout) must
+	// NOT strand it half-done — the destroy path may sync host-backed mounts
+	// before SIGKILL, and cancelling that sync could lose host data. Every
+	// internal step is self-bounded (bounded sync, SIGKILL wait, quick fs
+	// removes), so the goroutine still completes without a deadline. (A ceiling
+	// here would be worse than none: it would also cover DeleteShed's unbounded
+	// lock-acquire wait and could expire before teardown even starts, skipping
+	// the sync.) Progress still flows — the sink unblocks on the request's own
+	// Done, so a disconnected client just stops receiving events.
+	s.streamSSE(w, r, context.WithoutCancel(r.Context()), s.deleteTimer(name), func(ctx context.Context) (any, error) {
+		// Delete has no resource to return; a benign payload keeps the terminal
+		// event shape consistent with create/pull. The client ignores it.
+		return map[string]string{"name": name}, s.backend.DeleteShed(ctx, name)
+	})
 }
 
 // handleStartShed starts a stopped shed.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -457,8 +457,11 @@ func (s *Server) handleDeleteShed(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Detach the teardown from client cancellation (as the SSE path does): a
+	// non-streaming client or proxy must not be able to abort a destroy
+	// mid-cleanup — the backend kills the VM then does multi-step host cleanup.
 	timer := s.deleteTimer(name)
-	ctx := backend.ContextWithProgress(r.Context(), timer.Track)
+	ctx := backend.ContextWithProgress(context.WithoutCancel(r.Context()), timer.Track)
 	err := s.backend.DeleteShed(ctx, name)
 	log.Printf("timing: %s", timer.Finish(err))
 	if err != nil {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -430,13 +430,14 @@ func (s *Server) handleEgressOff(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, shed)
 }
 
-// handleDeleteShed deletes a shed.
-// DELETE /api/sheds/{name}?keep_volume=bool
+// handleDeleteShed deletes a shed. Delete always discards the writable volume;
+// any stray ?keep_volume query is ignored for back-compat with old clients (it
+// was a no-op on both backends).
+// DELETE /api/sheds/{name}
 func (s *Server) handleDeleteShed(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
-	keepVolume := r.URL.Query().Get("keep_volume") == "true"
 
-	if err := s.backend.DeleteShed(r.Context(), name, keepVolume); err != nil {
+	if err := s.backend.DeleteShed(r.Context(), name); err != nil {
 		code, errCode, msg := mapBackendError(err)
 		writeError(w, code, errCode, msg)
 		return

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -225,11 +225,12 @@ func TestMapBackendError_SentinelErrors(t *testing.T) {
 	}
 }
 
-// createShedFakeBackend stubs only what handleCreateShedSSE touches.
-// CreateShed runs the configured fn so tests can emit progress/warning events
-// before returning a result.
+// createShedFakeBackend stubs only what the create/delete SSE handlers touch.
+// CreateShed / DeleteShed run the configured fn so tests can emit
+// progress/warning events before returning.
 type createShedFakeBackend struct {
 	createFn func(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error)
+	deleteFn func(ctx context.Context, name string) error
 }
 
 func (f *createShedFakeBackend) Type() backend.Type { return backend.TypeVZ }
@@ -243,7 +244,10 @@ func (f *createShedFakeBackend) GetShed(_ context.Context, _ string) (*config.Sh
 func (f *createShedFakeBackend) ListSheds(_ context.Context) ([]config.Shed, error) {
 	panic("unexpected")
 }
-func (f *createShedFakeBackend) DeleteShed(_ context.Context, _ string) error {
+func (f *createShedFakeBackend) DeleteShed(ctx context.Context, name string) error {
+	if f.deleteFn != nil {
+		return f.deleteFn(ctx, name)
+	}
 	panic("unexpected")
 }
 func (f *createShedFakeBackend) StartShed(_ context.Context, _ string) (*config.Shed, error) {
@@ -444,5 +448,91 @@ func TestCreateShed_SSE_PhaseOnlyEventsNotStreamed(t *testing.T) {
 	if progressEvents != 1 {
 		t.Errorf("got %d progress events, want exactly 1 (the Status call); "+
 			"phase-only events must not be streamed", progressEvents)
+	}
+}
+
+// TestDeleteShed_SSE_StreamsProgressAndComplete verifies that a delete requested
+// with Accept: text/event-stream streams the backend's Status phases as progress
+// events and finishes with a terminal `complete` event (#232).
+func TestDeleteShed_SSE_StreamsProgressAndComplete(t *testing.T) {
+	be := &createShedFakeBackend{
+		deleteFn: func(ctx context.Context, _ string) error {
+			backend.Status(ctx, "Terminating virtual machine...")
+			backend.Status(ctx, "Removing volume...")
+			return nil
+		},
+	}
+	srv := NewServer(be, &config.ServerConfig{Name: "test-server"}, "", nil, nil)
+
+	r := httptest.NewRequest(http.MethodDelete, "/api/sheds/myshed", nil)
+	r.Header.Set("Accept", "text/event-stream")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	var progress, complete int
+	for _, e := range parseSSEEvents(t, w.Body.String()) {
+		switch e.Event {
+		case "progress":
+			progress++
+		case "complete":
+			complete++
+		}
+	}
+	if progress < 1 {
+		t.Errorf("expected >=1 progress event, got %d:\n%s", progress, w.Body.String())
+	}
+	if complete != 1 {
+		t.Errorf("expected exactly 1 complete event, got %d:\n%s", complete, w.Body.String())
+	}
+}
+
+// TestDeleteShed_PlainReturns204 verifies that a delete WITHOUT the SSE Accept
+// header keeps the plain 204 No Content behavior (back-compat for non-streaming
+// clients and old CLIs).
+func TestDeleteShed_PlainReturns204(t *testing.T) {
+	be := &createShedFakeBackend{
+		deleteFn: func(context.Context, string) error { return nil },
+	}
+	srv := NewServer(be, &config.ServerConfig{Name: "test-server"}, "", nil, nil)
+
+	r := httptest.NewRequest(http.MethodDelete, "/api/sheds/myshed", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d; want 204 (body: %s)", w.Code, w.Body.String())
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("expected empty 204 body, got: %s", w.Body.String())
+	}
+}
+
+// TestDeleteShed_SSE_SurfacesError verifies a backend delete failure is surfaced
+// as a terminal SSE `error` event (the stream still opens with 200 first).
+func TestDeleteShed_SSE_SurfacesError(t *testing.T) {
+	be := &createShedFakeBackend{
+		deleteFn: func(context.Context, string) error { return config.ErrShedNotFoundSentinel },
+	}
+	srv := NewServer(be, &config.ServerConfig{Name: "test-server"}, "", nil, nil)
+
+	r := httptest.NewRequest(http.MethodDelete, "/api/sheds/ghost", nil)
+	r.Header.Set("Accept", "text/event-stream")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 (SSE opens before the error), body: %s", w.Code, w.Body.String())
+	}
+	var sawError bool
+	for _, e := range parseSSEEvents(t, w.Body.String()) {
+		if e.Event == "error" {
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Errorf("no error event in stream:\n%s", w.Body.String())
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -243,7 +243,7 @@ func (f *createShedFakeBackend) GetShed(_ context.Context, _ string) (*config.Sh
 func (f *createShedFakeBackend) ListSheds(_ context.Context) ([]config.Shed, error) {
 	panic("unexpected")
 }
-func (f *createShedFakeBackend) DeleteShed(_ context.Context, _ string, _ bool) error {
+func (f *createShedFakeBackend) DeleteShed(_ context.Context, _ string) error {
 	panic("unexpected")
 }
 func (f *createShedFakeBackend) StartShed(_ context.Context, _ string) (*config.Shed, error) {

--- a/internal/api/routes_test.go
+++ b/internal/api/routes_test.go
@@ -29,7 +29,7 @@ func (routesFakeBackend) GetShed(_ context.Context, _ string) (*config.Shed, err
 	return nil, config.ErrShedNotFoundSentinel
 }
 func (routesFakeBackend) ListSheds(_ context.Context) ([]config.Shed, error) { return nil, nil }
-func (routesFakeBackend) DeleteShed(_ context.Context, _ string, _ bool) error {
+func (routesFakeBackend) DeleteShed(_ context.Context, _ string) error {
 	return config.ErrShedNotFoundSentinel
 }
 func (routesFakeBackend) StartShed(_ context.Context, _ string) (*config.Shed, error) {

--- a/internal/api/snapshot_handlers_test.go
+++ b/internal/api/snapshot_handlers_test.go
@@ -47,7 +47,7 @@ func (f *snapshotFakeBackend) GetShed(_ context.Context, _ string) (*config.Shed
 func (f *snapshotFakeBackend) ListSheds(_ context.Context) ([]config.Shed, error) {
 	panic("unexpected")
 }
-func (f *snapshotFakeBackend) DeleteShed(_ context.Context, _ string, _ bool) error {
+func (f *snapshotFakeBackend) DeleteShed(_ context.Context, _ string) error {
 	panic("unexpected")
 }
 func (f *snapshotFakeBackend) StartShed(_ context.Context, _ string) (*config.Shed, error) {

--- a/internal/api/system_handlers_test.go
+++ b/internal/api/system_handlers_test.go
@@ -35,7 +35,7 @@ func (f *fakeBackend) GetShed(ctx context.Context, name string) (*config.Shed, e
 	panic("unexpected")
 }
 func (f *fakeBackend) ListSheds(ctx context.Context) ([]config.Shed, error) { panic("unexpected") }
-func (f *fakeBackend) DeleteShed(ctx context.Context, name string, keepVolume bool) error {
+func (f *fakeBackend) DeleteShed(ctx context.Context, name string) error {
 	panic("unexpected")
 }
 func (f *fakeBackend) StartShed(ctx context.Context, name string) (*config.Shed, error) {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -39,8 +39,10 @@ type Backend interface {
 	// ListSheds returns all sheds managed by this backend.
 	ListSheds(ctx context.Context) ([]config.Shed, error)
 
-	// DeleteShed removes a shed. If keepVolume is true, the workspace is preserved.
-	DeleteShed(ctx context.Context, name string, keepVolume bool) error
+	// DeleteShed removes a shed (destroy semantics: the writable volume is
+	// always discarded, and a running shed is SIGKILLed without a graceful
+	// guest shutdown — use StopShed for a graceful stop).
+	DeleteShed(ctx context.Context, name string) error
 
 	// StartShed starts a stopped shed.
 	StartShed(ctx context.Context, name string) (*config.Shed, error)

--- a/internal/config/mounts_test.go
+++ b/internal/config/mounts_test.go
@@ -318,3 +318,35 @@ func TestProjectAddDirTargets(t *testing.T) {
 		})
 	}
 }
+
+// TestHasWritableHostMount guards the #232 fast-delete sync decision: a running
+// shed with ANY writable host-backed mount (project OR configured server
+// `mounts:`) must be flushed before the destroy SIGKILL, or unsynced guest
+// writes to host data are lost. A shed with only readonly / no host mounts takes
+// the no-sync fast path.
+func TestHasWritableHostMount(t *testing.T) {
+	ro := MountConfig{Source: "/h/ro", Target: "/t/ro", ReadOnly: true}
+	rw := MountConfig{Source: "/h/rw", Target: "/t/rw", ReadOnly: false}
+
+	tests := []struct {
+		name          string
+		projectMounts []MountConfig
+		serverCfg     *ServerConfig
+		want          bool
+	}{
+		{"no mounts, nil serverCfg", nil, nil, false},
+		{"only readonly project mount", []MountConfig{ro}, nil, false},
+		{"writable project mount", []MountConfig{ro, rw}, nil, true},
+		{"writable configured mount only", nil, &ServerConfig{Mounts: map[string]MountConfig{"a": rw}}, true},
+		{"readonly configured mount only", nil, &ServerConfig{Mounts: map[string]MountConfig{"a": ro}}, false},
+		{"all readonly across both", []MountConfig{ro}, &ServerConfig{Mounts: map[string]MountConfig{"a": ro}}, false},
+		{"empty serverCfg mounts", nil, &ServerConfig{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasWritableHostMount(tt.projectMounts, tt.serverCfg); got != tt.want {
+				t.Errorf("HasWritableHostMount() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -1242,6 +1242,28 @@ func (m MountConfig) MatchesExclude(relPath string) bool {
 	return MatchesExcludePatterns(relPath, m.Exclude)
 }
 
+// HasWritableHostMount reports whether a shed with the given project mounts
+// (--local-dir/--add-dir), running under serverCfg, has any writable
+// host-backed directory. A destroy/delete SIGKILLs the guest without a graceful
+// shutdown; if any such mount exists the guest must be synced first, or unsynced
+// writes to that host data are lost. (The discarded upper needs no sync — only
+// host-backed mounts, which outlive the shed, do.) serverCfg may be nil.
+func HasWritableHostMount(projectMounts []MountConfig, serverCfg *ServerConfig) bool {
+	for _, m := range projectMounts {
+		if !m.ReadOnly {
+			return true
+		}
+	}
+	if serverCfg != nil {
+		for _, m := range serverCfg.Mounts {
+			if !m.ReadOnly {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // MatchesExcludePatterns reports whether relPath matches any of the given glob
 // patterns. Patterns like "dir/*" also match the directory itself and deeply
 // nested paths (e.g., "dir/sub/deep/file").

--- a/internal/firecracker/backend.go
+++ b/internal/firecracker/backend.go
@@ -62,10 +62,9 @@ func (b *FirecrackerBackend) ListSheds(ctx context.Context) ([]config.Shed, erro
 	return b.client.ListSheds(ctx)
 }
 
-// DeleteShed removes a shed. If keepVolume is true, the workspace is preserved.
-// Note: For Firecracker, keepVolume is ignored as the rootfs is always part of the instance.
-func (b *FirecrackerBackend) DeleteShed(ctx context.Context, name string, keepVolume bool) error {
-	return b.client.DeleteShed(ctx, name, keepVolume)
+// DeleteShed removes a shed (destroy semantics — see backend.DeleteShed).
+func (b *FirecrackerBackend) DeleteShed(ctx context.Context, name string) error {
+	return b.client.DeleteShed(ctx, name)
 }
 
 // StartShed starts a stopped shed.

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -635,6 +635,7 @@ func (c *Client) DeleteShed(ctx context.Context, name string) error {
 	}
 
 	if meta.Status == config.StatusRunning {
+		backend.Status(ctx, "Terminating virtual machine...")
 		// Use the lock-aware variant so we don't deadlock on the per-shed
 		// mutex we already hold (sync.Mutex is non-reentrant).
 		if _, err := c.stopShedLocked(ctx, meta, stopDestroy); err != nil {
@@ -658,6 +659,7 @@ func (c *Client) DeleteShed(ctx context.Context, name string) error {
 		}
 	}
 
+	backend.Status(ctx, "Releasing network...")
 	if err := c.netMgr.DeleteTAPDevice(meta.TAPDevice); err != nil {
 		log.Printf("Warning: failed to delete TAP device %s: %v", meta.TAPDevice, err)
 	}
@@ -671,6 +673,7 @@ func (c *Client) DeleteShed(ctx context.Context, name string) error {
 		_ = c.egressMgr.Release(name)
 	}
 
+	backend.Status(ctx, "Removing volume...")
 	if err := meta.Delete(c.cfg.InstanceDir); err != nil {
 		return fmt.Errorf("failed to delete instance: %w", err)
 	}

--- a/internal/firecracker/client.go
+++ b/internal/firecracker/client.go
@@ -623,7 +623,7 @@ func (c *Client) ListSheds(ctx context.Context) ([]config.Shed, error) {
 }
 
 // DeleteShed removes a shed.
-func (c *Client) DeleteShed(ctx context.Context, name string, keepVolume bool) error {
+func (c *Client) DeleteShed(ctx context.Context, name string) error {
 	defer c.acquireCreateLock(name)()
 
 	meta, err := LoadMetadata(c.cfg.InstanceDir, name)
@@ -637,7 +637,7 @@ func (c *Client) DeleteShed(ctx context.Context, name string, keepVolume bool) e
 	if meta.Status == config.StatusRunning {
 		// Use the lock-aware variant so we don't deadlock on the per-shed
 		// mutex we already hold (sync.Mutex is non-reentrant).
-		if _, err := c.stopShedLocked(ctx, meta); err != nil {
+		if _, err := c.stopShedLocked(ctx, meta, stopDestroy); err != nil {
 			log.Printf("Warning: stop failed during delete of %s: %v", name, err)
 			// stopShedLocked failed — clean up resources it would have released
 			c.credMgr.StopListener(name)
@@ -693,6 +693,17 @@ func (c *Client) StartShed(ctx context.Context, name string) (*config.Shed, erro
 }
 
 // StopShed stops a running shed.
+// stopMode selects stopShedLocked's teardown: stopGraceful is StopShed's clean,
+// restartable path; stopDestroy is delete's fast SIGKILL path (see the
+// stopDestroy case for the project-mount sync exception). stopGraceful is the
+// zero value, so a forgotten mode defaults to the safe graceful path.
+type stopMode int
+
+const (
+	stopGraceful stopMode = iota
+	stopDestroy
+)
+
 func (c *Client) StopShed(ctx context.Context, name string) (*config.Shed, error) {
 	defer c.acquireCreateLock(name)()
 
@@ -704,14 +715,14 @@ func (c *Client) StopShed(ctx context.Context, name string) (*config.Shed, error
 		return nil, err
 	}
 
-	return c.stopShedLocked(ctx, meta)
+	return c.stopShedLocked(ctx, meta, stopGraceful)
 }
 
 // stopShedLocked performs the stop logic assuming the caller already holds
 // acquireCreateLock(meta.Name). This split exists so DeleteShed can stop a
 // running shed without re-entering the non-reentrant per-shed mutex it is
 // already holding. The public StopShed acquires the lock and delegates here.
-func (c *Client) stopShedLocked(ctx context.Context, meta *Metadata) (*config.Shed, error) {
+func (c *Client) stopShedLocked(ctx context.Context, meta *Metadata, mode stopMode) (*config.Shed, error) {
 	if meta.Status != config.StatusRunning {
 		return nil, fmt.Errorf("%w: %s", config.ErrShedNotRunningSentinel, meta.Name)
 	}
@@ -730,16 +741,6 @@ func (c *Client) stopShedLocked(ctx context.Context, meta *Metadata) (*config.Sh
 	// Stop P9 servers before shutting down
 	c.stopP9Servers(meta.Name)
 
-	agent := c.newAgentClient(meta.Name)
-
-	// Run shutdown hook before stopping the VM
-	vmutil.RunShutdownSequence(ctx, agent, meta.Name, meta.LandingDir, c.cfg.StopTimeout.Duration(), os.Stdout, os.Stderr)
-
-	// Ask the guest to flush dirty buffers to the virtio-blk devices
-	// before firecracker terminates. Without this, post-stop snapshots
-	// and any host-side read of upper.ext4 see a stale pre-sync state.
-	vmutil.SyncFilesystems(ctx, agent, c.cfg.StopTimeout.Duration())
-
 	// Get or create VM handle
 	c.mu.Lock()
 	vm := c.vms[meta.Name]
@@ -749,15 +750,39 @@ func (c *Client) stopShedLocked(ctx context.Context, meta *Metadata) (*config.Sh
 		vm = &VM{meta: meta, cfg: c.cfg}
 	}
 
-	if err := vm.Stop(ctx); err != nil {
-		return nil, fmt.Errorf("failed to stop VM: %w", err)
+	switch mode {
+	case stopGraceful:
+		agent := c.newAgentClient(meta.Name)
+		// Run the shutdown hook, then ask the guest to flush dirty buffers to
+		// the virtio-blk devices before firecracker terminates. Without this,
+		// post-stop snapshots and any host-side read of upper.ext4 see a stale
+		// pre-sync state.
+		vmutil.RunShutdownSequence(ctx, agent, meta.Name, meta.LandingDir, c.cfg.StopTimeout.Duration(), os.Stdout, os.Stderr)
+		vmutil.SyncFilesystems(ctx, agent, c.cfg.StopTimeout.Duration())
+		if err := vm.Stop(ctx); err != nil {
+			return nil, fmt.Errorf("failed to stop VM: %w", err)
+		}
+	case stopDestroy:
+		// Delete discards the upper, so the shutdown hook and the graceful VM
+		// shutdown are wasted work — SIGKILL immediately. EXCEPTION: if the shed
+		// has any WRITABLE host-backed mount (--local-dir/--add-dir OR a
+		// configured server `mounts:` entry), flush the guest (bounded) first so
+		// a raw kill doesn't lose unsynced writes to that host data. A shed with
+		// no writable host mount skips the agent entirely (the fast path).
+		if config.HasWritableHostMount(meta.ProjectMounts, c.serverCfg) {
+			agent := c.newAgentClient(meta.Name)
+			vmutil.SyncFilesystems(ctx, agent, c.cfg.StopTimeout.Duration())
+		}
+		if err := vm.Kill(ctx); err != nil {
+			return nil, fmt.Errorf("failed to kill VM: %w", err)
+		}
 	}
 
-	// vm.Stop's post-SIGKILL waitForProcessExit swallows its timeout
-	// and returns nil even when firecracker refused to die. Verify
-	// before flipping status — otherwise the next StartShed would find
-	// PID=0 in metadata and silently spawn a second firecracker under
-	// the same name.
+	// The VM teardown above (vm.Stop or vm.Kill) swallows its post-SIGKILL
+	// waitForProcessExit timeout and returns nil even when firecracker refused
+	// to die. Verify before flipping status — otherwise the next StartShed
+	// would find PID=0 in metadata and silently spawn a second firecracker
+	// under the same name.
 	if meta.PID > 0 && vmutil.IsProcessAlive(meta.PID) && isFirecrackerProcess(meta.PID) {
 		return nil, fmt.Errorf("%w: %s (pid %d)", config.ErrStopIncompleteSentinel, meta.Name, meta.PID)
 	}

--- a/internal/firecracker/client_test.go
+++ b/internal/firecracker/client_test.go
@@ -124,7 +124,7 @@ func TestStopShedLockedDoesNotReacquireLock(t *testing.T) {
 		_, _ = c.stopShedLocked(context.Background(), &Metadata{
 			Name:   "test-shed",
 			Status: config.StatusStopped,
-		})
+		}, stopGraceful)
 		close(done)
 	}()
 

--- a/internal/firecracker/stub_nonlinux.go
+++ b/internal/firecracker/stub_nonlinux.go
@@ -74,7 +74,7 @@ func (b *FirecrackerBackend) ListSheds(ctx context.Context) ([]config.Shed, erro
 }
 
 // DeleteShed returns an error on non-linux platforms.
-func (b *FirecrackerBackend) DeleteShed(ctx context.Context, name string, keepVolume bool) error {
+func (b *FirecrackerBackend) DeleteShed(ctx context.Context, name string) error {
 	return errNonLinux()
 }
 

--- a/internal/firecracker/system.go
+++ b/internal/firecracker/system.go
@@ -339,7 +339,7 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 	report.Items = report.Items[:0]
 
 	for _, ic := range instanceCandidates {
-		if err := c.DeleteShed(ctx, ic.Name, false); err != nil {
+		if err := c.DeleteShed(ctx, ic.Name); err != nil {
 			report.Skipped = append(report.Skipped, config.SkippedItem{
 				Kind: "instance", Name: ic.Name,
 				Reason: fmt.Sprintf("delete failed: %v", err),

--- a/internal/firecracker/vm.go
+++ b/internal/firecracker/vm.go
@@ -289,6 +289,42 @@ func (vm *VM) Stop(ctx context.Context) error {
 	return waitErr
 }
 
+// Kill terminates the VM immediately with SIGKILL, skipping BOTH graceful
+// sub-paths that Stop uses (the firecracker `machine.Shutdown` when a machine
+// handle is live, and the `stopByPID` SIGTERM-then-wait when it isn't — the
+// server-restart case). This is the destroy/delete path: the writable upper is
+// discarded, so a clean guest shutdown is pointless and the ~stop_timeout wait
+// is pure latency. It mirrors Stop's proven force-kill fallback (SIGKILL +
+// waitForProcessExit + socket cleanup), so it leaves no more behind than a
+// graceful stop whose guest ignored the shutdown.
+func (vm *VM) Kill(_ context.Context) error {
+	defer vm.cleanupSockets()
+
+	// SIGKILL by PID when we have a usable one — covers both the in-process case
+	// and the server-restart case (no live machine handle).
+	if vm.meta.PID > 0 && isFirecrackerProcess(vm.meta.PID) {
+		if err := syscall.Kill(vm.meta.PID, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+			return fmt.Errorf("failed to SIGKILL VM %s (pid %d): %w", vm.meta.Name, vm.meta.PID, err)
+		}
+		if !waitForProcessExit(vm.meta.PID, 2*time.Second) {
+			log.Printf("Warning: VM %s PID %d did not exit within timeout after SIGKILL", vm.meta.Name, vm.meta.PID)
+		}
+		return nil
+	}
+
+	// No usable PID. machine.PID() can fail at Start (logged, non-fatal),
+	// leaving meta.PID unset even though the VMM is live — graceful Stop would
+	// still drive it via the SDK handle, so Kill must too, or a delete could
+	// orphan a running firecracker while removing its metadata/upper. StopVMM
+	// signals the firecracker process and waits for cleanup.
+	if vm.machine != nil {
+		if err := vm.machine.StopVMM(); err != nil {
+			return fmt.Errorf("failed to StopVMM %s: %w", vm.meta.Name, err)
+		}
+	}
+	return nil
+}
+
 // cleanupSockets removes the API and vsock socket files for this VM.
 func (vm *VM) cleanupSockets() {
 	socketDir := vm.cfg.SocketDir

--- a/internal/vz/backend.go
+++ b/internal/vz/backend.go
@@ -62,9 +62,9 @@ func (b *VZBackend) ListSheds(ctx context.Context) ([]config.Shed, error) {
 	return b.client.ListSheds(ctx)
 }
 
-// DeleteShed removes a shed.
-func (b *VZBackend) DeleteShed(ctx context.Context, name string, keepVolume bool) error {
-	return b.client.DeleteShed(ctx, name, keepVolume)
+// DeleteShed removes a shed (destroy semantics — see backend.DeleteShed).
+func (b *VZBackend) DeleteShed(ctx context.Context, name string) error {
+	return b.client.DeleteShed(ctx, name)
 }
 
 // StartShed starts a stopped shed.

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -281,6 +281,7 @@ func (c *Client) DeleteShed(ctx context.Context, name string) error {
 	}
 
 	if meta.Status == config.StatusRunning {
+		backend.Status(ctx, "Terminating virtual machine...")
 		// Use the lock-aware variant so we don't deadlock on the per-shed
 		// mutex we already hold (sync.Mutex is non-reentrant).
 		if _, err := c.stopShedLocked(ctx, meta, stopDestroy); err != nil {
@@ -310,6 +311,7 @@ func (c *Client) DeleteShed(ctx context.Context, name string) error {
 		_ = c.egressMgr.Release(name)
 	}
 
+	backend.Status(ctx, "Removing volume...")
 	if err := meta.Delete(c.cfg.InstanceDir); err != nil {
 		return fmt.Errorf("failed to delete instance: %w", err)
 	}

--- a/internal/vz/client.go
+++ b/internal/vz/client.go
@@ -269,7 +269,7 @@ func (c *Client) ListSheds(ctx context.Context) ([]config.Shed, error) {
 }
 
 // DeleteShed removes a shed.
-func (c *Client) DeleteShed(ctx context.Context, name string, keepVolume bool) error {
+func (c *Client) DeleteShed(ctx context.Context, name string) error {
 	defer c.acquireCreateLock(name)()
 
 	meta, err := LoadMetadata(c.cfg.InstanceDir, name)
@@ -283,7 +283,7 @@ func (c *Client) DeleteShed(ctx context.Context, name string, keepVolume bool) e
 	if meta.Status == config.StatusRunning {
 		// Use the lock-aware variant so we don't deadlock on the per-shed
 		// mutex we already hold (sync.Mutex is non-reentrant).
-		if _, err := c.stopShedLocked(ctx, meta); err != nil {
+		if _, err := c.stopShedLocked(ctx, meta, stopDestroy); err != nil {
 			log.Printf("Warning: stop failed during delete of %s: %v", name, err)
 			// stopShedLocked failed — clean up resources it would have released
 			c.credMgr.StopListener(name)
@@ -331,6 +331,17 @@ func (c *Client) StartShed(ctx context.Context, name string) (*config.Shed, erro
 	return orchestrator.StartShed(ctx, &vzStarter{c: c}, orchestrator.StartRequest{Name: name})
 }
 
+// stopMode selects stopShedLocked's teardown: stopGraceful is StopShed's clean,
+// restartable path; stopDestroy is delete's fast SIGKILL path (see the
+// stopDestroy case for the project-mount sync exception). stopGraceful is the
+// zero value, so a forgotten mode defaults to the safe graceful path.
+type stopMode int
+
+const (
+	stopGraceful stopMode = iota
+	stopDestroy
+)
+
 // StopShed stops a running shed.
 func (c *Client) StopShed(ctx context.Context, name string) (*config.Shed, error) {
 	defer c.acquireCreateLock(name)()
@@ -343,14 +354,14 @@ func (c *Client) StopShed(ctx context.Context, name string) (*config.Shed, error
 		return nil, err
 	}
 
-	return c.stopShedLocked(ctx, meta)
+	return c.stopShedLocked(ctx, meta, stopGraceful)
 }
 
 // stopShedLocked performs the stop logic assuming the caller already holds
 // acquireCreateLock(meta.Name). This split exists so DeleteShed can stop a
 // running shed without re-entering the non-reentrant per-shed mutex it is
 // already holding. The public StopShed acquires the lock and delegates here.
-func (c *Client) stopShedLocked(ctx context.Context, meta *Metadata) (*config.Shed, error) {
+func (c *Client) stopShedLocked(ctx context.Context, meta *Metadata, mode stopMode) (*config.Shed, error) {
 	if meta.Status != config.StatusRunning {
 		return nil, fmt.Errorf("%w: %s", config.ErrShedNotRunningSentinel, meta.Name)
 	}
@@ -366,17 +377,6 @@ func (c *Client) stopShedLocked(ctx context.Context, meta *Metadata) (*config.Sh
 		}
 	}
 
-	agent := c.newAgentClient(meta.Name)
-
-	// Run shutdown hook before stopping the VM
-	vmutil.RunShutdownSequence(ctx, agent, meta.Name, meta.LandingDir, c.cfg.StopTimeout.Duration(), os.Stdout, os.Stderr)
-
-	// Ask the guest to flush its dirty buffers to the virtio-blk
-	// devices before vfkit terminates. Without this, post-stop
-	// snapshots and any host-side read of upper.ext4 see a stale
-	// pre-sync state — vfkit does not synchronously flush on SIGTERM.
-	vmutil.SyncFilesystems(ctx, agent, c.cfg.StopTimeout.Duration())
-
 	// Get or create VM handle
 	c.mu.Lock()
 	vm := c.vms[meta.Name]
@@ -386,14 +386,38 @@ func (c *Client) stopShedLocked(ctx context.Context, meta *Metadata) (*config.Sh
 		vm = &VM{meta: meta, cfg: c.cfg}
 	}
 
-	if err := vm.Stop(ctx); err != nil {
-		return nil, fmt.Errorf("failed to stop VM: %w", err)
+	switch mode {
+	case stopGraceful:
+		agent := c.newAgentClient(meta.Name)
+		// Run the shutdown hook, then ask the guest to flush its dirty buffers
+		// to the virtio-blk devices before vfkit terminates. Without this,
+		// post-stop snapshots and any host-side read of upper.ext4 see a stale
+		// pre-sync state — vfkit does not synchronously flush on SIGTERM.
+		vmutil.RunShutdownSequence(ctx, agent, meta.Name, meta.LandingDir, c.cfg.StopTimeout.Duration(), os.Stdout, os.Stderr)
+		vmutil.SyncFilesystems(ctx, agent, c.cfg.StopTimeout.Duration())
+		if err := vm.Stop(ctx); err != nil {
+			return nil, fmt.Errorf("failed to stop VM: %w", err)
+		}
+	case stopDestroy:
+		// Delete discards the overlay, so the shutdown hook and the graceful VM
+		// shutdown are wasted work — SIGKILL immediately. EXCEPTION: if the shed
+		// has any WRITABLE host-backed mount (--local-dir/--add-dir OR a
+		// configured server `mounts:` entry), flush the guest (bounded) first so
+		// a raw kill doesn't lose unsynced writes to that host data. A shed with
+		// no writable host mount skips the agent entirely (the fast path).
+		if config.HasWritableHostMount(meta.ProjectMounts, c.serverCfg) {
+			agent := c.newAgentClient(meta.Name)
+			vmutil.SyncFilesystems(ctx, agent, c.cfg.StopTimeout.Duration())
+		}
+		if err := vm.Kill(ctx); err != nil {
+			return nil, fmt.Errorf("failed to kill VM: %w", err)
+		}
 	}
 
-	// vm.Stop's post-SIGKILL waitForProcessExit swallows its timeout
-	// and returns nil even when vfkit refused to die (uninterruptible
-	// I/O, kernel hang, etc). Verify before flipping status — otherwise
-	// the next StartShed would find PID=0 in metadata and silently
+	// The VM teardown above (vm.Stop or vm.Kill) swallows its post-SIGKILL
+	// waitForProcessExit timeout and returns nil even when vfkit refused to die
+	// (uninterruptible I/O, kernel hang, etc). Verify before flipping status —
+	// otherwise the next StartShed would find PID=0 in metadata and silently
 	// spawn a second vfkit under the same name.
 	if meta.PID > 0 && vmutil.IsProcessAlive(meta.PID) && isVfkitProcess(meta.PID) {
 		return nil, fmt.Errorf("%w: %s (pid %d)", config.ErrStopIncompleteSentinel, meta.Name, meta.PID)

--- a/internal/vz/client_test.go
+++ b/internal/vz/client_test.go
@@ -356,7 +356,7 @@ func TestStopShedLockedDoesNotReacquireLock(t *testing.T) {
 		_, _ = c.stopShedLocked(context.Background(), &Metadata{
 			Name:   "test-shed",
 			Status: config.StatusStopped,
-		})
+		}, stopGraceful)
 		close(done)
 	}()
 

--- a/internal/vz/stub_nondarwin.go
+++ b/internal/vz/stub_nondarwin.go
@@ -72,7 +72,7 @@ func (b *VZBackend) ListSheds(ctx context.Context) ([]config.Shed, error) {
 }
 
 // DeleteShed returns an error on non-darwin platforms.
-func (b *VZBackend) DeleteShed(ctx context.Context, name string, keepVolume bool) error {
+func (b *VZBackend) DeleteShed(ctx context.Context, name string) error {
 	return errNonDarwin
 }
 

--- a/internal/vz/system.go
+++ b/internal/vz/system.go
@@ -393,7 +393,7 @@ func (c *Client) Prune(ctx context.Context, opts backend.PruneOptions) (config.P
 	// 3a: delete candidate instances via DeleteShed (handles TAP/cred
 	// cleanup correctly and re-checks running state under its own lock).
 	for _, ic := range instanceCandidates {
-		if err := c.DeleteShed(ctx, ic.Name, false); err != nil {
+		if err := c.DeleteShed(ctx, ic.Name); err != nil {
 			report.Skipped = append(report.Skipped, config.SkippedItem{
 				Kind: "instance", Name: ic.Name,
 				Reason: fmt.Sprintf("delete failed: %v", err),

--- a/internal/vz/vm.go
+++ b/internal/vz/vm.go
@@ -246,6 +246,43 @@ func (vm *VM) Stop(ctx context.Context) error {
 	return nil
 }
 
+// Kill terminates the VM immediately with SIGKILL, skipping the graceful
+// SIGTERM-then-wait path Stop uses (both the process-handle and stopByPID
+// variants). Used by the destroy/delete path: the writable overlay is
+// discarded, so a clean guest shutdown is pointless and the ~stop_timeout wait
+// is pure latency. Mirrors Stop's force-kill fallback (SIGKILL + reap +
+// socket/handle cleanup).
+func (vm *VM) Kill(_ context.Context) error {
+	defer vm.cleanupSockets()
+	defer vm.clearProcessHandles()
+
+	if vm.meta.PID <= 0 {
+		return nil
+	}
+	if !isVfkitProcess(vm.meta.PID) {
+		// PID is dead or reused by an unrelated process — never SIGKILL it.
+		log.Printf("Warning: PID %d is not a vfkit process, skipping SIGKILL", vm.meta.PID)
+		return nil
+	}
+
+	if vm.cmd != nil && vm.cmd.Process != nil {
+		if err := vm.cmd.Process.Signal(syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) && !errors.Is(err, os.ErrProcessDone) {
+			return fmt.Errorf("failed to SIGKILL VM %s (pid %d): %w", vm.meta.Name, vm.meta.PID, err)
+		}
+		vm.waitForReap(2 * time.Second)
+		return nil
+	}
+
+	// No live process handle (server-restart case) — kill by PID.
+	if err := syscall.Kill(vm.meta.PID, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("failed to SIGKILL VM %s (pid %d): %w", vm.meta.Name, vm.meta.PID, err)
+	}
+	if !waitForProcessExit(vm.meta.PID, 2*time.Second) {
+		log.Printf("Warning: VM %s PID %d did not exit within timeout after SIGKILL", vm.meta.Name, vm.meta.PID)
+	}
+	return nil
+}
+
 func (vm *VM) waitForReap(timeout time.Duration) {
 	if vm.waitCh == nil {
 		return

--- a/skills/shed/references/commands.md
+++ b/skills/shed/references/commands.md
@@ -44,7 +44,7 @@ Client (`shed`) commands only. Server operation (`shed-server setup/serve/instal
 | `shed list [--all] [-s <server>] [-v]` | List sheds (default server, or all servers) |
 | `shed start <name> [--timeout <dur>]` | Start a stopped shed |
 | `shed stop <name>` | Stop a running shed (state kept) |
-| `shed delete <name> [--keep-volume] [--force/-f]` | Delete a shed (`--force` skips confirm; required with `--json`) |
+| `shed delete <name> [--force/-f]` | Delete a shed — destroys the shed and its volume (`--force` skips confirm; required with `--json`) |
 | `shed reset <name> [--force/-f]` | Discard the per-shed writable upper (in-VM changes); keeps the lower image and the workspace. Shed must be stopped |
 
 ```bash

--- a/tests/integration/test_delete_fast.py
+++ b/tests/integration/test_delete_fast.py
@@ -54,6 +54,10 @@ def test_delete_running_shed_is_fast(shed_server, test_shed_name):
         text=True,
         timeout=30,
     )
+    assert listing.returncode == 0, (
+        f"list failed (exit {listing.returncode}): "
+        f"stdout={listing.stdout!r} stderr={listing.stderr!r}"
+    )
     assert test_shed_name not in listing.stdout, (
         f"shed {test_shed_name} still present after delete:\n{listing.stdout}"
     )

--- a/tests/integration/test_delete_fast.py
+++ b/tests/integration/test_delete_fast.py
@@ -1,0 +1,59 @@
+"""Fast `shed delete` of a running shed (issue #232).
+
+Deleting a RUNNING shed used to take ~30s — the teardown ran the guest
+`hooks.shutdown` + `sync` + a graceful VM shutdown before terminating — which
+also raced the CLI's hardcoded 30s client timeout (a delete that succeeded
+server-side would surface a scary `context deadline exceeded` on the client).
+
+Delete always discards the writable upper, so the destroy path now SIGKILLs
+immediately and skips that graceful work (a running shed with a writable
+host-backed mount is still `sync`ed first). This is a live regression guard: a
+running-shed delete must complete well under the old ~30s and the shed must
+actually be gone. The fix is entirely server-side, so it holds regardless of
+the CLI version driving the delete.
+
+Parameterized over ["vz", "fc"] via the shed_server fixture; skips cleanly when
+a backend is unreachable.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+
+
+def test_delete_running_shed_is_fast(shed_server, test_shed_name):
+    """A running shed deletes far under the old ~30s, and is actually gone."""
+    shed_server.create(test_shed_name, image="base")
+
+    start = time.monotonic()
+    r = subprocess.run(
+        ["shed", "-s", shed_server.name, "delete", test_shed_name, "--force"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    elapsed = time.monotonic() - start
+
+    assert r.returncode == 0, (
+        f"delete failed (exit {r.returncode}): stdout={r.stdout!r} stderr={r.stderr!r}"
+    )
+    # The old graceful teardown took ~30s; the fast destroy path is ~1-2s. A
+    # 10s ceiling decisively catches a regression to the old behavior while
+    # tolerating CI/dev-machine variance and (for FC) SSH round-trips.
+    assert elapsed < 10, (
+        f"delete of a running shed took {elapsed:.1f}s — expected the fast "
+        f"destroy path (<10s); a regression to the graceful ~30s teardown?"
+    )
+
+    # The shed must actually be gone (a fast delete that didn't delete is worse
+    # than a slow one).
+    listing = subprocess.run(
+        ["shed", "-s", shed_server.name, "list"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert test_shed_name not in listing.stdout, (
+        f"shed {test_shed_name} still present after delete:\n{listing.stdout}"
+    )


### PR DESCRIPTION
## What & why

Closes #232. `shed delete` of a **running** shed took ~30s and the CLI aborted with `context deadline exceeded (Client.Timeout exceeded while awaiting headers)` — on a delete that *succeeded* server-side (a live FC repro logged `DELETE … 204 0B in 30.114650629s`). Two complementary fixes, applied to **both** the VZ and Firecracker backends.

### Commit 1 — fast destroy path (`ef71602`)

The teardown ran the guest `hooks.shutdown` + `sync` + a graceful VM shutdown before terminating. But **delete always discards the writable upper** (`keepVolume` was a no-op on both backends), so that graceful work is wasted. A new `stopDestroy` branch in `stopShedLocked` (shared with `StopShed`'s graceful path) SIGKILLs immediately via a new `vm.Kill()`, keeping all mandatory host cleanup (cred listener, egress, 9P, TAP, metadata, upper removal) **unconditional** so nothing leaks.

- **~30s → ~1–2s** (measured **3–4 ms** server-side, see E2E below).
- **`docker rm -f` semantics:** deleting a running shed no longer runs the guest shutdown hook or a graceful shutdown; use `shed stop` for a graceful, restartable stop. **Writable host-backed mounts** (`--local-dir`/`--add-dir` *and* configured server `mounts:`) are still `sync`ed before the kill so unsynced writes to host data aren't lost.
- Removes the dead `--keep-volume` flag and the `keepVolume` param end-to-end.
- FC `vm.Kill` falls back to the SDK machine handle (`StopVMM`) when the PID wasn't captured at start, so a delete can't orphan a running VMM.

### Commit 2 — SSE progress streaming (`c355636`)

Mirrors the existing `create`/`image pull` SSE. The CLI now shows `Terminating virtual machine… → Removing volume…` and, on an active stream, is bounded by the configured create-timeout (context deadline) instead of the 30s quick-op ceiling — so a slow teardown never looks hung or times out. The create/delete SSE pump+drain+terminal machinery is factored into a shared `Server.streamSSE`. The plain 204 path is kept for non-streaming clients; the client falls back cleanly on a 204 or non-SSE 200 from an old server. The teardown runs on a cancellation-detached context so a client disconnect can't strand a half-destroyed shed mid-sync.

## Review

Plan reviewed by `/planning:ask-panel` (Codex + CodeRabbit; Kimi was down). Each commit went through `/simplify` (4 agents) then `/codex:rescue`. Notable findings that shaped the code:

- **Sync must cover writable *configured* mounts, not just project mounts** (Codex) — the sync exception was too narrow; a localmac-style shed with writable `mounts:` would lose data. Now uses `config.HasWritableHostMount` (project ∪ configured).
- **FC `vm.Kill` no-op when PID capture failed** (Codex) — added the `StopVMM` machine-handle fallback.
- **Extracted `Server.streamSSE`** (reuse + simplification + altitude all agreed) — the SSE scaffold was copied 3×.
- **Removed a harmful 5-min teardown ceiling** (Codex) — I had added it as an optional hardening, but it wrapped the unbounded lock-acquire wait and could expire before teardown, skipping the sync. Reverted to plain `WithoutCancel`; the teardown steps are self-bounded, so the goroutine can't leak.
- **Restored non-SSE-200 tolerance** in the client fallback (Codex).

## Validation

**Live E2E (VZ dev server running this branch):**
- Delete of a running shed: **server-side 3–4 ms** (`timing: delete … total=4ms`), down from the 30.11 s repro. **No orphan vfkit**, shed gone.
- New client → new server: `200` SSE, streams `Terminating virtual machine… / Removing volume…`.
- Old client (brew v0.7.6) → new server: plain `204`, still fast (3 ms) — back-compat confirmed both directions.

**Tests:**
- `make test` green (adds `TestHasWritableHostMount`, delete-SSE API tests, `DeleteShedWithProgress` client tests incl. 204 / non-SSE-200 fallback). FC package validated on Linux via Docker.
- `make lint` — 0 issues, both backends. `gofmt` clean.
- New parameterized integration `test_delete_fast` (vz+fc) — passing against the VZ dev server.

**Perf:** delete of a running shed ~30 s → ~1–2 s (3–4 ms server-side). FC mirrors the VZ path and passes the Linux unit tests; a Firecracker fleet E2E on a mini is recommended before release (happy to run it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoHk27xjf1khfuijtcru6u


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `shed delete` now streams deletion progress updates (when supported) via `--force` / `-f`.
* **Bug Fixes**
  * Deleting a running shed now performs a faster “destroy” flow and reliably completes (confirmed by integration coverage).
  * Legacy non-streaming and non-SSE response shapes are handled correctly; streaming errors are surfaced to the caller.
* **Documentation**
  * Updated CLI and command references to remove `--keep-volume` and describe the forced destroy semantics.
* **Tests**
  * Added unit and integration tests for progress streaming and fast running-shed deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->