### PR TITLE
refactor(api): share streamSSE for image pull, decouple it from PhaseTimer

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -210,7 +210,8 @@ func newProgressSink(r *http.Request, ch chan<- backend.ProgressEvent) backend.P
 
 // handleCreateShedSSE streams create progress as Server-Sent Events.
 func (s *Server) handleCreateShedSSE(w http.ResponseWriter, r *http.Request, req config.CreateShedRequest) {
-	s.streamSSE(w, r, r.Context(), s.createTimer(req), func(ctx context.Context) (any, error) {
+	timer := s.createTimer(req)
+	s.streamSSE(w, r, r.Context(), timer.Track, logTimingFinish(timer), func(ctx context.Context) (any, error) {
 		shed, err := s.backend.CreateShed(ctx, req)
 		if err != nil {
 			log.Printf("CreateShed failed for %q (backend=%s): %v", req.Name, req.Backend, err)
@@ -227,9 +228,15 @@ func (s *Server) handleCreateShedSSE(w http.ResponseWriter, r *http.Request, req
 // client disconnect can't strand a half-torn-down shed. The progress sink is
 // always tied to the request, so a disconnected client simply stops receiving
 // events. work returns the payload for the terminal "complete" event (ignored
-// on error). (handlePullImageSSE predates this and still inlines the same
-// shape; it can adopt this helper too.)
-func (s *Server) streamSSE(w http.ResponseWriter, r *http.Request, baseCtx context.Context, timer *backend.PhaseTimer, work func(ctx context.Context) (any, error)) {
+// on error).
+//
+// track is an optional extra progress sink teed alongside the client stream
+// (create/delete pass timer.Track to record per-phase durations; pull passes
+// nil). onFinish, if non-nil, runs once with the operation's error after the
+// stream drains (create/delete log the timing summary via logTimingFinish; pull
+// passes nil and logs its own digest+duration inside work). Passing the resolved
+// sink + finalizer rather than a *PhaseTimer keeps this pump backend-agnostic.
+func (s *Server) streamSSE(w http.ResponseWriter, r *http.Request, baseCtx context.Context, track backend.ProgressFunc, onFinish func(error), work func(ctx context.Context) (any, error)) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		writeError(w, http.StatusInternalServerError, config.ErrBackendError, "streaming not supported")
@@ -244,10 +251,10 @@ func (s *Server) streamSSE(w http.ResponseWriter, r *http.Request, baseCtx conte
 	events := make(chan backend.ProgressEvent, sseProgressBuffer)
 	sseFn := newProgressSink(r, events)
 
-	// Tee the progress stream: the timer records per-phase durations server-side
-	// (logged below); sseFn forwards the human-readable messages to the client.
-	// Timing never goes on the wire.
-	ctx := backend.ContextWithProgress(baseCtx, backend.TeeProgress(timer.Track, sseFn))
+	// Tee the progress stream: track (when non-nil) records per-phase durations
+	// server-side; sseFn forwards the human-readable messages to the client.
+	// Timing never goes on the wire. TeeProgress drops a nil track.
+	ctx := backend.ContextWithProgress(baseCtx, backend.TeeProgress(track, sseFn))
 
 	type result struct {
 		payload any
@@ -282,7 +289,9 @@ drain:
 		}
 	}
 
-	log.Printf("timing: %s", timer.Finish(res.err))
+	if onFinish != nil {
+		onFinish(res.err)
+	}
 
 	if res.err != nil {
 		_, errCode, msg := mapBackendError(res.err)
@@ -291,6 +300,16 @@ drain:
 		writeSSEEvent(w, "complete", res.payload)
 	}
 	flusher.Flush()
+}
+
+// logTimingFinish returns a streamSSE onFinish callback that stops the timer and
+// logs the per-phase timing summary. Create/delete pass it; pull passes nil (it
+// has no PhaseTimer). The timer is captured non-nil at the call site, so no
+// nil-receiver method value ever reaches streamSSE.
+func logTimingFinish(timer *backend.PhaseTimer) func(error) {
+	return func(err error) {
+		log.Printf("timing: %s", timer.Finish(err))
+	}
 }
 
 // writeSSEEvent writes a single Server-Sent Event.
@@ -493,7 +512,8 @@ func (s *Server) handleDeleteShedSSE(w http.ResponseWriter, r *http.Request, nam
 	// lock-acquire wait and could expire before teardown even starts, skipping
 	// the sync.) Progress still flows — the sink unblocks on the request's own
 	// Done, so a disconnected client just stops receiving events.
-	s.streamSSE(w, r, context.WithoutCancel(r.Context()), s.deleteTimer(name), func(ctx context.Context) (any, error) {
+	timer := s.deleteTimer(name)
+	s.streamSSE(w, r, context.WithoutCancel(r.Context()), timer.Track, logTimingFinish(timer), func(ctx context.Context) (any, error) {
 		// Delete has no resource to return; a benign payload keeps the terminal
 		// event shape consistent with create/pull. The client ignores it.
 		return map[string]string{"name": name}, s.backend.DeleteShed(ctx, name)
@@ -880,64 +900,20 @@ func (s *Server) handlePullImage(w http.ResponseWriter, r *http.Request) {
 
 // handlePullImageSSE streams pull progress as Server-Sent Events. The backend
 // already emits per-stage progress into the context via backend.Phase/Status
-// (see internal/vz/image.go, internal/firecracker/image.go), so we only need
-// to install a progress sink and forward the human-readable messages.
+// (see internal/vz/image.go, internal/firecracker/image.go); this delegates the
+// streaming to streamSSE with no timing tee/finalizer (nil, nil) — pull has no
+// PhaseTimer and times itself, keeping its own digest+duration log lines.
 func (s *Server) handlePullImageSSE(w http.ResponseWriter, r *http.Request, req config.ImagePullRequest) {
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		writeError(w, http.StatusInternalServerError, config.ErrBackendError, "streaming not supported")
-		return
-	}
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
-
-	start := time.Now()
-	events := make(chan backend.ProgressEvent, sseProgressBuffer)
-	sseFn := newProgressSink(r, events)
-	ctx := backend.ContextWithProgress(r.Context(), sseFn)
-
-	type pullResult struct {
-		digest string
-		err    error
-	}
-	done := make(chan pullResult, 1)
-	go func() {
+	s.streamSSE(w, r, r.Context(), nil, nil, func(ctx context.Context) (any, error) {
+		start := time.Now()
 		digest, err := s.backend.PullImage(ctx, req.DockerRef, req.Tag, req.Platform, req.WithLayers)
-		done <- pullResult{digest, err}
-	}()
-
-	var res pullResult
-	for streaming := true; streaming; {
-		select {
-		case event := <-events:
-			writeSSEEvent(w, "progress", event)
-			flusher.Flush()
-		case res = <-done:
-			streaming = false
+		if err != nil {
+			log.Printf("PullImage failed for %q after %s: %v", req.DockerRef, time.Since(start).Round(time.Millisecond), err)
+			return nil, err
 		}
-	}
-drain:
-	for {
-		select {
-		case event := <-events:
-			writeSSEEvent(w, "progress", event)
-			flusher.Flush()
-		default:
-			break drain
-		}
-	}
-
-	if res.err != nil {
-		log.Printf("PullImage failed for %q after %s: %v", req.DockerRef, time.Since(start).Round(time.Millisecond), res.err)
-		_, errCode, msg := mapBackendError(res.err)
-		writeSSEEvent(w, "error", config.NewAPIError(errCode, msg))
-	} else {
-		log.Printf("PullImage %q -> %s in %s", req.DockerRef, vmimage.ShortDigest(res.digest), time.Since(start).Round(time.Millisecond))
-		writeSSEEvent(w, "complete", config.ImagePullResponse{Tag: req.Tag, Digest: res.digest})
-	}
-	flusher.Flush()
+		log.Printf("PullImage %q -> %s in %s", req.DockerRef, vmimage.ShortDigest(digest), time.Since(start).Round(time.Millisecond))
+		return config.ImagePullResponse{Tag: req.Tag, Digest: digest}, nil
+	})
 }
 
 // handlePushImage uploads the manifest held by the named tag (or by a

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -639,17 +639,27 @@ func TestPullImage_SSE_BlobGating(t *testing.T) {
 			},
 		}
 	}
-	if body := servePullSSE(t, newBE(), "").Body.String(); strings.Contains(body, `"kind":"blob"`) {
-		t.Errorf("blob event leaked without ?progress=blob:\n%s", body)
+	tests := []struct {
+		name     string
+		query    string
+		wantBlob bool
+	}{
+		{"gated out by default", "", false},
+		{"included with ?progress=blob", "?progress=blob", true},
 	}
-	if body := servePullSSE(t, newBE(), "?progress=blob").Body.String(); !strings.Contains(body, `"kind":"blob"`) {
-		t.Errorf("blob event missing with ?progress=blob:\n%s", body)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := servePullSSE(t, newBE(), tt.query).Body.String()
+			if got := strings.Contains(body, `"kind":"blob"`); got != tt.wantBlob {
+				t.Errorf("blob event present=%v, want %v:\n%s", got, tt.wantBlob, body)
+			}
+		})
 	}
 }
 
 // TestSSE_TimingLog_OnlyWithTimer guards the refactor's core branch: streamSSE
-// emits a `timing:` log line only for a non-nil timer (create/delete), never for
-// the nil-timer pull path.
+// runs onFinish (which logs the `timing:` line) only when the caller passes one
+// — create/delete do, the nil-onFinish pull path does not.
 func TestSSE_TimingLog_OnlyWithTimer(t *testing.T) {
 	var buf bytes.Buffer
 	oldOut, oldFlags := log.Writer(), log.Flags()
@@ -657,28 +667,43 @@ func TestSSE_TimingLog_OnlyWithTimer(t *testing.T) {
 	log.SetFlags(0)
 	defer func() { log.SetOutput(oldOut); log.SetFlags(oldFlags) }()
 
-	// create SSE (non-nil timer) logs `timing: create ...`.
-	createBE := &createShedFakeBackend{
-		createFn: func(_ context.Context, req config.CreateShedRequest) (*config.Shed, error) {
-			return &config.Shed{Name: req.Name, Status: config.StatusRunning}, nil
-		},
+	// create SSE passes logTimingFinish(timer), so it logs `timing: create …`.
+	serveCreateSSE := func(*testing.T) {
+		be := &createShedFakeBackend{
+			createFn: func(_ context.Context, req config.CreateShedRequest) (*config.Shed, error) {
+				return &config.Shed{Name: req.Name, Status: config.StatusRunning}, nil
+			},
+		}
+		body, _ := json.Marshal(config.CreateShedRequest{Name: "myshed"})
+		r := httptest.NewRequest(http.MethodPost, "/api/sheds", bytes.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+		r.Header.Set("Accept", "text/event-stream")
+		NewServer(be, &config.ServerConfig{Name: "test-server"}, "", nil, nil).Router().ServeHTTP(httptest.NewRecorder(), r)
 	}
-	cbody, _ := json.Marshal(config.CreateShedRequest{Name: "myshed"})
-	cr := httptest.NewRequest(http.MethodPost, "/api/sheds", bytes.NewReader(cbody))
-	cr.Header.Set("Content-Type", "application/json")
-	cr.Header.Set("Accept", "text/event-stream")
-	NewServer(createBE, &config.ServerConfig{Name: "test-server"}, "", nil, nil).Router().ServeHTTP(httptest.NewRecorder(), cr)
-	if !strings.Contains(buf.String(), "timing: create") {
-		t.Errorf("create SSE did not emit a `timing:` log:\n%s", buf.String())
+	// pull SSE passes a nil onFinish, so it must NOT log a `timing:` line.
+	servePull := func(t *testing.T) {
+		be := &createShedFakeBackend{
+			pullFn: func(context.Context, string, string, string, bool) (string, error) { return "sha256:x", nil },
+		}
+		servePullSSE(t, be, "")
 	}
 
-	// pull SSE (nil timer) must NOT emit a `timing:` line.
-	buf.Reset()
-	pullBE := &createShedFakeBackend{
-		pullFn: func(context.Context, string, string, string, bool) (string, error) { return "sha256:x", nil },
+	tests := []struct {
+		name       string
+		serve      func(*testing.T)
+		needle     string
+		wantTiming bool
+	}{
+		{"create logs timing", serveCreateSSE, "timing: create", true},
+		{"pull logs no timing", servePull, "timing:", false},
 	}
-	servePullSSE(t, pullBE, "")
-	if strings.Contains(buf.String(), "timing:") {
-		t.Errorf("pull SSE emitted a `timing:` log despite a nil timer:\n%s", buf.String())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf.Reset()
+			tt.serve(t)
+			if got := strings.Contains(buf.String(), tt.needle); got != tt.wantTiming {
+				t.Errorf("%q present=%v, want %v:\n%s", tt.needle, got, tt.wantTiming, buf.String())
+			}
+		})
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -231,6 +232,7 @@ func TestMapBackendError_SentinelErrors(t *testing.T) {
 type createShedFakeBackend struct {
 	createFn func(ctx context.Context, req config.CreateShedRequest) (*config.Shed, error)
 	deleteFn func(ctx context.Context, name string) error
+	pullFn   func(ctx context.Context, dockerRef, tag, platform string, withLayers bool) (string, error)
 }
 
 func (f *createShedFakeBackend) Type() backend.Type { return backend.TypeVZ }
@@ -280,7 +282,10 @@ func (f *createShedFakeBackend) InspectImage(_ context.Context, _ string) (confi
 func (f *createShedFakeBackend) TagImage(_ context.Context, _, _ string) error {
 	panic("unexpected")
 }
-func (f *createShedFakeBackend) PullImage(_ context.Context, _, _, _ string, _ bool) (string, error) {
+func (f *createShedFakeBackend) PullImage(ctx context.Context, dockerRef, tag, platform string, withLayers bool) (string, error) {
+	if f.pullFn != nil {
+		return f.pullFn(ctx, dockerRef, tag, platform, withLayers)
+	}
 	panic("unexpected")
 }
 func (f *createShedFakeBackend) PushImage(_ context.Context, _, _ string) error {
@@ -534,5 +539,146 @@ func TestDeleteShed_SSE_SurfacesError(t *testing.T) {
 	}
 	if !sawError {
 		t.Errorf("no error event in stream:\n%s", w.Body.String())
+	}
+}
+
+// servePullSSE issues an SSE image-pull request against a fake backend and
+// returns the recorder. query (e.g. "?progress=blob") is appended to the URL.
+func servePullSSE(t *testing.T, be backend.Backend, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	srv := NewServer(be, &config.ServerConfig{Name: "test-server"}, "", nil, nil)
+	body, _ := json.Marshal(config.ImagePullRequest{DockerRef: "ghcr.io/x/y:v1", Tag: "testtag"})
+	r := httptest.NewRequest(http.MethodPost, "/api/images/pull"+query, bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Accept", "text/event-stream")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, r)
+	return w
+}
+
+// TestPullImage_SSE_StreamsProgressAndComplete verifies pull streams through the
+// shared streamSSE helper with no timing tee/finalizer (nil track, nil onFinish).
+// The backend.Phase event is a phase-only boundary: it exercises the nil-track
+// tee path (TeeProgress(nil, sseFn) must forward cleanly, not panic) and, having
+// no message, must be dropped from the wire by the sink.
+func TestPullImage_SSE_StreamsProgressAndComplete(t *testing.T) {
+	be := &createShedFakeBackend{
+		pullFn: func(ctx context.Context, _, _, _ string, _ bool) (string, error) {
+			backend.Phase(ctx, "image")             // phase-only: exercises the nil-track tee path; must NOT reach the wire
+			backend.Status(ctx, "Pulling image...") // user-visible
+			return "sha256:deadbeef", nil
+		},
+	}
+	w := servePullSSE(t, be, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	var progress int
+	var completeData string
+	for _, e := range parseSSEEvents(t, w.Body.String()) {
+		switch e.Event {
+		case "progress":
+			progress++
+		case "complete":
+			completeData = e.Data
+		}
+	}
+	// Exactly one progress event — the Status. The phase-only backend.Phase event
+	// must be dropped (proves the nil-track path keeps the sink's Message=="" drop).
+	if progress != 1 {
+		t.Errorf("got %d progress events, want exactly 1 (the Status; phase-only dropped):\n%s", progress, w.Body.String())
+	}
+	var resp config.ImagePullResponse
+	if err := json.Unmarshal([]byte(completeData), &resp); err != nil {
+		t.Fatalf("complete payload is not an ImagePullResponse: %v (data: %q)", err, completeData)
+	}
+	if resp.Tag != "testtag" || resp.Digest != "sha256:deadbeef" {
+		t.Errorf("complete = %+v, want {Tag:testtag Digest:sha256:deadbeef}", resp)
+	}
+}
+
+// TestPullImage_SSE_SurfacesError verifies a pull failure is surfaced as a
+// terminal SSE error event carrying the mapped code.
+func TestPullImage_SSE_SurfacesError(t *testing.T) {
+	be := &createShedFakeBackend{
+		pullFn: func(context.Context, string, string, string, bool) (string, error) {
+			return "", config.ErrImageNotFoundSentinel
+		},
+	}
+	w := servePullSSE(t, be, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 (SSE opens before the error), body: %s", w.Code, w.Body.String())
+	}
+	var errData string
+	for _, e := range parseSSEEvents(t, w.Body.String()) {
+		if e.Event == "error" {
+			errData = e.Data
+		}
+	}
+	if errData == "" {
+		t.Fatalf("no error event in stream:\n%s", w.Body.String())
+	}
+	var apiErr config.APIError
+	if err := json.Unmarshal([]byte(errData), &apiErr); err != nil {
+		t.Fatalf("error payload is not an APIError: %v (data: %q)", err, errData)
+	}
+	if apiErr.Error.Code != config.ErrImageNotFound {
+		t.Errorf("error code = %q, want %q", apiErr.Error.Code, config.ErrImageNotFound)
+	}
+}
+
+// TestPullImage_SSE_BlobGating verifies pull still routes structured per-blob
+// byte events through newProgressSink after the refactor: gated out without
+// ?progress=blob, present with it.
+func TestPullImage_SSE_BlobGating(t *testing.T) {
+	newBE := func() *createShedFakeBackend {
+		return &createShedFakeBackend{
+			pullFn: func(ctx context.Context, _, _, _ string, _ bool) (string, error) {
+				backend.BlobProgress(ctx, backend.ProgressEvent{ID: "sha256:layer", Message: "layer", Current: 1, Total: 2})
+				return "sha256:ok", nil
+			},
+		}
+	}
+	if body := servePullSSE(t, newBE(), "").Body.String(); strings.Contains(body, `"kind":"blob"`) {
+		t.Errorf("blob event leaked without ?progress=blob:\n%s", body)
+	}
+	if body := servePullSSE(t, newBE(), "?progress=blob").Body.String(); !strings.Contains(body, `"kind":"blob"`) {
+		t.Errorf("blob event missing with ?progress=blob:\n%s", body)
+	}
+}
+
+// TestSSE_TimingLog_OnlyWithTimer guards the refactor's core branch: streamSSE
+// emits a `timing:` log line only for a non-nil timer (create/delete), never for
+// the nil-timer pull path.
+func TestSSE_TimingLog_OnlyWithTimer(t *testing.T) {
+	var buf bytes.Buffer
+	oldOut, oldFlags := log.Writer(), log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() { log.SetOutput(oldOut); log.SetFlags(oldFlags) }()
+
+	// create SSE (non-nil timer) logs `timing: create ...`.
+	createBE := &createShedFakeBackend{
+		createFn: func(_ context.Context, req config.CreateShedRequest) (*config.Shed, error) {
+			return &config.Shed{Name: req.Name, Status: config.StatusRunning}, nil
+		},
+	}
+	cbody, _ := json.Marshal(config.CreateShedRequest{Name: "myshed"})
+	cr := httptest.NewRequest(http.MethodPost, "/api/sheds", bytes.NewReader(cbody))
+	cr.Header.Set("Content-Type", "application/json")
+	cr.Header.Set("Accept", "text/event-stream")
+	NewServer(createBE, &config.ServerConfig{Name: "test-server"}, "", nil, nil).Router().ServeHTTP(httptest.NewRecorder(), cr)
+	if !strings.Contains(buf.String(), "timing: create") {
+		t.Errorf("create SSE did not emit a `timing:` log:\n%s", buf.String())
+	}
+
+	// pull SSE (nil timer) must NOT emit a `timing:` line.
+	buf.Reset()
+	pullBE := &createShedFakeBackend{
+		pullFn: func(context.Context, string, string, string, bool) (string, error) { return "sha256:x", nil },
+	}
+	servePullSSE(t, pullBE, "")
+	if strings.Contains(buf.String(), "timing:") {
+		t.Errorf("pull SSE emitted a `timing:` log despite a nil timer:\n%s", buf.String())
 	}
 }


### PR DESCRIPTION
## What & why

Follow-up to #234. That PR factored the SSE pump/drain/terminal-event machinery out of `handleCreateShedSSE`/`handleDeleteShedSSE` into a shared `Server.streamSSE`, but left `handlePullImageSSE` as the **last inlined copy** of the same fragile concurrency scaffold (the drain-vs-close race + the terminal-event shape). All three #234 plan reviewers flagged the 3× duplication; converting pull was explicitly deferred. This finishes the job — the SSE boilerplate now lives in exactly one place, so a future fix (keepalive ping, drain-race tweak) is made once instead of three times.

## The change

- **`handlePullImageSSE` now delegates to `streamSSE`** — the inlined flusher preamble, goroutine, pump loop, drain loop, and terminal `complete`/`error` writes are deleted. Pull's own self-timing (`start := time.Now()` + its digest/duration log lines) moves into the `work` closure.

- **`streamSSE` is decoupled from `PhaseTimer`.** Its signature changed from `timer *backend.PhaseTimer` to a resolved pair `(track backend.ProgressFunc, onFinish func(error))`:
  - create/delete pass `timer.Track` + `logTimingFinish(timer)` (a small helper that logs `timing: %s` from `timer.Finish(err)`).
  - pull passes `(nil, nil)` — it has no `PhaseTimer` and logs its own digest+duration.

  This keeps the pump backend-agnostic and **structurally removes a footgun**: a nilable `*PhaseTimer` would force callers to route `timer.Track` through a guarded `var track` because `(*PhaseTimer)(nil).Track` is a *non-nil* method value that survives `TeeProgress`'s nil-filter and would panic on the first phase event. Passing the already-resolved sink means the nil-receiver method value never exists — `TeeProgress(nil, sseFn)` cleanly drops the nil and streams only to the client.

Pure server-side refactor: **no wire-behavior change.** `progress` events (including `?progress=blob` gating via `newProgressSink`), the terminal `complete` carrying `ImagePullResponse{Tag, Digest}`, and the `error` event (mapped code) are byte-for-byte identical. create/delete keep their `timing:` log line and delete keeps its `context.WithoutCancel` teardown detachment.

## Review

Per-commit `/simplify` (4 agents) then a correctness pass:

- **Altitude agent** proposed the `*PhaseTimer` → `(track, onFinish)` signature — it deletes the one genuinely hazardous thing in the diff (the nil-receiver method value) rather than commenting around it, and decouples `streamSSE` from `PhaseTimer`. Adopted.
- **Simplification agent**: deleted a refactor-archaeology comment and a duplicate in-body comment. The `logTimingFinish` helper single-sources the `timing: %s` format so the two-caller closure isn't duplicated.
- **Reuse / efficiency agents**: clean (kept the single shared `TeeProgress` path; the create-SSE block in the timing test stays inline, consistent with the four existing SSE tests).
- **Correctness pass** (cursor; Codex CLI wasn't available in this environment): **no findings** — wire behavior preserved, `TeeProgress(nil, sseFn)` safe, create/delete timing intact, delete `WithoutCancel` intact, no goroutine leak / double-close / nil-deref.

## Tests

New handler-level pull-SSE coverage (the pull handler had none):
- `TestPullImage_SSE_StreamsProgressAndComplete` — a phase-only `backend.Phase` event exercises the nil-track tee path and is dropped from the wire; the `Status` line streams; terminal `complete` decodes to `ImagePullResponse{Tag, Digest}`.
- `TestPullImage_SSE_SurfacesError` — terminal `error` decodes to `APIError` with the mapped `IMAGE_NOT_FOUND` code.
- `TestPullImage_SSE_BlobGating` — `KindBlob` byte-tick events are gated out without `?progress=blob`, present with it (proves pull still routes through `newProgressSink`).
- `TestSSE_TimingLog_OnlyWithTimer` — captures `log` output and asserts the `timing:` line fires for create (non-nil finalizer) but **not** for pull (nil) — guards the refactor's core branch.

## Validation

- `go test ./...` green on host (macOS/VZ). api + FC packages cross-compile + `go vet` clean under `GOOS=linux`; `internal/api` has no build tags, so the host run exercises the identical code path Linux would.
- `golangci-lint` — 0 issues, both `darwin` and `GOOS=linux` (api + firecracker). `gofmt` clean.
- No E2E — pure server-side refactor with no wire-behavior change; the existing create/delete SSE tests and `progress_sink_test.go` stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoHk27xjf1khfuijtcru6u


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced real-time SSE progress streaming for image pulls, with optional blob-level progress details when requested.
* **Bug Fixes**
  * Improved SSE event handling so image pull streams reliably emit progress, complete, and terminal error events.
  * Ensured timing-related log output is shown only for phase-timed requests (not for pull-based streaming).
* **Tests**
  * Added coverage for pull SSE progress/completion, error surfacing, and blob-gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->