### PR TITLE
fix: shed tunnels on secure-mode servers from the CLI (#237)

### DIFF
--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -79,13 +79,11 @@ func (c *APIClient) newHTTPClient(timeout time.Duration) *http.Client {
 
 // pinnedTransport returns a transport that verifies the server's leaf cert
 // against the pinned "sha256:<hex>" fingerprint instead of a CA chain, or nil
-// when there is no pin (plain HTTP). It wraps the shared servertls pin config
-// so the CLI and the Connect tunnel verify identically.
+// when there is no pin (plain HTTP). It delegates to servertls.PinnedTransport
+// so the CLI, the Connect tunnel, and the startup probe build the pinned
+// transport identically from one place.
 func pinnedTransport(fingerprint string) http.RoundTripper {
-	if fingerprint == "" {
-		return nil
-	}
-	return &http.Transport{TLSClientConfig: servertls.PinnedClientConfig(fingerprint)}
+	return servertls.PinnedTransport(fingerprint)
 }
 
 // NewAPIClient creates a plain-HTTP API client for the given host and port

--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -58,6 +58,17 @@ func (c *APIClient) setAuth(req *http.Request) {
 	}
 }
 
+// currentToken returns the client's current in-memory bearer (control) token.
+// It may have been re-minted since construction — proactively near expiry or
+// reactively on a 401 retry — even when persisting the refresh back to config
+// was skipped (ambiguous alias) or failed. The tunnel path reads it so a
+// forwarded connection dials the Connect API with the freshest token rather
+// than the possibly-stale one in the config entry. Safe to call after a
+// synchronous request (e.g. ensureRunningShed) with no request in flight.
+func (c *APIClient) currentToken() string {
+	return c.token
+}
+
 // newHTTPClient builds an *http.Client carrying the pinning transport (if any),
 // so every request path — including the long-running, ad-hoc clients used for
 // SSE and timeouts — verifies the pinned TLS cert. timeout 0 means no

--- a/cmd/shed/tunnels.go
+++ b/cmd/shed/tunnels.go
@@ -21,10 +21,16 @@ import (
 
 // connectTargetFromEntry resolves how `shed forward` dials the Connect API for a
 // server entry. When the entry pins a TLS cert on an https api_url, the tunnel
-// dials that host:port over pinned TLS and sends the credentials-scoped token
-// (the Connect route requires the credentials scope when auth is enforced).
-// Otherwise it is the legacy plain-TCP dial to host:http_port, byte-identical.
-func connectTargetFromEntry(entry *config.ServerEntry) (tunnels.ConnectTarget, error) {
+// dials that host:port over pinned TLS and sends token as the bearer credential
+// (the Connect route accepts a control or credentials token when auth is
+// enforced; the CLI passes its live control token). Otherwise it is the legacy
+// plain-TCP dial to host:http_port, byte-identical, and token is unused.
+//
+// token is supplied by the caller rather than read from entry so tunnel dials
+// use the client's freshest in-memory control token — which may have been
+// re-minted since the entry was loaded without that refresh being persisted
+// back to config. Callers that only inspect the target without dialing pass "".
+func connectTargetFromEntry(entry *config.ServerEntry, token string) (tunnels.ConnectTarget, error) {
 	if entry.APIURL != "" {
 		u, err := url.Parse(entry.APIURL)
 		if err != nil {
@@ -41,7 +47,7 @@ func connectTargetFromEntry(entry *config.ServerEntry) (tunnels.ConnectTarget, e
 			return tunnels.ConnectTarget{
 				Addr:   u.Host,
 				TLSPin: entry.TLSCertFingerprint,
-				Token:  entry.CredentialsToken,
+				Token:  token,
 			}, nil
 		}
 	}
@@ -266,12 +272,15 @@ func runTunnelsStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Resolve how to reach the Connect API: pinned TLS + credentials token when
-	// the entry has an https api_url, else the legacy plain-TCP dial. Done here
+	// Resolve how to reach the Connect API: pinned TLS + control token when the
+	// entry has an https api_url, else the legacy plain-TCP dial. Done here
 	// (before the daemon fork) so a misconfigured target fails in the user's
 	// terminal; the detached worker re-resolves it from config itself, keeping
-	// the credentials token off its command line.
-	target, err := connectTargetFromEntry(entry)
+	// the token off its command line. Pass the client's live token —
+	// ensureRunningShed above may have re-minted it in-memory (proactively near
+	// expiry, or reactively on a 401) even when persisting it back to config was
+	// skipped or failed, so the entry's stored copy can be stale.
+	target, err := connectTargetFromEntry(entry, client.currentToken())
 	if err != nil {
 		return err
 	}
@@ -452,8 +461,9 @@ func runTunnelsConfig(cmd *cobra.Command, args []string) error {
 	}
 
 	// Show the address the tunnel would actually dial (the https api_url
-	// endpoint when the entry is TLS-pinned, else host:http_port).
-	target, err := connectTargetFromEntry(entry)
+	// endpoint when the entry is TLS-pinned, else host:http_port). This is a
+	// preview that never dials, so no token is needed.
+	target, err := connectTargetFromEntry(entry, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/shed/tunnels.go
+++ b/cmd/shed/tunnels.go
@@ -299,6 +299,12 @@ func runTunnelsStart(cmd *cobra.Command, args []string) error {
 }
 
 func runForegroundTunnel(mgr *tunnels.Manager, shedName string, target tunnels.ConnectTarget, ports []tunnels.PortMapping, profile string) error {
+	// Fail loudly if the tunnel can't authenticate, before binding any listener
+	// (so we never leave a listener up that resets every connection).
+	if err := probeConnectAuth(target, shedName); err != nil {
+		return err
+	}
+
 	activeTunnels, err := mgr.StartTunnels(target, shedName, ports)
 	if err != nil {
 		return fmt.Errorf("failed to start tunnels: %w", err)

--- a/cmd/shed/tunnels_daemon.go
+++ b/cmd/shed/tunnels_daemon.go
@@ -23,9 +23,26 @@ const readyFDEnv = "SHED_TUNNEL_READY_FD"
 
 // daemonReadyTimeout bounds how long the parent waits for the worker to report
 // it is listening. It must cover the worker's config load + findShedServer +
-// ensureRunningShed + listener bind; the parent already started the shed, so
-// those are fast, but be generous.
+// ensureRunningShed + the startup Connect auth probe (tunnelProbeTimeout) +
+// listener bind; the parent already started the shed, so those are fast, but be
+// generous.
 const daemonReadyTimeout = 15 * time.Second
+
+// tunnelProbeTimeout bounds the startup Connect auth probe. It stays well under
+// daemonReadyTimeout so a failing probe can report ERR: to the parent before the
+// parent gives up and kills the worker with a generic readiness timeout.
+const tunnelProbeTimeout = 5 * time.Second
+
+// probeConnectAuth checks that the tunnel target can authenticate to the Connect
+// API (see tunnels.ConnectClient.Probe), bounded by tunnelProbeTimeout. Both the
+// foreground and detached-worker start paths run it before binding listeners, so
+// an auth/transport failure fails `shed tunnels start` loudly instead of
+// surfacing later as a per-connection reset.
+func probeConnectAuth(target tunnels.ConnectTarget, shedName string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), tunnelProbeTimeout)
+	defer cancel()
+	return tunnels.NewConnectClient(target).Probe(ctx, shedName)
+}
 
 // spawnTunnelDaemon re-execs this binary as a detached background worker for the
 // given shed, waits for it to report that the tunnels are listening, then
@@ -173,6 +190,15 @@ func runDaemonWorker(mgr *tunnels.Manager, shedName, serverName string, target t
 	ready, err := openReadyPipe()
 	if err != nil {
 		return err
+	}
+
+	// Validate Connect auth before binding listeners or reporting readiness, so a
+	// broken tunnel fails `shed tunnels start` in the user's terminal (via the
+	// ERR: channel) rather than looking healthy and resetting every connection.
+	if probeErr := probeConnectAuth(target, shedName); probeErr != nil {
+		fmt.Fprintf(ready, "ERR:%s\n", probeErr)
+		_ = ready.Close()
+		return probeErr
 	}
 
 	// Bind listeners, then record state under our own (detached) PID.

--- a/cmd/shed/tunnels_daemon.go
+++ b/cmd/shed/tunnels_daemon.go
@@ -30,8 +30,8 @@ const daemonReadyTimeout = 15 * time.Second
 // spawnTunnelDaemon re-execs this binary as a detached background worker for the
 // given shed, waits for it to report that the tunnels are listening, then
 // returns — handing the terminal back while the worker keeps running. The
-// worker re-resolves its connect target from config, so the credentials token
-// never appears on its command line.
+// worker re-resolves its connect target from config, so the bearer token never
+// appears on its command line.
 func spawnTunnelDaemon(shedName string, ports []tunnels.PortMapping) error {
 	exe, err := os.Executable()
 	if err != nil {

--- a/cmd/shed/tunnels_target_test.go
+++ b/cmd/shed/tunnels_target_test.go
@@ -9,7 +9,8 @@ import (
 func TestConnectTargetFromEntry(t *testing.T) {
 	t.Run("plain entry → host:http_port, no pin/token", func(t *testing.T) {
 		entry := &config.ServerEntry{Host: "host.example", HTTPPort: 8080}
-		got, err := connectTargetFromEntry(entry)
+		// The plain-TCP path ignores the token argument — nothing carries it.
+		got, err := connectTargetFromEntry(entry, "ignored-on-plain")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -18,14 +19,14 @@ func TestConnectTargetFromEntry(t *testing.T) {
 		}
 	})
 
-	t.Run("https api_url + pin → tls target with creds token", func(t *testing.T) {
+	t.Run("https api_url + pin → tls target with caller-supplied token", func(t *testing.T) {
 		entry := &config.ServerEntry{
 			Host: "host.example", HTTPPort: 8080,
 			APIURL:             "https://host.example:8443",
 			TLSCertFingerprint: "sha256:abc123",
-			CredentialsToken:   "shed_credentials_xyz",
+			ControlToken:       "shed_control_stale", // must be ignored: the caller passes the live token
 		}
-		got, err := connectTargetFromEntry(entry)
+		got, err := connectTargetFromEntry(entry, "shed_control_live")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -35,8 +36,10 @@ func TestConnectTargetFromEntry(t *testing.T) {
 		if got.TLSPin != "sha256:abc123" {
 			t.Errorf("pin = %q, want sha256:abc123", got.TLSPin)
 		}
-		if got.Token != "shed_credentials_xyz" {
-			t.Errorf("token = %q, want the credentials token", got.Token)
+		// The target carries the caller's live token, not entry.ControlToken —
+		// so a refresh-in-flight isn't dropped for the possibly-stale config copy.
+		if got.Token != "shed_control_live" {
+			t.Errorf("token = %q, want the caller-supplied live token", got.Token)
 		}
 	})
 
@@ -45,7 +48,7 @@ func TestConnectTargetFromEntry(t *testing.T) {
 			Host: "host.example", HTTPPort: 8080,
 			APIURL: "https://host.example:8443", // no tls_cert_fingerprint
 		}
-		if _, err := connectTargetFromEntry(entry); err == nil {
+		if _, err := connectTargetFromEntry(entry, "tok"); err == nil {
 			t.Error("an https api_url without a pin must error, not dial unpinned")
 		}
 	})
@@ -55,7 +58,7 @@ func TestConnectTargetFromEntry(t *testing.T) {
 			Host: "host.example", HTTPPort: 8080,
 			APIURL: "https://host.example", TLSCertFingerprint: "sha256:abc",
 		}
-		if _, err := connectTargetFromEntry(entry); err == nil {
+		if _, err := connectTargetFromEntry(entry, "tok"); err == nil {
 			t.Error("a port-less https api_url should error in resolution, not at dial time")
 		}
 	})
@@ -65,12 +68,12 @@ func TestConnectTargetFromEntry(t *testing.T) {
 			Host: "host.example", HTTPPort: 8080,
 			APIURL: "http://host.example:8080",
 		}
-		got, err := connectTargetFromEntry(entry)
+		got, err := connectTargetFromEntry(entry, "ignored-on-plain")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got.Addr != "host.example:8080" || got.TLSPin != "" {
-			t.Errorf("non-https api_url = %+v, want the plain host:port path", got)
+		if got.Addr != "host.example:8080" || got.TLSPin != "" || got.Token != "" {
+			t.Errorf("non-https api_url = %+v, want the plain host:port path with no token", got)
 		}
 	})
 }

--- a/docs/guides/security-configuration.md
+++ b/docs/guides/security-configuration.md
@@ -217,10 +217,10 @@ the host key pinned in `known_hosts`. The only trust-on-first-use moment is
 `--tls-fingerprint` / `--fingerprint` to verify out-of-band). See the
 [connection-flow table](../reference/security.md#connection-flow-whats-encrypted-where).
 
-The credential bus and Connect tunnel ride that same TLS listener, gated by the
-`credentials` scope — so a co-located host-agent reaches them over
-`https://127.0.0.1:8443` with the pinned cert. There is no plaintext channel,
-implicit or opt-in.
+The credential bus (`credentials` scope) and Connect tunnel (`control` or
+`credentials`) ride that same TLS listener — so a co-located host-agent reaches
+them over `https://127.0.0.1:8443` with the pinned cert. There is no plaintext
+channel, implicit or opt-in.
 
 ## Troubleshooting startup rejections
 

--- a/docs/guides/vps-deployment.md
+++ b/docs/guides/vps-deployment.md
@@ -32,8 +32,9 @@ bind_address: 0.0.0.0            # face the network (loopback is the default) â€
 `secure` mode forces `auth.ssh.mode: enforce`, enforces HTTP bearer tokens, turns
 on pinned TLS (`https_port` defaults to `8443`), and serves **no plain-HTTP
 listener** (TLS-only) â€” so the only API is HTTPS on `8443`, with the credential
-bus and Connect tunnel gated by the `credentials` scope. (`shed server add`
-against a secure server therefore needs `--https-port`, as below.)
+bus gated by the `credentials` scope and the Connect tunnel accepting `control`
+or `credentials`. (`shed server add` against a secure server therefore needs
+`--https-port`, as below.)
 
 !!! warning "`bind_address` is required for a remote server"
     Since v0.7.4 `bind_address` **defaults to loopback (`127.0.0.1`) in secure
@@ -124,8 +125,8 @@ bring your own TLS certificate instead of the self-signed one with
 ## Co-located host-agent
 
 If you instead run the host-agent **on the VPS itself**, no extra config is
-needed: the credential bus and Connect tunnel ride the single pinned-TLS listener
-(gated by the `credentials` scope), and the on-box host-agent reaches them over
+needed: the credential bus (`credentials` scope) and Connect tunnel (`control` or
+`credentials`) ride the single pinned-TLS listener, and the on-box host-agent reaches them over
 `https://127.0.0.1:8443` with the pinned cert. Remote `shed forward` keeps
 working at the same time, because there is no longer a separate loopback-only
 listener. See the [network surface](../reference/security.md#network-surface).

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -9,9 +9,10 @@ The `shed-server` exposes a REST API for managing sheds.
     relies on a trusted network (Tailscale, firewall rules). In `auth.mode:
     secure` every request needs an `Authorization: Bearer <token>` header of the
     required scope, except the bootstrap endpoints `GET /api/info` and
-    `GET /api/ssh-host-key`. The credential bus (`/api/plugins/*`) and the
-    Connect tunnel (`/api/sheds/{name}/connect/{port}`) require the `credentials`
-    scope; everything else needs `control`. Tokens are **not** issued over HTTP —
+    `GET /api/ssh-host-key`. The credential bus (`/api/plugins/*`) requires the
+    `credentials` scope; the Connect tunnel
+    (`/api/sheds/{name}/connect/{port}`) accepts **either** `control` or
+    `credentials`; everything else needs `control`. Tokens are **not** issued over HTTP —
     they are minted over the SSH `_bootstrap` channel (see
     [Authentication](#authentication)). See [Security](security.md) for the full
     model and pinned TLS.
@@ -924,7 +925,7 @@ After the 101 response, the connection becomes a bidirectional byte stream to th
 | 502 | `CONNECT_FAILED` | Could not connect to the port (service not running) |
 | 503 | `SHED_NOT_RUNNING` | Shed is not running |
 
-**Security:** The Connect API has the same access control as other API endpoints — network-level only (Tailscale, firewall). It connects to the VM's loopback interface and does not support arbitrary destinations.
+**Security:** In `open` mode the Connect API relies on network-level trust (Tailscale, firewall) like the rest of the API; in `secure` mode it requires a bearer token of the `control` **or** `credentials` scope over pinned TLS. It connects to the VM's loopback interface and does not support arbitrary destinations.
 
 **Consumers:**
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -99,15 +99,16 @@ the scope, and an expiry.
 
 | Scope | Grants |
 |-------|--------|
-| `control` | The control plane: lifecycle, images, sessions, snapshots, and the Connect tunnel for `shed forward`. |
-| `credentials` | The credential bus (`/api/plugins/*`) and the Connect tunnel — vends live SSH signatures and cloud credentials. |
+| `control` | The control plane (lifecycle, images, sessions, snapshots) and the Connect tunnel for `shed forward`. |
+| `credentials` | The credential bus (`/api/plugins/*`) — live SSH signatures and cloud credentials — and the Connect tunnel (used by the host-agent's reverse proxy). |
 
 (The pre-v0.7.1 `admin` scope is removed.) Under `secure` mode every request needs
-a matching `Authorization: Bearer` token of the required scope; the bus and
-Connect tunnel specifically require `credentials`, so a leaked `control` token
-cannot reach them. `GET /api/info` stays reachable without a token so
-`shed server add` can read the auth mode and ports before the operator holds
-one.
+a matching `Authorization: Bearer` token of the required scope. The bus requires
+`credentials`, so a leaked `control` token cannot reach the live-secret bus; the
+Connect tunnel accepts **either** scope (the CLI dials it with `control`, the
+host-agent's proxy with `credentials`). `GET /api/info` stays reachable without a
+token so `shed server add` can read the auth mode and ports before the operator
+holds one.
 
 ### Short TTL, transparent refresh
 
@@ -193,9 +194,10 @@ There is **one HTTP listener per mode** (SSH always listens separately on
 (`https_port`) listener in `secure` mode — in secure mode there is **no
 plain-HTTP listener at all**. The credential bus (`/api/plugins/*`)
 and the Connect tunnel (`/api/sheds/*/connect/*`) ride that same listener; in
-secure mode they are gated by the `credentials` scope (so a leaked `control`
-token can't reach them) and travel over TLS. A co-located host-agent reaches the
-bus over `https://127.0.0.1:8443` with the pinned cert. There is no separate
+secure mode the bus is gated by the `credentials` scope (so a leaked `control`
+token can't reach it) while the Connect tunnel accepts control or credentials,
+and both travel over TLS. A co-located host-agent reaches the bus over
+`https://127.0.0.1:8443` with the pinned cert. There is no separate
 internal/loopback listener. These knobs shape what is reachable where:
 
 | Field | Effect |
@@ -311,7 +313,7 @@ are **rejected at startup**:
 
 | Removed / renamed | Replacement |
 |-------------------|-------------|
-| `internal_http_port` | Removed — the credential bus + Connect tunnel ride the single listener (gated by the `credentials` scope in secure mode); a co-located host-agent reaches them over `https://127.0.0.1:8443`. |
+| `internal_http_port` | Removed — the credential bus (credentials scope) and Connect tunnel (control or credentials) ride the single listener in secure mode; a co-located host-agent reaches them over `https://127.0.0.1:8443`. |
 | `http_bind` / `ssh_bind` | A single `bind_address` governs every listener (HTTP, HTTPS, SSH). |
 
 Plus a behavior change: **`bind_address` defaults to loopback (`127.0.0.1`) in

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -20,10 +20,12 @@ import (
 // bootstrap channel and bound to the minting key. The store is shared with the
 // bootstrap handler via SetTokenStore.
 //
-// Scope: the credential bus (/api/plugins/*) and the Connect tunnel
-// (/api/sheds/*/connect/*) require a credentials-scoped token; every other
-// /api route requires a control-scoped token. So a leaked control token can't
-// reach the bus, and a credentials token is bus-only.
+// Scope: the credential bus (/api/plugins/*) requires a credentials-scoped
+// token; the Connect tunnel (/api/sheds/*/connect/*) accepts either a control
+// or a credentials token (the `shed forward` CLI holds control; the host-agent's
+// reverse proxy holds credentials); every other /api route requires a
+// control-scoped token. So a leaked control token can't reach the bus, and a
+// credentials token can't manage the fleet.
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	if !s.cfg.HTTPAuthEnforced() {
 		return next
@@ -38,14 +40,25 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing or invalid bearer token")
 			return
 		}
-		if requiresCredentialsScope(r.URL.Path) {
+		switch {
+		case isCredentialBusPath(r.URL.Path):
 			if rec.Scope != authtoken.ScopeCredentials {
 				writeError(w, http.StatusForbidden, "FORBIDDEN", "credentials scope required")
 				return
 			}
-		} else if rec.Scope != authtoken.ScopeControl {
-			writeError(w, http.StatusForbidden, "FORBIDDEN", "control scope required")
-			return
+		case isConnectRoute(r.URL.Path):
+			// The Connect tunnel is a data-plane port-forward, not the credential
+			// bus: `shed forward` reaches it with a control token and the
+			// host-agent's reverse proxy with a credentials token, so accept either.
+			if rec.Scope != authtoken.ScopeControl && rec.Scope != authtoken.ScopeCredentials {
+				writeError(w, http.StatusForbidden, "FORBIDDEN", "control or credentials scope required")
+				return
+			}
+		default:
+			if rec.Scope != authtoken.ScopeControl {
+				writeError(w, http.StatusForbidden, "FORBIDDEN", "control scope required")
+				return
+			}
 		}
 		next.ServeHTTP(w, r)
 	})
@@ -74,14 +87,26 @@ func isBootstrapExempt(r *http.Request) bool {
 		(r.URL.Path == "/api/info" || r.URL.Path == "/api/ssh-host-key")
 }
 
-// requiresCredentialsScope reports whether path is a credential-bus or Connect
-// route, which require a credentials-scoped token. Shed names can't contain
-// slashes, so "/connect/" only ever appears as the Connect tunnel route.
-func requiresCredentialsScope(path string) bool {
-	if path == "/api/plugins" || strings.HasPrefix(path, "/api/plugins/") {
-		return true
+// isCredentialBusPath reports whether path is the credential bus (/api/plugins*),
+// which requires a credentials-scoped token so a leaked control token can't
+// subscribe to the live-secret bus.
+func isCredentialBusPath(path string) bool {
+	return path == "/api/plugins" || strings.HasPrefix(path, "/api/plugins/")
+}
+
+// isConnectRoute reports whether path is the Connect tunnel
+// (/api/sheds/<name>/connect/<port>), which accepts a control OR credentials
+// token. It matches the exact route shape — three segments after /api/sheds/
+// with "connect" in the middle — rather than a "/connect/" substring, so a shed
+// literally named "connect" (e.g. POST /api/sheds/connect/start) is NOT
+// misclassified as the tunnel and stays control-only.
+func isConnectRoute(path string) bool {
+	rest, ok := strings.CutPrefix(path, "/api/sheds/")
+	if !ok {
+		return false
 	}
-	return strings.HasPrefix(path, "/api/sheds/") && strings.Contains(path, "/connect/")
+	parts := strings.Split(rest, "/")
+	return len(parts) == 3 && parts[1] == "connect" && parts[0] != "" && parts[2] != ""
 }
 
 // bearerToken extracts the token from an "Authorization: Bearer <token>"

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -63,8 +63,17 @@ func TestAuthMiddlewareEnforce(t *testing.T) {
 		{"control plane, credentials token forbidden", "GET", "/api/sheds", cred, 403},
 		{"bus, credentials token", "GET", "/api/plugins/listeners", cred, 200},
 		{"bus, control token forbidden", "GET", "/api/plugins/listeners", ctl, 403},
+		{"connect, control token", "GET", "/api/sheds/x/connect/22", ctl, 200},
 		{"connect, credentials token", "GET", "/api/sheds/x/connect/22", cred, 200},
-		{"connect, control token forbidden", "GET", "/api/sheds/x/connect/22", ctl, 403},
+		{"connect, no token", "GET", "/api/sheds/x/connect/22", "", 401},
+		// A shed literally named "connect" must NOT slip a credentials token onto
+		// a control-only lifecycle route via a loose "/connect/" substring match.
+		{"shed named connect, control token", "POST", "/api/sheds/connect/start", ctl, 200},
+		{"shed named connect, credentials token forbidden", "POST", "/api/sheds/connect/start", cred, 403},
+		// Connect classification is route-shape exact, not a substring: neither a
+		// missing port nor an extra segment counts as the tunnel (→ control-only).
+		{"connect prefix without port, credentials forbidden", "GET", "/api/sheds/x/connect", cred, 403},
+		{"connect with trailing segment, credentials forbidden", "GET", "/api/sheds/x/connect/22/extra", cred, 403},
 		{"create, control token", "POST", "/api/sheds", ctl, 200},
 	}
 	for _, tt := range tests {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -69,8 +69,9 @@ func (s *Server) useCommonMiddleware(r chi.Router) {
 // secure mode, plain HTTP in open mode. It registers the full route surface on
 // a single listener: the control plane (info, lifecycle, images, system,
 // snapshots, sessions, egress) plus the credential bus (/api/plugins/*) and the
-// Connect tunnel (/api/sheds/*/connect/*), which require a credentials-scoped
-// token in secure mode (see authMiddleware).
+// Connect tunnel (/api/sheds/*/connect/*). In secure mode the bus requires a
+// credentials-scoped token, the Connect tunnel accepts control or credentials,
+// and everything else requires control (see authMiddleware).
 func (s *Server) Router() chi.Router {
 	r := chi.NewRouter()
 	s.useCommonMiddleware(r)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -153,8 +153,8 @@ func (s *Server) Router() chi.Router {
 			r.Get("/sheds", s.handleListPluginSheds)
 		})
 
-		// Sheds: lifecycle routes plus the Connect tunnel leaf (credentials
-		// scope) — all on the single listener.
+		// Sheds: lifecycle routes (control scope) plus the Connect tunnel leaf
+		// (control or credentials) — all on the single listener.
 		r.Route("/sheds", func(r chi.Router) {
 			r.Get("/", s.handleListSheds)
 			r.Post("/", s.handleCreateShed)

--- a/internal/authtoken/authtoken.go
+++ b/internal/authtoken/authtoken.go
@@ -33,8 +33,8 @@ import (
 // intentionally absent: minting and revocation are gated by SSH access, so there
 // is no separate HTTP admin capability.
 const (
-	ScopeControl     = "control"     // shed lifecycle / control plane (CLI, desktop)
-	ScopeCredentials = "credentials" // credential bus + Connect tunnel + egress stream
+	ScopeControl     = "control"     // shed lifecycle / control plane (CLI, desktop); also accepted on the Connect tunnel
+	ScopeCredentials = "credentials" // credential bus (/api/plugins/*); also accepted on the Connect tunnel (host-agent reverse proxy)
 )
 
 // Client kinds are advisory metadata, recorded for audit (token ls) only.

--- a/internal/servertls/cert.go
+++ b/internal/servertls/cert.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -80,6 +81,21 @@ func PinnedClientConfig(fingerprint string) *tls.Config {
 			return nil
 		},
 	}
+}
+
+// PinnedTransport returns an *http.Transport (as http.RoundTripper) whose TLS
+// config pins the server's self-signed cert by fingerprint, or a genuinely-nil
+// http.RoundTripper when fingerprint is empty (so an http.Client falls back to
+// DefaultTransport for the plain-HTTP path). It is the shared constructor for
+// pinned HTTP clients — the CLI control plane and the Connect tunnel/probe — so
+// they all verify identically. The nil return is untyped on purpose: returning
+// a typed (*http.Transport)(nil) would make a non-nil http.RoundTripper wrapping
+// a nil pointer, which http.Client would use instead of DefaultTransport.
+func PinnedTransport(fingerprint string) http.RoundTripper {
+	if fingerprint == "" {
+		return nil
+	}
+	return &http.Transport{TLSClientConfig: PinnedClientConfig(fingerprint)}
 }
 
 // loadIfCovers loads the persisted cert+key and returns it only when it parses

--- a/internal/tunnels/connect.go
+++ b/internal/tunnels/connect.go
@@ -4,11 +4,14 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 
+	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/servertls"
 	"github.com/charliek/shed/internal/vmutil"
 )
@@ -16,13 +19,13 @@ import (
 // ConnectTarget describes how to reach a shed-server's Connect API. Addr is the
 // host:port to dial. When TLSPin is set, the connection is wrapped in TLS
 // verified against that pinned cert fingerprint; when Token is set, it is sent
-// as the credentials-scoped bearer token on the upgrade request. An empty
-// TLSPin and Token reproduce the legacy plain-TCP, unauthenticated dial
-// byte-for-byte.
+// as the bearer token on the upgrade request (the Connect route accepts a
+// control or credentials token). An empty TLSPin and Token reproduce the legacy
+// plain-TCP, unauthenticated dial byte-for-byte.
 type ConnectTarget struct {
 	Addr   string // host:port to dial
 	TLSPin string // "sha256:<hex>"; empty = plain TCP
-	Token  string // credentials bearer token; empty = no Authorization header
+	Token  string // bearer token (control or credentials); empty = no Authorization header
 }
 
 // ConnectClient dials shed VMs via the shed-server Connect API.
@@ -96,6 +99,69 @@ func (c *ConnectClient) Dial(ctx context.Context, shedName string, port uint16) 
 	}
 
 	return &vmutil.BufferedConn{Conn: conn, Reader: reader}, nil
+}
+
+// Probe verifies the tunnel can authenticate to the Connect API without
+// contacting any guest, so a broken tunnel fails loudly at startup instead of
+// resetting every connection. It issues a plain GET to the real Connect route
+// with port 0: the auth middleware runs first, then handleConnect rejects
+// port 0 with 400 INVALID_PORT *before* dialing the guest. So:
+//
+//   - 400 → authenticated and the Connect route is reachable (regardless of
+//     whether any guest port is listening yet)
+//   - 401 → the token is missing/invalid/expired
+//   - 403 → the token's scope isn't accepted on the Connect route (e.g. an
+//     older shed-server that still gates Connect on the credentials scope)
+//   - anything else / a transport or TLS-pin error → also a failure
+//
+// The caller bounds the probe with ctx's deadline (there is no internal
+// timeout), so a stalled server can't wedge startup.
+func (c *ConnectClient) Probe(ctx context.Context, shedName string) error {
+	scheme := "http"
+	if c.target.TLSPin != "" {
+		scheme = "https"
+	}
+	transport := servertls.PinnedTransport(c.target.TLSPin) // nil ⇒ DefaultTransport (plain HTTP)
+	reqURL := fmt.Sprintf("%s://%s/api/sheds/%s/connect/0", scheme, c.target.Addr, url.PathEscape(shedName))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("build connect probe request: %w", err)
+	}
+	if c.target.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.target.Token)
+	}
+
+	client := &http.Client{Transport: transport}
+	if transport != nil {
+		// One-shot probe: close our own pinned transport's idle keep-alive conn so
+		// it doesn't linger for the (long-lived) daemon worker's lifetime. Guarded
+		// so we never touch the shared DefaultTransport used by the plain path.
+		defer client.CloseIdleConnections()
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("connect probe to %s: %w", c.target.Addr, err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusBadRequest:
+		// The only 400 handleConnect returns on this route is INVALID_PORT (for
+		// port 0), emitted *after* auth passes. Confirm the shed error code so a
+		// generic 400 from a proxy, wrong service, or TLS-terminating middlebox
+		// doesn't false-pass as "authenticated" (see internal/api/connect.go).
+		var apiErr config.APIError
+		if json.NewDecoder(resp.Body).Decode(&apiErr) == nil && apiErr.Error.Code == "INVALID_PORT" {
+			return nil // authenticated, Connect route reachable
+		}
+		return fmt.Errorf("connect probe: unexpected 400 from %s — not the shed Connect API (INVALID_PORT); check the endpoint", c.target.Addr)
+	case http.StatusUnauthorized:
+		return fmt.Errorf("connect probe: shed-server rejected the tunnel token (401); it may be missing or expired")
+	case http.StatusForbidden:
+		return fmt.Errorf("connect probe: tunnel token scope not accepted on the Connect route (403); the shed-server may be too old to accept a control token — upgrade it")
+	default:
+		return fmt.Errorf("connect probe: unexpected HTTP %d from the Connect route", resp.StatusCode)
+	}
 }
 
 // dial opens the transport to the Connect API: a raw TCP conn (byte-identical

--- a/internal/tunnels/connect_test.go
+++ b/internal/tunnels/connect_test.go
@@ -2,12 +2,15 @@ package tunnels
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/servertls"
 )
 
@@ -60,7 +63,7 @@ func roundTrip(t *testing.T, conn io.ReadWriter) {
 }
 
 func TestConnectClientDialTLSPinned(t *testing.T) {
-	const token = "shed_credentials_test"
+	const token = "shed_control_test"
 	srv := httptest.NewTLSServer(upgradeEchoHandler(t, token))
 	defer srv.Close()
 
@@ -86,7 +89,7 @@ func TestConnectClientDialWrongPin(t *testing.T) {
 }
 
 func TestConnectClientDialMissingToken(t *testing.T) {
-	const token = "shed_credentials_test"
+	const token = "shed_control_test"
 	srv := httptest.NewTLSServer(upgradeEchoHandler(t, token))
 	defer srv.Close()
 
@@ -94,7 +97,7 @@ func TestConnectClientDialMissingToken(t *testing.T) {
 	// Pinned but no token → the server rejects the upgrade (not 101).
 	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin})
 	if _, err := client.Dial(context.Background(), "myshed", 8080); err == nil {
-		t.Error("a missing credentials token must be rejected by the connect route")
+		t.Error("a missing token must be rejected by the connect route")
 	}
 }
 
@@ -110,4 +113,146 @@ func TestConnectClientDialPlain(t *testing.T) {
 	}
 	defer conn.Close()
 	roundTrip(t, conn)
+}
+
+// probeStatusHandler asserts the probe targets the exact connect/0 route and
+// returns status. If wantToken is set, a missing/mismatched bearer yields 401
+// (mirroring the real auth middleware); otherwise status is returned. A 400 is
+// written as the shed INVALID_PORT error envelope, mirroring handleConnect, so
+// the probe's error-code check treats it as "authenticated".
+func probeStatusHandler(t *testing.T, wantToken string, status int) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/sheds/myshed/connect/0" {
+			t.Errorf("probe hit %s %s, want GET /api/sheds/myshed/connect/0", r.Method, r.URL.Path)
+		}
+		if wantToken != "" && r.Header.Get("Authorization") != "Bearer "+wantToken {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if status == http.StatusBadRequest {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(config.APIError{Error: config.APIErrorDetail{Code: "INVALID_PORT", Message: "port must be 1-65535"}})
+			return
+		}
+		http.Error(w, "probe", status)
+	}
+}
+
+func TestConnectProbeStatusHandling(t *testing.T) {
+	const token = "shed_control_test"
+	tests := []struct {
+		name    string
+		status  int
+		wantErr bool
+	}{
+		{"400 INVALID_PORT means authenticated", http.StatusBadRequest, false},
+		{"401 token missing/invalid", http.StatusUnauthorized, true},
+		{"403 scope not accepted / old server", http.StatusForbidden, true},
+		{"unexpected 500", http.StatusInternalServerError, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewTLSServer(probeStatusHandler(t, "", tt.status))
+			defer srv.Close()
+			pin := servertls.Fingerprint(srv.Certificate().Raw)
+			client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin, Token: token})
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			err := client.Probe(ctx, "myshed")
+			if tt.wantErr && err == nil {
+				t.Errorf("status %d: want error, got nil", tt.status)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("status %d: want nil, got %v", tt.status, err)
+			}
+		})
+	}
+}
+
+// TestConnectProbeGeneric400 proves a 400 that is NOT the shed INVALID_PORT
+// envelope (e.g. from a proxy or wrong service) fails the probe rather than
+// false-passing as "authenticated".
+func TestConnectProbeGeneric400(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad request from some middlebox", http.StatusBadRequest) // plain text, no shed envelope
+	}))
+	defer srv.Close()
+	pin := servertls.Fingerprint(srv.Certificate().Raw)
+	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin, Token: "t"})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Probe(ctx, "myshed"); err == nil {
+		t.Error("a generic 400 (not INVALID_PORT) must fail the probe, not pass")
+	}
+}
+
+// TestConnectProbeToken proves the probe sends the target token on the connect/0
+// route: with the right token the server 400s (pass); without it, 401s (fail).
+func TestConnectProbeToken(t *testing.T) {
+	const token = "shed_control_test"
+	srv := httptest.NewTLSServer(probeStatusHandler(t, token, http.StatusBadRequest))
+	defer srv.Close()
+	pin := servertls.Fingerprint(srv.Certificate().Raw)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin, Token: token}).Probe(ctx, "myshed"); err != nil {
+		t.Errorf("probe with valid token: %v", err)
+	}
+	if err := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin}).Probe(ctx, "myshed"); err == nil {
+		t.Error("probe without a token must fail (401)")
+	}
+}
+
+// TestConnectProbePlain: open mode (no pin, no token) — connect/0 400s → pass.
+func TestConnectProbePlain(t *testing.T) {
+	srv := httptest.NewServer(probeStatusHandler(t, "", http.StatusBadRequest))
+	defer srv.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := NewConnectClient(ConnectTarget{Addr: addrOf(srv)}).Probe(ctx, "myshed"); err != nil {
+		t.Errorf("plain probe: %v", err)
+	}
+}
+
+func TestConnectProbeWrongPin(t *testing.T) {
+	srv := httptest.NewTLSServer(probeStatusHandler(t, "", http.StatusBadRequest))
+	defer srv.Close()
+	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: "sha256:" + strings.Repeat("00", 32), Token: "t"})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Probe(ctx, "myshed"); err == nil {
+		t.Error("probe must fail the TLS handshake on a wrong pin")
+	}
+}
+
+func TestConnectProbeUnreachable(t *testing.T) {
+	srv := httptest.NewServer(probeStatusHandler(t, "", http.StatusBadRequest))
+	addr := addrOf(srv)
+	srv.Close() // nothing listening now
+	client := NewConnectClient(ConnectTarget{Addr: addr})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Probe(ctx, "myshed"); err == nil {
+		t.Error("probe must fail when the server is unreachable")
+	}
+}
+
+func TestConnectProbeContextDeadline(t *testing.T) {
+	block := make(chan struct{})
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block // stall until the test unblocks us
+	}))
+	defer srv.Close()
+	defer close(block) // LIFO: runs before srv.Close() so the handler returns and Close() doesn't hang
+
+	pin := servertls.Fingerprint(srv.Certificate().Raw)
+	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin, Token: "t"})
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if err := client.Probe(ctx, "myshed"); err == nil {
+		t.Error("probe must fail when the server stalls past the context deadline")
+	}
 }


### PR DESCRIPTION
Fixes #237.

## Problem

On an `auth.mode: secure` server, `shed tunnels` is completely non-functional from the CLI — every forwarded connection resets (`curl: (56) Connection reset by peer`) — and, worse, `shed tunnels start` reports ✓ and `shed tunnels list` shows the tunnel healthy the whole time. Two distinct bugs:

1. **The CLI tunnel can never authenticate (two-sided).**
   - **Server:** the Connect route (`/api/sheds/*/connect/*`) required the `credentials` scope, so the CLI's control token was rejected (403 / 401).
   - **Client:** the CLI dialed with `entry.CredentialsToken` — but nothing in `cmd/shed` ever populates that field (only the host-agent mints a credentials token), so the CLI sent **no** `Authorization` header at all → the observed 401.
2. **The failure was invisible.** Readiness was reported after listener-bind only; nothing validated the upstream Connect path, so a 100%-broken tunnel looked healthy.

## Fix

**Connect route now accepts `control` OR `credentials`** (not credentials-only). The route has two consumers — `shed forward` (CLI, control scope) and `shed-ext-proxy-host` (the host-agent's reverse proxy, which holds a credentials token). Control-only would have fixed the CLI but regressed the proxy; either-scope fixes the CLI without regressing it. The credential **bus (`/api/plugins/*`) stays credentials-only**, preserving the live-secret isolation. This matches what `security.md`'s scope table already documented.

**The CLI sends its control token**, sourced from the client's freshest in-memory token (so a refresh-in-flight isn't dropped for a stale config copy).

**Startup Connect auth probe** — `shed tunnels start` now validates auth before binding any listener, so a broken tunnel fails loudly in the terminal instead of resetting connections silently. The probe hits the real route with port 0 (`GET /api/sheds/{name}/connect/0`): auth runs first, then `handleConnect` returns `400 INVALID_PORT` **before** dialing the guest. So it validates auth + TLS pin + reachability **without contacting the guest** — it won't false-fail when your app isn't listening yet, and won't open a connection to it. The `400` body's error code is checked so a generic proxy `400` can't false-pass.

**Docs reconciled** — `api.md` and `security.md` (and two guides) contradicted each other on the tunnel's scope; all now say control-or-credentials for the tunnel, credentials-only for the bus.

## Commits
1. `fix(api)` — Connect route accepts control or credentials; exact route-shape matching so a shed named `connect` can't route a credentials token onto a control-only lifecycle path.
2. `fix(cli)` — send the control token (via an explicit token param to `connectTargetFromEntry`) using the client's live token.
3. `fix(cli)` — startup Connect auth probe (`ConnectClient.Probe`), wired into foreground + daemon-worker; pinned-TLS transport centralized in `servertls.PinnedTransport`.
4. `docs` — reconcile the scope docs.

## Testing
- `make build`, `make test`, `make lint` all green.
- New/updated unit tests: the auth scope matrix (`connect`+control=200, +credentials=200, no-token=401, plus the `connect`-named-shed and route-shape cases); `connectTargetFromEntry` sends the caller's live token; and a full probe suite (`400 INVALID_PORT`→pass, generic 400→fail, 401/403/wrong-pin/unreachable/timeout→fail, plain-mode). Race-clean.
- Auth-layer logic covered by unit tests; no live VM required.

## Out of scope (follow-ups)
- Long-lived tunnel token expiry (a tunnel outliving the 24h TTL; `ConnectClient` doesn't re-mint mid-life).
- The RST-vs-clean-error cosmetics on mid-life dial failures.
- **`/api/egress/stream` scope mismatch** — the host-agent consumer holds a credentials token, but that route currently requires `control` (and the `authtoken.go` comment over-claimed it as credentials). Confirmed a genuine latent bug during review; recommend a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoHk27xjf1khfuijtcru6u


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secure Connect tunnels now accept either control- or credentials-scoped tokens.
  * Tunnel startup now checks authentication earlier and reports failures before opening listeners.

* **Bug Fixes**
  * Fixed token handling so tunnel connections use the latest in-memory token after refreshes.
  * Improved route matching so Connect access rules apply correctly even with similar path names.

* **Documentation**
  * Updated security, deployment, and API guides to reflect the new token-scope behavior and secure tunnel requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->