### PR TITLE
fix: egress-stream scope + unify token refresh so background tunnels survive the TTL (#237 follow-up)

### DIFF
--- a/cmd/shed/client.go
+++ b/cmd/shed/client.go
@@ -15,28 +15,13 @@ import (
 	"time"
 
 	"github.com/charliek/shed/internal/backend"
+	"github.com/charliek/shed/internal/clienttoken"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/servertls"
 )
 
-const (
-	// DefaultTimeout for quick API operations (list, stop, delete, etc.)
-	DefaultTimeout = 30 * time.Second
-
-	// tokenRefreshWindow is how long before expiry a bootstrap-minted control
-	// token is proactively re-minted, so a request never races the expiry.
-	tokenRefreshWindow = 2 * time.Hour
-)
-
-// needsRefresh reports whether a bootstrap-minted token (expiresAt non-zero) is
-// expired or within tokenRefreshWindow of expiry and should be re-minted. A zero
-// expiresAt — a static/legacy token or an open server — never refreshes.
-func needsRefresh(expiresAt, now time.Time) bool {
-	if expiresAt.IsZero() {
-		return false
-	}
-	return !now.Before(expiresAt.Add(-tokenRefreshWindow))
-}
+// DefaultTimeout for quick API operations (list, stop, delete, etc.)
+const DefaultTimeout = 30 * time.Second
 
 // APIClient provides methods for interacting with the shed server API.
 type APIClient struct {
@@ -44,29 +29,34 @@ type APIClient struct {
 	httpClient    *http.Client
 	transport     http.RoundTripper // non-nil when TLS-pinned; shared by every client below
 	createTimeout time.Duration
-	token         string // bearer token (control scope), sent when non-empty
-	// refreshFn, when set, re-mints the bearer token (over the SSH bootstrap)
-	// and persists it; doRequest calls it once on a 401 and retries. nil for
-	// static tokens, open servers, and plain-HTTP clients.
-	refreshFn func() (string, error)
+	// tokens holds the bearer token and, in secure mode, transparently re-mints
+	// it (proactively near expiry, reactively on a 401). Static for open servers,
+	// plain-HTTP clients, and legacy fixed tokens. Never nil.
+	tokens *clienttoken.Source
 }
 
-// setAuth adds the bearer token header when the client is configured with one.
+// setAuth adds the bearer token header when the client has a non-empty token.
 func (c *APIClient) setAuth(req *http.Request) {
-	if c.token != "" {
-		req.Header.Set("Authorization", "Bearer "+c.token)
+	if tok := c.tokens.Token(); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
 	}
 }
 
-// currentToken returns the client's current in-memory bearer (control) token.
-// It may have been re-minted since construction — proactively near expiry or
-// reactively on a 401 retry — even when persisting the refresh back to config
-// was skipped (ambiguous alias) or failed. The tunnel path reads it so a
-// forwarded connection dials the Connect API with the freshest token rather
-// than the possibly-stale one in the config entry. Safe to call after a
-// synchronous request (e.g. ensureRunningShed) with no request in flight.
+// currentToken returns the client's current in-memory bearer (control) token. It
+// may have been re-minted since construction — proactively near expiry or
+// reactively on a 401 — even when persisting the refresh back to config was
+// skipped (ambiguous alias) or failed. The tunnel path reads it so a forwarded
+// connection dials with the freshest token rather than the possibly-stale one in
+// the config entry.
 func (c *APIClient) currentToken() string {
-	return c.token
+	return c.tokens.Token()
+}
+
+// TokenSource returns the client's token source, so a long-lived consumer (the
+// tunnel daemon) can seed its own Source from the freshly-refreshed token+expiry
+// this client obtained during setup.
+func (c *APIClient) TokenSource() *clienttoken.Source {
+	return c.tokens
 }
 
 // newHTTPClient builds an *http.Client carrying the pinning transport (if any),
@@ -99,7 +89,7 @@ func newAPIClient(baseURL, token, tlsFingerprint string, createTimeout time.Dura
 		baseURL:       strings.TrimRight(baseURL, "/"),
 		transport:     pinnedTransport(tlsFingerprint),
 		createTimeout: createTimeout,
-		token:         token,
+		tokens:        clienttoken.Static(token),
 	}
 	c.httpClient = c.newHTTPClient(DefaultTimeout)
 	return c
@@ -113,34 +103,40 @@ func newAPIClient(baseURL, token, tlsFingerprint string, createTimeout time.Dura
 func NewAPIClientFromEntry(entry *config.ServerEntry, createTimeout time.Duration) *APIClient {
 	c := newAPIClient(entry.BaseURL(), entry.ControlToken, entry.TLSCertFingerprint, createTimeout)
 	if entry.ControlTokenExpiresAt.IsZero() {
-		return c
+		return c // static/legacy token or open server — no refresh
 	}
-	host, sshPort := entry.Host, entry.SSHPort
 	// Resolve which config entry this is, so a refreshed token can be persisted.
 	// "" means no unambiguous match (a one-off entry, or duplicate aliases to the
 	// same endpoint) — the refresh still works for this client's lifetime, it
 	// just isn't saved.
 	name := serverNameForEntry(entry)
-	c.refreshFn = func() (string, error) {
+	c.tokens = clienttoken.New(entry.ControlToken, entry.ControlTokenExpiresAt,
+		controlTokenRefresh(entry.Host, entry.SSHPort, name))
+	// Proactively re-mint a near-expiry token so a request never races expiry. A
+	// mint failure here is non-fatal (EnsureFresh keeps the stale token); the
+	// reactive 401-retry surfaces any error on the next request.
+	c.tokens.EnsureFresh()
+	return c
+}
+
+// controlTokenRefresh returns a refresh callback that mints a control token over
+// the SSH bootstrap channel and, when persistName != "", best-effort persists it
+// to that config entry. It is shared by NewAPIClientFromEntry (persisting) and
+// the tunnel daemon (persistName "" — mint-only, so a long-lived daemon never
+// rewrites the user's config from its own stale in-memory copy).
+func controlTokenRefresh(host string, sshPort int, persistName string) func() (string, time.Time, error) {
+	return func() (string, time.Time, error) {
 		bundle, err := bootstrapFn(host, sshPort, "control", "cli")
 		if err != nil {
-			return "", err
+			return "", time.Time{}, err
 		}
-		// The token is valid the moment it is minted; persisting it is
-		// best-effort so a Save failure never wastes the mint or fails the
-		// request (the next process just re-mints).
-		persistControlToken(name, bundle.Token, bundle.ExpiresAt)
-		return bundle.Token, nil
-	}
-	// Proactively re-mint a near-expiry token so a request never races expiry.
-	// A mint failure here is non-fatal: the stale token is kept and the reactive
-	// 401-retry surfaces any error on the next request.
-	if needsRefresh(entry.ControlTokenExpiresAt, time.Now()) {
-		if tok, err := c.refreshFn(); err == nil {
-			c.token = tok
+		if persistName != "" {
+			// Best-effort: a Save failure never wastes the mint or fails the
+			// request (the next process just re-mints).
+			persistControlToken(persistName, bundle.Token, bundle.ExpiresAt)
 		}
+		return bundle.Token, bundle.ExpiresAt, nil
 	}
-	return c
 }
 
 // configMu serializes refresh-path access to the shared clientConfig global —
@@ -221,23 +217,38 @@ func (c *APIClient) sendRequest(method, path string, body interface{}) (*http.Re
 	return c.httpClient.Do(req)
 }
 
+// refreshedOn401 is the shared on-401 re-mint for the request paths. When resp is
+// a 401 and the token source can refresh, it closes resp.Body, re-mints the token
+// that failed (sentToken — the generation the caller sent, so a concurrent
+// refresh isn't double-minted), and returns retry=true so the caller re-runs its
+// request exactly once (panel decision #11). A static token (not Refreshable) or
+// a non-401 returns retry=false. Only a failed re-mint returns an error; each
+// caller wraps its own resend error as it sees fit.
+func (c *APIClient) refreshedOn401(resp *http.Response, sentToken string) (retry bool, err error) {
+	if resp.StatusCode != http.StatusUnauthorized || !c.tokens.Refreshable() {
+		return false, nil
+	}
+	_ = resp.Body.Close()
+	if _, rerr := c.tokens.Refresh(sentToken); rerr != nil {
+		return false, fmt.Errorf("re-authenticating after 401: %w", rerr)
+	}
+	return true, nil
+}
+
 // doRequest performs an HTTP request with JSON body and response handling. It
 // handles connection errors, status validation, and JSON decoding, and
 // transparently re-mints + retries once on a 401 (an expired bootstrap token).
 func (c *APIClient) doRequest(method, path string, body, result interface{}, expectedStatus ...int) error {
+	sent := c.tokens.Token()
 	resp, err := c.sendRequest(method, path, body)
 	if err != nil {
 		return fmt.Errorf("failed to connect to server: %w", err)
 	}
-	// A bootstrap-minted token can expire mid-session: on 401, re-mint once over
-	// SSH and retry the request a single time (panel decision #11).
-	if resp.StatusCode == http.StatusUnauthorized && c.refreshFn != nil {
-		_ = resp.Body.Close()
-		tok, rerr := c.refreshFn()
-		if rerr != nil {
-			return fmt.Errorf("re-authenticating after 401: %w", rerr)
-		}
-		c.token = tok
+	retry, rerr := c.refreshedOn401(resp, sent)
+	if rerr != nil {
+		return rerr
+	}
+	if retry {
 		resp, err = c.sendRequest(method, path, body)
 		if err != nil {
 			return fmt.Errorf("failed to connect to server: %w", err)
@@ -626,17 +637,16 @@ func (c *APIClient) DeleteShedWithProgress(name string, onProgress func(backend.
 		return resp, nil
 	}
 
+	sent := c.tokens.Token()
 	resp, err := send()
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode == http.StatusUnauthorized && c.refreshFn != nil {
-		_ = resp.Body.Close()
-		tok, rerr := c.refreshFn()
-		if rerr != nil {
-			return fmt.Errorf("re-authenticating after 401: %w", rerr)
-		}
-		c.token = tok
+	retry, rerr := c.refreshedOn401(resp, sent)
+	if rerr != nil {
+		return rerr
+	}
+	if retry {
 		if resp, err = send(); err != nil {
 			return err
 		}

--- a/cmd/shed/refresh_test.go
+++ b/cmd/shed/refresh_test.go
@@ -7,30 +7,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charliek/shed/internal/clienttoken"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/sdk"
 )
 
-func TestNeedsRefresh(t *testing.T) {
-	now := time.Unix(1_700_000_000, 0)
-	tests := []struct {
-		name      string
-		expiresAt time.Time
-		want      bool
-	}{
-		{"zero expiry (static token / open server) never refreshes", time.Time{}, false},
-		{"far-future expiry does not refresh", now.Add(24 * time.Hour), false},
-		{"within the refresh window refreshes", now.Add(time.Hour), true},
-		{"exactly at the window edge refreshes", now.Add(tokenRefreshWindow), true},
-		{"expired refreshes", now.Add(-time.Minute), true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := needsRefresh(tt.expiresAt, now); got != tt.want {
-				t.Errorf("needsRefresh = %v, want %v", got, tt.want)
-			}
-		})
-	}
+// refreshingSource builds a Source seeded with tok that mints newTok on refresh
+// (recording whether it fired), with far-future expiries so only the reactive
+// path is exercised.
+func refreshingSource(tok, newTok string, fired *bool) *clienttoken.Source {
+	return clienttoken.New(tok, time.Now().Add(24*time.Hour), func() (string, time.Time, error) {
+		if fired != nil {
+			*fired = true
+		}
+		return newTok, time.Now().Add(24 * time.Hour), nil
+	})
 }
 
 func TestDoRequest401RefreshAndRetry(t *testing.T) {
@@ -47,7 +38,7 @@ func TestDoRequest401RefreshAndRetry(t *testing.T) {
 	defer srv.Close()
 
 	c := newAPIClient(srv.URL, "stale", "", DefaultTimeout)
-	c.refreshFn = func() (string, error) { refreshed = true; return "new", nil }
+	c.tokens = refreshingSource("stale", "new", &refreshed)
 
 	var out struct {
 		OK bool `json:"ok"`
@@ -56,7 +47,7 @@ func TestDoRequest401RefreshAndRetry(t *testing.T) {
 		t.Fatalf("doRequest: %v", err)
 	}
 	if !refreshed {
-		t.Error("refreshFn should have been called on the 401")
+		t.Error("refresh should have been called on the 401")
 	}
 	if !out.OK {
 		t.Error("the retry should have succeeded with the refreshed token")
@@ -75,7 +66,10 @@ func TestDoRequest401RetryAtMostOnce(t *testing.T) {
 	defer srv.Close()
 
 	c := newAPIClient(srv.URL, "stale", "", DefaultTimeout)
-	c.refreshFn = func() (string, error) { refreshes++; return "new", nil }
+	c.tokens = clienttoken.New("stale", time.Now().Add(24*time.Hour), func() (string, time.Time, error) {
+		refreshes++
+		return "new", time.Now().Add(24 * time.Hour), nil
+	})
 
 	if err := c.doRequest("GET", "/x", nil, nil); err == nil {
 		t.Error("expected an error when the 401 persists after refresh")
@@ -85,6 +79,54 @@ func TestDoRequest401RetryAtMostOnce(t *testing.T) {
 	}
 	if hits != 2 {
 		t.Errorf("want 2 requests (initial + one retry), got %d", hits)
+	}
+}
+
+// TestDoRequest401StaticNoRetry: a static token (not Refreshable) must NOT retry
+// on a 401 — behavior preserved from the pre-Source client.
+func TestDoRequest401StaticNoRetry(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := newAPIClient(srv.URL, "static", "", DefaultTimeout) // static Source, no refresh
+	if err := c.doRequest("GET", "/x", nil, nil); err == nil {
+		t.Error("expected an error on 401")
+	}
+	if hits != 1 {
+		t.Errorf("a static token must not retry; want 1 request, got %d", hits)
+	}
+}
+
+// TestDeleteShedWithProgress401RefreshAndRetry exercises the streaming delete
+// path's own on-401 refresh (it bypasses doRequest): 401 → re-mint → 204 (done).
+func TestDeleteShedWithProgress401RefreshAndRetry(t *testing.T) {
+	var hits int
+	refreshed := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if r.Header.Get("Authorization") == "Bearer new" {
+			w.WriteHeader(http.StatusNoContent) // delete OK, no stream
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := newAPIClient(srv.URL, "stale", "", DefaultTimeout)
+	c.tokens = refreshingSource("stale", "new", &refreshed)
+
+	if err := c.DeleteShedWithProgress("myshed", nil); err != nil {
+		t.Fatalf("DeleteShedWithProgress: %v", err)
+	}
+	if !refreshed {
+		t.Error("refresh should have been called on the 401")
+	}
+	if hits != 2 {
+		t.Errorf("want 2 requests (401 then 204), got %d", hits)
 	}
 }
 
@@ -128,8 +170,8 @@ func TestProactiveRefreshOnNearExpiry(t *testing.T) {
 
 	entry := clientConfig.Servers["s"]
 	c := NewAPIClientFromEntry(&entry, DefaultTimeout)
-	if c.token != "fresh" {
-		t.Errorf("client token = %q, want fresh (proactively refreshed)", c.token)
+	if c.tokens.Token() != "fresh" {
+		t.Errorf("client token = %q, want fresh (proactively refreshed)", c.tokens.Token())
 	}
 	if got := clientConfig.Servers["s"].ControlToken; got != "fresh" {
 		t.Errorf("in-memory token = %q, want fresh", got)
@@ -160,11 +202,11 @@ func TestNoRefreshForStaticToken(t *testing.T) {
 	if called {
 		t.Error("a static token (zero expiry) must not bootstrap")
 	}
-	if c.refreshFn != nil {
-		t.Error("a static token must not get a refreshFn")
+	if c.tokens.Refreshable() {
+		t.Error("a static token must not be refreshable")
 	}
-	if c.token != "static" {
-		t.Errorf("token = %q, want static", c.token)
+	if c.tokens.Token() != "static" {
+		t.Errorf("token = %q, want static", c.tokens.Token())
 	}
 }
 

--- a/cmd/shed/tunnels.go
+++ b/cmd/shed/tunnels.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/charliek/shed/internal/clienttoken"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/tunnels"
 )
@@ -284,6 +285,10 @@ func runTunnelsStart(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	// A self-refreshing token source so a long-lived tunnel survives the control
+	// token's TTL. Built here for foreground and (re-)built by the detached worker
+	// when it re-runs; the parent -d process starts no tunnels itself.
+	tokenSrc := tunnelTokenSource(client, entry, target)
 
 	switch {
 	case tunnelBackground && !tunnelDaemon:
@@ -291,21 +296,35 @@ func runTunnelsStart(cmd *cobra.Command, args []string) error {
 		return spawnTunnelDaemon(shedName, allPorts)
 	case tunnelDaemon:
 		// Detached worker: start tunnels, report readiness, block on signal.
-		return runDaemonWorker(mgr, shedName, serverName, target, allPorts, profileName)
+		return runDaemonWorker(mgr, shedName, serverName, target, tokenSrc, allPorts, profileName)
 	default:
 		// Foreground mode: start tunnels and block on signal.
-		return runForegroundTunnel(mgr, shedName, target, allPorts, profileName)
+		return runForegroundTunnel(mgr, shedName, target, tokenSrc, allPorts, profileName)
 	}
 }
 
-func runForegroundTunnel(mgr *tunnels.Manager, shedName string, target tunnels.ConnectTarget, ports []tunnels.PortMapping, profile string) error {
+// tunnelTokenSource returns a self-refreshing token source for a secure tunnel,
+// seeded from the client's freshly-minted token+expiry (post ensureRunningShed).
+// It re-mints over SSH but NEVER persists to config: a background daemon may run
+// for days, and writing its stale in-memory config back would clobber unrelated
+// foreground edits (e.g. a `shed server add`). Returns nil for the plain/legacy
+// path (no token, no refresh).
+func tunnelTokenSource(client *APIClient, entry *config.ServerEntry, target tunnels.ConnectTarget) *clienttoken.Source {
+	if target.TLSPin == "" {
+		return nil
+	}
+	return clienttoken.New(client.currentToken(), client.TokenSource().ExpiresAt(),
+		controlTokenRefresh(entry.Host, entry.SSHPort, "")) // "" persistName ⇒ mint-only
+}
+
+func runForegroundTunnel(mgr *tunnels.Manager, shedName string, target tunnels.ConnectTarget, source *clienttoken.Source, ports []tunnels.PortMapping, profile string) error {
 	// Fail loudly if the tunnel can't authenticate, before binding any listener
 	// (so we never leave a listener up that resets every connection).
-	if err := probeConnectAuth(target, shedName); err != nil {
+	if err := probeConnectAuth(target, source, shedName); err != nil {
 		return err
 	}
 
-	activeTunnels, err := mgr.StartTunnels(target, shedName, ports)
+	activeTunnels, err := mgr.StartTunnels(target, source, shedName, ports)
 	if err != nil {
 		return fmt.Errorf("failed to start tunnels: %w", err)
 	}

--- a/cmd/shed/tunnels_daemon.go
+++ b/cmd/shed/tunnels_daemon.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/charliek/shed/internal/clienttoken"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/tunnels"
 )
@@ -38,10 +39,10 @@ const tunnelProbeTimeout = 5 * time.Second
 // foreground and detached-worker start paths run it before binding listeners, so
 // an auth/transport failure fails `shed tunnels start` loudly instead of
 // surfacing later as a per-connection reset.
-func probeConnectAuth(target tunnels.ConnectTarget, shedName string) error {
+func probeConnectAuth(target tunnels.ConnectTarget, source *clienttoken.Source, shedName string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), tunnelProbeTimeout)
 	defer cancel()
-	return tunnels.NewConnectClient(target).Probe(ctx, shedName)
+	return tunnels.NewConnectClient(target, source).Probe(ctx, shedName)
 }
 
 // spawnTunnelDaemon re-execs this binary as a detached background worker for the
@@ -186,7 +187,7 @@ func parseReadyMessage(line string) error {
 // parent over the inherited pipe, then blocks until signalled and tears down.
 // The ordering is load-bearing: listeners bound -> state saved -> "OK" written,
 // so `shed tunnels list` immediately after the parent returns sees the entry.
-func runDaemonWorker(mgr *tunnels.Manager, shedName, serverName string, target tunnels.ConnectTarget, ports []tunnels.PortMapping, profile string) error {
+func runDaemonWorker(mgr *tunnels.Manager, shedName, serverName string, target tunnels.ConnectTarget, source *clienttoken.Source, ports []tunnels.PortMapping, profile string) error {
 	ready, err := openReadyPipe()
 	if err != nil {
 		return err
@@ -195,14 +196,14 @@ func runDaemonWorker(mgr *tunnels.Manager, shedName, serverName string, target t
 	// Validate Connect auth before binding listeners or reporting readiness, so a
 	// broken tunnel fails `shed tunnels start` in the user's terminal (via the
 	// ERR: channel) rather than looking healthy and resetting every connection.
-	if probeErr := probeConnectAuth(target, shedName); probeErr != nil {
+	if probeErr := probeConnectAuth(target, source, shedName); probeErr != nil {
 		fmt.Fprintf(ready, "ERR:%s\n", probeErr)
 		_ = ready.Close()
 		return probeErr
 	}
 
 	// Bind listeners, then record state under our own (detached) PID.
-	activeTunnels, startErr := mgr.StartTunnels(target, shedName, ports)
+	activeTunnels, startErr := mgr.StartTunnels(target, source, shedName, ports)
 	if startErr != nil {
 		startErr = fmt.Errorf("failed to start tunnels: %w", startErr)
 	} else if saveErr := mgr.SaveBackground(shedName, serverName, profile, os.Getpid(), ports); saveErr != nil {

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -11,8 +11,9 @@ The `shed-server` exposes a REST API for managing sheds.
     required scope, except the bootstrap endpoints `GET /api/info` and
     `GET /api/ssh-host-key`. The credential bus (`/api/plugins/*`) requires the
     `credentials` scope; the Connect tunnel
-    (`/api/sheds/{name}/connect/{port}`) accepts **either** `control` or
-    `credentials`; everything else needs `control`. Tokens are **not** issued over HTTP —
+    (`/api/sheds/{name}/connect/{port}`) and the egress audit stream
+    (`/api/egress/stream`) accept **either** `control` or `credentials`;
+    everything else needs `control`. Tokens are **not** issued over HTTP —
     they are minted over the SSH `_bootstrap` channel (see
     [Authentication](#authentication)). See [Security](security.md) for the full
     model and pinned TLS.

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -99,14 +99,15 @@ the scope, and an expiry.
 
 | Scope | Grants |
 |-------|--------|
-| `control` | The control plane (lifecycle, images, sessions, snapshots) and the Connect tunnel for `shed forward`. |
-| `credentials` | The credential bus (`/api/plugins/*`) — live SSH signatures and cloud credentials — and the Connect tunnel (used by the host-agent's reverse proxy). |
+| `control` | The control plane (lifecycle, images, sessions, snapshots), the Connect tunnel for `shed forward`, and the egress audit stream. |
+| `credentials` | The credential bus (`/api/plugins/*`) — live SSH signatures and cloud credentials — plus the Connect tunnel and the egress audit stream (used by the host-agent's reverse proxy / egress subscriber). |
 
 (The pre-v0.7.1 `admin` scope is removed.) Under `secure` mode every request needs
 a matching `Authorization: Bearer` token of the required scope. The bus requires
 `credentials`, so a leaked `control` token cannot reach the live-secret bus; the
-Connect tunnel accepts **either** scope (the CLI dials it with `control`, the
-host-agent's proxy with `credentials`). `GET /api/info` stays reachable without a
+Connect tunnel and the egress audit stream accept **either** scope (the CLI uses
+`control`, the host-agent's proxy / egress subscriber uses `credentials`).
+`GET /api/info` stays reachable without a
 token so `shed server add` can read the auth mode and ports before the operator
 holds one.
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -131,6 +131,13 @@ Every client refreshes transparently, so the TTL is invisible in normal use:
   the TTL. It no longer reads a static `credentials_token` from config.
 - **shed-desktop** — requests a `control` token from the local host-agent (over
   the host-agent's Unix socket) and refreshes near expiry / on `401`.
+- **background tunnels** (`shed tunnels start -d`) — the detached daemon re-mints
+  its `control` token the same way (proactively near expiry, reactively on a
+  `401`); once running those re-mints are **in memory only**, so a multi-day daemon
+  never rewrites `~/.shed/config.yaml` and can't clobber a concurrent foreground
+  edit. It re-mints non-interactively (SSH `BatchMode`), so it needs SSH access
+  without a prompt — an agent that outlives the launching terminal, or a
+  passphrase-less / agent-loaded key.
 
 ### Revocation follows the allowlist
 

--- a/docs/reference/tunnels.md
+++ b/docs/reference/tunnels.md
@@ -135,6 +135,30 @@ running after the launching terminal is closed.
   file is truncated on each start and is not rotated (it only records errors, so
   it stays small in normal use).
 
+## Secure mode
+
+On a server running `auth.mode: secure`, the tunnel authenticates to the Connect
+API with a bearer token over pinned TLS (the Connect route accepts a `control` or
+`credentials` scope; the CLI uses its control token). Two behaviors matter:
+
+- **Startup probe.** `shed tunnels start` validates that it can authenticate
+  *before* binding any local listener, so a scope/token/TLS-pin problem fails the
+  command in your terminal instead of silently resetting every connection. The
+  probe does not touch the guest, so starting a tunnel before the in-VM service is
+  up still succeeds.
+- **Transparent token refresh.** The short-lived control token (`auth.token_ttl`,
+  default 24h) is re-minted automatically so a long-running background tunnel
+  keeps working across expiry — proactively just before expiry and reactively if a
+  connection is rejected — over the same SSH `_bootstrap` channel `shed server add`
+  uses. Because the background daemon is detached, it re-mints **non-interactively**:
+  it needs your SSH key available without a prompt (an `ssh-agent` that outlives
+  the launching terminal, or an agent-loaded / unencrypted key). If neither is
+  available when the token expires, new connections through a multi-day tunnel fail
+  until you restart it, and the reason is logged to `~/.shed/logs/tunnel-<shed>.log`.
+  Once running, the daemon re-mints its tunnel token **in memory only**, so a
+  long-lived daemon won't rewrite `~/.shed/config.yaml` and clobber a concurrent
+  foreground edit. (Open-mode servers use no token and are unaffected.)
+
 ## Port Conflicts
 
 If a local port is already in use, the tunnel will fail to start with a descriptive error. Use a different local port:

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -21,11 +21,12 @@ import (
 // bootstrap handler via SetTokenStore.
 //
 // Scope: the credential bus (/api/plugins/*) requires a credentials-scoped
-// token; the Connect tunnel (/api/sheds/*/connect/*) accepts either a control
-// or a credentials token (the `shed forward` CLI holds control; the host-agent's
-// reverse proxy holds credentials); every other /api route requires a
-// control-scoped token. So a leaked control token can't reach the bus, and a
-// credentials token can't manage the fleet.
+// token; the Connect tunnel (/api/sheds/*/connect/*) and the egress audit stream
+// (/api/egress/stream) accept either a control or a credentials token (the CLI
+// holds control; the host-agent's reverse proxy / egress subscriber holds
+// credentials); every other /api route requires a control-scoped token. So a
+// leaked control token can't reach the bus, and a credentials token can't manage
+// the fleet.
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	if !s.cfg.HTTPAuthEnforced() {
 		return next
@@ -46,10 +47,12 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 				writeError(w, http.StatusForbidden, "FORBIDDEN", "credentials scope required")
 				return
 			}
-		case isConnectRoute(r.URL.Path):
-			// The Connect tunnel is a data-plane port-forward, not the credential
-			// bus: `shed forward` reaches it with a control token and the
-			// host-agent's reverse proxy with a credentials token, so accept either.
+		case isConnectRoute(r.URL.Path) || isEgressStreamPath(r.Method, r.URL.Path):
+			// Neither is the credential bus. The Connect tunnel is a data-plane
+			// port-forward (`shed forward` uses control; the host-agent's reverse
+			// proxy uses credentials); the egress stream is fleet-global audit
+			// metadata (host-agent subscriber uses credentials; a control token may
+			// tail it too). Both accept either scope.
 			if rec.Scope != authtoken.ScopeControl && rec.Scope != authtoken.ScopeCredentials {
 				writeError(w, http.StatusForbidden, "FORBIDDEN", "control or credentials scope required")
 				return
@@ -107,6 +110,17 @@ func isConnectRoute(path string) bool {
 	}
 	parts := strings.Split(rest, "/")
 	return len(parts) == 3 && parts[1] == "connect" && parts[0] != "" && parts[2] != ""
+}
+
+// isEgressStreamPath reports whether r targets the fleet-global egress audit SSE
+// stream (GET /api/egress/stream), consumed by the host-agent (credentials) and
+// tailable by the CLI (control). It is method-scoped to GET on purpose: the
+// sibling POST/DELETE /api/egress/{name} mutators (handleEgressSet/Off) are
+// control-only, so a shed named "stream" must not let a credentials token onto
+// POST/DELETE /api/egress/stream. Only this exact GET is dual-scope; every other
+// /api/egress/* route (profiles, per-shed show/set/off) stays control-only.
+func isEgressStreamPath(method, path string) bool {
+	return method == http.MethodGet && path == "/api/egress/stream"
 }
 
 // bearerToken extracts the token from an "Authorization: Bearer <token>"

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -74,6 +74,20 @@ func TestAuthMiddlewareEnforce(t *testing.T) {
 		// missing port nor an extra segment counts as the tunnel (→ control-only).
 		{"connect prefix without port, credentials forbidden", "GET", "/api/sheds/x/connect", cred, 403},
 		{"connect with trailing segment, credentials forbidden", "GET", "/api/sheds/x/connect/22/extra", cred, 403},
+		// The fleet-global egress audit stream accepts either scope (host-agent
+		// subscriber holds credentials; a control token may tail it).
+		{"egress stream, control token", "GET", "/api/egress/stream", ctl, 200},
+		{"egress stream, credentials token", "GET", "/api/egress/stream", cred, 200},
+		{"egress stream, no token", "GET", "/api/egress/stream", "", 401},
+		// Only GET /stream is dual-scope; other egress routes stay control-only.
+		{"egress profiles, control token", "GET", "/api/egress/profiles", ctl, 200},
+		{"egress profiles, credentials token forbidden", "GET", "/api/egress/profiles", cred, 403},
+		{"egress per-shed, credentials token forbidden", "GET", "/api/egress/myshed", cred, 403},
+		// A shed named "stream" must NOT let a credentials token onto the
+		// control-only POST/DELETE egress mutators via the /stream path.
+		{"egress stream POST, credentials forbidden", "POST", "/api/egress/stream", cred, 403},
+		{"egress stream DELETE, credentials forbidden", "DELETE", "/api/egress/stream", cred, 403},
+		{"egress stream POST, control token", "POST", "/api/egress/stream", ctl, 200},
 		{"create, control token", "POST", "/api/sheds", ctl, 200},
 	}
 	for _, tt := range tests {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -408,6 +408,10 @@ func (s *Server) handleEgressSet(w http.ResponseWriter, r *http.Request) {
 
 // handleEgressStream streams egress decisions as Server-Sent Events for the
 // host-agent subscriber (shed-extensions). GET /api/egress/stream
+//
+// In secure mode this route accepts a control OR credentials token (the
+// host-agent holds credentials; a control token may tail it) — see
+// authMiddleware. It is fleet-global: a subscriber sees every shed's decisions.
 func (s *Server) handleEgressStream(w http.ResponseWriter, r *http.Request) {
 	if s.egressAudit == nil {
 		writeError(w, http.StatusNotImplemented, config.ErrBackendError, "egress control is not enabled")

--- a/internal/authtoken/authtoken.go
+++ b/internal/authtoken/authtoken.go
@@ -33,8 +33,8 @@ import (
 // intentionally absent: minting and revocation are gated by SSH access, so there
 // is no separate HTTP admin capability.
 const (
-	ScopeControl     = "control"     // shed lifecycle / control plane (CLI, desktop); also accepted on the Connect tunnel
-	ScopeCredentials = "credentials" // credential bus (/api/plugins/*); also accepted on the Connect tunnel (host-agent reverse proxy)
+	ScopeControl     = "control"     // shed lifecycle / control plane (CLI, desktop); also accepted on the Connect tunnel and egress stream
+	ScopeCredentials = "credentials" // credential bus (/api/plugins/*); also accepted on the Connect tunnel + egress audit stream (host-agent)
 )
 
 // Client kinds are advisory metadata, recorded for audit (token ls) only.

--- a/internal/clienttoken/source.go
+++ b/internal/clienttoken/source.go
@@ -16,7 +16,11 @@ import (
 )
 
 // tokenRefreshWindow is how long before expiry a token is proactively re-minted
-// by EnsureFresh, so a request never races the expiry.
+// by EnsureFresh, so a request never races the expiry. It is a fixed threshold,
+// not derived from the token's TTL: a token_ttl at or below it makes EnsureFresh
+// re-mint eagerly (up to once per call) — still correct, and reactive Refresh
+// covers expiry regardless — but the default token_ttl (24h) sits far above it,
+// so in normal operation a token is re-minted at most once, within its final 2h.
 const tokenRefreshWindow = 2 * time.Hour
 
 // ErrStatic is returned by Refresh when the Source has no refresh callback (a

--- a/internal/clienttoken/source.go
+++ b/internal/clienttoken/source.go
@@ -1,0 +1,147 @@
+// Package clienttoken holds a bearer token that transparently re-mints itself,
+// shared by every shed client that talks to a secure-mode shed-server: the CLI
+// API client and the tunnel Connect client. A Source pairs the current token
+// with its expiry and an injected refresh callback (the actual SSH mint +
+// optional persist lives in the caller, keeping this package a dependency-free
+// leaf). Refresh is proactive (before expiry) and reactive (on a 401),
+// generation-aware, and coalesced so concurrent callers mint at most once.
+package clienttoken
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// tokenRefreshWindow is how long before expiry a token is proactively re-minted
+// by EnsureFresh, so a request never races the expiry.
+const tokenRefreshWindow = 2 * time.Hour
+
+// ErrStatic is returned by Refresh when the Source has no refresh callback (a
+// static token, an open server, or a plain-HTTP client). Callers use it — or,
+// preferably, a prior Refreshable() check — to know a 401 must not be retried.
+var ErrStatic = errors.New("clienttoken: source has no refresh callback")
+
+// Source is a concurrency-safe holder for a bearer token and its expiry, with an
+// optional refresh callback. The zero value is not usable; construct with New or
+// Static.
+type Source struct {
+	mu        sync.Mutex
+	token     string
+	expiresAt time.Time
+	// refresh mints a new token (and its expiry). nil ⇒ static: the token never
+	// changes. It is invoked without the mutex held, at most once per coalesced
+	// batch (see Refresh).
+	refresh func() (token string, exp time.Time, err error)
+	sf      singleflight.Group
+}
+
+// New returns a refreshing Source seeded with token/expiresAt. A nil refresh
+// yields a static Source (equivalent to Static).
+func New(token string, expiresAt time.Time, refresh func() (string, time.Time, error)) *Source {
+	return &Source{token: token, expiresAt: expiresAt, refresh: refresh}
+}
+
+// Static returns a Source that never mints — Token returns token, EnsureFresh is
+// a no-op, and Refresh returns ErrStatic.
+func Static(token string) *Source {
+	return &Source{token: token}
+}
+
+// Token returns the current bearer token. It is cheap and safe to call on every
+// request build (including a retry, which then picks up a just-refreshed token).
+func (s *Source) Token() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.token
+}
+
+// ExpiresAt returns the current token's expiry (zero for a static token). Used to
+// seed a sibling Source from a freshly-refreshed one.
+func (s *Source) ExpiresAt() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.expiresAt
+}
+
+// Refreshable reports whether this Source can re-mint. Callers gate their on-401
+// retry on this so a static token behaves exactly as before (no retry).
+func (s *Source) Refreshable() bool {
+	return s.refresh != nil
+}
+
+// needsRefresh reports whether a token with the given expiry should be
+// proactively re-minted: expiry is set (non-zero) and now is within
+// tokenRefreshWindow of it (or past it). A zero expiry never refreshes.
+func needsRefresh(expiresAt, now time.Time) bool {
+	if expiresAt.IsZero() {
+		return false
+	}
+	return !now.Before(expiresAt.Add(-tokenRefreshWindow))
+}
+
+// EnsureFresh proactively re-mints when the current token is within the refresh
+// window of its expiry, so the next request never races expiry. It is
+// best-effort: a mint error leaves the existing token in place (the reactive
+// Refresh path surfaces errors to a real request). No-op for a static Source.
+func (s *Source) EnsureFresh() {
+	if s.refresh == nil {
+		return
+	}
+	s.mu.Lock()
+	prev := s.token
+	stale := needsRefresh(s.expiresAt, time.Now())
+	s.mu.Unlock()
+	if stale {
+		_, _ = s.Refresh(prev)
+	}
+}
+
+// Refresh re-mints the token and returns the new one. It is:
+//   - generation-aware: if another caller already advanced the token past prev,
+//     it returns the current token without minting again (so a stale 401 that
+//     lost the race doesn't trigger a redundant mint);
+//   - coalesced: concurrent Refresh/EnsureFresh calls share a single mint via
+//     singleflight.
+//
+// prev is the token the caller used on the request that failed (or the token it
+// observed before EnsureFresh). Returns ErrStatic when the Source cannot mint.
+func (s *Source) Refresh(prev string) (string, error) {
+	if s.refresh == nil {
+		return s.Token(), ErrStatic
+	}
+	// Fast generation check BEFORE singleflight: a caller whose token was already
+	// superseded (prev != current) just uses the current token, and must not enter
+	// the shared mint — otherwise it could win the singleflight with a "no mint
+	// needed" answer and hand it to a genuine current-generation caller that
+	// coalesced on, starving a real refresh.
+	if cur := s.Token(); cur != prev {
+		return cur, nil
+	}
+	// Key the singleflight by the generation being replaced (prev == the current
+	// token here). Same-generation callers coalesce onto one mint; a caller
+	// replacing a *different* generation uses a different key and gets its own
+	// mint rather than a stale answer.
+	v, err, _ := s.sf.Do(prev, func() (interface{}, error) {
+		if cur := s.Token(); cur != prev {
+			return cur, nil // another batch minted past prev between the check above and here
+		}
+		// Mint without the mutex held (a network round-trip); singleflight
+		// guarantees only one goroutine runs this at a time for this generation.
+		tok, exp, mintErr := s.refresh()
+		if mintErr != nil {
+			return "", mintErr
+		}
+		s.mu.Lock()
+		s.token = tok
+		s.expiresAt = exp
+		s.mu.Unlock()
+		return tok, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}

--- a/internal/clienttoken/source_test.go
+++ b/internal/clienttoken/source_test.go
@@ -1,0 +1,263 @@
+package clienttoken
+
+import (
+	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNeedsRefresh(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+		want      bool
+	}{
+		{"zero expiry (static token / open server) never refreshes", time.Time{}, false},
+		{"far-future expiry does not refresh", now.Add(24 * time.Hour), false},
+		{"within the refresh window refreshes", now.Add(time.Hour), true},
+		{"exactly at the window edge refreshes", now.Add(tokenRefreshWindow), true},
+		{"expired refreshes", now.Add(-time.Minute), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := needsRefresh(tt.expiresAt, now); got != tt.want {
+				t.Errorf("needsRefresh = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// countingRefresh returns a refresh callback that mints "tokN" tokens and counts
+// invocations.
+func countingRefresh(count *int32, ttl time.Duration) func() (string, time.Time, error) {
+	return func() (string, time.Time, error) {
+		n := atomic.AddInt32(count, 1)
+		return "tok" + strconv.Itoa(int(n)), time.Now().Add(ttl), nil
+	}
+}
+
+func TestStaticSourceNeverMints(t *testing.T) {
+	s := Static("static-tok")
+	if s.Refreshable() {
+		t.Error("static source must not be refreshable")
+	}
+	if s.Token() != "static-tok" {
+		t.Errorf("Token = %q, want static-tok", s.Token())
+	}
+	s.EnsureFresh() // no-op
+	if s.Token() != "static-tok" {
+		t.Errorf("EnsureFresh mutated a static token: %q", s.Token())
+	}
+	tok, err := s.Refresh("static-tok")
+	if !errors.Is(err, ErrStatic) {
+		t.Errorf("Refresh on static: err = %v, want ErrStatic", err)
+	}
+	if tok != "" && tok != "static-tok" {
+		t.Errorf("Refresh on static returned unexpected token %q", tok)
+	}
+}
+
+func TestEnsureFreshWithinWindowMintsOnce(t *testing.T) {
+	var count int32
+	// Expiry inside the window ⇒ EnsureFresh should mint.
+	s := New("old", time.Now().Add(time.Hour), countingRefresh(&count, 24*time.Hour))
+	s.EnsureFresh()
+	if got := atomic.LoadInt32(&count); got != 1 {
+		t.Fatalf("mint count = %d, want 1", got)
+	}
+	if s.Token() != "tok1" {
+		t.Errorf("token = %q, want tok1", s.Token())
+	}
+	// Now far from expiry ⇒ a second EnsureFresh must NOT mint again.
+	s.EnsureFresh()
+	if got := atomic.LoadInt32(&count); got != 1 {
+		t.Errorf("mint count = %d after fresh EnsureFresh, want 1 (no re-mint)", got)
+	}
+}
+
+func TestEnsureFreshFarFromExpiryDoesNotMint(t *testing.T) {
+	var count int32
+	s := New("old", time.Now().Add(24*time.Hour), countingRefresh(&count, 24*time.Hour))
+	s.EnsureFresh()
+	if got := atomic.LoadInt32(&count); got != 0 {
+		t.Errorf("mint count = %d, want 0 (far from expiry)", got)
+	}
+	if s.Token() != "old" {
+		t.Errorf("token = %q, want old (unchanged)", s.Token())
+	}
+}
+
+func TestEnsureFreshZeroExpiryDoesNotMint(t *testing.T) {
+	var count int32
+	// Refreshable but zero expiry: proactive refresh must not fire.
+	s := New("old", time.Time{}, countingRefresh(&count, 24*time.Hour))
+	s.EnsureFresh()
+	if got := atomic.LoadInt32(&count); got != 0 {
+		t.Errorf("mint count = %d, want 0 (zero expiry)", got)
+	}
+}
+
+func TestRefreshMintsAndUpdatesExpiry(t *testing.T) {
+	var count int32
+	exp := time.Now().Add(24 * time.Hour)
+	s := New("old", time.Now().Add(time.Hour), func() (string, time.Time, error) {
+		atomic.AddInt32(&count, 1)
+		return "new", exp, nil
+	})
+	tok, err := s.Refresh("old")
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if tok != "new" || s.Token() != "new" {
+		t.Errorf("token = %q / %q, want new", tok, s.Token())
+	}
+	if !s.ExpiresAt().Equal(exp) {
+		t.Errorf("expiry = %v, want %v (updated on refresh)", s.ExpiresAt(), exp)
+	}
+	if got := atomic.LoadInt32(&count); got != 1 {
+		t.Errorf("mint count = %d, want 1", got)
+	}
+}
+
+func TestRefreshGenerationAware(t *testing.T) {
+	var count int32
+	s := New("old", time.Now().Add(time.Hour), countingRefresh(&count, 24*time.Hour))
+	// First 401 with prev=old ⇒ mints (token becomes tok1).
+	if _, err := s.Refresh("old"); err != nil {
+		t.Fatal(err)
+	}
+	// A second, stale 401 that still thinks the token is "old" must NOT re-mint;
+	// it should observe the already-advanced token.
+	tok, err := s.Refresh("old")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok != "tok1" {
+		t.Errorf("stale Refresh returned %q, want the current tok1", tok)
+	}
+	if got := atomic.LoadInt32(&count); got != 1 {
+		t.Errorf("mint count = %d, want 1 (generation-aware, no double mint)", got)
+	}
+}
+
+func TestRefreshError(t *testing.T) {
+	sentinel := errors.New("mint boom")
+	s := New("old", time.Now().Add(time.Hour), func() (string, time.Time, error) {
+		return "", time.Time{}, sentinel
+	})
+	if _, err := s.Refresh("old"); !errors.Is(err, sentinel) {
+		t.Errorf("Refresh err = %v, want the mint error", err)
+	}
+	if s.Token() != "old" {
+		t.Errorf("token = %q, want old (unchanged after a failed mint)", s.Token())
+	}
+}
+
+// TestRefreshConcurrentCoalesces fires many goroutines that all 401 with the same
+// prev token; singleflight + the generation check must yield exactly one mint.
+// Run with -race for the concurrency guarantee.
+func TestRefreshConcurrentCoalesces(t *testing.T) {
+	var count int32
+	release := make(chan struct{})
+	s := New("old", time.Now().Add(time.Hour), func() (string, time.Time, error) {
+		atomic.AddInt32(&count, 1)
+		<-release // hold the mint open so concurrent callers pile onto singleflight
+		return "new", time.Now().Add(24 * time.Hour), nil
+	})
+
+	const n = 16
+	var wg sync.WaitGroup
+	toks := make([]string, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			tok, err := s.Refresh("old")
+			if err != nil {
+				t.Errorf("goroutine %d: %v", i, err)
+				return
+			}
+			toks[i] = tok
+		}(i)
+	}
+	// Let the goroutines enter Refresh, then release the single in-flight mint.
+	time.Sleep(20 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&count); got != 1 {
+		t.Errorf("mint count = %d, want 1 (coalesced)", got)
+	}
+	for i, tok := range toks {
+		if tok != "new" {
+			t.Errorf("goroutine %d got %q, want new", i, tok)
+		}
+	}
+}
+
+// TestRefreshDifferentGenerationsDoNotCoalesce proves a stale-generation caller
+// cannot starve a current-generation mint. While a current-gen mint (prev==cur)
+// is in flight, a stale caller (prev != cur) must return the current token
+// immediately without blocking on — or coalescing with — that mint. (This fails
+// against a constant singleflight key, which would coalesce the two.)
+func TestRefreshDifferentGenerationsDoNotCoalesce(t *testing.T) {
+	var count int32
+	var once sync.Once
+	mintStarted := make(chan struct{})
+	release := make(chan struct{})
+	s := New("cur", time.Now().Add(time.Hour), func() (string, time.Time, error) {
+		atomic.AddInt32(&count, 1)
+		once.Do(func() { close(mintStarted) })
+		<-release
+		return "minted", time.Now().Add(24 * time.Hour), nil
+	})
+
+	curDone := make(chan string, 1)
+	go func() { tok, _ := s.Refresh("cur"); curDone <- tok }() // current gen → mints (blocks)
+	<-mintStarted                                              // mint is in flight
+
+	staleDone := make(chan string, 1)
+	go func() { tok, _ := s.Refresh("stale"); staleDone <- tok }() // different gen → must not coalesce
+	select {
+	case tok := <-staleDone:
+		if tok != "cur" {
+			t.Errorf("stale caller got %q, want cur (no mint, no coalesce)", tok)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stale caller blocked on the in-flight current-gen mint — generations coalesced")
+	}
+
+	close(release)
+	if tok := <-curDone; tok != "minted" {
+		t.Errorf("current caller got %q, want minted", tok)
+	}
+	if got := atomic.LoadInt32(&count); got != 1 {
+		t.Errorf("mint count = %d, want 1", got)
+	}
+}
+
+// TestEnsureFreshAndRefreshRace exercises proactive + reactive paths together
+// under -race with no assertion beyond "no data race / no panic".
+func TestEnsureFreshAndRefreshRace(t *testing.T) {
+	var count int32
+	s := New("old", time.Now().Add(time.Hour), countingRefresh(&count, time.Hour))
+	var wg sync.WaitGroup
+	for i := 0; i < 24; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				s.EnsureFresh()
+			} else {
+				_, _ = s.Refresh(s.Token())
+			}
+			_ = s.Token()
+			_ = s.ExpiresAt()
+		}(i)
+	}
+	wg.Wait()
+}

--- a/internal/tunnels/connect.go
+++ b/internal/tunnels/connect.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/charliek/shed/internal/clienttoken"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/servertls"
 	"github.com/charliek/shed/internal/vmutil"
@@ -31,20 +32,74 @@ type ConnectTarget struct {
 // ConnectClient dials shed VMs via the shed-server Connect API.
 type ConnectClient struct {
 	target ConnectTarget
+	// source, when non-nil, supplies the bearer token and transparently re-mints
+	// it (proactively before expiry, reactively on a 401) so a long-lived tunnel
+	// survives the token TTL. nil ⇒ the static target.Token (legacy/plain path).
+	source *clienttoken.Source
 }
 
-// NewConnectClient creates a new Connect API client for the given target.
-func NewConnectClient(target ConnectTarget) *ConnectClient {
-	return &ConnectClient{target: target}
+// NewConnectClient creates a Connect API client for the given target. A non-nil
+// source makes the client self-refreshing; nil uses the static target.Token
+// (and no token at all for the plain/legacy path).
+func NewConnectClient(target ConnectTarget, source *clienttoken.Source) *ConnectClient {
+	return &ConnectClient{target: target, source: source}
+}
+
+// authToken returns the bearer token to send: the live token from the refreshing
+// source when present, else the static target.Token. It never returns a token for
+// an unpinned (plain-TCP) target — a bearer token must only travel over the
+// pinned-TLS connection, never plaintext — so a misconfigured source can't leak
+// one over the legacy path.
+func (c *ConnectClient) authToken() string {
+	if c.target.TLSPin == "" {
+		return ""
+	}
+	if c.source != nil {
+		return c.source.Token()
+	}
+	return c.target.Token
 }
 
 // Dial opens a TCP tunnel to a shed VM port via the Connect API. It performs an
 // HTTP upgrade handshake and returns the underlying connection (over pinned TLS
-// when the target is pinned).
+// when the target is pinned). When the client has a refreshing source, it
+// re-mints the token proactively before dialing and, on a 401, once reactively
+// before re-dialing — so a tunnel outlives the control-token TTL.
 func (c *ConnectClient) Dial(ctx context.Context, shedName string, port uint16) (net.Conn, error) {
-	conn, err := c.dial(ctx)
+	if c.source != nil {
+		c.source.EnsureFresh() // proactive: re-mint if within the expiry window
+	}
+	sent := c.authToken()
+	conn, status, err := c.attemptDial(ctx, shedName, port, sent)
 	if err != nil {
 		return nil, err
+	}
+	// A control token can expire mid-tunnel: on a 401, re-mint once and re-dial
+	// from scratch (the raw upgrade connection can't be reused for a retry).
+	if status == http.StatusUnauthorized && c.source != nil && c.source.Refreshable() {
+		if _, rerr := c.source.Refresh(sent); rerr != nil {
+			return nil, fmt.Errorf("connect API returned 401 and token re-mint failed: %w", rerr)
+		}
+		// Re-read through authToken so the retry re-applies the plaintext guard
+		// (never a bearer over an unpinned connection) rather than the raw token.
+		if conn, status, err = c.attemptDial(ctx, shedName, port, c.authToken()); err != nil {
+			return nil, err
+		}
+	}
+	if status != http.StatusSwitchingProtocols {
+		return nil, fmt.Errorf("connect API returned HTTP %d (expected 101)", status)
+	}
+	return conn, nil
+}
+
+// attemptDial performs a single dial + Connect upgrade with the given bearer
+// token. On a 101 it returns the established connection and status 101; on any
+// other HTTP status it closes the connection and returns (nil, status, nil); a
+// transport/handshake/cancellation error returns (nil, 0, err).
+func (c *ConnectClient) attemptDial(ctx context.Context, shedName string, port uint16, token string) (net.Conn, int, error) {
+	conn, err := c.dial(ctx)
+	if err != nil {
+		return nil, 0, err
 	}
 
 	// The upgrade write + http.ReadResponse below don't honor ctx on their own,
@@ -58,16 +113,16 @@ func (c *ConnectClient) Dial(ctx context.Context, shedName string, port uint16) 
 	path := fmt.Sprintf("/api/sheds/%s/connect/%d", shedName, port)
 	var req strings.Builder
 	fmt.Fprintf(&req, "GET %s HTTP/1.1\r\nHost: %s\r\nConnection: Upgrade\r\nUpgrade: shed-tcp\r\n", path, c.target.Addr)
-	if c.target.Token != "" {
-		fmt.Fprintf(&req, "Authorization: Bearer %s\r\n", c.target.Token)
+	if token != "" {
+		fmt.Fprintf(&req, "Authorization: Bearer %s\r\n", token)
 	}
 	req.WriteString("\r\n")
 	if _, err := conn.Write([]byte(req.String())); err != nil {
 		conn.Close()
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return nil, ctxErr // watcher closed conn on cancel; report cancellation, not a write error
+			return nil, 0, ctxErr // watcher closed conn on cancel; report cancellation, not a write error
 		}
-		return nil, fmt.Errorf("send upgrade request: %w", err)
+		return nil, 0, fmt.Errorf("send upgrade request: %w", err)
 	}
 
 	// Read the response.
@@ -76,9 +131,9 @@ func (c *ConnectClient) Dial(ctx context.Context, shedName string, port uint16) 
 	if err != nil {
 		conn.Close()
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return nil, ctxErr // watcher closed conn on cancel; report cancellation, not a read error
+			return nil, 0, ctxErr // watcher closed conn on cancel; report cancellation, not a read error
 		}
-		return nil, fmt.Errorf("read upgrade response: %w", err)
+		return nil, 0, fmt.Errorf("read upgrade response: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusSwitchingProtocols {
@@ -86,7 +141,7 @@ func (c *ConnectClient) Dial(ctx context.Context, shedName string, port uint16) 
 			resp.Body.Close()
 		}
 		conn.Close()
-		return nil, fmt.Errorf("connect API returned HTTP %d (expected 101)", resp.StatusCode)
+		return nil, resp.StatusCode, nil
 	}
 
 	// Stop the cancel-watcher before handing the conn back so it can't close the
@@ -95,10 +150,10 @@ func (c *ConnectClient) Dial(ctx context.Context, shedName string, port uint16) 
 	stopWatch()
 	if ctx.Err() != nil {
 		conn.Close()
-		return nil, ctx.Err()
+		return nil, 0, ctx.Err()
 	}
 
-	return &vmutil.BufferedConn{Conn: conn, Reader: reader}, nil
+	return &vmutil.BufferedConn{Conn: conn, Reader: reader}, http.StatusSwitchingProtocols, nil
 }
 
 // Probe verifies the tunnel can authenticate to the Connect API without
@@ -117,6 +172,9 @@ func (c *ConnectClient) Dial(ctx context.Context, shedName string, port uint16) 
 // The caller bounds the probe with ctx's deadline (there is no internal
 // timeout), so a stalled server can't wedge startup.
 func (c *ConnectClient) Probe(ctx context.Context, shedName string) error {
+	if c.source != nil {
+		c.source.EnsureFresh() // probe with a fresh token so a near-expiry one doesn't fail startup
+	}
 	scheme := "http"
 	if c.target.TLSPin != "" {
 		scheme = "https"
@@ -127,8 +185,8 @@ func (c *ConnectClient) Probe(ctx context.Context, shedName string) error {
 	if err != nil {
 		return fmt.Errorf("build connect probe request: %w", err)
 	}
-	if c.target.Token != "" {
-		req.Header.Set("Authorization", "Bearer "+c.target.Token)
+	if tok := c.authToken(); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
 	}
 
 	client := &http.Client{Transport: transport}

--- a/internal/tunnels/connect_test.go
+++ b/internal/tunnels/connect_test.go
@@ -7,9 +7,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/charliek/shed/internal/clienttoken"
 	"github.com/charliek/shed/internal/config"
 	"github.com/charliek/shed/internal/servertls"
 )
@@ -68,7 +71,7 @@ func TestConnectClientDialTLSPinned(t *testing.T) {
 	defer srv.Close()
 
 	pin := servertls.Fingerprint(srv.Certificate().Raw)
-	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin, Token: token})
+	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin, Token: token}, nil)
 
 	conn, err := client.Dial(context.Background(), "myshed", 8080)
 	if err != nil {
@@ -82,7 +85,7 @@ func TestConnectClientDialWrongPin(t *testing.T) {
 	srv := httptest.NewTLSServer(upgradeEchoHandler(t, ""))
 	defer srv.Close()
 
-	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: "sha256:" + strings.Repeat("00", 32)})
+	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: "sha256:" + strings.Repeat("00", 32)}, nil)
 	if _, err := client.Dial(context.Background(), "myshed", 8080); err == nil {
 		t.Error("a wrong pin must fail the TLS handshake")
 	}
@@ -95,7 +98,7 @@ func TestConnectClientDialMissingToken(t *testing.T) {
 
 	pin := servertls.Fingerprint(srv.Certificate().Raw)
 	// Pinned but no token → the server rejects the upgrade (not 101).
-	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin})
+	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin}, nil)
 	if _, err := client.Dial(context.Background(), "myshed", 8080); err == nil {
 		t.Error("a missing token must be rejected by the connect route")
 	}
@@ -106,13 +109,115 @@ func TestConnectClientDialPlain(t *testing.T) {
 	srv := httptest.NewServer(upgradeEchoHandler(t, ""))
 	defer srv.Close()
 
-	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv)})
+	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv)}, nil)
 	conn, err := client.Dial(context.Background(), "myshed", 8080)
 	if err != nil {
 		t.Fatalf("Dial plain: %v", err)
 	}
 	defer conn.Close()
 	roundTrip(t, conn)
+}
+
+// TestConnectClientDialRefreshesOn401 proves a tunnel with a refreshing source
+// survives token expiry: the first upgrade (stale token) 401s, the client
+// re-mints once and re-dials, and the second upgrade (fresh token) reaches 101.
+func TestConnectClientDialRefreshesOn401(t *testing.T) {
+	const newTok = "shed_control_new"
+	var mints int32
+	srv := httptest.NewTLSServer(upgradeEchoHandler(t, newTok)) // only "Bearer new" upgrades
+	defer srv.Close()
+
+	pin := servertls.Fingerprint(srv.Certificate().Raw)
+	src := clienttoken.New("shed_control_old", time.Now().Add(24*time.Hour), func() (string, time.Time, error) {
+		atomic.AddInt32(&mints, 1)
+		return newTok, time.Now().Add(24 * time.Hour), nil
+	})
+	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin}, src)
+
+	conn, err := client.Dial(context.Background(), "myshed", 8080)
+	if err != nil {
+		t.Fatalf("Dial should succeed after 401 → refresh → re-dial: %v", err)
+	}
+	defer conn.Close()
+	roundTrip(t, conn)
+	if got := atomic.LoadInt32(&mints); got != 1 {
+		t.Errorf("mints = %d, want 1 (one re-mint on the 401)", got)
+	}
+}
+
+// TestConnectClientConcurrentDialsCoalesceRefresh drives the real tunnel-layer
+// concurrency: N port tunnels share one ConnectClient/source, all 401 with the
+// stale token at once, and must coalesce to a single re-mint. Run with -race.
+func TestConnectClientConcurrentDialsCoalesceRefresh(t *testing.T) {
+	const newTok = "shed_control_new"
+	var mints int32
+	srv := httptest.NewTLSServer(upgradeEchoHandler(t, newTok))
+	defer srv.Close()
+
+	pin := servertls.Fingerprint(srv.Certificate().Raw)
+	src := clienttoken.New("shed_control_old", time.Now().Add(24*time.Hour), func() (string, time.Time, error) {
+		atomic.AddInt32(&mints, 1)
+		return newTok, time.Now().Add(24 * time.Hour), nil
+	})
+	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin}, src)
+
+	const n = 12
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn, err := client.Dial(context.Background(), "myshed", 8080)
+			if err != nil {
+				t.Errorf("concurrent Dial: %v", err)
+				return
+			}
+			roundTrip(t, conn)
+			_ = conn.Close()
+		}()
+	}
+	wg.Wait()
+	if got := atomic.LoadInt32(&mints); got != 1 {
+		t.Errorf("mints = %d across %d concurrent dials, want 1 (coalesced)", got, n)
+	}
+}
+
+// TestConnectClientPlainNeverSendsToken: the unpinned/plain path must not put a
+// bearer token on the wire even when a token-bearing source is (mis)configured.
+func TestConnectClientPlainNeverSendsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("plain path sent Authorization %q; a token must never travel over plaintext", auth)
+		}
+		http.Error(w, "no upgrade", http.StatusOK) // any non-101; we only care about the header
+	}))
+	defer srv.Close()
+
+	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv)}, clienttoken.Static("must-not-be-sent"))
+	_, _ = client.Dial(context.Background(), "myshed", 8080) // fails (non-101); that's fine
+}
+
+// TestConnectClientPlainNeverSendsTokenOnRetry: even the 401 re-mint+re-dial path
+// must not put a bearer on the wire for an unpinned target (a refreshable source
+// exercises the retry, unlike the Static source above).
+func TestConnectClientPlainNeverSendsTokenOnRetry(t *testing.T) {
+	var sawAuth int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			atomic.StoreInt32(&sawAuth, 1)
+		}
+		http.Error(w, "unauthorized", http.StatusUnauthorized) // always 401 → drives refresh + retry
+	}))
+	defer srv.Close()
+
+	src := clienttoken.New("old", time.Now().Add(24*time.Hour), func() (string, time.Time, error) {
+		return "new", time.Now().Add(24 * time.Hour), nil
+	})
+	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv)}, src) // plain + refreshable
+	_, _ = client.Dial(context.Background(), "myshed", 8080)          // fails after retry; that's fine
+	if atomic.LoadInt32(&sawAuth) == 1 {
+		t.Error("plain path sent a bearer token on the 401 retry; a token must never travel over plaintext")
+	}
 }
 
 // probeStatusHandler asserts the probe targets the exact connect/0 route and
@@ -157,7 +262,7 @@ func TestConnectProbeStatusHandling(t *testing.T) {
 			srv := httptest.NewTLSServer(probeStatusHandler(t, "", tt.status))
 			defer srv.Close()
 			pin := servertls.Fingerprint(srv.Certificate().Raw)
-			client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin, Token: token})
+			client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin, Token: token}, nil)
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
 			err := client.Probe(ctx, "myshed")
@@ -180,7 +285,7 @@ func TestConnectProbeGeneric400(t *testing.T) {
 	}))
 	defer srv.Close()
 	pin := servertls.Fingerprint(srv.Certificate().Raw)
-	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin, Token: "t"})
+	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin, Token: "t"}, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	if err := client.Probe(ctx, "myshed"); err == nil {
@@ -198,10 +303,10 @@ func TestConnectProbeToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	if err := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin, Token: token}).Probe(ctx, "myshed"); err != nil {
+	if err := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin, Token: token}, nil).Probe(ctx, "myshed"); err != nil {
 		t.Errorf("probe with valid token: %v", err)
 	}
-	if err := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin}).Probe(ctx, "myshed"); err == nil {
+	if err := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin}, nil).Probe(ctx, "myshed"); err == nil {
 		t.Error("probe without a token must fail (401)")
 	}
 }
@@ -212,7 +317,7 @@ func TestConnectProbePlain(t *testing.T) {
 	defer srv.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	if err := NewConnectClient(ConnectTarget{Addr: addrOf(srv)}).Probe(ctx, "myshed"); err != nil {
+	if err := NewConnectClient(ConnectTarget{Addr: addrOf(srv)}, nil).Probe(ctx, "myshed"); err != nil {
 		t.Errorf("plain probe: %v", err)
 	}
 }
@@ -220,7 +325,7 @@ func TestConnectProbePlain(t *testing.T) {
 func TestConnectProbeWrongPin(t *testing.T) {
 	srv := httptest.NewTLSServer(probeStatusHandler(t, "", http.StatusBadRequest))
 	defer srv.Close()
-	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: "sha256:" + strings.Repeat("00", 32), Token: "t"})
+	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: "sha256:" + strings.Repeat("00", 32), Token: "t"}, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	if err := client.Probe(ctx, "myshed"); err == nil {
@@ -232,7 +337,7 @@ func TestConnectProbeUnreachable(t *testing.T) {
 	srv := httptest.NewServer(probeStatusHandler(t, "", http.StatusBadRequest))
 	addr := addrOf(srv)
 	srv.Close() // nothing listening now
-	client := NewConnectClient(ConnectTarget{Addr: addr})
+	client := NewConnectClient(ConnectTarget{Addr: addr}, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	if err := client.Probe(ctx, "myshed"); err == nil {
@@ -249,7 +354,7 @@ func TestConnectProbeContextDeadline(t *testing.T) {
 	defer close(block) // LIFO: runs before srv.Close() so the handler returns and Close() doesn't hang
 
 	pin := servertls.Fingerprint(srv.Certificate().Raw)
-	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin, Token: "t"})
+	client := NewConnectClient(ConnectTarget{Addr: addrOf(srv), TLSPin: pin, Token: "t"}, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	if err := client.Probe(ctx, "myshed"); err == nil {

--- a/internal/tunnels/manager.go
+++ b/internal/tunnels/manager.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"syscall"
 	"time"
+
+	"github.com/charliek/shed/internal/clienttoken"
 )
 
 // Manager handles tunnel lifecycle operations.
@@ -52,8 +54,10 @@ func (m *Manager) State() *TunnelState {
 
 // StartTunnels starts tunnels for all port mappings using the Connect API.
 // Returns the active tunnels that the caller should manage (stop on shutdown).
-func (m *Manager) StartTunnels(target ConnectTarget, shedName string, ports []PortMapping) ([]*Tunnel, error) {
-	client := NewConnectClient(target)
+// A non-nil source makes every tunnel self-refresh its token (all ports share
+// the one client/source, so concurrent re-mints coalesce).
+func (m *Manager) StartTunnels(target ConnectTarget, source *clienttoken.Source, shedName string, ports []PortMapping) ([]*Tunnel, error) {
+	client := NewConnectClient(target, source)
 	var tunnels []*Tunnel
 
 	for _, pm := range ports {

--- a/internal/tunnels/tunnel_test.go
+++ b/internal/tunnels/tunnel_test.go
@@ -31,7 +31,7 @@ func assertStopReturns(t *testing.T, tun *Tunnel) {
 // conn is returned for the caller to exercise and is closed via t.Cleanup.
 func startTunnel(t *testing.T, srv *httptest.Server) (*Tunnel, net.Conn) {
 	t.Helper()
-	tun := NewTunnel(NewConnectClient(ConnectTarget{Addr: addrOf(srv)}), "myshed", PortMapping{Local: 0, Remote: 8080})
+	tun := NewTunnel(NewConnectClient(ConnectTarget{Addr: addrOf(srv)}, nil), "myshed", PortMapping{Local: 0, Remote: 8080})
 	if err := tun.Start(); err != nil {
 		t.Fatalf("start tunnel: %v", err)
 	}


### PR DESCRIPTION
Follow-ups to #237 (PR #238). Two latent issues surfaced during that fix; both are addressed here in phased commits, each run through build/test/lint → /simplify → /codex:rescue.

## 1. `/api/egress/stream` was mis-scoped (server-side)
After #237, the egress audit SSE stream fell to the control-only default, but its only consumer is the host-agent, which holds a **credentials** token → it would 403. Now it accepts **control or credentials** (like the Connect tunnel); the credential bus stays credentials-only and every other `/api/egress/*` route stays control-only.

The dual-scope grant is **GET-only** — and that matters: `chi` falls through `/api/egress/stream` to the `/{name}` route for non-GET methods (verified), so a path-only predicate would have let a credentials token run `POST`/`DELETE /api/egress/stream` against the control-only egress mutators for a shed literally named `stream`. (Caught by the review pass.)

## 2. Long-lived tunnels couldn't survive the token TTL (client-side)
A background tunnel captured its control token once at daemon start and never refreshed it, so after the 24h `token_ttl` every new connection 401'd and reset. Rather than bolt a third copy of refresh logic onto the tunnel, this unifies token refresh into a new shared type used by **both** the CLI API client and the tunnel:

- **`internal/clienttoken.Source`** — a concurrency-safe token holder with an injected refresh callback. `EnsureFresh()` (proactive, within a 2h window) + `Refresh(prev)` (reactive on 401), generation-aware and singleflight-coalesced so concurrent callers mint at most once; a static token never mints. The mint runs outside the lock.
- **APIClient** now delegates to a `Source`, collapsing its two duplicated on-401 retry sites into one helper (behavior preserved; `refresh_test.go` migrated).
- **The tunnel `ConnectClient`** takes an optional `Source`: `Dial` re-mints proactively and, on a 401, once reactively before re-dialing. All ports of a shed share one client/source (concurrent re-mints coalesce). Its source is **non-persisting** and seeded from the client's fresh token, so a multi-day daemon never rewrites `~/.shed/config.yaml`. A bearer token is never sent over an unpinned/plaintext connection (guarded on both the first attempt and the retry).

## Commits
1. `fix(api)` — egress stream accepts control or credentials (GET-only)
2. `feat(clienttoken)` — shared self-refreshing `Source` (+ tests)
3. `refactor(cli)` — APIClient delegates to `clienttoken.Source` (de-dups the two 401 sites; behavior preserved)
4. `fix(tunnel)` — tunnel adopts the Source so a background tunnel survives the TTL
5. `docs` — secure-mode tunnel probe + refresh, with the SSH-from-daemon caveat

## Testing

**Unit** — `make build/test/lint` green. New/updated coverage: the egress auth matrix (incl. the `POST`/`DELETE /api/egress/stream` guard); the `Source` (proactive/reactive/static/error, generation-awareness, cross-generation non-coalescing, concurrent single-mint under `-race`); APIClient migration (static-no-retry, streaming-delete 401 refresh, on-401 sites share the helper); tunnel Dial 401→refresh→re-dial, concurrent multi-dial coalescing (`-race`), and plaintext-never-sends-a-token on both the first attempt and the retry.

**Live** — validated end-to-end against a secure `shed-server` built from this branch (`token_ttl: 90s`), plus the pre-#237 `localmac-dev`:

- **Startup probe fails loudly on a too-old server** — on pre-#237 `localmac-dev`, `shed tunnels start` failed *before binding a listener* with `connect probe: tunnel token scope not accepted on the Connect route (403); the shed-server may be too old to accept a control token` (not a silent RST).
- **Tunnel end-to-end** on the #237 server — probe passed, control token accepted, and the guest's SSH banner (`SSH-2.0-OpenSSH_9.6p1`) forwarded through `localhost → Connect API → shed:22`.
- **Survives the TTL (the core fix)** — at ~106s (> the 90s TTL) with no intervening activity, the tunnel still served. The server log shows the detached daemon opening a `_bootstrap` SSH re-mint immediately before `Connect API: tunnel …:22 established`; the tunnel daemon log is empty (no auth errors).
- **Non-persisting daemon** — `~/.shed/config.yaml` mtime predated the daemon's re-mint, so it did not rewrite config.
- **CLI Source refresh** — the same 90s-TTL server logged ~22 `_bootstrap` re-mints while every foreground command succeeded across expiry.

Caveat (documented): the daemon re-mints non-interactively via SSH `BatchMode`, so it needs a passphrase-less / agent-loaded key. A VZ agent-boot quirk (unrelated to these changes — an offset vsock port) initially blocked the shed create; reverting to the default vsock ports fixed it.

## Out of scope (future)
- `shed tunnels list` last-connect-error column (a richer "why did it fail" surface).
- Threading `ctx` through the refresh callback (needs `sdkbootstrap.Run` cancellation first).
- An automated live short-TTL tunnel-refresh integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoHk27xjf1khfuijtcru6u


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added self-refreshing bearer tokens for secure, TLS-pinned tunnel connections, including background daemon runs.
  * Proactive authentication probing for secure tunnel startup before binding listeners.
* **Bug Fixes**
  * Centralized and standardized one-time 401 refresh-and-retry behavior for API calls and streaming delete flows.
  * Prevented incorrect-scope access patterns for egress stream and tunnel endpoints.
* **Documentation**
  * Updated API/security/tunnel references for secure mode behavior and which endpoints accept control vs credentials scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->