### PR TITLE
fix: keep the guest clock correct across host sleep (#236)

### DIFF
--- a/cmd/shed-agent/clocksync.go
+++ b/cmd/shed-agent/clocksync.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Clock-sync keeps the guest wall clock correct across host sleep. A VZ guest's
+// CLOCK_REALTIME is derived from a counter (arch_sys_counter) that freezes while
+// the host sleeps: the guest is paused externally and never sees a resume event,
+// so neither the kernel nor systemd-timesyncd re-syncs it on wake, and shed-agent
+// keeps running (it doesn't restart). The host-backed RTC keeps real time across
+// the pause, so the agent periodically steps CLOCK_REALTIME forward to it. See
+// issue #236.
+//
+// The pure decision/parse logic lives here (untagged) so it unit-tests on macOS
+// under `make test`; the syscall glue, the loop, and the runtime tunables
+// (interval, threshold, sysfs path) live in clocksync_linux.go.
+
+// minPlausibleClock and maxPlausibleClock bound a sane current-era wall clock. An
+// RTC read outside this window is treated as garbage and never used to step the
+// clock: the floor rejects a zero/1970 read (which would jump the clock backward),
+// and the ceiling rejects a corrupted huge value (which would also overflow time
+// arithmetic — e.g. t.UnixNano(), defined only for ~years 1678-2262 — before
+// reaching the syscall). The window is intentionally wide; it only has to exclude
+// garbage. A time.Time cannot be a const.
+var (
+	minPlausibleClock = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	maxPlausibleClock = time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)
+)
+
+// shouldStepClock reports whether CLOCK_REALTIME should be stepped forward to the
+// host-backed RTC. Forward-only by design: the failure this fixes is the guest
+// clock freezing *behind* real time during host sleep. An ahead-of-real clock is
+// rare and is left to systemd-timesyncd (which steps both directions over the
+// network); forward-only avoids a large backward wall-clock jump disrupting build
+// tools, caches, or TLS validity. An RTC read outside [minPlausibleClock,
+// maxPlausibleClock) is rejected as garbage.
+func shouldStepClock(sys, rtc time.Time, threshold time.Duration) bool {
+	if !rtc.After(minPlausibleClock) || !rtc.Before(maxPlausibleClock) {
+		return false
+	}
+	return rtc.Sub(sys) > threshold
+}
+
+// readRTCFrom reads a Linux RTC `since_epoch` sysfs node (UTC epoch seconds) and
+// returns the wall-clock time it represents. ok=false on a missing/unreadable
+// node or non-positive/garbage contents — which is how a backend without an RTC
+// (Firecracker x86) self-disables the resync. Pure file read + parse (no
+// syscall), so it unit-tests on all platforms.
+func readRTCFrom(path string) (time.Time, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return time.Time{}, false
+	}
+	secs, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil || secs <= 0 {
+		return time.Time{}, false
+	}
+	return time.Unix(secs, 0).UTC(), true
+}
+
+// clockSyncOutcome records what one reconcile pass did, for logging and tests.
+type clockSyncOutcome struct {
+	rtcPresent bool
+	stepped    bool
+	from       time.Time // system clock before the step
+	to         time.Time // RTC time we stepped to
+	err        error     // non-nil if the step syscall failed
+}
+
+// reconcileClock performs one RTC->system reconcile pass using injected
+// dependencies, so the read -> decide -> step path is unit-testable without
+// touching the real clock. It reads the RTC, decides via shouldStepClock, and
+// steps if warranted, returning what it did.
+func reconcileClock(
+	now func() time.Time,
+	readRTC func() (time.Time, bool),
+	step func(time.Time) error,
+	threshold time.Duration,
+) clockSyncOutcome {
+	rtc, ok := readRTC()
+	if !ok {
+		return clockSyncOutcome{rtcPresent: false}
+	}
+	sys := now()
+	if !shouldStepClock(sys, rtc, threshold) {
+		return clockSyncOutcome{rtcPresent: true}
+	}
+	if err := step(rtc); err != nil {
+		return clockSyncOutcome{rtcPresent: true, from: sys, to: rtc, err: err}
+	}
+	return clockSyncOutcome{rtcPresent: true, stepped: true, from: sys, to: rtc}
+}

--- a/cmd/shed-agent/clocksync_linux.go
+++ b/cmd/shed-agent/clocksync_linux.go
@@ -59,6 +59,12 @@ func stepClock(t time.Time) error {
 // (rare — only after a sleep) are always logged; repeated step errors are
 // deduplicated by message.
 func (s *Server) runClockSync(ctx context.Context) {
+	// One startup line so an operator can confirm the loop is live: with
+	// transition-only logging below, a healthy VZ that hasn't slept would
+	// otherwise log nothing until the first correction.
+	log.Printf("clock-sync: started (checking the host RTC every %s, stepping when drift > %s)",
+		defaultClockSyncInterval, defaultClockSyncThreshold)
+
 	rtcWasPresent := true // VZ's normal state; flips + logs once if absent (FC)
 	var lastErr string
 

--- a/cmd/shed-agent/clocksync_linux.go
+++ b/cmd/shed-agent/clocksync_linux.go
@@ -1,0 +1,102 @@
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// defaultClockSyncInterval is how often the agent compares the system clock
+	// to the RTC. Independent of defaultClockSyncThreshold (they happen to share
+	// the same value).
+	defaultClockSyncInterval = 30 * time.Second
+
+	// defaultClockSyncThreshold is the minimum system-vs-RTC gap that triggers a
+	// step. It is deliberately large: with systemd-timesyncd running, normal
+	// operation keeps the two within a second, so a gap this size means the guest
+	// was paused. Keeping it well above any NTP-vs-RTC disagreement means the
+	// agent only handles the big post-sleep jump and never fights timesyncd's
+	// fine-grained discipline.
+	defaultClockSyncThreshold = 30 * time.Second
+
+	// rtcSinceEpochPath is the sysfs node exposing the RTC as UTC epoch seconds.
+	// Present on the VZ PL031 RTC; absent on Firecracker x86 (which emulates no
+	// RTC — its time is held by kvmclock), where readRTCFrom returns ok=false and
+	// the loop no-ops.
+	rtcSinceEpochPath = "/sys/class/rtc/rtc0/since_epoch"
+)
+
+// readRTC reads the host-backed RTC via the sysfs since_epoch node. Returns
+// ok=false where no RTC exists (Firecracker x86), which disables the resync.
+func readRTC() (time.Time, bool) {
+	return readRTCFrom(rtcSinceEpochPath)
+}
+
+// stepClock sets CLOCK_REALTIME to t. Requires CAP_SYS_TIME — shed-agent runs as
+// root (no User= in shed-agent.service). If that service is ever hardened with
+// User=/CapabilityBoundingSet=, CAP_SYS_TIME must be retained or this returns
+// EPERM and clock-sync goes inert. Callers only pass RTC times that cleared
+// shouldStepClock's plausibility window, so t.UnixNano() is safely in range.
+func stepClock(t time.Time) error {
+	ts := unix.NsecToTimespec(t.UnixNano())
+	return unix.ClockSettime(unix.CLOCK_REALTIME, &ts)
+}
+
+// runClockSync periodically steps the guest system clock forward to the
+// host-backed RTC, correcting the drift that accumulates while the host sleeps
+// (see clocksync.go for the why). It re-reads the RTC every tick so a
+// late-appearing RTC is still picked up, and no-ops cleanly where none exists.
+// Owned by the server: runs under s.wg/s.ctx and exits on ctx cancellation.
+//
+// Logging is transition-only to avoid journal spam on the tick cadence: the
+// "no RTC" line is logged once, when the RTC first reads absent; actual steps
+// (rare — only after a sleep) are always logged; repeated step errors are
+// deduplicated by message.
+func (s *Server) runClockSync(ctx context.Context) {
+	rtcWasPresent := true // VZ's normal state; flips + logs once if absent (FC)
+	var lastErr string
+
+	reconcile := func() {
+		out := reconcileClock(time.Now, readRTC, stepClock, defaultClockSyncThreshold)
+
+		if out.rtcPresent != rtcWasPresent {
+			if out.rtcPresent {
+				log.Printf("clock-sync: RTC present at %s; active", rtcSinceEpochPath)
+			} else {
+				log.Printf("clock-sync: no RTC at %s; idle (systemd-timesyncd handles drift)", rtcSinceEpochPath)
+			}
+			rtcWasPresent = out.rtcPresent
+		}
+
+		switch {
+		case out.stepped:
+			log.Printf("clock-sync: stepped clock forward %s (system %s -> RTC %s)",
+				out.to.Sub(out.from).Round(time.Second),
+				out.from.UTC().Format(time.RFC3339), out.to.UTC().Format(time.RFC3339))
+			lastErr = ""
+		case out.err != nil && out.err.Error() != lastErr:
+			log.Printf("clock-sync: failed to step clock to RTC %s: %v",
+				out.to.UTC().Format(time.RFC3339), out.err)
+			lastErr = out.err.Error()
+		}
+	}
+
+	reconcile() // immediate pass (covers an agent restart shortly after a sleep)
+
+	ticker := time.NewTicker(defaultClockSyncInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			reconcile()
+		}
+	}
+}

--- a/cmd/shed-agent/clocksync_test.go
+++ b/cmd/shed-agent/clocksync_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestShouldStepClock(t *testing.T) {
+	base := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	const threshold = 30 * time.Second
+
+	tests := []struct {
+		name string
+		sys  time.Time
+		rtc  time.Time
+		want bool
+	}{
+		{"system far behind RTC steps", base, base.Add(10 * time.Minute), true},
+		{"system just over threshold behind steps", base, base.Add(31 * time.Second), true},
+		{"system exactly at threshold does not step", base, base.Add(30 * time.Second), false},
+		{"system within threshold does not step", base, base.Add(5 * time.Second), false},
+		{"system ahead of RTC does not step (forward-only)", base, base.Add(-10 * time.Minute), false},
+		// RTC below the plausibility floor is rejected even though it is far
+		// "ahead" of an equally implausible system clock (proves the floor gates
+		// a would-be forward step, not just the direction check).
+		{"rtc below floor does not step", time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC), time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC), false},
+		{"rtc at floor does not step", minPlausibleClock.Add(-time.Hour), minPlausibleClock, false},
+		// RTC above the plausibility ceiling — a corrupted since_epoch that would
+		// otherwise be seen as "far ahead" and overflow time arithmetic — is
+		// rejected rather than stepped to.
+		{"rtc above ceiling does not step", base, maxPlausibleClock.Add(time.Hour), false},
+		{"rtc at an absurd future value does not step", base, time.Unix(1<<62, 0).UTC(), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldStepClock(tt.sys, tt.rtc, threshold); got != tt.want {
+				t.Errorf("shouldStepClock(sys=%v, rtc=%v) = %v, want %v", tt.sys, tt.rtc, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadRTCFrom(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantOK  bool
+		wantSec int64
+	}{
+		{"valid", write("valid", "1783058612"), true, 1783058612},
+		{"trailing newline", write("nl", "1783058612\n"), true, 1783058612}, // real sysfs always has one
+		{"surrounding whitespace", write("ws", "  1783058612 \n"), true, 1783058612},
+		{"empty", write("empty", ""), false, 0},
+		{"non-numeric", write("garbage", "not-a-number"), false, 0},
+		{"negative", write("neg", "-5"), false, 0},
+		{"zero", write("zero", "0"), false, 0},
+		{"overflow", write("of", "999999999999999999999999"), false, 0},
+		{"missing file", filepath.Join(dir, "does-not-exist"), false, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := readRTCFrom(tt.path)
+			if ok != tt.wantOK {
+				t.Fatalf("readRTCFrom(%s) ok = %v, want %v", tt.name, ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got.Unix() != tt.wantSec {
+				t.Errorf("readRTCFrom(%s) = %d, want %d", tt.name, got.Unix(), tt.wantSec)
+			}
+			if got.Location() != time.UTC {
+				t.Errorf("readRTCFrom(%s) location = %v, want UTC", tt.name, got.Location())
+			}
+		})
+	}
+}
+
+func TestReconcileClock(t *testing.T) {
+	sysTime := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	const threshold = 30 * time.Second
+	now := func() time.Time { return sysTime }
+
+	t.Run("no RTC is a no-op", func(t *testing.T) {
+		stepCalled := false
+		out := reconcileClock(now,
+			func() (time.Time, bool) { return time.Time{}, false },
+			func(time.Time) error { stepCalled = true; return nil },
+			threshold)
+		if out.rtcPresent || out.stepped || stepCalled {
+			t.Errorf("got %+v, stepCalled=%v; want no-op", out, stepCalled)
+		}
+	})
+
+	t.Run("within threshold present but no step", func(t *testing.T) {
+		stepCalled := false
+		out := reconcileClock(now,
+			func() (time.Time, bool) { return sysTime.Add(5 * time.Second), true },
+			func(time.Time) error { stepCalled = true; return nil },
+			threshold)
+		if !out.rtcPresent || out.stepped || stepCalled {
+			t.Errorf("got %+v, stepCalled=%v; want present, no step", out, stepCalled)
+		}
+	})
+
+	t.Run("far behind steps forward to the RTC time", func(t *testing.T) {
+		rtc := sysTime.Add(10 * time.Minute)
+		var steppedTo time.Time
+		out := reconcileClock(now,
+			func() (time.Time, bool) { return rtc, true },
+			func(to time.Time) error { steppedTo = to; return nil },
+			threshold)
+		if !out.stepped || !out.to.Equal(rtc) || !out.from.Equal(sysTime) {
+			t.Errorf("got %+v; want stepped from %v to %v", out, sysTime, rtc)
+		}
+		if !steppedTo.Equal(rtc) {
+			t.Errorf("step called with %v, want %v", steppedTo, rtc)
+		}
+	})
+
+	// Regression: a corrupted RTC that reads a huge, parseable value must not be
+	// stepped to (it would overflow the clock-set syscall / jump the clock wildly).
+	// The node reads fine, so rtcPresent stays true; the value is just rejected.
+	t.Run("implausibly-far-future RTC is present but not stepped to", func(t *testing.T) {
+		stepCalled := false
+		out := reconcileClock(now,
+			func() (time.Time, bool) { return maxPlausibleClock.Add(24 * time.Hour), true },
+			func(time.Time) error { stepCalled = true; return nil },
+			threshold)
+		if out.stepped || stepCalled {
+			t.Errorf("got %+v, stepCalled=%v; want no step for implausible RTC", out, stepCalled)
+		}
+		if !out.rtcPresent {
+			t.Error("got rtcPresent=false; want true (RTC readable, value out of range)")
+		}
+	})
+
+	t.Run("step error is reported, not swallowed", func(t *testing.T) {
+		rtc := sysTime.Add(10 * time.Minute)
+		wantErr := errors.New("boom")
+		out := reconcileClock(now,
+			func() (time.Time, bool) { return rtc, true },
+			func(time.Time) error { return wantErr },
+			threshold)
+		if out.stepped || !errors.Is(out.err, wantErr) {
+			t.Errorf("got %+v; want stepped=false, err=%v", out, wantErr)
+		}
+	})
+}

--- a/cmd/shed-agent/server.go
+++ b/cmd/shed-agent/server.go
@@ -183,6 +183,15 @@ func (s *Server) Start() error {
 		return fmt.Errorf("failed to start HTTP server: %w", err)
 	}
 
+	// Periodically re-sync the guest clock from the host-backed RTC. The VZ
+	// guest wall clock freezes across host sleep and is never corrected on wake
+	// (see runClockSync); no-ops where no RTC exists (Firecracker).
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.runClockSync(s.ctx)
+	}()
+
 	log.Printf("Listening on vsock ports: console=%d, message=%d, tcp_proxy=%d; HTTP on 127.0.0.1:%d",
 		s.consolePort, s.notifyPort, s.tcpProxyPort, s.httpPort)
 	return nil

--- a/docs/reference/vz-operations.md
+++ b/docs/reference/vz-operations.md
@@ -172,8 +172,9 @@ Verify inside a shed:
 
 ```bash
 timedatectl                                  # "NTP service: active"
-# After a host sleep, the agent logs the correction:
 sudo journalctl -u shed-agent | grep clock-sync
+# clock-sync: started (checking the host RTC every 30s, stepping when drift > 30s)
+# ...and after a host sleep, the correction:
 # clock-sync: stepped clock forward 2h3m0s (system ... -> RTC ...)
 ```
 

--- a/docs/reference/vz-operations.md
+++ b/docs/reference/vz-operations.md
@@ -161,6 +161,28 @@ ps aux | grep vfkit
 cat ~/Library/Application\ Support/shed/vz/instances/myproject/metadata.json
 ```
 
+## Time synchronization
+
+VZ guests keep their clock correct two ways:
+
+- **`systemd-timesyncd`** provides standard network time discipline (SNTP).
+- **`shed-agent`** periodically steps the system clock forward to the host-backed RTC. This covers host **sleep/suspend**: while the host sleeps, the paused guest's wall clock (`CLOCK_REALTIME`, derived from a frozen counter) falls behind real time and gets no resume event to correct it. The RTC keeps real time across the pause, so the agent re-syncs from it within ~30 s of a large drift — before `timesyncd`'s next network poll would. Without this, a guest resumed after a long sleep can be hours behind, which breaks AWS SigV4/STS signing, TLS validity windows, and token expiry.
+
+Verify inside a shed:
+
+```bash
+timedatectl                                  # "NTP service: active"
+# After a host sleep, the agent logs the correction:
+sudo journalctl -u shed-agent | grep clock-sync
+# clock-sync: stepped clock forward 2h3m0s (system ... -> RTC ...)
+```
+
+On an **older image** built before this shipped (no `systemd-timesyncd`, so `timedatectl` shows `NTP service: n/a`), step the clock from the correct RTC manually, then re-pull a current image:
+
+```bash
+sudo timedatectl set-time "$(cat /sys/class/rtc/rtc0/date) $(cat /sys/class/rtc/rtc0/time)"
+```
+
 ## macOS-Specific Notes
 
 - **Code signing**: The shed-server binary must be signed with the `com.apple.security.virtualization` entitlement.

--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -99,7 +99,7 @@ RUN printf '%s\n' \
 # `apt install` inside a shed).
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       systemd systemd-sysv dbus \
+       systemd systemd-sysv systemd-timesyncd dbus \
        sudo zip unzip ca-certificates hostname \
        tmux git curl wget neovim jq ncurses-term ripgrep tree \
        openssh-server \
@@ -154,9 +154,13 @@ RUN set -euo pipefail && \
           /lib/systemd/system/sockets.target.wants/*initctl* \
           /lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup* \
           /lib/systemd/system/systemd-update-utmp* && \
-    # Enable services shipped by base. docker is enabled in the `full`
-    # stage where it's actually installed.
-    SYSTEMD_OFFLINE=1 systemctl enable ssh shed-agent shed-firstboot network-setup && \
+    # Enable services shipped by base. systemd-timesyncd is included for
+    # parity with VZ and general clock discipline (best-effort on FC, which
+    # needs outbound DNS + NTP; kvmclock is FC's real safety net and it has
+    # no RTC — see #236); the explicit enable is load-bearing because the
+    # *.wants/* cleanup above nukes the symlink dpkg created. docker is
+    # enabled in the `full` stage where it's actually installed.
+    SYSTEMD_OFFLINE=1 systemctl enable ssh shed-agent shed-firstboot network-setup systemd-timesyncd && \
     # SSH server policy.
     mkdir -p /run/sshd /etc/ssh/sshd_config.d && \
     printf '%s\n' \

--- a/vz/Dockerfile
+++ b/vz/Dockerfile
@@ -89,7 +89,7 @@ RUN printf '%s\n' \
 # users who need them can `apt install` inside a shed.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       systemd systemd-sysv systemd-resolved dbus \
+       systemd systemd-sysv systemd-resolved systemd-timesyncd dbus \
        sudo zip unzip ca-certificates hostname \
        tmux git gh curl wget neovim jq ncurses-term ripgrep tree \
        openssh-server \
@@ -140,10 +140,14 @@ RUN set -euo pipefail && \
           /lib/systemd/system/sockets.target.wants/*initctl* \
           /lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup* \
           /lib/systemd/system/systemd-update-utmp* && \
-    # Enable services shipped by base. docker is enabled in the `full`
-    # stage where it's actually installed.
+    # Enable services shipped by base. systemd-timesyncd is included so the
+    # guest keeps wall-clock time (it otherwise ships no time-sync and its
+    # clock drifts behind after host sleep — see #236); the explicit enable
+    # is load-bearing because the *.wants/* cleanup above nukes the symlink
+    # dpkg created. docker is enabled in the `full` stage where it's actually
+    # installed.
     SYSTEMD_OFFLINE=1 systemctl enable ssh shed-agent shed-firstboot \
-        network-setup systemd-networkd systemd-resolved && \
+        network-setup systemd-networkd systemd-resolved systemd-timesyncd && \
     # SSH server policy.
     mkdir -p /run/sshd /etc/ssh/sshd_config.d && \
     printf '%s\n' \


### PR DESCRIPTION
## Problem

Fixes #236. A long-running shed guest ships **no time synchronization of any kind**. When the host (Mac) sleeps while a shed is running, the VZ guest is paused externally; its wall clock (`CLOCK_REALTIME`, derived from the frozen `arch_sys_counter`) stops advancing and gets no resume event to correct it. On wake the guest clock is behind real time — the reporter observed ~3 h — which breaks anything that validates request-signing time: AWS SigV4 / STS (`Signature expired`), TLS validity windows, token expiry.

Verified against the code (a repo-wide sweep for `timesyncd|chrony|ntp|hwclock|settimeofday|rtc` returns nothing):
- Neither `vz/Dockerfile` nor `firecracker/Dockerfile` installs `systemd-timesyncd` (Ubuntu 24.04 packages it separately from the `systemd` metapackage, so it was simply absent).
- `cmd/shed-agent` never touches the clock.

Two clarifications the report understated:
- **The RTC half is VZ-specific.** Firecracker (x86, `CONFIG_ACPI=n`/`CONFIG_PCI=n`) emulates **no RTC**; its time is held by kvmclock and its hosts don't sleep. The agent resync must — and does — no-op cleanly there.
- **A one-shot-at-boot RTC sync would not fix this.** At fresh boot the clock is already correct (the kernel's `hctosys` reads the RTC). The bug is *resume from host sleep*, where nothing restarts the agent — so the correction must be **periodic**.

## The fix (two complementary halves)

1. **Install + enable `systemd-timesyncd`** in both guest images — standard SNTP network discipline; `timedatectl` now reports `NTP service: active`. On VZ it complements the agent; on FC it's the (best-effort) network time source alongside kvmclock.
2. **`shed-agent` periodically steps `CLOCK_REALTIME` forward to the host-backed RTC** (VZ PL031), which keeps real time across the pause. It is **forward-only** and gated on a **large (30 s) gap**, so it only corrects the big post-sleep jump and never fights timesyncd's fine discipline or jumps the clock backward; the RTC read is **bounded to `[2024, 2100)`** to reject garbage; and it's a **clean no-op where no RTC exists** (FC). This closes the immediate post-wake window that `timesyncd` alone leaves open — timesyncd has no resume hook either, so it only re-syncs at its next poll (adaptive, up to ~34 min).

## Commits

- **`feat(agent): re-sync guest clock from host-backed RTC after host sleep`** — the periodic resync. Pure decision/parse logic (forward-only threshold check, RTC `since_epoch` parse, plausibility window, reconcile orchestration) lives in an **untagged** file with table tests that run under `make test` on macOS; only the `ClockSettime` syscall + ticker loop are Linux-tagged.
- **`feat(images): install and enable systemd-timesyncd in guest images`** — VZ + FC Dockerfiles. The explicit `systemctl enable` is load-bearing: the microVM systemd cleanup earlier in the same `RUN` deletes `*.wants/*`, so re-enabling recreates the `sysinit.target.wants/systemd-timesyncd.service` symlink.
- **`docs(vz): note guest time-sync behavior after host sleep`** — `docs/reference/vz-operations.md`.

## Testing

**Unit** — `make test` + `make lint` green; agent package also run under `golang:1.25 -race` in Docker (macOS `make test` skips the linux-tagged package). Table tests cover the threshold / forward-only / plausibility-window decision, the `since_epoch` parse (trailing newline, whitespace, empty, non-numeric, negative, overflow, missing file), and the reconcile orchestration (no-RTC no-op, within-threshold, steps-forward-to-RTC, **implausibly-far-future RTC rejected**, step-error propagated).

**Live (VZ)** — rebuilt the rootfs `--variant base` into a parallel dev image store (one rebuild bakes both halves), created a throwaway shed, verified, and cleaned up:
- `systemctl is-enabled systemd-timesyncd` → **enabled**, `is-active` → **active**, `timedatectl` → `NTP service: active` (was `n/a` pre-fix). The build log showed `Created symlink …/sysinit.target.wants/systemd-timesyncd.service` created *after* the `*.wants/*` cleanup, confirming the enable survives it.
- **Isolated skew test** (NTP disabled so only the agent can act): skewed the system clock **back 10 min** with `date -s`, leaving the RTC untouched (confirmed). Within ~45 s the agent stepped it forward to the RTC and logged the exact expected line:
  ```
  clock-sync: stepped clock forward 10m1s (system 2026-07-03T06:26:08Z -> RTC 2026-07-03T06:36:09Z)
  ```
  With timesyncd disabled, only the agent could have corrected the clock. Fresh-boot no-drift case: agent correctly stays idle (no step below threshold).
- A Phase-0 spike also caught the pre-existing `ztest` shed itself ~14 min drift-behind (RTC correct) — a live reproduction of the bug, and direct evidence the VZ RTC reads through to host time across drift.

**FC** — the agent no-ops without an RTC (unit-tested via the `ok=false` path; `strings` confirms the same binary is baked). The FC timesyncd install builds via the same `docker build --check`-clean Dockerfile. Not booted on a live FC host: the bug is VZ-specific (FC hosts don't sleep; kvmclock holds FC time, and FC has no RTC).

## Delivery

The fix reaches users when they pull a **rebuilt guest image** (both the agent and timesyncd ship inside the image, not the host `shed-server`).

## Out of scope / follow-ups

- An explicit `NTP=` server drop-in, only if Ubuntu's compiled-in `ntp.ubuntu.com` fallback proves unreachable in an egress-filtered deployment.
- Agent-vs-timesyncd could theoretically oscillate only if the **host's own clock** diverges from NTP by >30 s (a broken host clock); on an NTP-disciplined Mac this doesn't occur, and the host RTC is the intended authority anyway.

---

The plan for this change was refined by a review panel (Codex — rate-limited, substituted by Cursor — plus Kimi K2.6 and CodeRabbit); their findings (large threshold to avoid timesyncd contention, forward-only stepping, injectable reconcile for tests, the NTP-disabled skew methodology, and the upper-bound plausibility guard) are all incorporated. The upper-bound overflow guard in particular was a real bug caught by the per-commit correctness review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoHk27xjf1khfuijtcru6u
