### PR TITLE
docs(fc): document guest time-sync + correct the FC clocksource note

### DIFF
--- a/cmd/shed-agent/clocksync_linux.go
+++ b/cmd/shed-agent/clocksync_linux.go
@@ -27,8 +27,8 @@ const (
 
 	// rtcSinceEpochPath is the sysfs node exposing the RTC as UTC epoch seconds.
 	// Present on the VZ PL031 RTC; absent on Firecracker x86 (which emulates no
-	// RTC — its time is held by kvmclock), where readRTCFrom returns ok=false and
-	// the loop no-ops.
+	// RTC — its time comes from a paravirtualized clock, kvm-clock/TSC), where
+	// readRTCFrom returns ok=false and the loop no-ops.
 	rtcSinceEpochPath = "/sys/class/rtc/rtc0/since_epoch"
 )
 

--- a/docs/reference/fc-operations.md
+++ b/docs/reference/fc-operations.md
@@ -234,6 +234,10 @@ shed exec myproject -- ip addr show
 shed exec myproject -- curl -I https://google.com
 ```
 
+## Time synchronization
+
+Firecracker guests keep their clock correct via **`systemd-timesyncd`** (network SNTP) — `timedatectl` reports `NTP service: active`. Unlike VZ, there is **no agent-side RTC resync**: Firecracker x86 emulates no RTC (`/sys/class/rtc/` is absent), so `shed-agent` logs a single `clock-sync: no RTC … idle` line at startup and does nothing further. That is by design — the guest clock is served by Firecracker's paravirtualized clock (kvm-clock/TSC), and Firecracker hosts don't sleep, so the host-sleep drift that the [VZ agent corrects from the RTC](vz-operations.md#time-synchronization) doesn't arise here.
+
 ## Storage
 
 ### VM Disk Layout

--- a/firecracker/Dockerfile
+++ b/firecracker/Dockerfile
@@ -156,8 +156,9 @@ RUN set -euo pipefail && \
           /lib/systemd/system/systemd-update-utmp* && \
     # Enable services shipped by base. systemd-timesyncd is included for
     # parity with VZ and general clock discipline (best-effort on FC, which
-    # needs outbound DNS + NTP; kvmclock is FC's real safety net and it has
-    # no RTC — see #236); the explicit enable is load-bearing because the
+    # needs outbound DNS + NTP; FC's paravirtualized clock (kvm-clock/TSC) is
+    # its real safety net and it has no RTC — see #236); the explicit enable
+    # is load-bearing because the
     # *.wants/* cleanup above nukes the symlink dpkg created. docker is
     # enabled in the `full` stage where it's actually installed.
     SYSTEMD_OFFLINE=1 systemctl enable ssh shed-agent shed-firstboot network-setup systemd-timesyncd && \


### PR DESCRIPTION
Small follow-up to #240 (issue #236), after **live-validating the fix on a Firecracker guest** (this was reasoned-only before).

## What this adds
- **`docs/reference/fc-operations.md`** — a "Time synchronization" section symmetric with the VZ one: FC guests run `systemd-timesyncd`, and the agent no-ops because FC x86 has no RTC. Links to the VZ section for the host-sleep story.
- **Comment accuracy** — two comments (`clocksync_linux.go`, `firecracker/Dockerfile`) said FC time is "held by kvmclock"; a live FC guest reports `current_clocksource=tsc`, so they now say "a paravirtualized clock (kvm-clock/TSC)".

## Live FC validation (mini3 dev server, rebuilt FC image)
- Agent journal: `clock-sync: started …` then `clock-sync: no RTC at /sys/class/rtc/rtc0/since_epoch; idle …` (logged once — the FC no-op path, working as designed).
- `systemctl is-enabled systemd-timesyncd` → **enabled**, `is-active` → **active**.
- `timedatectl` → **`System clock synchronized: yes`, `NTP service: active`** (mini3 has NTP egress).
- `/sys/class/rtc/` absent → confirms the no-RTC premise.

No behavior change — docs + comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoHk27xjf1khfuijtcru6u