### PR TITLE
fix(release): desktop-apt-dispatch skipped on combined tags

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -930,12 +930,20 @@ jobs:
 
   # ---- Tell charliek/apt-charliek to pull the new shed-desktop .deb ----
   # Skips prereleases (X.Y.Z-suffix tags — the rc-rehearsal path). Plain
-  # `needs: desktop-linux` is deliberate: a skipped desktop-linux (go-only
-  # tag) or a failed one both mean there's nothing new to index, so default
-  # needs semantics (skip) are exactly right — no `always()` here.
+  # Runs after the shed-desktop .deb is uploaded (desktop-linux), so the
+  # re-collect it triggers actually finds the asset — the Go-side release job
+  # dispatches apt earlier, before this deb exists, so that collect can't index
+  # shed-desktop. Needs the explicit `always()`-composition because desktop-linux
+  # runs via `if: always()` over a (correctly) skipped desktop-release-create on
+  # combined tags; a plain `success()` gate gets poisoned by that transitive skip
+  # and the job wrongly skips. Runs iff desktop shipped AND its .deb built.
   desktop-apt-dispatch:
     name: Dispatch apt-charliek (shed-desktop)
-    needs: desktop-linux
+    needs: [release-plan, desktop-linux]
+    if: >-
+      always() &&
+      needs.release-plan.outputs.ship_desktop == 'true' &&
+      needs.desktop-linux.result == 'success'
     runs-on: ubuntu-latest
     env:
       TAG: ${{ github.event.inputs.version || github.ref_name }}


### PR DESCRIPTION
## Problem

On the first combined release (v0.7.10), the **Dispatch apt-charliek (shed-desktop)** job skipped, so apt was never told to re-collect after `shed-desktop_0.7.10_*.deb` uploaded. The Go-side release job dispatches apt *earlier* (right after goreleaser, before the desktop deb exists), so that collect couldn't index shed-desktop either — apt kept serving 0.0.14 until a manual re-collect.

## Root cause

The skipped-needs trap the Phase 2 plan flagged. `desktop-apt-dispatch` used the implicit `if: success()` over `needs: desktop-linux`. `desktop-linux` runs via `if: always()` and transitively needs `desktop-release-create`, which is (correctly) **skipped** on a combined tag (goreleaser owns release creation). That transitive skip poisons the downstream `success()`, so the dispatch skipped despite `desktop-linux` succeeding. It was the one desktop job that didn't get the explicit `always()`-composition guard.

## Fix

Gate it explicitly: `always() && ship_desktop == 'true' && needs.desktop-linux.result == 'success'`. Runs iff desktop shipped and its deb built; skips cleanly on go-only tags.

Verified: YAML parses; the actionlint findings on this file are all pre-existing (`client-id`/`app-id` DB staleness, SC2129 style) and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED6csoQ3peM3GHc4c1CtqY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the desktop package publishing flow so it only runs when the desktop build completes successfully.
  * Fixed skip handling in release automation to avoid preventing the package dispatch step when earlier jobs are intentionally skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->