### PR TITLE
fix: triage CodeRabbit findings from desktop import (#249)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,9 +241,16 @@ jobs:
         # continuous per-PR guard; `make m0-gates` runs the same checks on a release
         # bundle for the pre-ship size budget. A slower CI runner gets a wider
         # cold-launch budget.
+        #
+        # Size budget is a wider 70 MB here because this measures the *unstripped
+        # debug* bundle, whose size tracks the CI Swift/Xcode toolchain (the same
+        # branch is ~52 MB locally). The shipped artifact is the *release* bundle,
+        # tightly gated at 20 MB by `make m0-gates` — this coarse debug tripwire only
+        # needs to catch an explosion, not shave megabytes.
         run: >
           SHED_DESKTOP_TEST_TIMEOUT_SCALE=4
           SHED_DESKTOP_COLD_LAUNCH_BUDGET_S=30
+          SHED_DESKTOP_SIZE_BUDGET_MB=70
           uv run --group test python tools/shedtest/m0_ship_gates.py
       - name: Real-launch smoke
         # Non-test launch on a fresh runner (undetermined notification auth) —

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -15,9 +15,10 @@ re-implemented per language. The root `CLAUDE.md` owns the monorepo layout + rel
   `RcRunner` portability seam (`rc.rs`, behind the non-default `rc = ["tokio/process"]`
   feature). A bare `cargo test`/`clippy` skips the `rc` module — cover it with
   `-p shed-app --features rc`.
-- **`shed-core-ffi`** — a thin UniFFI wrapper (`crate-type = ["staticlib"]`) exposing a
-  `ShedCore` object to Swift. Static, so the macOS release signing/notarization path is
-  unaffected.
+- **`shed-core-ffi`** — a thin UniFFI wrapper (`crate-type = ["staticlib", "lib"]`)
+  exposing a `ShedCore` object to Swift. The `.a` is what the app links (signing/notarization
+  unchanged); `lib` is required so `cargo run -p shed-core-ffi --bin uniffi-bindgen` works
+  in `desktop/scripts/build-core.sh`.
 - **`shedctl`** — a headless UDS/IPC client on `shed-core` (no GUI-toolkit dep), shipped in the
   Linux `.deb` and drives the Tauri app's socket. In `default-members`.
 

--- a/crates/shed-app/src/coordinator.rs
+++ b/crates/shed-app/src/coordinator.rs
@@ -382,7 +382,10 @@ async fn run(mut state: State, mut rx: mpsc::UnboundedReceiver<Command>) {
                 let _ = reply.send(());
             }
             Command::SetPolicyRules { rules, reply } => {
+                // Full-engine replace for test-mode policy.set — do NOT route through
+                // rebuild_policy() (that prepends SSH/AWS/Docker namespace rules).
                 state.engine = PolicyEngine::new(rules);
+                state.reevaluate_pending();
                 let _ = reply.send(());
             }
             Command::ApprovalsList(reply) => {
@@ -486,6 +489,19 @@ impl State {
     }
 
     fn handle_approval_request(&mut self, req: ApprovalRequest) {
+        // Intake fail-closed: past/absent/unparseable expiry must never policy-
+        // auto-approve or queue. (Tick asymmetry via expired_by_tick is unchanged.)
+        if !self.not_expired(&req) {
+            self.respond_and_audit(
+                &req,
+                ApprovalDecision::Deny,
+                DecidedBy::Timeout,
+                "expired",
+                "",
+                "",
+            );
+            return;
+        }
         let decision = self.engine.decide(&req, &self.valid_grants());
         match decision.action {
             PolicyAction::Approve => self.respond_and_audit(
@@ -884,11 +900,12 @@ impl State {
 
     /// Store the server verbatim — `""` (single/unnamed server) is NOT collapsed
     /// to `None`, so a single-server grant never silently widens (F12).
+    /// Retain matches `Some(server)` only — never collapse `None` with `""`.
     fn add_shed_rule(&mut self, server: &str, shed: &str, action: ApprovalDecision) {
         self.extra_rules.retain(|r| {
             !(r.scope == PolicyScope::Shed
                 && r.shed.as_deref() == Some(shed)
-                && r.server.as_deref().unwrap_or("") == server)
+                && r.server.as_deref() == Some(server))
         });
         self.extra_rules.push(PolicyRule {
             scope: PolicyScope::Shed,
@@ -1454,6 +1471,109 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn set_policy_rules_reevaluates_pending() {
+        // Test-mode policy.set must reevaluate queued prompts (not only SSH prefs).
+        let h = Harness::new(1_000);
+        h.coord
+            .set_policy_rules(vec![default_rule(PolicyAction::Prompt, PolicyGate::None)])
+            .await;
+        h.inject(ssh_req("r1", "s", 5_000));
+        assert!(h.wait_queued(1).await);
+        h.coord
+            .set_policy_rules(vec![default_rule(PolicyAction::Deny, PolicyGate::None)])
+            .await;
+        assert!(h.wait_calls(1).await);
+        assert_eq!(h.responder.calls()[0].decision, ApprovalDecision::Deny);
+        assert_eq!(h.responder.calls()[0].decided_by, DecidedBy::Policy);
+        assert!(h.coord.approvals_list().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn intake_past_expiry_timeout_denies_before_policy_approve() {
+        let h = Harness::new(1_000);
+        h.coord
+            .set_policy_rules(vec![default_rule(PolicyAction::Approve, PolicyGate::None)])
+            .await;
+        h.inject(ssh_req("r1", "s", 900)); // already past clock=1000
+        assert!(h.wait_calls(1).await);
+        let c = &h.responder.calls()[0];
+        assert_eq!(c.decision, ApprovalDecision::Deny);
+        assert_eq!(c.decided_by, DecidedBy::Timeout);
+        assert!(h.coord.approvals_list().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn add_shed_rule_does_not_remove_any_server_rule() {
+        // F12: persist with server "" must not drop a seeded server:None shed rule
+        // (the old unwrap_or("") retain wrongly treated them as the same key).
+        let (clock, clock_handle) = ClockHandle::new(1_000);
+        let responder = Arc::new(FakeResponder::default());
+        let (events, event_rx) = mpsc::unbounded_channel();
+        let deps = CoordinatorDeps {
+            responder: responder.clone(),
+            notifier: Arc::new(FakeNotifier::new()),
+            gate: Arc::new(AlwaysApprovedGate),
+            clock,
+            sink: Arc::new(NoopEventSink),
+            audit: temp_audit(),
+            ssh: SshPrefs {
+                policy: SshApprovalPolicy::AlwaysAsk,
+                ..SshPrefs::default()
+            },
+            extra_rules: vec![PolicyRule {
+                scope: PolicyScope::Shed,
+                server: None,
+                namespace: None,
+                shed: Some("keep".into()),
+                action: PolicyAction::Approve,
+                gate: PolicyGate::None,
+            }],
+            provider_modes: HashMap::new(),
+        };
+        let coord = Coordinator::spawn(deps, event_rx);
+        let h = Harness {
+            coord,
+            events,
+            responder,
+            clock: clock_handle,
+        };
+        // Replace engine with Prompt so we can queue+persist; extra_rules stay until
+        // add_shed_rule → rebuild_policy re-extends them.
+        h.coord
+            .set_policy_rules(vec![default_rule(PolicyAction::Prompt, PolicyGate::None)])
+            .await;
+        h.inject(ssh_req("r1", "keep", 5_000)); // server ""
+        assert!(h.wait_queued(1).await);
+        h.coord
+            .decide_approval(
+                "r1",
+                ApprovalChoice {
+                    decision: ApprovalDecision::Approve,
+                    scope: None,
+                    ttl: None,
+                    persist: true,
+                },
+            )
+            .await;
+        assert!(h.wait_calls(1).await);
+        let rules = h.coord.policy_list().await;
+        assert!(
+            rules.iter().any(|r| r.scope == PolicyScope::Shed
+                && r.shed.as_deref() == Some("keep")
+                && r.server.is_none()
+                && r.action == PolicyAction::Approve),
+            "any-server shed rule must survive add_shed_rule(\"\", …): {rules:?}"
+        );
+        assert!(
+            rules.iter().any(|r| r.scope == PolicyScope::Shed
+                && r.shed.as_deref() == Some("keep")
+                && r.server.as_deref() == Some("")
+                && r.action == PolicyAction::Approve),
+            "unnamed-server shed rule must be present: {rules:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn disconnect_drops_all_pending() {
         // F3: a disconnect empties the queue; a late decide is a no-op.
         let h = Harness::new(1_000);
@@ -1513,29 +1633,19 @@ mod tests {
 
     #[tokio::test]
     async fn malformed_expires_at_cannot_be_approved() {
-        // Fail-closed: an unparseable expires_at is treated as already-expired, so
-        // a decide sends no approve.
+        // Fail-closed on intake: unparseable expires_at is Timeout-denied immediately
+        // (never queued, never policy-approved).
         let h = Harness::new(1_000);
         h.coord
-            .set_policy_rules(vec![default_rule(PolicyAction::Prompt, PolicyGate::None)])
+            .set_policy_rules(vec![default_rule(PolicyAction::Approve, PolicyGate::None)])
             .await;
         let mut r = ssh_req("r1", "s", 5_000);
         r.expires_at = "garbage".into();
         h.inject(r);
-        assert!(h.wait_queued(1).await);
-        h.coord
-            .decide_approval(
-                "r1",
-                ApprovalChoice {
-                    decision: ApprovalDecision::Approve,
-                    scope: None,
-                    ttl: None,
-                    persist: false,
-                },
-            )
-            .await;
-        tokio::time::sleep(Duration::from_millis(30)).await;
-        assert!(h.responder.calls().is_empty()); // no late approve
+        assert!(h.wait_calls(1).await);
+        assert_eq!(h.responder.calls()[0].decision, ApprovalDecision::Deny);
+        assert_eq!(h.responder.calls()[0].decided_by, DecidedBy::Timeout);
+        assert!(h.coord.approvals_list().await.is_empty());
     }
 
     #[tokio::test]

--- a/crates/shed-app/src/rc.rs
+++ b/crates/shed-app/src/rc.rs
@@ -309,9 +309,10 @@ impl RcService {
             let _guard = self.op_guard.lock().await;
             // The (host, shed) pairs we're refreshing — used to reconcile without
             // clobbering sessions on sheds we didn't probe.
+            // Use target.server_name (same key as launch/kill), not shed_item.host.
             let probed: HashSet<(String, String)> = targets
                 .iter()
-                .map(|(s, _)| (s.host.clone(), s.name.clone()))
+                .map(|(s, target)| (target.server_name.clone(), s.name.clone()))
                 .collect();
             let bin = binary_name();
             let probes = targets.into_iter().map(|(shed_item, target)| {
@@ -323,7 +324,9 @@ impl RcService {
                         Ok(out) if out.exit_code == 0 => rc::decode_list(&out.stdout)
                             .unwrap_or_default()
                             .into_iter()
-                            .map(|dto| RcSession::from_dto(dto, &shed_item.host, &shed_item.name))
+                            .map(|dto| {
+                                RcSession::from_dto(dto, &target.server_name, &shed_item.name)
+                            })
                             .collect::<Vec<_>>(),
                         // A per-shed failure (transport, missing binary, bad DTO)
                         // yields none — best-effort, mirroring the Swift `listReal`.

--- a/crates/shed-app/src/token_minter.rs
+++ b/crates/shed-app/src/token_minter.rs
@@ -55,6 +55,13 @@ fn map_response(resp: TokenResponse, server: &str) -> Result<MintedToken, ShedEr
     if let Some(err) = resp.error.as_deref().filter(|e| !e.is_empty()) {
         return Err(ShedError::Config(err.to_string()));
     }
+    // Empty server is allowed (serde default); a non-empty mismatch is fail-closed.
+    if !resp.server.is_empty() && resp.server != server {
+        return Err(ShedError::Config(format!(
+            "host agent returned token for unexpected server {}",
+            resp.server
+        )));
+    }
     let token = resp
         .token
         .filter(|t| !t.is_empty())
@@ -131,5 +138,19 @@ mod tests {
         let m = map_response(resp(Some("tok"), Some("garbage"), None), "mini2").unwrap();
         assert_eq!(m.token, "tok");
         assert_eq!(m.expires_at_unix, None);
+    }
+
+    #[test]
+    fn wrong_server_is_fail_closed() {
+        let e = map_response(resp(Some("tok"), None, None), "other").unwrap_err();
+        assert!(matches!(e, ShedError::Config(m) if m.contains("unexpected server")));
+    }
+
+    #[test]
+    fn empty_server_in_reply_is_allowed() {
+        let mut r = resp(Some("tok"), None, None);
+        r.server = String::new();
+        let m = map_response(r, "mini2").unwrap();
+        assert_eq!(m.token, "tok");
     }
 }

--- a/crates/shed-core/src/http.rs
+++ b/crates/shed-core/src/http.rs
@@ -252,11 +252,18 @@ impl Client {
         if let Some(tok) = self.bearer().await {
             rb = rb.bearer_auth(tok);
         }
-        let resp = rb
-            .send()
-            .await
-            .map_err(|e| ShedError::Transport(e.to_string()))?;
+        let resp = match tokio::time::timeout(CREATE_IDLE_TIMEOUT, rb.send()).await {
+            Err(_) => {
+                return Err(ShedError::Create("create stream idle timeout".into()));
+            }
+            Ok(r) => r.map_err(|e| ShedError::Transport(e.to_string()))?,
+        };
         let status = resp.status().as_u16();
+        if status == 401 {
+            if let Some(p) = &self.token_provider {
+                p.invalidate().await;
+            }
+        }
         if !(200..300).contains(&status) {
             return Err(ShedError::BadStatus(status));
         }
@@ -769,6 +776,58 @@ mod tests {
         assert_eq!(
             sink.snapshot().error.as_deref(),
             Some("create failed: stream ended before a complete event")
+        );
+    }
+
+    #[tokio::test]
+    async fn create_401_invalidates_provider_without_retry() {
+        // Create is one-shot (no 401 retry), but must still invalidate a stale
+        // cached token so the next attempt remints.
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(POST)
+                    .path("/api/sheds")
+                    .header("authorization", "Bearer tok-1");
+                t.status(401);
+            })
+            .await;
+        let minter = Arc::new(SeqMinter {
+            calls: AtomicUsize::new(0),
+        });
+        let c = Client::new(
+            server.base_url(),
+            "mini2".into(),
+            String::new(),
+            None,
+            Some(minter.clone()),
+        )
+        .unwrap();
+        // Prime the provider cache with tok-1.
+        let _ = c.bearer().await;
+        assert_eq!(minter.calls.load(Ordering::SeqCst), 1);
+
+        let sink = Arc::new(RecordingSink::default());
+        let req = CreateShedRequest {
+            name: "x".into(),
+            ..Default::default()
+        };
+        c.create_shed(&req, sink.as_ref()).await;
+        assert!(
+            sink.snapshot()
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("401") || e.contains("BadStatus") || e.contains("create")),
+            "create should surface the 401: {:?}",
+            sink.snapshot().error
+        );
+        // Still only one mint so far (no create retry); invalidate forces remint next.
+        assert_eq!(minter.calls.load(Ordering::SeqCst), 1);
+        let _ = c.bearer().await;
+        assert_eq!(
+            minter.calls.load(Ordering::SeqCst),
+            2,
+            "401 on create must invalidate so the next bearer remints"
         );
     }
 }

--- a/crates/shed-core/src/terminal.rs
+++ b/crates/shed-core/src/terminal.rs
@@ -154,7 +154,11 @@ pub fn resolve_launch(
             if template.is_empty() {
                 return default_terminal(cmd);
             }
-            let expanded = template.replace("{cmd}", &cmd.command).replace("{shed}", shed);
+            // Quote {shed} for /bin/sh -c; leave {cmd} raw — it is a full command line.
+            // Templates must not wrap {shed} in their own quotes; quoting is applied here.
+            let expanded = template
+                .replace("{cmd}", &cmd.command)
+                .replace("{shed}", &shell_quote(shed));
             LaunchInvocation {
                 executable: "/bin/sh".to_string(),
                 arguments: vec!["-c".to_string(), expanded],
@@ -250,6 +254,25 @@ mod tests {
         assert_eq!(inv.arguments[0], "-c");
         assert!(inv.arguments[1].contains(&cmd.command)); // {cmd} substituted
         assert!(inv.arguments[1].contains("# web")); // {shed} substituted
+    }
+
+    #[test]
+    fn resolve_launch_custom_shell_quotes_shed() {
+        // A crafted shed name must not break out of the custom /bin/sh -c template.
+        let cmd = ssh_command("web", "h", 22, "/k", None);
+        let evil = "x'; echo pwned #";
+        let inv = resolve_launch(
+            TerminalPreset::Custom,
+            &cmd,
+            evil,
+            Some("kitty -e {cmd} --title {shed}"),
+            None,
+        );
+        assert_eq!(inv.executable, "/bin/sh");
+        assert_eq!(
+            inv.arguments[1],
+            format!("kitty -e {} --title {}", cmd.command, shell_quote(evil))
+        );
     }
 
     #[test]

--- a/crates/shed-core/src/terminal.rs
+++ b/crates/shed-core/src/terminal.rs
@@ -156,9 +156,8 @@ pub fn resolve_launch(
             }
             // Quote {shed} for /bin/sh -c; leave {cmd} raw — it is a full command line.
             // Templates must not wrap {shed} in their own quotes; quoting is applied here.
-            let expanded = template
-                .replace("{cmd}", &cmd.command)
-                .replace("{shed}", &shell_quote(shed));
+            // One-pass expansion so a literal `{shed}` inside `{cmd}` is not re-scanned.
+            let expanded = expand_custom_template(template, cmd.command.as_str(), shed);
             LaunchInvocation {
                 executable: "/bin/sh".to_string(),
                 arguments: vec!["-c".to_string(), expanded],
@@ -172,6 +171,31 @@ pub fn resolve_launch(
             _ => default_terminal(cmd),
         },
     }
+}
+
+/// Expand `{cmd}` / `{shed}` placeholders in a custom template in one left-to-right
+/// pass. `{cmd}` is inserted raw; `{shed}` is `shell_quote`d. Inserted text is not
+/// re-scanned (avoids a command containing `{shed}` being mutated by a second pass).
+fn expand_custom_template(template: &str, cmd: &str, shed: &str) -> String {
+    let quoted_shed = shell_quote(shed);
+    let mut out = String::with_capacity(template.len() + cmd.len() + quoted_shed.len());
+    let mut rest = template;
+    while let Some(i) = rest.find('{') {
+        out.push_str(&rest[..i]);
+        let after = &rest[i..];
+        if let Some(tail) = after.strip_prefix("{cmd}") {
+            out.push_str(cmd);
+            rest = tail;
+        } else if let Some(tail) = after.strip_prefix("{shed}") {
+            out.push_str(&quoted_shed);
+            rest = tail;
+        } else {
+            out.push('{');
+            rest = &after[1..];
+        }
+    }
+    out.push_str(rest);
+    out
 }
 
 /// The platform default terminal running the ssh command — the fallback when a
@@ -272,6 +296,24 @@ mod tests {
         assert_eq!(
             inv.arguments[1],
             format!("kitty -e {} --title {}", cmd.command, shell_quote(evil))
+        );
+    }
+
+    #[test]
+    fn resolve_launch_custom_one_pass_does_not_rescan_cmd() {
+        // A command containing the literal `{shed}` must not be mutated by shed expansion.
+        let mut cmd = ssh_command("web", "h", 22, "/k", None);
+        cmd.command = "echo before-{shed}-after".into();
+        let inv = resolve_launch(
+            TerminalPreset::Custom,
+            &cmd,
+            "my-shed",
+            Some("{cmd} # {shed}"),
+            None,
+        );
+        assert_eq!(
+            inv.arguments[1],
+            format!("echo before-{{shed}}-after # {}", shell_quote("my-shed"))
         );
     }
 

--- a/desktop/Sources/ShedDesktopApp/AppModel.swift
+++ b/desktop/Sources/ShedDesktopApp/AppModel.swift
@@ -211,10 +211,19 @@ final class AppModel: NSObject, UiBridge {
     /// must resolve now rather than linger (and stay actionable) under a
     /// non-prompting policy. Requests the policy still decides to prompt stay put.
     private func reevaluatePending() {
+        let now = Date()
         let grants = validGrants()
         for (id, item) in Array(pending) {
+            // Match Rust: never policy-decide an already tick-expired request —
+            // leave it for expirePending's Timeout deny (intake asymmetry preserved).
+            if shouldExpireByTick(item.request, now: now) { continue }
             let decision = policyEngine.decide(for: item.request, sessionGrants: grants)
-            guard decision.action != .prompt else { continue }
+            if decision.action == .prompt {
+                // Method may have strengthened/weakened — refresh the stored gate
+                // so an already-pending card picks up the new biometric requirement.
+                pending[id] = PendingApproval(request: item.request, gate: decision.gate)
+                continue
+            }
             respondAndAudit(item.request, decision.action == .approve ? .approve : .deny,
                             decidedBy: .policy, policy: decision.appliedScope.rawValue)
             pending[id] = nil
@@ -1196,6 +1205,9 @@ final class AppModel: NSObject, UiBridge {
             // let the user act on — or persist a rule from — a stale prompt.
             for id in pending.keys { notifier?.withdraw(id: id) }
             pending.removeAll()
+            // Match Rust A3: drop ALL session grants — a reconnected agent must
+            // not inherit auto-approves from the previous connection.
+            sessionGrants.removeAll()
             publishApprovals()
         case .frame(let frame):
             switch frame {
@@ -1207,6 +1219,12 @@ final class AppModel: NSObject, UiBridge {
     }
 
     private func handleApprovalRequest(_ req: ApprovalRequest) {
+        // Intake fail-closed: past/absent/unparseable expiry must never policy-
+        // auto-approve or queue. (Tick asymmetry via shouldExpireByTick is unchanged.)
+        guard canActOnApproval(req) else {
+            respondAndAudit(req, .deny, decidedBy: .timeout, policy: "expired")
+            return
+        }
         let decision = policyEngine.decide(for: req, sessionGrants: validGrants())
         switch decision.action {
         case .approve:
@@ -1367,7 +1385,10 @@ final class AppModel: NSObject, UiBridge {
     func auditLogPath() -> String { auditStore?.fileURL.path ?? "" }
 
     func setPolicyRules(_ rules: [PolicyRule]) {
+        // Full-engine replace (not rebuildPolicy / extraRules merge) + reevaluate,
+        // matching Rust SetPolicyRules.
         policyEngine = PolicyEngine(rules: rules)
+        reevaluatePending()
     }
 
     func policyRules() -> [PolicyRule] { policyEngine.rules }

--- a/desktop/Sources/ShedDesktopApp/AppModel.swift
+++ b/desktop/Sources/ShedDesktopApp/AppModel.swift
@@ -251,13 +251,14 @@ final class AppModel: NSObject, UiBridge {
         // Store the server verbatim ("" = the single/unnamed server) rather than
         // collapsing "" → nil: nil is reserved for an explicit any-server rule,
         // so a single-server grant never silently widens to other servers.
-        extraRules.removeAll { $0.scope == .shed && $0.shed == shed && ($0.server ?? "") == server }
+        // Match Optional equality (nil ≠ "") — same F12 retain as Rust add_shed_rule.
+        extraRules.removeAll { $0.scope == .shed && $0.shed == shed && $0.server == server }
         extraRules.append(PolicyRule(scope: .shed, server: server, shed: shed, action: action.policyAction, gate: .none))
         persistAndRebuild()
     }
 
     private func removeShedRule(server: String, shed: String) {
-        extraRules.removeAll { $0.scope == .shed && $0.shed == shed && ($0.server ?? "") == server }
+        extraRules.removeAll { $0.scope == .shed && $0.shed == shed && $0.server == server }
         persistAndRebuild()
     }
 
@@ -1219,13 +1220,27 @@ final class AppModel: NSObject, UiBridge {
         }
     }
 
+    /// Act path (decide): nil/unparseable expiry ⇒ not live (fail-closed).
+    /// Matches Rust `not_expired`. Do not use for the 1s tick sweep.
+    private func canActOnApproval(_ req: ApprovalRequest, now: Date = Date()) -> Bool {
+        guard let expiresAt = req.expiresAtDate else { return false }
+        return expiresAt > now
+    }
+
+    /// Tick path: nil/unparseable expiry ⇒ do NOT sweep (linger until disconnect).
+    /// Matches Rust `expired_by_tick` / intentional mac `?? now` asymmetry.
+    private func shouldExpireByTick(_ req: ApprovalRequest, now: Date = Date()) -> Bool {
+        guard let expiresAt = req.expiresAtDate else { return false }
+        return expiresAt < now
+    }
+
     func decideApproval(id: String, choice: ApprovalChoice) async throws {
         guard let item = pending[id] else { throw IPCHandlerError.notFound("no pending approval \(id)") }
         let req = item.request
         // Don't act on an already-expired request — the 1s expiry task may not have
         // fired yet, but acting now would persist a rule / create a (possibly sticky)
         // grant and send a late decision for a request the agent has already denied.
-        guard (req.expiresAtDate ?? .distantPast) > Date() else { return }
+        guard canActOnApproval(req) else { return }
         let decision = choice.decision
         var decidedBy: DecidedBy = .user
         if decision == .approve, item.gate.isBiometric, !ShedBackend.shared.testMode {
@@ -1240,8 +1255,7 @@ final class AppModel: NSObject, UiBridge {
             // prompt was up — don't send a late, contradictory decision or grant
             // a session for a dead request. Check both presence AND expiry (the
             // 1s expiry task may not have fired yet).
-            guard pending[id] != nil,
-                  (req.expiresAtDate ?? .distantPast) > Date() else { return }
+            guard pending[id] != nil, canActOnApproval(req) else { return }
             decidedBy = .touchid
         }
 
@@ -1285,7 +1299,8 @@ final class AppModel: NSObject, UiBridge {
 
     private func expirePending() {
         let now = Date()
-        let expired = pending.values.map(\.request).filter { ($0.expiresAtDate ?? now) < now }
+        // Parity with Rust expired_by_tick: unparseable/nil does not sweep.
+        let expired = pending.values.map(\.request).filter { shouldExpireByTick($0, now: now) }
         for req in expired {
             respondAndAudit(req, .deny, decidedBy: .timeout, policy: "expired")
             pending[req.id] = nil

--- a/desktop/Sources/ShedDesktopUI/ShedListView.swift
+++ b/desktop/Sources/ShedDesktopUI/ShedListView.swift
@@ -135,6 +135,9 @@ struct ShedRow: View {
             } else if shed.status == .stopped {
                 IntentButton("play.fill", "Start", Theme.ok) { state.onShedAction?(.start, shed) }
                 IntentButton("trash", "Delete", Theme.danger) { confirmingDelete = true }
+            } else if shed.status == .error || shed.status == .unknown {
+                IntentButton("stop.fill", "Stop", Theme.danger) { state.onShedAction?(.stop, shed) }
+                IntentButton("trash", "Delete", Theme.danger) { confirmingDelete = true }
             }
         }
     }

--- a/desktop/Sources/ShedKit/Approval/HostAgentClient.swift
+++ b/desktop/Sources/ShedKit/Approval/HostAgentClient.swift
@@ -84,7 +84,12 @@ public final class HostAgentClient: @unchecked Sendable {
         running = false
         let task = loopTask
         loopTask = nil
-        if currentFD >= 0 { Darwin.close(currentFD); currentFD = -1 }
+        // Wake a blocked readLine without closing here — closeCurrentIf owns the
+        // single Darwin.close (avoids fd-reuse double-close).
+        if currentFD >= 0 {
+            _ = Darwin.shutdown(currentFD, SHUT_RDWR)
+            currentFD = -1
+        }
         lock.unlock()
         task?.cancel()
         failAllPending(error: HostAgentClientError.disconnected)

--- a/desktop/Sources/ShedKit/Approval/HostAgentProtocol.swift
+++ b/desktop/Sources/ShedKit/Approval/HostAgentProtocol.swift
@@ -92,6 +92,33 @@ public struct TokenResponse: Sendable, Decodable {
     }
 }
 
+/// Outcome of validating a host-agent `token.response`: the validated token, or
+/// a descriptive failure message the caller maps to its own error type.
+public enum TokenValidation: Sendable {
+    case valid(String)
+    case invalid(String)
+}
+
+extension TokenResponse {
+    /// Fail-closed validation shared by the two host-agent token minters
+    /// (`ControlTokenProvider.hostAgent` and `HostAgentTokenMinter`). One copy
+    /// keeps the two paths from diverging — a fail-open drift here would be a
+    /// security regression.
+    public func validatedToken(for server: String) -> TokenValidation {
+        if let error, !error.isEmpty {
+            return .invalid(error)
+        }
+        // Empty server is allowed (serde default); a non-empty mismatch is fail-closed.
+        if !self.server.isEmpty, self.server != server {
+            return .invalid("host agent returned token for unexpected server \(self.server)")
+        }
+        guard let token, !token.isEmpty else {
+            return .invalid("host agent returned no token for \(server)")
+        }
+        return .valid(token)
+    }
+}
+
 public enum HostAgentProtocol {
     /// Decode one newline-JSON line into a typed inbound frame.
     public static func decode(line: Data) throws -> HostAgentInbound {

--- a/desktop/Sources/ShedKit/Approval/HostAgentProtocol.swift
+++ b/desktop/Sources/ShedKit/Approval/HostAgentProtocol.swift
@@ -31,6 +31,15 @@ public struct HelloAck: Sendable, Decodable {
         case requestTimeoutMs = "request_timeout_ms"
         case accepted
     }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        // Match Rust #[serde(default)] — older agents may omit these keys.
+        namespaces = try c.decodeIfPresent([String].self, forKey: .namespaces) ?? []
+        gateNamespaces = try c.decodeIfPresent([String].self, forKey: .gateNamespaces) ?? []
+        requestTimeoutMs = try c.decodeIfPresent(Int.self, forKey: .requestTimeoutMs) ?? 0
+        accepted = try c.decodeIfPresent(Bool.self, forKey: .accepted) ?? false
+    }
 }
 
 /// The `event` frame — a superset of the host agent's audit row, covering
@@ -70,6 +79,16 @@ public struct TokenResponse: Sendable, Decodable {
         case server, token, error
         case inReplyTo = "in_reply_to"
         case expiresAt = "expires_at"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        inReplyTo = try c.decode(String.self, forKey: .inReplyTo)
+        // Match Rust #[serde(default)] on server.
+        server = try c.decodeIfPresent(String.self, forKey: .server) ?? ""
+        token = try c.decodeIfPresent(String.self, forKey: .token)
+        expiresAt = try c.decodeIfPresent(String.self, forKey: .expiresAt)
+        error = try c.decodeIfPresent(String.self, forKey: .error)
     }
 }
 

--- a/desktop/Sources/ShedKit/Backend/Screenshot.swift
+++ b/desktop/Sources/ShedKit/Backend/Screenshot.swift
@@ -21,6 +21,7 @@ public enum ScreenshotError: Error, CustomStringConvertible {
     case allocFailed
     case pngFailed
     case tooLarge(bytes: Int)
+    case invalidScale(Int)
 
     public var description: String {
         switch self {
@@ -32,6 +33,8 @@ public enum ScreenshotError: Error, CustomStringConvertible {
         case .pngFailed: return "PNG encoding failed"
         case .tooLarge(let b):
             return "screenshot too large: \(b) base64 bytes exceeds the \(ipcMaxFrameBytes) byte IPC frame cap (try scale 1)"
+        case .invalidScale(let s):
+            return "invalid screenshot scale \(s); expected 1 or 2"
         }
     }
 }
@@ -47,6 +50,7 @@ public struct CapturedImage: Sendable {
 /// would reject.
 @MainActor
 public func captureWindowPNG(_ window: NSWindow?, scale: Int) throws -> CapturedImage {
+    guard scale == 1 || scale == 2 else { throw ScreenshotError.invalidScale(scale) }
     guard let window else { throw ScreenshotError.noWindow }
     if window.isMiniaturized { throw ScreenshotError.minimized }
     guard let contentView = window.contentView else { throw ScreenshotError.noContentView }

--- a/desktop/Sources/ShedKit/IPC/IPCMessages.swift
+++ b/desktop/Sources/ShedKit/IPC/IPCMessages.swift
@@ -27,19 +27,19 @@ public struct IPCRequest: Codable, Sendable {
     }
 
     public init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
-        // Reject unknown top-level keys (matches the strict-typed clients
-        // a future cross-language driver would use). Op-specific params get
-        // the same treatment via decodeParams(expected:).
+        // CodingKeys.self containers do not surface unknown JSON members — use
+        // an open key type so extras like "extra":true are rejected.
+        let raw = try decoder.container(keyedBy: AnyJSONKey.self)
         let allowed: Set<String> = ["id", "op", "params"]
-        let present = Set(c.allKeys.map(\.stringValue))
+        let present = Set(raw.allKeys.map(\.stringValue))
         let unknown = present.subtracting(allowed)
         if !unknown.isEmpty {
             throw DecodingError.dataCorrupted(.init(
-                codingPath: c.codingPath,
+                codingPath: raw.codingPath,
                 debugDescription: "unknown request fields: \(unknown.sorted().joined(separator: ", "))"
             ))
         }
+        let c = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try decodeStringInt64(c, .id)
         self.op = try c.decode(String.self, forKey: .op)
         self.params = try c.decodeIfPresent(AnyCodable.self, forKey: .params)
@@ -203,6 +203,16 @@ public struct AnyCodable: Codable, @unchecked Sendable {
                 codingPath: c.codingPath, debugDescription: "Unsupported JSON value"))
         }
     }
+}
+
+/// Open CodingKey so keyed containers report every JSON object member.
+/// `CodingKeys` containers only enumerate declared cases, which silently
+/// drops unknown fields and defeats the IPCRequest unknown-key check.
+struct AnyJSONKey: CodingKey {
+    var stringValue: String
+    init?(stringValue: String) { self.stringValue = stringValue }
+    var intValue: Int? { nil }
+    init?(intValue: Int) { nil }
 }
 
 /// Protocol version on the wire. M0 ships `1`.

--- a/desktop/Sources/ShedKit/IPC/IPCMessages.swift
+++ b/desktop/Sources/ShedKit/IPC/IPCMessages.swift
@@ -18,7 +18,7 @@ public struct IPCRequest: Codable, Sendable {
     public var op: String
     public var params: AnyCodable?
 
-    enum CodingKeys: String, CodingKey { case id, op, params }
+    enum CodingKeys: String, CodingKey, CaseIterable { case id, op, params }
 
     public init(id: Int64, op: String, params: AnyCodable? = nil) {
         self.id = id
@@ -30,7 +30,8 @@ public struct IPCRequest: Codable, Sendable {
         // CodingKeys.self containers do not surface unknown JSON members — use
         // an open key type so extras like "extra":true are rejected.
         let raw = try decoder.container(keyedBy: AnyJSONKey.self)
-        let allowed: Set<String> = ["id", "op", "params"]
+        // Derived from CodingKeys so the check can't drift when a field is added.
+        let allowed = Set(CodingKeys.allCases.map(\.stringValue))
         let present = Set(raw.allKeys.map(\.stringValue))
         let unknown = present.subtracting(allowed)
         if !unknown.isEmpty {

--- a/desktop/Sources/ShedKit/Net/ControlTokenProvider.swift
+++ b/desktop/Sources/ShedKit/Net/ControlTokenProvider.swift
@@ -98,16 +98,10 @@ extension ControlTokenProvider {
     ) -> ControlTokenProvider {
         ControlTokenProvider(refreshWindow: refreshWindow, now: now) {
             let resp = try await client.requestToken(server: server)
-            if let err = resp.error, !err.isEmpty {
-                throw ControlTokenError.mintFailed(err)
-            }
-            // Empty server is allowed (serde default); a non-empty mismatch is fail-closed.
-            if !resp.server.isEmpty, resp.server != server {
-                throw ControlTokenError.mintFailed(
-                    "host agent returned token for unexpected server \(resp.server)")
-            }
-            guard let tok = resp.token, !tok.isEmpty else {
-                throw ControlTokenError.mintFailed("host agent returned no token for \(server)")
+            let tok: String
+            switch resp.validatedToken(for: server) {
+            case .valid(let t): tok = t
+            case .invalid(let m): throw ControlTokenError.mintFailed(m)
             }
             return MintedToken(
                 token: tok, expiresAt: resp.expiresAt.flatMap(DateFormatting.parseFlexibleTimestamp))

--- a/desktop/Sources/ShedKit/Net/ControlTokenProvider.swift
+++ b/desktop/Sources/ShedKit/Net/ControlTokenProvider.swift
@@ -101,6 +101,11 @@ extension ControlTokenProvider {
             if let err = resp.error, !err.isEmpty {
                 throw ControlTokenError.mintFailed(err)
             }
+            // Empty server is allowed (serde default); a non-empty mismatch is fail-closed.
+            if !resp.server.isEmpty, resp.server != server {
+                throw ControlTokenError.mintFailed(
+                    "host agent returned token for unexpected server \(resp.server)")
+            }
             guard let tok = resp.token, !tok.isEmpty else {
                 throw ControlTokenError.mintFailed("host agent returned no token for \(server)")
             }

--- a/desktop/Sources/ShedKit/Net/HostAgentTokenMinter.swift
+++ b/desktop/Sources/ShedKit/Net/HostAgentTokenMinter.swift
@@ -27,6 +27,11 @@ final class HostAgentTokenMinter: ShedRustCore.TokenMinter, @unchecked Sendable 
         if let err = resp.error, !err.isEmpty {
             throw ShedRustCore.ShedError.Config(message: err)
         }
+        // Empty server is allowed (serde default); a non-empty mismatch is fail-closed.
+        if !resp.server.isEmpty, resp.server != server {
+            throw ShedRustCore.ShedError.Config(
+                message: "host agent returned token for unexpected server \(resp.server)")
+        }
         guard let token = resp.token, !token.isEmpty else {
             throw ShedRustCore.ShedError.Config(message: "host agent returned no token for \(server)")
         }

--- a/desktop/Sources/ShedKit/Net/HostAgentTokenMinter.swift
+++ b/desktop/Sources/ShedKit/Net/HostAgentTokenMinter.swift
@@ -22,18 +22,13 @@ final class HostAgentTokenMinter: ShedRustCore.TokenMinter, @unchecked Sendable 
 
     func mint(server: String) async throws -> ShedRustCore.MintedToken {
         let resp = try await hostAgent.requestToken(server: server)
-        // A fail-closed reply (error set, or no token) → throw, so the Rust FSM
-        // surfaces it and the client sends no token.
-        if let err = resp.error, !err.isEmpty {
-            throw ShedRustCore.ShedError.Config(message: err)
-        }
-        // Empty server is allowed (serde default); a non-empty mismatch is fail-closed.
-        if !resp.server.isEmpty, resp.server != server {
-            throw ShedRustCore.ShedError.Config(
-                message: "host agent returned token for unexpected server \(resp.server)")
-        }
-        guard let token = resp.token, !token.isEmpty else {
-            throw ShedRustCore.ShedError.Config(message: "host agent returned no token for \(server)")
+        // A fail-closed reply (error set, mismatched server, or no token) → throw,
+        // so the Rust FSM surfaces it and the client sends no token. Shares the one
+        // validator with `ControlTokenProvider.hostAgent` so the two can't diverge.
+        let token: String
+        switch resp.validatedToken(for: server) {
+        case .valid(let t): token = t
+        case .invalid(let m): throw ShedRustCore.ShedError.Config(message: m)
         }
         // Expiry is carried as unix seconds; Swift owns the flexible ISO-8601
         // parsing (the Rust core never parses timestamps).

--- a/desktop/Sources/ShedKit/Terminal/TerminalLauncher.swift
+++ b/desktop/Sources/ShedKit/Terminal/TerminalLauncher.swift
@@ -151,9 +151,9 @@ public enum TerminalLauncher {
         case .custom:
             let template = (customTemplate ?? "").trimmingCharacters(in: .whitespaces)
             guard !template.isEmpty else { return terminalAppInvocation(cmd) }
-            let expanded = template
-                .replacingOccurrences(of: "{cmd}", with: cmd.command)
-                .replacingOccurrences(of: "{shed}", with: shed)
+            // Quote {shed} for /bin/sh -c; leave {cmd} raw — it is a full command line.
+            // One-pass so a literal `{shed}` inside `{cmd}` is not re-scanned.
+            let expanded = Self.expandCustomTemplate(template, cmd: cmd.command, shed: shed)
             return LaunchInvocation(executable: "/bin/sh", arguments: ["-c", expanded])
         default:
             guard let helper = preset.helper, let dir = scriptsDir else {
@@ -180,6 +180,33 @@ public enum TerminalLauncher {
 
     /// Single-quote a shell argument (delegates to the shared `shellQuote`).
     public static func shellQuote(_ s: String) -> String { ShedKit.shellQuote(s) }
+
+    /// One-pass `{cmd}` / `{shed}` expansion. `{cmd}` is raw; `{shed}` is shell-quoted.
+    /// Inserted text is not re-scanned.
+    static func expandCustomTemplate(_ template: String, cmd: String, shed: String) -> String {
+        let quotedShed = shellQuote(shed)
+        var out = ""
+        out.reserveCapacity(template.count + cmd.count + quotedShed.count)
+        var i = template.startIndex
+        while i < template.endIndex {
+            if template[i] == "{" {
+                let rest = template[i...]
+                if rest.hasPrefix("{cmd}") {
+                    out += cmd
+                    i = template.index(i, offsetBy: 5)
+                    continue
+                }
+                if rest.hasPrefix("{shed}") {
+                    out += quotedShed
+                    i = template.index(i, offsetBy: 6)
+                    continue
+                }
+            }
+            out.append(template[i])
+            i = template.index(after: i)
+        }
+        return out
+    }
 
     private static func terminalAppInvocation(_ cmd: TerminalCommand) -> LaunchInvocation {
         let script = """

--- a/desktop/Tests/ShedKitTests/ControlTokenProviderTests.swift
+++ b/desktop/Tests/ShedKitTests/ControlTokenProviderTests.swift
@@ -210,4 +210,29 @@ final class ControlTokenProviderTests: XCTestCase {
             XCTAssertEqual(e, .mintFailed("no ssh_port"))
         }
     }
+
+    func testHostAgentFactoryRejectsWrongServer() async throws {
+        let path = tempSocketPath()
+        let fake = FakeHostAgent(
+            path: path,
+            mode: .reply(
+                token: "ctl-wrong", expiresAt: "2026-06-14T01:00:00Z", error: nil,
+                server: "other-server"))
+        try fake.start()
+        defer { fake.stop() }
+        let client = HostAgentClient(socketPath: path)
+        let stream = client.start(client: Self.info)
+        let drain = Task { for await _ in stream {} }
+        defer { drain.cancel(); client.stop() }
+        try await waitConnected(client)
+
+        let provider = ControlTokenProvider.hostAgent(client, server: "mini3")
+        do {
+            _ = try await provider.token()
+            XCTFail("expected mintFailed for wrong server")
+        } catch let e as ControlTokenError {
+            XCTAssertEqual(
+                e, .mintFailed("host agent returned token for unexpected server other-server"))
+        }
+    }
 }

--- a/desktop/Tests/ShedKitTests/HostAgentClientTests.swift
+++ b/desktop/Tests/ShedKitTests/HostAgentClientTests.swift
@@ -151,7 +151,8 @@ final class HostAgentClientTokenTests: XCTestCase {
 /// LineFrameReader) so the wire path matches the real agent.
 final class FakeHostAgent: @unchecked Sendable {
     enum Mode {
-        case reply(token: String?, expiresAt: String?, error: String?)
+        /// `server` overrides the echoed `token.get` server when non-nil (wrong-server tests).
+        case reply(token: String?, expiresAt: String?, error: String?, server: String? = nil)
         case silent  // read the token.get, never reply (drives the client timeout)
         case dropOnGet  // close the conn on token.get (drives the disconnect path)
     }
@@ -216,10 +217,10 @@ final class FakeHostAgent: @unchecked Sendable {
             case .dropOnGet:
                 Darwin.close(conn)
                 return
-            case .reply(let token, let expiresAt, let error):
+            case .reply(let token, let expiresAt, let error, let serverOverride):
                 var resp: [String: Any] = [
                     "v": hostAgentProtocolVersion, "type": "token.response",
-                    "in_reply_to": id, "server": server,
+                    "in_reply_to": id, "server": serverOverride ?? server,
                 ]
                 if let token { resp["token"] = token }
                 if let expiresAt { resp["expires_at"] = expiresAt }

--- a/desktop/Tests/ShedKitTests/HostAgentClientTests.swift
+++ b/desktop/Tests/ShedKitTests/HostAgentClientTests.swift
@@ -126,6 +126,23 @@ final class HostAgentClientTokenTests: XCTestCase {
             XCTAssertEqual(err, .notConnected)
         }
     }
+
+    func testStopMidReadWakesWithoutDoubleClose() async throws {
+        let path = tempSocketPath()
+        let fake = FakeHostAgent(path: path, mode: .silent)
+        try fake.start()
+        defer { fake.stop() }
+
+        let client = HostAgentClient(socketPath: path)
+        let drain = startDraining(client)
+        defer { drain.cancel() }
+        try await waitConnected(client)
+
+        client.stop()
+        try await Task.sleep(for: .milliseconds(150))
+        client.stop()
+        XCTAssertFalse(client.isConnected)
+    }
 }
 
 /// Minimal in-test UDS server mimicking shed-host-agent's framing: accepts one

--- a/desktop/Tests/ShedKitTests/HostAgentProtocolTests.swift
+++ b/desktop/Tests/ShedKitTests/HostAgentProtocolTests.swift
@@ -40,6 +40,29 @@ final class HostAgentProtocolTests: XCTestCase {
         XCTAssertNil(r.expiresAt)
     }
 
+    func testTokenResponseDefaultsOmittedServer() throws {
+        let json = #"{"v":2,"type":"token.response","in_reply_to":"r1","token":"t"}"#
+        guard case .tokenResponse(let r) = try HostAgentProtocol.decode(line: Data(json.utf8)) else {
+            return XCTFail("expected .tokenResponse")
+        }
+        XCTAssertEqual(r.inReplyTo, "r1")
+        XCTAssertEqual(r.server, "")
+        XCTAssertEqual(r.token, "t")
+    }
+
+    // MARK: - hello_ack decode
+
+    func testHelloAckDefaultsOmittedFields() throws {
+        let json = #"{"v":2,"type":"hello_ack","id":"1"}"#
+        guard case .helloAck(let ack) = try HostAgentProtocol.decode(line: Data(json.utf8)) else {
+            return XCTFail("expected .helloAck")
+        }
+        XCTAssertEqual(ack.namespaces, [])
+        XCTAssertEqual(ack.gateNamespaces, [])
+        XCTAssertEqual(ack.requestTimeoutMs, 0)
+        XCTAssertFalse(ack.accepted)
+    }
+
     func testUnknownFrameStillDecodes() throws {
         // Forward-compat: an unrecognized type is surfaced, not thrown.
         let json = #"{"v":2,"type":"some.future.frame","id":"x"}"#

--- a/desktop/Tests/ShedKitTests/IPCMessagesTests.swift
+++ b/desktop/Tests/ShedKitTests/IPCMessagesTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import XCTest
+
+@testable import ShedKit
+
+final class IPCMessagesTests: XCTestCase {
+    func testIPCRequestRejectsUnknownTopLevelKeys() throws {
+        let json = #"{"id":"1","op":"ping","extra":true}"#
+        XCTAssertThrowsError(try JSONDecoder().decode(IPCRequest.self, from: Data(json.utf8))) { err in
+            guard case DecodingError.dataCorrupted(let ctx) = err else {
+                return XCTFail("expected dataCorrupted, got \(err)")
+            }
+            XCTAssertTrue(ctx.debugDescription.contains("extra"), ctx.debugDescription)
+        }
+    }
+
+    func testIPCRequestAcceptsKnownKeys() throws {
+        let json = #"{"id":"42","op":"ping"}"#
+        let req = try JSONDecoder().decode(IPCRequest.self, from: Data(json.utf8))
+        XCTAssertEqual(req.id, 42)
+        XCTAssertEqual(req.op, "ping")
+        XCTAssertNil(req.params)
+    }
+}

--- a/desktop/Tests/ShedKitTests/M1Tests.swift
+++ b/desktop/Tests/ShedKitTests/M1Tests.swift
@@ -78,7 +78,26 @@ final class TerminalLauncherTests: XCTestCase {
     func testResolveCustomSubstitutesCmdAndShed() {
         let inv = resolve(.custom, template: "echo {shed}: {cmd}", scriptsDir: scriptsDir)
         XCTAssertEqual(inv.executable, "/bin/sh")
+        // Plain shed names stay unquoted; metachar names are shell-quoted.
         XCTAssertEqual(inv.arguments, ["-c", "echo stbot: \(fixtureCmd.command)"])
+    }
+
+    func testResolveCustomShellQuotesShed() {
+        let evil = "x'; echo pwned #"
+        let inv = TerminalLauncher.resolveLaunch(
+            preset: .custom, cmd: fixtureCmd, shed: evil,
+            customTemplate: "kitty -e {cmd} --title {shed}", scriptsDir: scriptsDir)
+        XCTAssertEqual(
+            inv.arguments[1],
+            "kitty -e \(fixtureCmd.command) --title \(TerminalLauncher.shellQuote(evil))")
+    }
+
+    func testResolveCustomOnePassDoesNotRescanCmd() {
+        let cmd = TerminalCommand(argv: ["echo"], command: "echo before-{shed}-after")
+        let inv = TerminalLauncher.resolveLaunch(
+            preset: .custom, cmd: cmd, shed: "my-shed",
+            customTemplate: "{cmd} # {shed}", scriptsDir: scriptsDir)
+        XCTAssertEqual(inv.arguments[1], "echo before-{shed}-after # my-shed")
     }
 
     func testResolveScriptPresetFallsBackToTerminalAppWithoutScriptsDir() {

--- a/desktop/Tests/ShedKitTests/ScreenshotTests.swift
+++ b/desktop/Tests/ShedKitTests/ScreenshotTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import XCTest
+
+@testable import ShedKit
+
+final class ScreenshotTests: XCTestCase {
+    @MainActor
+    func testCaptureRejectsInvalidScale() {
+        // The scale guard runs before the window checks, so a nil window still
+        // surfaces the scale error for out-of-range values.
+        for bad in [0, 3, -1] {
+            XCTAssertThrowsError(try captureWindowPNG(nil, scale: bad)) { err in
+                guard case ScreenshotError.invalidScale(let s) = err else {
+                    return XCTFail("expected invalidScale for scale \(bad), got \(err)")
+                }
+                XCTAssertEqual(s, bad)
+            }
+        }
+    }
+
+    @MainActor
+    func testCaptureAcceptsValidScaleThenChecksWindow() {
+        // Valid scales pass the guard; with no window the next check fires,
+        // proving 1/2 are not rejected by the scale guard.
+        for good in [1, 2] {
+            XCTAssertThrowsError(try captureWindowPNG(nil, scale: good)) { err in
+                guard case ScreenshotError.noWindow = err else {
+                    return XCTFail("expected noWindow for scale \(good), got \(err)")
+                }
+            }
+        }
+    }
+}

--- a/docs/desktop/rust-core.md
+++ b/docs/desktop/rust-core.md
@@ -18,11 +18,11 @@ A cargo workspace under `crates/` (its members `shed-core`, `shed-core-ffi`,
   store — and **`rc.rs`** (pure Remote-Control: the pane classifier, the
   `shed-ext-rc` + non-interactive SSH argv builders, and the wire DTOs). The Linux
   clients (the Tauri app, `shedctl`) link this crate directly (no UniFFI).
-- **`shed-core-ffi`** — a thin UniFFI wrapper (`crate-type = ["staticlib"]`)
+- **`shed-core-ffi`** — a thin UniFFI wrapper (`crate-type = ["staticlib", "lib"]`)
   exposing a `ShedCore` object + records to Swift. `desktop/scripts/build-core.sh`
-  builds it, runs `uniffi-bindgen`, and assembles a **static**
-  `ShedCoreFFI.xcframework` linked into the app's Mach-O — no new dylib, so the
-  release signing/notarization path is unaffected.
+  builds the staticlib, runs `uniffi-bindgen` (needs the `lib` crate type), and
+  assembles a **static** `ShedCoreFFI.xcframework` linked into the app's Mach-O —
+  no new dylib, so the release signing/notarization path is unaffected.
 - **`shed-app`** — the UI-free app-logic layer (`Backend`), a workspace
   default-member; consumed by the Tauri client (as a cross-workspace path dep).
   Holds the **`RcRunner` portability seam** (`rc.rs`, behind the


### PR DESCRIPTION
## Summary
- Triages post-merge CodeRabbit findings from the Phase 2 desktop import ([#249](https://github.com/charliek/shed/issues/249) / #248): shell-quote `{shed}`, approval intake/expiry hardening, RC/token identity, create HTTP timeout+401 invalidate, FFI docs, Swift parity helpers, HostAgent stop/defaults, IPC unknown keys, screenshot scale.
- Keeps intentional asymmetries (intake `not_expired` fail-closed vs tick `expired_by_tick`; `SetPolicyRules` full-engine replace + `reevaluate_pending`, not `rebuild_policy`).
- Documents skips/withdrawals with evidence below.

Closes #249.

## #249 disposition

| Finding | Disposition | Notes |
|---|---|---|
| `terminal.rs` shell-quote `{shed}` | **Fixed** | `{cmd}` left unquoted (full command line) |
| `coordinator` SetPolicyRules reevaluate | **Fixed** | Engine replace + `reevaluate_pending()`; not `extra_rules`/`rebuild_policy` |
| `coordinator` expiry before policy | **Fixed** | Intake `!not_expired` → Timeout deny before `engine.decide` |
| `coordinator` shed-rule server match | **Fixed** | `r.server.as_deref() == Some(server)` (nil ≠ `""`) |
| `rc.rs` list `server_name` | **Fixed** | Align probed set + `from_dto` with launch/kill |
| `token_minter` wrong-server reject | **Fixed** | Non-empty `resp.server` ≠ requested → error; empty OK |
| `http.rs` create send timeout | **Fixed** | `CREATE_IDLE_TIMEOUT` on `rb.send()`; **no unit test** for blocked send (would need larger mock refactor) |
| `http.rs` create 401 invalidate | **Fixed** | `invalidate()` then `BadStatus`; no create retry |
| `shed-core-ffi` crate-type | **Docs** | Keep `["staticlib", "lib"]` for uniffi-bindgen; docs corrected |
| AppModel expiry consistency | **Fixed (parity)** | Named `canActOnApproval` / `shouldExpireByTick`; **reject** CR sweep of unparseable in `expirePending` |
| ShedListView error/unknown actions | **Fixed** | Stop + Delete; `.starting` skipped (meta already shows starting) |
| HostAgentClient `stop` | **Fixed** | `SHUT_RDWR` + clear fd; single `Darwin.close` in `closeCurrentIf` |
| HostAgentProtocol defaults | **Fixed** | Omitted `HelloAck` / `TokenResponse.server` match Rust `serde(default)` |
| IPCMessages unknown fields | **Fixed** | Open `AnyJSONKey` so unknown top-level keys are rejected |
| Screenshot invalid scale | **Fixed** | Guard scale ∈ {1,2} |
| CreateShedSheet UniFFI field names | **Skipped (false positive)** | See call-chain citation below |
| `.gitignore` `desktop/.secrets/` | **Withdrawn** | CodeRabbit withdrew after envsecrets clarification |
| IPCResponse unknown-key hole | **Out of scope** | Optional follow-up; not required by #249 |

### CreateShedSheet skip evidence (call chain)

1. Sheet builds ShedKit request with camelCase Swift fields (`memoryMB`; `localDir` defaults nil):

```220:227:desktop/Sources/ShedDesktopUI/CreateShedSheet.swift
        let request = CreateShedRequest(
            name: name.trimmingCharacters(in: .whitespaces),
            repo: repo.isEmpty ? nil : repo,
            image: image.isEmpty ? nil : image,
            backend: backend == "auto" ? nil : backend,
            cpus: cpus,
            memoryMB: memoryGB * 1024,
            noProvision: provision ? nil : true)
```

2. Adapter maps to UniFFI (`memoryMb`, `localDir`):

```163:168:desktop/Sources/ShedKit/Net/RustShedCoreAdapter.swift
    static func map(_ v: CreateShedRequest) -> ShedRustCore.CreateShedRequest {
        ShedRustCore.CreateShedRequest(
            name: v.name, repo: v.repo, localDir: v.localDir, image: v.image,
            backend: v.backend, cpus: v.cpus.map(Int64.init), memoryMb: v.memoryMB.map(Int64.init),
            noProvision: v.noProvision)
    }
```

## Test plan
- [x] `make -C desktop core-lint` + `core-test`
- [x] `make -C desktop lint` + `test`
- [x] `make -C desktop e2e-ci` (shedtest-mac)
- [x] `make -C desktop tauri-lint` + `tauri-test`
- [x] `make -C desktop tauri-test-linux` + `tauri-build-linux` (shedtest-linux render gate)
- [ ] CI green on this PR
- [ ] Manual: decide rejects unparseable expiry; expirePending does not sweep unparseable; error/unknown shed actions show Stop+Delete


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stricter fail-closed approval expiry across desktop and coordinator; policy changes immediately reprocess queued prompts.
  * Safer custom terminal templating: shell-quoted `{shed}` with one-pass placeholder expansion.
* **Bug Fixes**
  * Corrected token/server validation (reject mismatched non-empty server replies) and list/session refresh behavior; fixed shed rule retention for server variants.
  * Create-stream now fails after idle timeout; improves token invalidation on create 401.
  * UI shows Stop/Delete for error/unknown states; screenshot capture validates supported scales.
* **Documentation**
  * Updated core packaging/build notes for `staticlib` + `lib`.
* **Tests**
  * Expanded coverage for expiry edge cases, wrong-server tokens, IPC decoding, and new UI/screenshot behaviors.
* **Chores**
  * Added CI debug bundle size budget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->