### PR TITLE
test(desktop): hermetic down-host simulation + egress error-row e2e

### DIFF
--- a/.claude/skills/shedtest-linux/SKILL.md
+++ b/.claude/skills/shedtest-linux/SKILL.md
@@ -60,6 +60,16 @@ make -C desktop e2e-tauri       # shared suite + test_tauri at --target tauri (n
 - `e2e-tauri` runs the ONE `tools/shedtest` harness with `--target tauri`; mac-only ops stay
   gated off. On Linux the tray is a native menu (Tauri emits no Linux tray-click events → no
   popover; expected).
+- **Simulating a down (unreachable) host.** The shared session redirects EVERY configured
+  server to the one in-process mock, so a per-host error row can't appear there. To exercise
+  it, use a DEDICATED fixture config with an extra server plus the
+  `SHED_TAURI_MOCK_UNREACHABLE_HOSTS=<name,...>` override (comma-separated server NAMES, parsed
+  only in test mode) — the backend points those at `http://127.0.0.1:1` (deterministic
+  ECONNREFUSED) while the rest hit the mock. `test_tauri_downhost.py` is the pattern: it
+  launches its OWN throwaway instance (distinct HOME/XDG → distinct socket + single-instance
+  lock, so it coexists with the session app) against `fixtures/config-downhost.yaml`. Keep the
+  down host OUT of the shared `fixtures/config.yaml` (it would break the m0 golden gate + put an
+  error banner in every "healthy" screenshot).
 
 ## How the Docker legs are wired (so failures make sense)
 

--- a/crates/shed-app/src/backend.rs
+++ b/crates/shed-app/src/backend.rs
@@ -7,6 +7,7 @@
 //! `(test_mode, mock_base_url, config_path)` rather than a client's `SHED_*_` env
 //! struct, so the GTK + Tauri clients share one implementation.
 
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{Arc, LazyLock};
 
@@ -63,18 +64,28 @@ impl Backend {
         mock_base_url: Option<&str>,
         config_path: &Path,
     ) -> Self {
-        Self::from_env_parts_with_minter(test_mode, mock_base_url, config_path, None)
+        Self::from_env_parts_with_minter(
+            test_mode,
+            mock_base_url,
+            config_path,
+            None,
+            &HashSet::new(),
+        )
     }
 
     /// As [`from_env_parts`](Self::from_env_parts), but threads a control-token
     /// `minter` (the host-agent bridge) into every non-mock server's client, so a
     /// secure server mints/refreshes its bearer via `token.get` and fails closed
     /// on a mint failure (F6). GTK passes `None` (static-token only).
+    ///
+    /// `unreachable_hosts` is a TEST-ONLY per-host down simulation consulted only in
+    /// the mock arm (see [`from_config_with_minter`](Self::from_config_with_minter)).
     pub fn from_env_parts_with_minter(
         test_mode: bool,
         mock_base_url: Option<&str>,
         config_path: &Path,
         minter: Option<&Arc<dyn TokenMinter>>,
+        unreachable_hosts: &HashSet<String>,
     ) -> Self {
         if test_mode && mock_base_url.is_none() {
             return Self {
@@ -85,24 +96,31 @@ impl Backend {
             };
         }
         let config = ShedConfig::load(&config_path.to_string_lossy());
-        Self::from_config_with_minter(&config, mock_base_url, minter)
+        Self::from_config_with_minter(&config, mock_base_url, minter, unreachable_hosts)
     }
 
     /// Build clients from an already-parsed config. When `mock_base_url` is set
     /// (test mode) every server is redirected to that single hermetic mock —
     /// plain HTTP, no pin, no token — so no real host is touched.
     pub fn from_config(config: &ShedConfig, mock_base_url: Option<&str>) -> Self {
-        Self::from_config_with_minter(config, mock_base_url, None)
+        Self::from_config_with_minter(config, mock_base_url, None, &HashSet::new())
     }
 
     /// As [`from_config`](Self::from_config), but threads a control-token `minter`
     /// into every non-mock server (see
     /// [`from_env_parts_with_minter`](Self::from_env_parts_with_minter)). The mock
     /// path never gets a minter (hermetic — a static, tokenless mock).
+    ///
+    /// `unreachable_hosts` is a TEST-ONLY per-host down simulation: in the mock arm
+    /// a server whose NAME is in the set is pointed at a closed port
+    /// (`http://127.0.0.1:1`, a fast deterministic ECONNREFUSED) instead of the
+    /// mock, so the harness can exercise the per-host error row end-to-end.
+    /// Mock-mode-only by construction — the production `None` arm never consults it.
     pub fn from_config_with_minter(
         config: &ShedConfig,
         mock_base_url: Option<&str>,
         minter: Option<&Arc<dyn TokenMinter>>,
+        unreachable_hosts: &HashSet<String>,
     ) -> Self {
         let clients = config
             .servers
@@ -110,7 +128,12 @@ impl Backend {
             .filter_map(|s| {
                 let client = match mock_base_url {
                     Some(mock) => {
-                        Client::new(mock.to_string(), s.name.clone(), String::new(), None, None)
+                        let url = if unreachable_hosts.contains(&s.name) {
+                            "http://127.0.0.1:1".to_string()
+                        } else {
+                            mock.to_string()
+                        };
+                        Client::new(url, s.name.clone(), String::new(), None, None)
                     }
                     None => {
                         // A pin on a non-https URL fails closed in Client::new → that
@@ -481,6 +504,18 @@ mod tests {
         (name.to_string(), client)
     }
 
+    fn server_entry(name: &str) -> shed_core::config::ShedServerEntry {
+        shed_core::config::ShedServerEntry {
+            name: name.into(),
+            host: "127.0.0.1".into(),
+            http_port: 8080,
+            ssh_port: 2222,
+            control_token: String::new(),
+            api_url: String::new(),
+            tls_cert_fingerprint: String::new(),
+        }
+    }
+
     #[tokio::test]
     async fn from_env_parts_test_mode_without_mock_builds_no_clients() {
         // Hermeticity: a partial test env must not dial the developer's real hosts.
@@ -710,6 +745,57 @@ mod tests {
         let b = rows.iter().find(|r| r.host == "bad").unwrap();
         assert!(b.profiles.is_empty());
         assert!(b.error.is_some());
+    }
+
+    #[tokio::test]
+    async fn from_config_with_unreachable_host_yields_error_row() {
+        // The mock-arm per-host down override (backs SHED_*_MOCK_UNREACHABLE_HOSTS):
+        // a config-built backend whose `down` server is in the set points that
+        // client at a closed port while `mock` reaches the httpmock — so
+        // egress_profiles / system_df keep `down` as an error row (the e2e
+        // down-host contract, verified at the constructor level rather than only
+        // via hand-built clients).
+        let mock = MockServer::start_async().await;
+        mock.mock_async(|w, t| {
+            w.method(GET).path("/api/egress/profiles");
+            t.status(200).body(
+                r#"[{"name":"default","source":"config","profile":{"allow":["*.github.com"]}}]"#,
+            );
+        })
+        .await;
+        mock.mock_async(|w, t| {
+            w.method(GET).path("/api/system/df");
+            t.status(200).body(
+                r#"{"server_name":"mock","backend":"vz","totals":{"all":{"logical_bytes":1,"physical_bytes":1}}}"#,
+            );
+        })
+        .await;
+        let config = ShedConfig {
+            servers: vec![server_entry("mock"), server_entry("down")],
+            default_server: Some("mock".into()),
+        };
+        let unreachable: HashSet<String> = ["down".to_string()].into_iter().collect();
+        let backend =
+            Backend::from_config_with_minter(&config, Some(&mock.base_url()), None, &unreachable);
+
+        // egress: `mock` reaches the httpmock (profile decoded); `down` is KEPT as
+        // an error row (redirected to the closed port), never a dropped host.
+        let egress = backend.egress_profiles().await;
+        assert_eq!(egress.len(), 2);
+        let m = egress.iter().find(|r| r.host == "mock").unwrap();
+        assert!(m.error.is_none());
+        assert_eq!(m.profiles.len(), 1);
+        let d = egress.iter().find(|r| r.host == "down").unwrap();
+        assert!(d.profiles.is_empty());
+        assert!(d.error.is_some());
+
+        // system_df: same split — `mock` healthy, `down` an error row with no usage.
+        let df = backend.system_df().await;
+        assert_eq!(df.len(), 2);
+        let m = df.iter().find(|r| r.host == "mock").unwrap();
+        assert!(m.usage.is_some() && m.error.is_none());
+        let d = df.iter().find(|r| r.host == "down").unwrap();
+        assert!(d.usage.is_none() && d.error.is_some());
     }
 
     #[test]

--- a/desktop/Sources/ShedDesktopApp/AppModel.swift
+++ b/desktop/Sources/ShedDesktopApp/AppModel.swift
@@ -392,7 +392,13 @@ final class AppModel: NSObject, UiBridge {
             let baseURL: URL
             let pin: String
             if let mockBase, let url = URL(string: mockBase) {
-                baseURL = url
+                // TEST-ONLY: a server named in mockUnreachableHosts is pointed at a
+                // closed port (fast deterministic ECONNREFUSED) instead of the mock,
+                // so the per-host error row is exercisable e2e (parity with the Rust
+                // backend's mock-arm override).
+                baseURL = ShedBackend.shared.mockUnreachableHosts.contains(entry.name)
+                    ? (URL(string: "http://127.0.0.1:1") ?? url)
+                    : url
                 pin = ""  // hermetic mock is plain http; no pinning
             } else {
                 let resolved = entry.resolvedEndpoint()

--- a/desktop/Sources/ShedKit/Backend/ShedBackend.swift
+++ b/desktop/Sources/ShedKit/Backend/ShedBackend.swift
@@ -30,6 +30,12 @@ public final class ShedBackend {
     /// harness can fail fast if a run isn't actually hermetic.
     public private(set) var mockBaseURL: String?
 
+    /// TEST-ONLY per-host down simulation: the comma-separated server names from
+    /// `SHED_DESKTOP_MOCK_UNREACHABLE_HOSTS` (parsed only in test mode) that
+    /// `AppModel` points at a closed port instead of the mock, so the per-host
+    /// error row is exercisable e2e. Empty unless test mode + the var is set.
+    public private(set) var mockUnreachableHosts: Set<String> = []
+
     /// Route read/lifecycle/create ops through the Rust shed-core. Default **on**
     /// (M0); `SHED_DESKTOP_RUST_CORE=0` forces the legacy Swift `URLSession` path
     /// (a rollback escape hatch kept for ≥2 releases). Reported by `identify` as
@@ -73,6 +79,15 @@ public final class ShedBackend {
         self.testMode = env["SHED_DESKTOP_TEST_MODE"] == "1"
         self.mockBaseURL = env["SHED_DESKTOP_MOCK_BASE_URL"]
         self.rustCore = env["SHED_DESKTOP_RUST_CORE"] != "0"
+        // Only consulted in the mock branch; parse it only in test mode so a stray
+        // env var can never affect a production run.
+        self.mockUnreachableHosts = self.testMode
+            ? Set(
+                (env["SHED_DESKTOP_MOCK_UNREACHABLE_HOSTS"] ?? "")
+                    .split(separator: ",")
+                    .map { $0.trimmingCharacters(in: .whitespaces) }
+                    .filter { !$0.isEmpty })
+            : []
 
         let home = (env["HOME"] ?? NSHomeDirectory()) as NSString
         self.shedConfigPath = env["SHED_DESKTOP_SHED_CONFIG"]

--- a/desktop/tauri/src-tauri/src/env.rs
+++ b/desktop/tauri/src-tauri/src/env.rs
@@ -2,6 +2,7 @@
 //! Swift `ShedBackend` hermeticity hooks so the pytest harness can point the Tauri
 //! app at an in-process mock + a fixture config without touching real hosts.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
@@ -12,6 +13,11 @@ pub struct Env {
     /// (`SHED_TAURI_MOCK_BASE_URL`). Echoed by `identify` so the harness can fail
     /// fast if a run isn't actually hermetic.
     pub mock_base_url: Option<String>,
+    /// TEST-ONLY per-host down simulation: the comma-separated server NAMES from
+    /// `SHED_TAURI_MOCK_UNREACHABLE_HOSTS` (parsed only in test mode) that the
+    /// backend points at a closed port instead of the mock, so the harness can
+    /// exercise the per-host error row. Empty unless test mode + the var is set.
+    pub mock_unreachable_hosts: HashSet<String>,
     /// The shed config to read (`SHED_TAURI_SHED_CONFIG`, else `~/.shed/config.yaml`).
     #[allow(dead_code)] // read by the shed-app backend in A1b
     pub config_path: PathBuf,
@@ -41,9 +47,25 @@ impl Env {
                     default_config_path()
                 }
             });
+        // Only consulted in the mock arm; parse it only in test mode so a stray env
+        // var can never affect a production run.
+        let mock_unreachable_hosts = if test_mode {
+            var("SHED_TAURI_MOCK_UNREACHABLE_HOSTS")
+                .map(|v| {
+                    v.split(',')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default()
+        } else {
+            HashSet::new()
+        };
         Self {
             test_mode,
             mock_base_url: var("SHED_TAURI_MOCK_BASE_URL"),
+            mock_unreachable_hosts,
             config_path,
             socket_path: var("SHED_TAURI_SOCKET")
                 .map(PathBuf::from)

--- a/desktop/tauri/src-tauri/src/ipc.rs
+++ b/desktop/tauri/src-tauri/src/ipc.rs
@@ -1031,6 +1031,7 @@ mod tests {
         Env {
             test_mode: true,
             mock_base_url: mock.map(str::to_string),
+            mock_unreachable_hosts: std::collections::HashSet::new(),
             config_path: PathBuf::new(),
             socket_path: PathBuf::from("/run/user/0/shed-tauri/shed-tauri.sock"),
             host_agent_socket: PathBuf::from("/run/user/0/shed/host-agent.sock"),

--- a/desktop/tauri/src-tauri/src/lib.rs
+++ b/desktop/tauri/src-tauri/src/lib.rs
@@ -569,6 +569,7 @@ pub fn run() {
         env.mock_base_url.as_deref(),
         &env.config_path,
         minter.as_ref(),
+        &env.mock_unreachable_hosts,
     ));
 
     // The Agents / Remote-Control service (session store + process seam). Same

--- a/desktop/tools/shedtest/fixtures/config-downhost.yaml
+++ b/desktop/tools/shedtest/fixtures/config-downhost.yaml
@@ -1,0 +1,18 @@
+# Down-host fixture for the hermetic down-host E2E module (test_tauri_downhost.py).
+# Same shape as config.yaml, but TWO servers: `mock` (reachable — redirected to
+# the in-process mock like the shared fixture) and `down` (named in the launch's
+# SHED_*_MOCK_UNREACHABLE_HOSTS override, so the backend points it at a closed
+# port and it surfaces as a per-host error row). Host/port are placeholders — the
+# server name is what the override matches on. Kept SEPARATE from config.yaml so
+# the shared suite / m0 gates / screenshots see no `down` host.
+servers:
+    mock:
+        host: 127.0.0.1
+        http_port: 8080
+        ssh_port: 2222
+    down:
+        host: 127.0.0.1
+        http_port: 8080
+        ssh_port: 2222
+default_server: mock
+sheds: {}

--- a/desktop/tools/shedtest/test_tauri.py
+++ b/desktop/tools/shedtest/test_tauri.py
@@ -376,10 +376,11 @@ def test_egress_profiles_render(tauri):
     # host + source, the auto-selected first profile's detail shows its allow/deny
     # rules, and selection is drivable by name (egress.show).
     #
-    # NOTE: a down-host error row can't be simulated here — test mode points every
-    # configured server at the single in-process mock — so the error-row contract
-    # is pinned at the shed-app unit level
-    # (backend.rs::egress_profiles_keeps_error_row_for_down_host).
+    # NOTE: this module's shared session instance points every configured server at
+    # the single in-process mock, so the down-host error row is exercised e2e in the
+    # DEDICATED module test_tauri_downhost.py (its own instance + the down-host
+    # fixture + the SHED_TAURI_MOCK_UNREACHABLE_HOSTS override); the shed-app unit
+    # level pins it too (backend.rs::egress_profiles_keeps_error_row_for_down_host).
     tauri.wait_until(lambda: tauri.current_pane() is not None, timeout=15, what="frontend ready")
     tauri.navigate("egress")
     tauri.wait_until(lambda: tauri.current_pane() == "egress", timeout=15, what="pane=egress")

--- a/desktop/tools/shedtest/test_tauri_downhost.py
+++ b/desktop/tools/shedtest/test_tauri_downhost.py
@@ -1,0 +1,148 @@
+"""tauri-only down-host E2E: a per-host UNREACHABLE server surfaces as an error
+row end-to-end (the Egress pane's error rows + the System pane's per-host df),
+while the reachable `mock` host stays healthy.
+
+This is the e2e closure of the gap `test_tauri.py::test_egress_profiles_render`
+documents (the shared harness blanket-redirects every configured server to the
+one in-process mock, so the error row was only unit-tested). It launches its OWN
+hermetic app instance — a distinct throwaway HOME/XDG_RUNTIME_DIR → a distinct
+socket + single-instance lock (keyed to the socket dir), so it coexists with the
+session instance without touching the session fixture — pointed at the dedicated
+down-host fixture (`config-downhost.yaml`: servers `mock` + `down`) with `down`
+named in the `SHED_TAURI_MOCK_UNREACHABLE_HOSTS` override (the backend redirects
+it to a closed port → deterministic ECONNREFUSED).
+
+Gated on `--target tauri` (skipped otherwise), like `test_tauri.py`.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+import ui
+from client import TauriClient
+from fake_host_agent import FakeHostAgent
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("SHED_TEST_TARGET", "mac") != "tauri",
+    reason="tauri-only: hermetic down-host per-host error row",
+)
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+DOWNHOST_CONFIG = FIXTURES / "config-downhost.yaml"
+
+
+@contextmanager
+def _downhost_app(mock_base_url: str):
+    """Launch a SECOND, independent tauri instance (its own throwaway HOME +
+    XDG_RUNTIME_DIR → its own socket/lock) with the down-host fixture + the `down`
+    unreachable override, yield a ready client, and tear it down. Reuses the shared
+    `ui` subprocess helpers (env / hermetic-wait / terminate) but passes its OWN
+    socket/proc, so it never touches ui._state (the session instance's
+    bookkeeping).
+
+    It also owns a PRIVATE FakeHostAgent (started/stopped here, mirroring the
+    session `fake` fixture): the throwaway app connects to its own socket, so this
+    instance can never steal the session fake's single tracked connection and
+    misroute its emit_request/emit_event frames."""
+    cfg = ui._SUBPROC["tauri"]
+    if not cfg.binary.exists():
+        raise RuntimeError(
+            f"tauri binary not found at {cfg.binary}; build it first (make tauri-build).")
+    agent = FakeHostAgent()
+    agent.start()
+    try:
+        # Short prefix: the socket lives under this dir (itself under a long macOS
+        # TMPDIR), and a Unix socket path must stay under SUN_LEN (~104).
+        runtime_dir = Path(tempfile.mkdtemp(prefix="shed-dh-"))
+        sock = runtime_dir / cfg.sock_rel
+        log = runtime_dir / "downhost-ui.log"
+        env = ui.subproc_env(cfg, runtime_dir=runtime_dir, mock_base_url=mock_base_url,
+                             config_path=DOWNHOST_CONFIG, host_agent_socket=agent.socket_path,
+                             unreachable_hosts=("down",))
+        log_fh = open(log, "wb")
+        proc = subprocess.Popen([str(cfg.binary)], env=env, stdout=log_fh, stderr=subprocess.STDOUT)
+        try:
+            ui.await_hermetic("tauri", sock=sock, mock_base_url=mock_base_url,
+                              proc=proc, log=log)
+            client = TauriClient(sock)
+            try:
+                client.wait_until(lambda: client.current_pane() is not None,
+                                  timeout=30, what="down-host frontend ready")
+                yield client
+            finally:
+                client.close()
+        finally:
+            ui.terminate(proc)
+            log_fh.close()
+            shutil.rmtree(runtime_dir, ignore_errors=True)
+    finally:
+        agent.stop()
+
+
+@pytest.fixture
+def downhost(mock):
+    """A ready client for a self-managed down-host tauri instance. `mock` is the
+    session-scoped shared mock server (reused, not re-created); the instance itself
+    — and its private fake host-agent — is throwaway. The session `fake` fixture is
+    deliberately NOT requested, so this module never perturbs it."""
+    with _downhost_app(mock.base_url) as client:
+        yield client
+
+
+def test_egress_error_row_for_down_host(downhost):
+    # The Egress pane renders the reachable mock's two profiles AND exactly one
+    # error row for the unreachable `down` host — the e2e closure of the gap
+    # test_tauri.py::test_egress_profiles_render documents.
+    downhost.navigate("egress")
+    downhost.wait_until(lambda: downhost.current_pane() == "egress", timeout=15, what="pane=egress")
+    downhost.egress_show(tab="profiles")
+    downhost.wait_until(lambda: (downhost.egress_dump() or {}).get("tab") == "profiles",
+                        timeout=15, what="profiles sub-tab shown")
+    downhost.wait_until(lambda: len((downhost.egress_dump() or {}).get("errors") or []) == 1,
+                        timeout=15, what="down-host error row rendered")
+    d = downhost.egress_dump()
+    # mock's two profiles are intact (unaffected by the down host).
+    rows = {(p["host"], p["name"], p["source"]) for p in d["profiles"]}
+    assert rows == {("mock", "default", "config"), ("mock", "custom", "user")}, f"unexpected rows: {d}"
+    # exactly one error row, for `down`, with a non-empty error message.
+    assert len(d["errors"]) == 1, f"unexpected errors: {d['errors']}"
+    err = d["errors"][0]
+    assert err["host"] == "down"
+    assert err["error"], f"down-host error row has an empty message: {err}"
+
+
+def test_system_df_error_row_for_down_host(downhost):
+    # The System pane's per-host df keeps the `down` host as an error row (usage
+    # absent, error present) while `mock` stays healthy — never a dropped host.
+    usage = downhost.system_df()
+    by_host = {r["host"]: r for r in usage}
+    assert set(by_host) == {"mock", "down"}, f"unexpected hosts: {by_host}"
+    down = by_host["down"]
+    assert down.get("usage") is None, f"down host unexpectedly has usage: {down}"
+    assert down.get("error"), f"down host has no error: {down}"
+    assert by_host["mock"].get("usage") is not None, f"mock host has no usage: {by_host['mock']}"
+
+
+def test_badges_count_both_configured_hosts(downhost):
+    # `hosts` counts CONFIGURED hosts (derived from system.df, which keeps the down
+    # host as a row) → 2 in this instance, even though one is unreachable.
+    downhost.wait_until(lambda: (downhost.badges() or {}).get("hosts") == 2,
+                        timeout=15, what="badges report 2 configured hosts")
+    assert downhost.badges()["hosts"] == 2
+
+
+def test_identify_stays_hermetic(downhost, mock):
+    # The down-host override doesn't perturb the hermeticity contract: identify
+    # still echoes the mock base URL + the tauri platform (the handshake untouched).
+    info = downhost.identify()
+    assert info["mock_base_url"] == mock.base_url
+    assert info["platform"] == "tauri"
+    assert info["test_mode"] is True

--- a/desktop/tools/shedtest/ui.py
+++ b/desktop/tools/shedtest/ui.py
@@ -89,16 +89,22 @@ def socket_path(target: str = "mac") -> Path:
     return runtime / cfg.sock_rel
 
 
-def make_client(target: str) -> IPCClient:
-    """The IPC client for a target — the single source of the target→class map
-    (subprocess targets carry their `client_cls` in `_SUBPROC`)."""
-    sock = socket_path(target)
+def _client_at(target: str, sock: Path) -> IPCClient:
+    """The IPC client class for a target, bound to an EXPLICIT socket path — the
+    single source of the target→class map (subprocess targets carry their
+    `client_cls` in `_SUBPROC`). `make_client` resolves the socket from session
+    state; a self-managed instance (down-host) passes its own."""
     if target == "mac":
         return ShedDesktop(sock)
     cfg = _SUBPROC.get(target)
     if cfg is None:
         raise ValueError(f"unknown target {target!r} (want {'|'.join(TARGETS)})")
     return cfg.client_cls(sock)
+
+
+def make_client(target: str) -> IPCClient:
+    """The IPC client for a target at its session-resolved socket."""
+    return _client_at(target, socket_path(target))
 
 
 def launch_env(target: str) -> dict[str, str]:
@@ -192,14 +198,23 @@ def _quit_mac() -> None:
                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
 
 
+def terminate(proc: "subprocess.Popen[bytes] | None") -> None:
+    """terminate → wait → SIGKILL a subprocess UI child, tolerating one that has
+    already exited. Shared by `_quit_subproc` (the session instance) and a
+    self-managed instance's teardown (down-host)."""
+    if proc is None or proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=scaled_timeout(5))
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
 def _quit_subproc(target: str) -> None:
     st = _state[target]
-    if st.proc is not None and st.proc.poll() is None:
-        st.proc.terminate()
-        try:
-            st.proc.wait(timeout=scaled_timeout(5))
-        except subprocess.TimeoutExpired:
-            st.proc.kill()
+    terminate(st.proc)
     if st.log_fh is not None:
         st.log_fh.close()
     if st.runtime_dir is not None:
@@ -208,26 +223,32 @@ def _quit_subproc(target: str) -> None:
 
 
 def launch(target: str = "mac", *, mock_base_url: str, config_path: Path, state_dir: Path,
-           host_agent_socket: str | None = None) -> None:
+           host_agent_socket: str | None = None, unreachable_hosts: tuple[str, ...] = ()) -> None:
     """Launch the UI hermetically and block until it answers `identify`.
 
     `state_dir` is the throwaway per-session dir: on mac SHED_DESKTOP_STATE_DIR;
     on a subprocess target it doubles as HOME + XDG_RUNTIME_DIR (so ~/.shed and
     the runtime socket are both isolated). `host_agent_socket` backs the approval
-    gate — set for both mac + tauri (the fake host-agent).
+    gate — set for both mac + tauri (the fake host-agent). `unreachable_hosts` are
+    config server NAMES the backend points at a closed port instead of the mock
+    (the `<PREFIX>_MOCK_UNREACHABLE_HOSTS` down-host override) so the per-host error
+    row is exercisable e2e; wired for both targets, though only tauri drives it now.
     """
     if target == "mac":
         _launch_mac(mock_base_url=mock_base_url, config_path=config_path,
-                    state_dir=state_dir, host_agent_socket=host_agent_socket)
+                    state_dir=state_dir, host_agent_socket=host_agent_socket,
+                    unreachable_hosts=unreachable_hosts)
     elif target in _SUBPROC:
         _launch_subproc(target, mock_base_url=mock_base_url, config_path=config_path,
-                        runtime_dir=state_dir, host_agent_socket=host_agent_socket)
+                        runtime_dir=state_dir, host_agent_socket=host_agent_socket,
+                        unreachable_hosts=unreachable_hosts)
     else:
         raise ValueError(f"unknown target {target!r} (want {'|'.join(TARGETS)})")
 
 
 def _launch_mac(*, mock_base_url: str, config_path: Path, state_dir: Path,
-                host_agent_socket: str | None) -> None:
+                host_agent_socket: str | None,
+                unreachable_hosts: tuple[str, ...] = ()) -> None:
     if platform.system() != "Darwin":
         raise RuntimeError("the mac target requires macOS")
     if not APP.is_dir():
@@ -240,6 +261,8 @@ def _launch_mac(*, mock_base_url: str, config_path: Path, state_dir: Path,
     ]
     if host_agent_socket:
         argv += ["--env", f"SHED_DESKTOP_HOST_AGENT_SOCKET={host_agent_socket}"]
+    if unreachable_hosts:
+        argv += ["--env", f"SHED_DESKTOP_MOCK_UNREACHABLE_HOSTS={','.join(unreachable_hosts)}"]
     # Throwaway UserDefaults suite so preferences never touch the dev's real
     # defaults (the SHED_DESKTOP_STATE_DIR analog for UserDefaults).
     argv += ["--env", f"SHED_DESKTOP_DEFAULTS_SUITE={DEFAULTS_SUITE}"]
@@ -254,21 +277,18 @@ def _launch_mac(*, mock_base_url: str, config_path: Path, state_dir: Path,
     wait_alive("mac", mock_base_url=mock_base_url)
 
 
-def _launch_subproc(target: str, *, mock_base_url: str, config_path: Path,
-                    runtime_dir: Path, host_agent_socket: str | None = None) -> None:
-    cfg = _SUBPROC[target]
-    if not cfg.binary.exists():
-        raise RuntimeError(
-            f"{target} binary not found at {cfg.binary}; build it first "
-            f"(tauri: `make tauri-build`).")
-    # HOME/XDG_RUNTIME_DIR redirected to the temp dir (never the dev's ~/.shed or
-    # real runtime socket), config pinned to the fixture, test mode + mock set.
-    # <PREFIX>_SOCKET is cleared so the XDG default (under runtime_dir) is used.
+def subproc_env(cfg: _Subproc, *, runtime_dir: Path, mock_base_url: str,
+                config_path: Path, host_agent_socket: str | None = None,
+                unreachable_hosts: tuple[str, ...] = ()) -> dict[str, str]:
+    """The launch env for a subprocess UI — the single source of the subprocess
+    env-var contract, shared by the session launcher and a self-managed instance
+    (down-host). HOME/XDG_RUNTIME_DIR/XDG_CONFIG_HOME are redirected to the
+    throwaway `runtime_dir` (never the dev's ~/.shed, real runtime socket, or real
+    prefs), config is pinned to the fixture, test mode + mock are set, and
+    `<PREFIX>_SOCKET` is cleared so the XDG default (under runtime_dir) is used."""
     env = dict(os.environ)
     env["HOME"] = str(runtime_dir)
     env["XDG_RUNTIME_DIR"] = str(runtime_dir)
-    # Redirect the config dir too so tauri's app_config_dir (persisted prefs) is
-    # hermetic — else a dev's real $XDG_CONFIG_HOME would be written under test.
     env["XDG_CONFIG_HOME"] = str(runtime_dir / "config")
     env[f"{cfg.env_prefix}_TEST_MODE"] = "1"
     env[f"{cfg.env_prefix}_MOCK_BASE_URL"] = mock_base_url
@@ -276,7 +296,29 @@ def _launch_subproc(target: str, *, mock_base_url: str, config_path: Path,
     # The approval gate's host-agent socket (the fake, in tests).
     if host_agent_socket:
         env[f"{cfg.env_prefix}_HOST_AGENT_SOCKET"] = str(host_agent_socket)
+    # Down-host override: server NAMES the backend redirects to a closed port.
+    # Always set-or-clear (like the socket below) so an inherited value from the
+    # parent shell never leaks into a normal (empty) session.
+    unreachable_key = f"{cfg.env_prefix}_MOCK_UNREACHABLE_HOSTS"
+    if unreachable_hosts:
+        env[unreachable_key] = ",".join(unreachable_hosts)
+    else:
+        env.pop(unreachable_key, None)
     env.pop(f"{cfg.env_prefix}_SOCKET", None)
+    return env
+
+
+def _launch_subproc(target: str, *, mock_base_url: str, config_path: Path,
+                    runtime_dir: Path, host_agent_socket: str | None = None,
+                    unreachable_hosts: tuple[str, ...] = ()) -> None:
+    cfg = _SUBPROC[target]
+    if not cfg.binary.exists():
+        raise RuntimeError(
+            f"{target} binary not found at {cfg.binary}; build it first "
+            f"(tauri: `make tauri-build`).")
+    env = subproc_env(cfg, runtime_dir=runtime_dir, mock_base_url=mock_base_url,
+                      config_path=config_path, host_agent_socket=host_agent_socket,
+                      unreachable_hosts=unreachable_hosts)
     st = _state[target]
     st.env = env
     st.runtime_dir = runtime_dir
@@ -288,15 +330,21 @@ def _launch_subproc(target: str, *, mock_base_url: str, config_path: Path,
     wait_alive(target, mock_base_url=mock_base_url)
 
 
-def wait_alive(target: str = "mac", *, mock_base_url: str, timeout: float = 30.0) -> None:
-    """Block until the app answers `identify` AND confirms it's hermetic (test
-    mode + the expected mock base URL + the target's backend). Failing fast here
-    stops a misconfigured run from silently hitting a real server."""
+def await_hermetic(target: str, *, sock: Path, mock_base_url: str, timeout: float = 30.0,
+                   proc: "subprocess.Popen[bytes] | None" = None,
+                   log: Path | None = None) -> None:
+    """Block until the UI at `sock` answers `identify` AND confirms it's hermetic
+    (test mode + the expected mock base URL + the target's backend). Failing fast
+    here stops a misconfigured run from silently hitting a real server. A
+    subprocess UI passes its `proc`/`log` so a crashed-on-boot child (already
+    exited) is surfaced with its captured log rather than a slow timeout. `_state`-
+    free — shared by the session launcher (via `wait_alive`) and a self-managed
+    instance (down-host)."""
     timeout = scaled_timeout(timeout)
     deadline = time.monotonic() + timeout
     while True:
         try:
-            c = make_client(target)
+            c = _client_at(target, sock)
             try:
                 info = c.identify()
                 if _hermetic(target, info, mock_base_url):
@@ -305,15 +353,22 @@ def wait_alive(target: str = "mac", *, mock_base_url: str, timeout: float = 30.0
                 c.close()
         except (OSError, ShedError):
             pass
-        # A crashed-on-boot subprocess child (already exited) is a hard failure,
-        # not a slow boot — surface it (with the captured log) rather than time out.
-        st = _state.get(target)
-        if st is not None and st.proc is not None and st.proc.poll() is not None:
+        if proc is not None and proc.poll() is not None:
             raise RuntimeError(
-                f"{target} UI exited early (code {st.proc.returncode}); see {st.log}")
+                f"{target} UI exited early (code {proc.returncode}); see {log}")
         if time.monotonic() >= deadline:
             raise TimeoutError(f"{target} UI not hermetically ready within {timeout}s")
         time.sleep(0.25)
+
+
+def wait_alive(target: str = "mac", *, mock_base_url: str, timeout: float = 30.0) -> None:
+    """Session-instance wait: resolve the socket + subprocess bookkeeping from
+    `_state` and block until hermetically ready (see `await_hermetic`)."""
+    st = _state.get(target)
+    await_hermetic(
+        target, sock=socket_path(target), mock_base_url=mock_base_url, timeout=timeout,
+        proc=st.proc if st else None, log=st.log if st else None,
+    )
 
 
 def _hermetic(target: str, info: dict, mock_base_url: str) -> bool:

--- a/docs/desktop/test-automation.md
+++ b/docs/desktop/test-automation.md
@@ -39,6 +39,20 @@ make -C desktop e2e-swift   # mac: same, Rust core forced off (SHED_DESKTOP_RUST
 make -C desktop e2e-tauri   # tauri: shared suite + test_tauri (needs a display; Xvfb on Linux)
 ```
 
+### Simulating a down (unreachable) host
+
+The shared session redirects every configured server to the one in-process mock, so a
+per-host error row (an unreachable host in the Egress / System panes) can't appear there. To
+exercise it, point a **dedicated** fixture config at an extra server and name it in the
+`SHED_TAURI_MOCK_UNREACHABLE_HOSTS` / `SHED_DESKTOP_MOCK_UNREACHABLE_HOSTS` override
+(comma-separated server names, parsed only in test mode): the backend points those hosts at a
+closed port (`http://127.0.0.1:1`, a deterministic connection refusal) while the rest still hit
+the mock. `test_tauri_downhost.py` is the pattern — it launches its own throwaway app instance
+(distinct HOME/`XDG_RUNTIME_DIR` → distinct socket and single-instance lock, so it coexists
+with the session app) against `fixtures/config-downhost.yaml`. Keep the down host out of the
+shared `fixtures/config.yaml` so the golden ship-gates and healthy-path screenshots are
+undisturbed.
+
 ## The Linux render gate + `.deb`
 
 The Tauri client's real shipped WebView is WebKitGTK, so a Linux-only render gate runs the


### PR DESCRIPTION
Closes the gap noted in PR #255: the hermetic harness blanket-redirects every configured server to the single in-process mock, so the Egress/System per-host error rows were only unit-tested. Stacked on #255 (retargets to main when it merges).

## Design

A per-host **unreachable override layered on the existing mock redirect**: `Backend` constructors take an `unreachable_hosts` set; in the mock arm, a named server's client gets `http://127.0.0.1:1` (deterministic ECONNREFUSED) instead of the mock URL. Mock-mode-only by construction — the production arm never consults it. Driven by `SHED_TAURI_MOCK_UNREACHABLE_HOSTS` / `SHED_DESKTOP_MOCK_UNREACHABLE_HOSTS` (test-mode-only, always set-or-cleared so nothing leaks from the parent shell). The mac side gets the same plumbing via `ShedBackend.mockUnreachableHosts`.

The down host lives in a **dedicated fixture** (`config-downhost.yaml`) used by a self-contained `test_tauri_downhost.py` that launches its own throwaway app instance with a **private fake host-agent** — the shared fixture, m0 golden gate, screenshots, badges, and every existing test are untouched by design (a shared-config down host would break the Rust-vs-Swift golden byte-diff and index-0 assumptions; the 3-reviewer plan panel caught this).

New coverage: egress Profiles error row, System df error row, configured-host badge count, and the intact hermeticity echo — all against the real app. Launcher plumbing consolidated into reusable `ui.py` helpers (`subproc_env`/`await_hermetic`/`terminate`) shared with the session launcher.

## Verification

- shed-app: 72 tests (+ new ctor-level down-host test), clippy clean, rc feature leg green
- `make e2e-tauri`: 71 passed / 31 skipped (baseline + 4 new)
- `make e2e-ci` (mac): 74 / 28 — unaffected; Swift build + 137 unit tests green
- `make m0-gates`: green, untouched
- `make tauri-build-linux`: 73 / 29 — the second-instance module passes in-container
- Plan panel (Codex/Kimi/CodeRabbit) + per-commit /simplify + Codex code review; all findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QReoPKEdMBFuYDmL51LUDx
