### PR TITLE
feat(tauri): Preferences becomes a dedicated window (mac parity)

### DIFF
--- a/.claude/skills/shedtest-linux/SKILL.md
+++ b/.claude/skills/shedtest-linux/SKILL.md
@@ -60,6 +60,17 @@ make -C desktop e2e-tauri       # shared suite + test_tauri at --target tauri (n
 - `e2e-tauri` runs the ONE `tools/shedtest` harness with `--target tauri`; mac-only ops stay
   gated off. On Linux the tray is a native menu (Tauri emits no Linux tray-click events → no
   popover; expected).
+- **Driving the Preferences window.** Preferences is a dedicated native window (mac parity,
+  no longer a dashboard modal), so it has its own IPC surface rather than `ui.modal`:
+  `ui.show_preferences` (open/focus the lazy-created singleton; **it does NOT raise the
+  dashboard**) with `ui.open_preferences` as the mac-named alias op; `prefs.dump` →
+  `{visible, title, prefs}` (the window's UI truth — `visible`/`title` are Rust-side native
+  window state, `prefs` is the React-reported `{sections, values, mode}` snapshot keyed under
+  the **`preferences`** window label); `prefs.close` (hide, close-hides contract);
+  `prefs.provider_modes` / `prefs.set_provider` (AWS/Docker Allow|Deny, ungated); and
+  `prefs.remove_shed_rule {server, shed}` (the per-shed override row's remove button). Note
+  `ui.modal` now only ever reports `create` | `launch` | `null` — Preferences is never a
+  modal value.
 - **Simulating a down (unreachable) host.** The shared session redirects EVERY configured
   server to the one in-process mock, so a per-host error row can't appear there. To exercise
   it, use a DEDICATED fixture config with an extra server plus the
@@ -101,6 +112,13 @@ command for a small Python driver. Same wiring as the target (see the Makefile):
 - Reuse the `shed-tauri-linux-{cargo,target}` cache volumes so the Rust build is
   incremental across runs (`-v shed-tauri-linux-cargo:/usr/local/cargo/registry -v
   shed-tauri-linux-target:/target`), with `-e CARGO_TARGET_DIR=/target`.
+- **Pass `-e UV_PROJECT_ENVIRONMENT=/tmp/uv-venv`** (copy it verbatim from the
+  Makefile's `tauri-build-linux` render-gate block). `uv run` defaults to writing
+  its project venv at `.venv` next to `pyproject.toml` — but that's under the
+  read-only `/repo`→`/work` tree, so without this override `uv run` **wedges
+  silently** in the container (no venv it can write, no error you'll see) and the
+  driver never runs. Every Makefile Docker leg that runs `uv` sets it; the ad-hoc
+  driver run needs it too.
 - `--cap-add SYS_ADMIN --security-opt seccomp=unconfined --shm-size=1g` and
   `-e SHED_TAURI_BIN=/target/debug/shed-desktop-tauri` (point the harness at the
   binary this run builds). **Note:** `--cap-add SYS_ADMIN --security-opt
@@ -110,7 +128,12 @@ command for a small Python driver. Same wiring as the target (see the Makefile):
   agents, or secrets into a container running with these flags.
 
 Putting it together — the complete invocation (repo/worktree root; expects your
-driver at `$HOST_OUT/driver.py`):
+driver at `$HOST_OUT/driver.py`). **Set `ROOT`/`HOST_OUT` on their OWN line, as
+below — NOT as one-line prefix assignments on the `docker run` itself.** A prefix
+assignment (`HOST_OUT=/tmp/shed-shots docker run … -v "$HOST_OUT:/out"`) does NOT
+apply to that same command's own argument expansion — the shell expands `$HOST_OUT`
+before the assignment takes effect, so `-v ":/out"` binds an empty source and the
+PNGs vanish. Assign first, then run:
 
 ```bash
 make -C desktop tauri-ui-build
@@ -119,6 +142,7 @@ ROOT="$PWD"; HOST_OUT=/tmp/shed-shots; mkdir -p "$HOST_OUT"
 docker run --rm -v "$ROOT:/repo:ro" -v "$HOST_OUT:/out" \
   -v shed-tauri-linux-cargo:/usr/local/cargo/registry \
   -v shed-tauri-linux-target:/target -e CARGO_TARGET_DIR=/target \
+  -e UV_PROJECT_ENVIRONMENT=/tmp/uv-venv \
   -e SHED_TAURI_BIN=/target/debug/shed-desktop-tauri \
   --cap-add SYS_ADMIN --security-opt seccomp=unconfined --shm-size=1g \
   shed-tauri-linux:latest bash -c '
@@ -177,6 +201,27 @@ assertions, the pixels are the eyeball.
   An unrecognized `state` fails to deserialize and falls back to `RcState::Ready` with **no
   error** (`ipc.rs::build_inject_session`), so a fixture with a typo'd/invented state renders
   Ready and you chase a phantom. Send the exact wire value.
+- **WebKitGTK renders a raw `<select>` illegibly in dark mode** → its native button text
+  stays dark-on-dark. In the Preferences window every dropdown (terminal preset, SSH policy)
+  uses the dialog kit's `Select` (`components/dialog`, `appearance-none` + its own caret), NOT
+  a bare `<select>`. Reach for `Select` when adding any picker to the Tauri UI, or the dark
+  screenshot is unreadable (`PreferencesWindow.tsx`).
+- **`policy.set` resets the ENGINE but not the coordinator's `extra_rules`** → the harness's
+  per-test `policy.set` reset replaces the policy *engine's* rules, but the coordinator's
+  persisted per-shed `extra_rules` survive it and get recomposed into the engine on the next
+  `rebuild_policy` (a persisted approval decision from an earlier test resurrects there). So
+  the absolute shed-rule count is NOT yours to pin — write per-shed-rule assertions
+  **engine-relative** (`prefs.dump`'s `shed_rules_count` == `len(policy.list scope=="shed")`,
+  and filter `policy.list` to YOUR shed), never against a fixed number. `test_preferences_shed_rules`
+  is the pattern.
+- **No per-window screenshot capture exists** → `app.screenshot` grabs the whole X display
+  (`screenshot.rs::capture`, `grim`→`scrot`→`import`), not a chosen window, and the Preferences
+  window is fixed-size (520×640, not resizable). Its below-the-fold content can't be
+  photographed, so don't try to prove a lower section by pixels — trim the fixture so the
+  section you care about sits above the fold (e.g. an `always-deny` SSH policy hides both the
+  Duration and Method rows — `usesDuration`/`prompts` are false — collapsing the SSH card), and
+  rely on `prefs.dump`'s reported `sections`/`values` for the logical assertions. Pixels are the
+  eyeball; `prefs.dump` is the truth.
 
 ## Native run on a Mac (quick UI-comparison loop)
 

--- a/crates/shed-app/src/coordinator.rs
+++ b/crates/shed-app/src/coordinator.rs
@@ -118,6 +118,17 @@ enum Command {
         rules: Vec<PolicyRule>,
         reply: oneshot::Sender<()>,
     },
+    SetProviderMode {
+        ns: String,
+        decision: ApprovalDecision,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+    ProviderModes(oneshot::Sender<HashMap<String, ApprovalDecision>>),
+    RemoveShedRule {
+        server: String,
+        shed: String,
+        reply: oneshot::Sender<()>,
+    },
     ApprovalsList(oneshot::Sender<Vec<PendingApprovalItem>>),
     ActivityList {
         limit: usize,
@@ -250,6 +261,42 @@ impl Coordinator {
         {
             let _ = rx.await;
         }
+    }
+
+    /// Set an AWS/Docker provider approval mode (the Preferences segmented
+    /// Allow|Deny). Rebuilds the namespace policy from the new mode. REJECTS any
+    /// namespace other than `aws-credentials`/`docker-credentials` (only those two
+    /// providers are driven by a persistent mode; SSH has its own prefs path).
+    pub async fn set_provider_mode(
+        &self,
+        ns: impl Into<String>,
+        decision: ApprovalDecision,
+    ) -> Result<(), String> {
+        self.request(|reply| Command::SetProviderMode {
+            ns: ns.into(),
+            decision,
+            reply,
+        })
+        .await
+        .unwrap_or_else(|| Err("coordinator stopped".into()))
+    }
+
+    /// The current provider (AWS/Docker) modes — the single source of truth the
+    /// Preferences getter reads back (a namespace absent from the map is Deny).
+    pub async fn provider_modes(&self) -> HashMap<String, ApprovalDecision> {
+        self.request(Command::ProviderModes).await.unwrap_or_default()
+    }
+
+    /// Remove exactly ONE per-shed rule (the Preferences "Per-shed overrides"
+    /// row's remove button) and rebuild the policy — unlike [`set_policy_rules`],
+    /// which replaces the whole engine (test-mode only).
+    pub async fn remove_shed_rule(&self, server: impl Into<String>, shed: impl Into<String>) {
+        self.request(|reply| Command::RemoveShedRule {
+            server: server.into(),
+            shed: shed.into(),
+            reply,
+        })
+        .await;
     }
 
     pub async fn approvals_list(&self) -> Vec<PendingApprovalItem> {
@@ -386,6 +433,24 @@ async fn run(mut state: State, mut rx: mpsc::UnboundedReceiver<Command>) {
                 // rebuild_policy() (that prepends SSH/AWS/Docker namespace rules).
                 state.engine = PolicyEngine::new(rules);
                 state.reevaluate_pending();
+                let _ = reply.send(());
+            }
+            Command::SetProviderMode {
+                ns,
+                decision,
+                reply,
+            } => {
+                let _ = reply.send(state.set_provider_mode(ns, decision));
+            }
+            Command::ProviderModes(reply) => {
+                let _ = reply.send(state.provider_modes.clone());
+            }
+            Command::RemoveShedRule {
+                server,
+                shed,
+                reply,
+            } => {
+                state.remove_shed_rule(&server, &shed);
                 let _ = reply.send(());
             }
             Command::ApprovalsList(reply) => {
@@ -893,6 +958,39 @@ impl State {
             .unwrap_or(ApprovalDecision::Deny)
     }
 
+    /// Set an AWS/Docker provider mode, then rebuild the policy so the namespace
+    /// rule reflects it (and re-evaluate the pending queue for parity with the SSH
+    /// path). Only the two provider namespaces are accepted — anything else is a
+    /// caller error (SSH has its own prefs path; other namespaces have no mode).
+    fn set_provider_mode(
+        &mut self,
+        ns: String,
+        decision: ApprovalDecision,
+    ) -> Result<(), String> {
+        if ns != namespace::AWS && ns != namespace::DOCKER {
+            return Err(format!("provider mode not settable for namespace {ns:?}"));
+        }
+        self.provider_modes.insert(ns, decision);
+        self.rebuild_policy();
+        self.reevaluate_pending();
+        Ok(())
+    }
+
+    /// Remove the per-shed rule(s) matching (server, shed) from `extra_rules` and
+    /// rebuild the policy. `add_shed_rule` dedupes so there is normally one match,
+    /// but hydrated (hand-edited) prefs may carry duplicates — removal clears them
+    /// all. Mirrors [`add_shed_rule`](Self::add_shed_rule)'s retain predicate
+    /// (server matched verbatim — `""` is not collapsed to `None`).
+    fn remove_shed_rule(&mut self, server: &str, shed: &str) {
+        self.extra_rules.retain(|r| {
+            !(r.scope == PolicyScope::Shed
+                && r.shed.as_deref() == Some(shed)
+                && r.server.as_deref() == Some(server))
+        });
+        self.rebuild_policy();
+        self.reevaluate_pending();
+    }
+
     fn reset_ssh_grants(&mut self) {
         self.session_grants
             .retain(|k, _| k.namespace != namespace::SSH);
@@ -1287,6 +1385,14 @@ mod tests {
             scope: None,
             ttl: None,
             persist: false,
+        }
+    }
+    fn persist_approve() -> ApprovalChoice {
+        ApprovalChoice {
+            decision: ApprovalDecision::Approve,
+            scope: None,
+            ttl: None,
+            persist: true,
         }
     }
 
@@ -1859,5 +1965,91 @@ mod tests {
         let list = h.coord.approvals_list().await;
         assert_eq!(list.len(), 1); // still pending
         assert_eq!(list[0].gate, PolicyGate::BiometricsOrPassword); // gate refreshed
+    }
+
+    #[tokio::test]
+    async fn provider_mode_deny_by_default_then_set_approve_flips_policy() {
+        // Deny-when-unset is fail-closed (pin it): with no provider mode set, a
+        // docker-credentials request is auto-denied by the namespace policy rule.
+        let h = Harness::new(1_000);
+        assert!(
+            h.coord.provider_modes().await.is_empty(),
+            "provider modes start unset (Deny by default)"
+        );
+        h.inject(req("d1", namespace::DOCKER, "s", "", 5_000));
+        assert!(h.wait_calls(1).await);
+        assert_eq!(h.responder.calls()[0].decision, ApprovalDecision::Deny);
+        assert_eq!(h.responder.calls()[0].decided_by, DecidedBy::Policy);
+
+        // Setting docker → Approve flips the namespace rule; the getter reflects it.
+        h.coord
+            .set_provider_mode(namespace::DOCKER, ApprovalDecision::Approve)
+            .await
+            .expect("docker is a settable provider namespace");
+        assert_eq!(
+            h.coord.provider_modes().await.get(namespace::DOCKER).copied(),
+            Some(ApprovalDecision::Approve)
+        );
+        h.inject(req("d2", namespace::DOCKER, "s", "", 5_000));
+        assert!(h.wait_calls(2).await);
+        assert_eq!(h.responder.calls()[1].decision, ApprovalDecision::Approve);
+        assert_eq!(h.responder.calls()[1].decided_by, DecidedBy::Policy);
+    }
+
+    #[tokio::test]
+    async fn provider_mode_rejects_non_provider_namespace() {
+        // Only aws-credentials/docker-credentials are settable; SSH (its own prefs
+        // path) and any other namespace are rejected and leave the map untouched.
+        let h = Harness::new(1_000);
+        assert!(h
+            .coord
+            .set_provider_mode(namespace::SSH, ApprovalDecision::Approve)
+            .await
+            .is_err());
+        assert!(h
+            .coord
+            .set_provider_mode("bogus-namespace", ApprovalDecision::Deny)
+            .await
+            .is_err());
+        assert!(
+            h.coord.provider_modes().await.is_empty(),
+            "a rejected set must not mutate the provider-mode map"
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_shed_rule_removes_exactly_one_and_rebuilds() {
+        // Seed two per-shed approve rules (via the approve+persist path), then remove
+        // one: the other survives, the removed one is gone, and rebuild_policy re-
+        // extends the namespace rules (proof the engine was rebuilt, not replaced).
+        let h = Harness::new(1_000); // default SSH policy prompts
+        h.inject(ssh_req("ra", "a", 5_000));
+        assert!(h.wait_queued(1).await);
+        h.coord.decide_approval("ra", persist_approve()).await;
+        assert!(h.wait_calls(1).await);
+        h.inject(ssh_req("rb", "b", 5_000));
+        assert!(h.wait_queued(1).await);
+        h.coord.decide_approval("rb", persist_approve()).await;
+        assert!(h.wait_calls(2).await);
+
+        let has_shed = |rules: &[PolicyRule], shed: &str| {
+            rules
+                .iter()
+                .any(|r| r.scope == PolicyScope::Shed && r.shed.as_deref() == Some(shed))
+        };
+        let rules = h.coord.policy_list().await;
+        assert!(has_shed(&rules, "a") && has_shed(&rules, "b"));
+
+        // Remove shed "a" (server "" — ssh_req uses the unnamed single server).
+        h.coord.remove_shed_rule("", "a").await;
+        let rules = h.coord.policy_list().await;
+        assert!(!has_shed(&rules, "a"), "the removed rule must be gone");
+        assert!(has_shed(&rules, "b"), "the other rule must survive");
+        // The namespace rules are re-extended → the engine was rebuilt, not emptied.
+        assert!(
+            rules.iter().any(|r| r.scope == PolicyScope::Namespace
+                && r.namespace.as_deref() == Some(namespace::SSH)),
+            "rebuild_policy must re-add the SSH namespace rule: {rules:?}"
+        );
     }
 }

--- a/desktop/tauri/src-tauri/capabilities/preferences.json
+++ b/desktop/tauri/src-tauri/capabilities/preferences.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "preferences",
+  "description": "The Preferences window webview: it may call our app commands (get_prefs / terminal_presets / set_terminal_pref / loginitem_* / ssh_prefs_get / set_ssh_approval / gate_namespaces / provider_modes_get / set_provider_mode / policy_list_shed / remove_shed_rule / get_appearance_state / ui_report) and listen for Rust-emitted events (set-appearance / connected-changed / prefs-changed). App-defined commands need no extra ACL; only core + event access is granted, scoped to the `preferences` window (least privilege — it does NOT share `main`'s capability).",
+  "windows": ["preferences"],
+  "permissions": [
+    "core:default",
+    "core:event:default"
+  ]
+}

--- a/desktop/tauri/src-tauri/src/ipc.rs
+++ b/desktop/tauri/src-tauri/src/ipc.rs
@@ -259,6 +259,10 @@ impl Handler {
             "agents.dump" => Ok(self.agents_dump()),
             "prefs.get" => Ok(self.prefs_get()),
             "prefs.set_terminal" => self.prefs_set_terminal(params),
+            // Provider (AWS/Docker) approval modes — the production Preferences
+            // surface (ungated, unlike test-mode `policy.set`).
+            "prefs.provider_modes" => self.provider_modes().await,
+            "prefs.set_provider" => self.set_provider(params).await,
             // -- approvals (the security spine) --
             "approvals.list" => self.approvals_list().await,
             "approval.decide" => self.approval_decide(params).await,
@@ -357,6 +361,14 @@ impl Handler {
         let mode = params.get("mode").and_then(Value::as_str).unwrap_or("");
         if !matches!(mode, "light" | "dark") {
             return Err(err("bad_request", format!("unknown mode: {mode:?}")));
+        }
+        // Update the managed appearance cell DIRECTLY (in Rust) before emitting, so a
+        // window reading `get_appearance_state` sees the new value even if its
+        // `set-appearance` listener hasn't attached yet (kills the attach race).
+        if let Some(cell) = self.app.try_state::<crate::AppearanceState>() {
+            if let Ok(mut cur) = cell.0.lock() {
+                *cur = Some(mode.to_string());
+            }
         }
         let _ = self.app.emit("set-appearance", json!({ "mode": mode }));
         Ok(json!({}))
@@ -731,6 +743,7 @@ impl Handler {
         }
         let p: P = serde_json::from_value(params.clone())
             .map_err(|e| err("bad_request", e.to_string()))?;
+        let persist = p.persist;
         self.coordinator
             .decide_approval(
                 p.id,
@@ -738,10 +751,15 @@ impl Handler {
                     decision: p.decision,
                     scope: p.scope,
                     ttl: p.ttl,
-                    persist: p.persist,
+                    persist,
                 },
             )
             .await;
+        // A persisted decision adds a per-shed rule — mirror it into prefs.json (same
+        // path as the frontend command) so the override survives a restart.
+        if persist {
+            crate::persist_shed_rules(&self.prefs, &self.coordinator).await;
+        }
         Ok(json!({}))
     }
 
@@ -835,6 +853,31 @@ impl Handler {
     /// harness can assert what a set actually applied (the drivability North Star).
     async fn ssh_prefs(&self) -> Result<Value, (String, String)> {
         Ok(json!(self.coordinator.ssh_prefs().await))
+    }
+
+    /// `prefs.provider_modes` → the coordinator's current AWS/Docker approval modes
+    /// (`{namespace: "approve"|"deny"}`) — the read side of `prefs.set_provider`.
+    async fn provider_modes(&self) -> Result<Value, (String, String)> {
+        Ok(json!(self.coordinator.provider_modes().await))
+    }
+
+    /// `prefs.set_provider {namespace, decision}` → set an AWS/Docker provider mode +
+    /// persist (the same path as the frontend `set_provider_mode` command). The
+    /// coordinator rejects a non-provider namespace (surfaced as `bad_request`).
+    async fn set_provider(&self, params: &Value) -> Result<Value, (String, String)> {
+        #[derive(serde::Deserialize)]
+        struct P {
+            namespace: String,
+            decision: ApprovalDecision,
+        }
+        let p: P = serde_json::from_value(params.clone())
+            .map_err(|e| err("bad_request", e.to_string()))?;
+        self.coordinator
+            .set_provider_mode(p.namespace, p.decision)
+            .await
+            .map_err(|e| err("bad_request", e))?;
+        crate::persist_provider_modes(&self.prefs, &self.coordinator).await;
+        Ok(json!({}))
     }
 
     /// `loginitem.set {enabled}` → enable/disable launch-at-login (the Preferences

--- a/desktop/tauri/src-tauri/src/ipc.rs
+++ b/desktop/tauri/src-tauri/src/ipc.rs
@@ -107,6 +107,62 @@ pub fn present_main_window<R: tauri::Runtime>(app: &AppHandle<R>) {
     set_activation_policy_prod(app, true);
 }
 
+/// The Preferences window label (a dedicated webview, created lazily on first
+/// open). Its snapshot is keyed under this label, read by `prefs.dump`.
+pub const PREFERENCES_ID: &str = "preferences";
+
+/// The Preferences window's fixed content size. The mac window is 460×560; this
+/// carries the same grouped form with the Plex kit's roomier spacing. Fixed —
+/// the window is not resizable (mac parity).
+const PREFS_WIDTH: f64 = 520.0;
+const PREFS_HEIGHT: f64 = 640.0;
+
+/// Show + focus the singleton Preferences window — lazy-create on the first open,
+/// front-if-already-open after (mac `AppModel.openPreferences` parity). Closing it
+/// only HIDES it (the generic `CloseRequested` arm in `lib.rs` hides + prevents
+/// close for every window), so a reopen is a plain show+focus — the mac
+/// `isReleasedWhenClosed = false` semantics. Creation is marshalled to the main
+/// thread (required on macOS — the IPC handler runs on a tokio worker; harmless on
+/// Linux). Shared by the tray menu, the popover footer, the dashboard gear
+/// (`open_preferences` command), and the `ui.show_preferences`/`ui.open_preferences`
+/// ops — one Rust path. macOS-dev note: prefs closing while main is hidden leaves
+/// the Dock icon until the next policy flip — accepted (Linux is the shipped target).
+pub fn show_preferences_window(app: &AppHandle) {
+    let handle = app.clone();
+    // Marshal the WHOLE check-then-create-or-focus onto the main thread so it is
+    // atomic with respect to the sibling `prefs.close` hide (also main-thread
+    // marshalled). Main-thread closures run FIFO, so a create queued before a
+    // close always runs before it — the last op queued wins the final state, and
+    // two rapid opens can't race two builders (the second sees the window and
+    // focuses instead of double-building).
+    let _ = app.run_on_main_thread(move || {
+        if let Some(w) = handle.get_webview_window(PREFERENCES_ID) {
+            let _ = w.show();
+            let _ = w.unminimize();
+            let _ = w.set_focus();
+            set_activation_policy_prod(&handle, true);
+            return;
+        }
+        if let Err(e) = tauri::WebviewWindowBuilder::new(
+            &handle,
+            PREFERENCES_ID,
+            tauri::WebviewUrl::App("preferences.html".into()),
+        )
+        .title("shed desktop — Preferences")
+        .inner_size(PREFS_WIDTH, PREFS_HEIGHT)
+        .resizable(false)
+        .maximizable(false)
+        .minimizable(false)
+        .center()
+        .build()
+        {
+            eprintln!("shed-desktop-tauri: preferences window unavailable ({e})");
+            return;
+        }
+        set_activation_policy_prod(&handle, true);
+    });
+}
+
 /// Flip the macOS activation policy in PRODUCTION only (guarded off under the
 /// harness — an unguarded flip can leave `main` unmounted so `ui_report` never fires
 /// and `wait_until(current_pane)` times out). `regular` shows the Dock icon (a
@@ -206,8 +262,8 @@ impl Handler {
             "ui.navigate" => self.navigate(params),
             "ui.current_pane" => Ok(json!({ "pane": self.ui_get("pane") })),
             "ui.computed_style" => Ok(json!({ "style": self.ui_get("style") })),
-            // Which modal (if any) the frontend has open: "prefs" | "create" |
-            // "launch" | null.
+            // Which modal (if any) the frontend has open: "create" | "launch" |
+            // null. (Preferences is a dedicated window, not a modal — see prefs.dump.)
             "ui.modal" => Ok(json!({ "modal": self.ui_get("modal") })),
             // The sidebar nav badge counts the shell reported {sheds, agents, hosts,
             // pending}, or null before its first report.
@@ -217,9 +273,11 @@ impl Handler {
                 present_main_window(&self.app);
                 Ok(json!({}))
             }
-            "ui.show_preferences" => {
-                present_main_window(&self.app);
-                let _ = self.app.emit("show-preferences", json!({}));
+            // Open/focus the dedicated Preferences window (it no longer raises the
+            // dashboard — mac parity). `ui.open_preferences` is the mac op name,
+            // aliased so the now-shared behavior has one name across targets.
+            "ui.show_preferences" | "ui.open_preferences" => {
+                show_preferences_window(&self.app);
                 Ok(json!({}))
             }
             "ui.show_create" => {
@@ -263,6 +321,26 @@ impl Handler {
             // surface (ungated, unlike test-mode `policy.set`).
             "prefs.provider_modes" => self.provider_modes().await,
             "prefs.set_provider" => self.set_provider(params).await,
+            // The Preferences window's drivable surface: its merged snapshot +
+            // native state, hide (close-hides contract), and the per-shed override
+            // remove (the row button's path, ungated like prefs.set_provider — it
+            // only removes an override, falling back to the namespace policy).
+            "prefs.dump" => Ok(self.prefs_dump()),
+            "prefs.close" => {
+                // Marshal the hide onto the main thread so it stays FIFO-ordered
+                // with the main-thread-marshalled create/focus in
+                // `show_preferences_window` — otherwise a close could run before a
+                // still-queued create and be a no-op, leaving the window open even
+                // though close was the last op.
+                let handle = self.app.clone();
+                let _ = self.app.run_on_main_thread(move || {
+                    if let Some(w) = handle.get_webview_window(PREFERENCES_ID) {
+                        let _ = w.hide();
+                    }
+                });
+                Ok(json!({}))
+            }
+            "prefs.remove_shed_rule" => self.remove_shed_rule(params).await,
             // -- approvals (the security spine) --
             "approvals.list" => self.approvals_list().await,
             "approval.decide" => self.approval_decide(params).await,
@@ -326,6 +404,46 @@ impl Handler {
             "popover_visible": popover_visible,
             "popover_height": popover_height,
         })
+    }
+
+    /// `prefs.dump` → the Preferences window's drivable state: the React-reported
+    /// snapshot (`{sections, values, mode}`, keyed under the `preferences` window
+    /// label) MERGED with Rust-side native window truth (`visible`, `title`) read
+    /// like `tray.dump` — a native hide/close never triggers a React report, so
+    /// visibility must come from Rust. `visible` is false + `prefs` null before the
+    /// first open (the window is created lazily).
+    fn prefs_dump(&self) -> Value {
+        let snapshot = self.ui.lock().ok().and_then(|s| s.get(PREFERENCES_ID, "prefs"));
+        let win = self.app.get_webview_window(PREFERENCES_ID);
+        let visible = win
+            .as_ref()
+            .and_then(|w| w.is_visible().ok())
+            .unwrap_or(false);
+        let title = win.as_ref().and_then(|w| w.title().ok());
+        json!({
+            "visible": visible,
+            "title": title,
+            "prefs": snapshot,
+        })
+    }
+
+    /// `prefs.remove_shed_rule {server, shed}` → remove one per-shed override rule +
+    /// persist the remaining set (the same path as the window's remove button).
+    /// `server` is matched verbatim (`""` = the single/unnamed server — F12).
+    async fn remove_shed_rule(&self, params: &Value) -> Result<Value, (String, String)> {
+        let server = req_str(params, "server")?.to_string();
+        let shed = req_str(params, "shed")?.to_string();
+        self.coordinator.remove_shed_rule(server, shed).await;
+        crate::persist_shed_rules(&self.prefs, &self.coordinator).await;
+        self.emit_prefs_changed();
+        Ok(json!({}))
+    }
+
+    /// Emit `prefs-changed` so the Preferences window (if open) re-fetches values an
+    /// IPC-driven mutation changed behind its back (its own controls keep local
+    /// state directly; the dashboard has no prefs UI to notify).
+    fn emit_prefs_changed(&self) {
+        let _ = self.app.emit("prefs-changed", ());
     }
 
     /// `ui.navigate {pane}` → tell the frontend to switch panes (a `navigate`
@@ -510,8 +628,11 @@ impl Handler {
             .get("template")
             .and_then(Value::as_str)
             .map(str::to_string);
-        self.terminal
-            .prefs_set_terminal(req_str(params, "preset")?, template)
+        let r = self
+            .terminal
+            .prefs_set_terminal(req_str(params, "preset")?, template)?;
+        self.emit_prefs_changed();
+        Ok(r)
     }
 
     // -- RC / Agents (B2.3) — the launcher + session table -------------------
@@ -759,6 +880,7 @@ impl Handler {
         // path as the frontend command) so the override survives a restart.
         if persist {
             crate::persist_shed_rules(&self.prefs, &self.coordinator).await;
+            self.emit_prefs_changed();
         }
         Ok(json!({}))
     }
@@ -845,6 +967,7 @@ impl Handler {
         // harness-driven change also survives a restart.
         let (m, pol, ttl) = crate::ssh_prefs_wire(&self.coordinator.ssh_prefs().await);
         self.prefs.set_ssh(m, pol, ttl);
+        self.emit_prefs_changed();
         Ok(json!({}))
     }
 
@@ -877,6 +1000,7 @@ impl Handler {
             .await
             .map_err(|e| err("bad_request", e))?;
         crate::persist_provider_modes(&self.prefs, &self.coordinator).await;
+        self.emit_prefs_changed();
         Ok(json!({}))
     }
 
@@ -889,6 +1013,7 @@ impl Handler {
             .and_then(Value::as_bool)
             .ok_or_else(|| err("bad_request", "missing 'enabled' (bool)"))?;
         crate::login_item_set(&self.app, &self.env, enabled).map_err(|e| err("action_failed", e))?;
+        self.emit_prefs_changed();
         Ok(json!({}))
     }
 

--- a/desktop/tauri/src-tauri/src/lib.rs
+++ b/desktop/tauri/src-tauri/src/lib.rs
@@ -28,14 +28,15 @@ use shed_app::{
     HelloClientInfo, HostAgentClient, HostAgentTokenMinter, RcService, SshPrefs,
 };
 use shed_core::approval::{
-    ApprovalChoice, ApprovalDecision, ApprovalMethod, ApprovalScope, SshApprovalPolicy,
+    namespace, ApprovalChoice, ApprovalDecision, ApprovalMethod, ApprovalScope, PolicyRule,
+    PolicyScope, SshApprovalPolicy,
 };
 use shed_core::models::CreateShedRequest;
 use shed_core::rc::RcKind;
 use shed_core::token::TokenMinter;
 use single_instance::AcquireError;
 use state::{SharedUi, UiState};
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 /// A React frontend reports its rendered snapshot (`{pane, style, sheds,
 /// refresh_token}`) here, so the harness reads the real rendered state over IPC
@@ -300,12 +301,14 @@ async fn approvals_list(
 #[tauri::command]
 async fn approval_decide(
     coordinator: tauri::State<'_, Coordinator>,
+    prefs: tauri::State<'_, prefs::SharedPrefs>,
     id: String,
     decision: ApprovalDecision,
     scope: Option<ApprovalScope>,
     ttl: Option<String>,
     persist: Option<bool>,
 ) -> Result<(), String> {
+    let persist = persist.unwrap_or(false);
     coordinator
         .decide_approval(
             id,
@@ -313,10 +316,15 @@ async fn approval_decide(
                 decision,
                 scope,
                 ttl,
-                persist: persist.unwrap_or(false),
+                persist,
             },
         )
         .await;
+    // A persisted (always-allow/deny) decision adds a per-shed rule — mirror it into
+    // prefs.json so the override survives a restart (the hydration source of truth).
+    if persist {
+        persist_shed_rules(&prefs, &coordinator).await;
+    }
     Ok(())
 }
 
@@ -400,6 +408,174 @@ async fn ssh_prefs_get(
     coordinator: tauri::State<'_, Coordinator>,
 ) -> Result<serde_json::Value, String> {
     Ok(serde_json::json!(coordinator.ssh_prefs().await))
+}
+
+// -- provider (AWS/Docker) approval modes + per-shed overrides -----------------
+
+/// Serialize the coordinator's provider modes to their wire strings (the map the
+/// Preferences segmented control reads back + the shape persisted to prefs.json),
+/// via serde rather than a hand-maintained enum→string match. An unserializable
+/// value falls back to the fail-closed `"deny"`.
+pub(crate) fn provider_modes_wire(
+    modes: &HashMap<String, ApprovalDecision>,
+) -> HashMap<String, String> {
+    modes
+        .iter()
+        .map(|(ns, d)| {
+            let wire = serde_json::to_value(d)
+                .ok()
+                .and_then(|v| v.as_str().map(str::to_string))
+                .unwrap_or_else(|| "deny".to_string());
+            (ns.clone(), wire)
+        })
+        .collect()
+}
+
+/// The per-shed (scope == Shed) rules from the engine, as wire JSON for persistence.
+/// The namespace rules (SSH/AWS/Docker) are rebuilt from prefs at startup, so only
+/// the derived per-shed overrides are persisted.
+pub(crate) fn shed_rules_wire(rules: &[PolicyRule]) -> Vec<serde_json::Value> {
+    rules
+        .iter()
+        .filter(|r| r.scope == PolicyScope::Shed)
+        .map(|r| serde_json::json!(r))
+        .collect()
+}
+
+/// Mirror the coordinator's current per-shed override rules into prefs.json — the
+/// single write-through every rule-mutating path (persist decision, remove) shares,
+/// so the persisted set always matches the live engine (the hydration source of truth).
+pub(crate) async fn persist_shed_rules(prefs: &prefs::PrefsStore, coordinator: &Coordinator) {
+    prefs.set_extra_rules(shed_rules_wire(&coordinator.policy_list().await));
+}
+
+/// Mirror the coordinator's current provider (AWS/Docker) modes into prefs.json — the
+/// shared write-through for every provider-mode change so the choice survives a restart.
+pub(crate) async fn persist_provider_modes(prefs: &prefs::PrefsStore, coordinator: &Coordinator) {
+    prefs.set_provider_modes(provider_modes_wire(&coordinator.provider_modes().await));
+}
+
+/// Rebuild the provider modes from the persisted store, keyed by the FULL namespace
+/// constants and parsing each decision via serde — falling back to the fail-closed
+/// `Deny` for any unparseable value, and ignoring any namespace other than the two
+/// providers (so a corrupt file never panics and never widens a mode). Empty when
+/// absent (unset == Deny by default in the coordinator).
+fn provider_modes_from_store(store: &prefs::PrefsStore) -> HashMap<String, ApprovalDecision> {
+    store
+        .get()
+        .provider_modes
+        .into_iter()
+        .filter(|(ns, _)| ns == namespace::AWS || ns == namespace::DOCKER)
+        .map(|(ns, v)| {
+            let d = parse_wire::<ApprovalDecision>(&v).unwrap_or(ApprovalDecision::Deny);
+            (ns, d)
+        })
+        .collect()
+}
+
+/// Rebuild the per-shed override rules from the persisted store, skipping any rule a
+/// current build can't parse (corrupt-tolerant — a dropped rule fails closed to the
+/// namespace policy rather than blocking startup).
+fn extra_rules_from_store(store: &prefs::PrefsStore) -> Vec<PolicyRule> {
+    store
+        .get()
+        .extra_rules
+        .into_iter()
+        .filter_map(|v| serde_json::from_value::<PolicyRule>(v).ok())
+        // extra_rules is per-shed override storage: a hand-edited/corrupt prefs.json
+        // must not be able to inject default- or namespace-scope policy at startup.
+        .filter(|r| r.scope == PolicyScope::Shed)
+        .collect()
+}
+
+/// The current provider (AWS/Docker) modes (`{namespace: "approve"|"deny"}`) — drives
+/// the Preferences segmented Allow|Deny so it reflects the running coordinator.
+#[tauri::command]
+async fn provider_modes_get(
+    coordinator: tauri::State<'_, Coordinator>,
+) -> Result<serde_json::Value, String> {
+    Ok(serde_json::json!(coordinator.provider_modes().await))
+}
+
+/// Set an AWS/Docker provider mode + persist, so the choice survives a restart. The
+/// coordinator rejects any namespace other than the two providers (surfaced as the
+/// error string). Persists the coordinator's RESULTING modes (source of truth).
+#[tauri::command]
+async fn set_provider_mode(
+    coordinator: tauri::State<'_, Coordinator>,
+    prefs: tauri::State<'_, prefs::SharedPrefs>,
+    ns: String,
+    decision: ApprovalDecision,
+) -> Result<(), String> {
+    coordinator.set_provider_mode(ns, decision).await?;
+    persist_provider_modes(&prefs, &coordinator).await;
+    Ok(())
+}
+
+/// The per-shed override rules (scope == shed) — the Preferences "Per-shed overrides"
+/// list. A filtered read of the full policy (the namespace rules are excluded).
+#[tauri::command]
+async fn policy_list_shed(
+    coordinator: tauri::State<'_, Coordinator>,
+) -> Result<serde_json::Value, String> {
+    let rules = coordinator.policy_list().await;
+    Ok(serde_json::json!(shed_rules_wire(&rules)))
+}
+
+/// Remove one per-shed override rule (the row's remove button) + persist the
+/// remaining set, so the removal survives a restart.
+#[tauri::command]
+async fn remove_shed_rule(
+    coordinator: tauri::State<'_, Coordinator>,
+    prefs: tauri::State<'_, prefs::SharedPrefs>,
+    server: String,
+    shed: String,
+) -> Result<(), String> {
+    coordinator.remove_shed_rule(server, shed).await;
+    persist_shed_rules(&prefs, &coordinator).await;
+    Ok(())
+}
+
+// -- appearance (light/dark) sync across webviews ------------------------------
+
+/// The app-wide light/dark appearance, held in Rust so a second webview (the
+/// Preferences window) reads the initial value synchronously and every window stays
+/// in sync via the `set-appearance` event. `None` = unset (fall back to the OS
+/// `prefers-color-scheme`, popover-parity default).
+pub(crate) struct AppearanceState(pub(crate) Mutex<Option<String>>);
+
+/// The current app-wide appearance (`{mode: "light"|"dark"|null}`) — the Preferences
+/// window reads this on mount so it opens in the dashboard's mode without a flash.
+#[tauri::command]
+fn get_appearance_state(app: tauri::AppHandle) -> serde_json::Value {
+    let mode = app
+        .state::<AppearanceState>()
+        .0
+        .lock()
+        .ok()
+        .and_then(|m| m.clone());
+    serde_json::json!({ "mode": mode })
+}
+
+/// Set the app-wide appearance + broadcast `set-appearance` to every window.
+/// Idempotent: a no-op (no re-emit) when unchanged, so the dashboard's mode effect
+/// re-invoking this on an IPC-driven change can't loop. Invoked from the dashboard's
+/// mode effect (both the manual toggle and IPC-driven changes flow through it).
+#[tauri::command]
+fn set_appearance_state(app: tauri::AppHandle, mode: String) -> Result<(), String> {
+    if !matches!(mode.as_str(), "light" | "dark") {
+        return Err(format!("unknown mode: {mode:?}"));
+    }
+    let cell = app.state::<AppearanceState>();
+    {
+        let mut cur = cell.0.lock().map_err(|_| "appearance state poisoned")?;
+        if cur.as_deref() == Some(mode.as_str()) {
+            return Ok(()); // unchanged — no re-emit (breaks the echo loop)
+        }
+        *cur = Some(mode.clone());
+    }
+    let _ = app.emit("set-appearance", serde_json::json!({ "mode": mode }));
+    Ok(())
 }
 
 // -- launch-at-login (B4) ------------------------------------------------------
@@ -595,6 +771,9 @@ pub fn run() {
         .manage(rc_service.clone())
         // The macOS test-mode login-item cell (see [`LoginItemCell`]).
         .manage(LoginItemCell(Mutex::new(false)))
+        // The app-wide light/dark appearance, shared across webviews (unset at
+        // launch → the OS `prefers-color-scheme` is the fallback).
+        .manage(AppearanceState(Mutex::new(None)))
         .invoke_handler(tauri::generate_handler![
             ui_report,
             list_sheds,
@@ -618,6 +797,12 @@ pub fn run() {
             gate_namespaces,
             set_ssh_approval,
             ssh_prefs_get,
+            provider_modes_get,
+            set_provider_mode,
+            policy_list_shed,
+            remove_shed_rule,
+            get_appearance_state,
+            set_appearance_state,
             loginitem_status,
             loginitem_set,
             open_dashboard,
@@ -687,6 +872,11 @@ pub fn run() {
             // to the default on an absent/corrupt file), so the user's choice
             // survives a restart rather than resetting to the coordinator default.
             let ssh_prefs = ssh_prefs_from_store(&prefs);
+            // Same treatment for the provider (AWS/Docker) modes + per-shed override
+            // rules — hydrate from the persisted store so the user's choices survive
+            // a restart rather than resetting to the coordinator defaults.
+            let provider_modes = provider_modes_from_store(&prefs);
+            let extra_rules = extra_rules_from_store(&prefs);
             // Pushes coordinator changes to the webview (app.emit) so the
             // Approvals/Activity panes re-fetch reactively.
             let coord_sink: shed_app::traits::EventSinkRef =
@@ -707,8 +897,8 @@ pub fn run() {
                         sink: coord_sink,
                         audit,
                         ssh: ssh_prefs,
-                        extra_rules: Vec::new(),
-                        provider_modes: HashMap::new(),
+                        extra_rules,
+                        provider_modes,
                     },
                     host_events,
                 );

--- a/desktop/tauri/src-tauri/src/lib.rs
+++ b/desktop/tauri/src-tauri/src/lib.rs
@@ -664,7 +664,8 @@ fn open_dashboard(app: tauri::AppHandle) {
     tray::open_dashboard(&app);
 }
 
-/// The popover footer's "Preferences…" → raise the dashboard + open Preferences.
+/// The popover footer's "Preferences…" + the dashboard header gear → open/focus
+/// the dedicated Preferences window (and dismiss the popover if shown).
 #[tauri::command]
 fn open_preferences(app: tauri::AppHandle) {
     tray::open_preferences(&app);

--- a/desktop/tauri/src-tauri/src/prefs.rs
+++ b/desktop/tauri/src-tauri/src/prefs.rs
@@ -3,10 +3,12 @@
 //! shed-card "Open in Terminal" button reads them). A small JSON file in the app
 //! config dir; the mac app uses UserDefaults, this is the windowed-app analog.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use shed_core::terminal::TerminalPreset;
 
@@ -27,6 +29,18 @@ pub struct Prefs {
     pub ssh_policy: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ssh_ttl: Option<String>,
+    /// The AWS/Docker provider approval modes, keyed by the FULL namespace string
+    /// (`aws-credentials`/`docker-credentials`) → the raw wire decision string
+    /// (`approve`/`deny`). Raw strings (not typed enums), like the SSH fields, so an
+    /// old file (absent) or a value a downgraded build can't parse never fails the
+    /// whole-file decode; the parse-with-fallback-to-deny happens at hydration.
+    #[serde(default)]
+    pub provider_modes: HashMap<String, String>,
+    /// The per-shed policy overrides (the Preferences "Per-shed overrides" list),
+    /// stored as raw wire `PolicyRule` JSON. Untyped `Value`s so a rule a downgraded
+    /// build can't parse is skipped at hydration rather than failing the whole file.
+    #[serde(default)]
+    pub extra_rules: Vec<Value>,
 }
 
 /// Owns the prefs file path + the in-memory copy; writes through on every set.
@@ -72,6 +86,25 @@ impl PrefsStore {
             prefs.ssh_method = Some(method);
             prefs.ssh_policy = Some(policy);
             prefs.ssh_ttl = Some(ttl);
+            self.save(&prefs);
+        }
+    }
+
+    /// Persist the AWS/Docker provider modes (full namespace → wire-decision map),
+    /// write-through like `set_ssh`. The caller sources this from the coordinator's
+    /// current modes, so it's a complete snapshot, not a partial merge.
+    pub fn set_provider_modes(&self, modes: HashMap<String, String>) {
+        if let Ok(mut prefs) = self.inner.lock() {
+            prefs.provider_modes = modes;
+            self.save(&prefs);
+        }
+    }
+
+    /// Persist the per-shed override rules (raw wire `PolicyRule` JSON), write-through.
+    /// The caller sources these from the coordinator's current shed rules.
+    pub fn set_extra_rules(&self, rules: Vec<Value>) {
+        if let Ok(mut prefs) = self.inner.lock() {
+            prefs.extra_rules = rules;
             self.save(&prefs);
         }
     }

--- a/desktop/tauri/src-tauri/src/state.rs
+++ b/desktop/tauri/src-tauri/src/state.rs
@@ -4,9 +4,10 @@
 //!
 //! The truth op reads the RENDERED UI state, not a backend re-query: each webview
 //! is the source of truth for what IT shows, and Rust relays what it reported.
-//! Snapshots are keyed by the reporting WINDOW's label, so a second webview (the
-//! B1b menu-bar popover, label `popover`) reports under its own key and can't
-//! clobber the dashboard's `main` snapshot (`pane`/`sheds`/`refresh_token`). WITHIN
+//! Snapshots are keyed by the reporting WINDOW's label, so the other webviews (the
+//! B1b menu-bar popover, label `popover`; the Preferences window, label
+//! `preferences`) report under their own keys and can't clobber the dashboard's
+//! `main` snapshot (`pane`/`sheds`/`refresh_token`). WITHIN
 //! a window the object keys are merged, so a partial reporter (the Agents pane
 //! publishing only `agents`) doesn't clobber that window's other keys.
 

--- a/desktop/tauri/src-tauri/src/tray.rs
+++ b/desktop/tauri/src-tauri/src/tray.rs
@@ -150,10 +150,10 @@ fn open_pane(app: &AppHandle, pane: &str) {
     let _ = app.emit("navigate", serde_json::json!({ "pane": pane }));
 }
 
-/// Raise the dashboard + open the Preferences modal (the `ui.show_preferences` path).
+/// Open/focus the dedicated Preferences window (the `ui.show_preferences` path —
+/// the single `show_preferences_window` helper; it does not raise the dashboard).
 fn open_prefs(app: &AppHandle) {
-    show_main(app);
-    let _ = app.emit("show-preferences", serde_json::json!({}));
+    crate::ipc::show_preferences_window(app);
 }
 
 // -- B1b popover show/hide (shared by the mac tray-icon click AND the hermetic
@@ -212,7 +212,7 @@ pub fn open_dashboard(app: &AppHandle) {
     hide_popover(app);
 }
 
-/// The popover footer's "Preferences…": the Preferences menu action + dismiss the
+/// The popover footer's "Preferences…": open the Preferences window + dismiss the
 /// popover.
 pub fn open_preferences(app: &AppHandle) {
     open_prefs(app);

--- a/desktop/tauri/ui/preferences.html
+++ b/desktop/tauri/ui/preferences.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" data-mode="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>shed desktop — Preferences</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/preferences.tsx"></script>
+  </body>
+</html>

--- a/desktop/tauri/ui/src/App.tsx
+++ b/desktop/tauri/ui/src/App.tsx
@@ -16,19 +16,17 @@ import {
   cardCls, Dot, StatusChip, Tag, ImageChip, KindBadge, ActBtn,
   PageHead, HeadAction, Empty, agentColor, type Tone,
 } from "@/components/primitives";
-import { Scrim, DialogShell, Field, Select, Segmented, Switch, dialogInput, dialogBtnSecondary, useEscClose } from "@/components/dialog";
+import { Scrim, DialogShell, Field, Select, Segmented, dialogInput, dialogBtnSecondary, useEscClose } from "@/components/dialog";
 import {
   useUiBridge, shedAction, fetchSystemDf, openTerminal,
-  fetchTerminalPresets, getPrefs, setTerminalPref,
-  getLoginItem, setLoginItem,
   createStart, createStatus, createCancel, fetchHosts,
   fetchApprovals, decideApproval, fetchActivity, fetchGateNamespaces,
   fetchEgressProfiles, reportEgress, inTauri,
-  getSshApproval, setSshApproval,
+  openPreferences, setAppearanceState,
   rcLaunch, rcKill, reportAgents, useRcSessions,
   useCoordinatorData, useNowTick,
-  type Pane, type Shed, type HostDiskUsage, type TerminalPresetInfo,
-  type Modal, type CreateProgress, type Approval, type AuditEntry, type SshPrefs,
+  type Pane, type Shed, type HostDiskUsage,
+  type Modal, type CreateProgress, type Approval, type AuditEntry,
   type EgressProfile, type EgressProfileInfo, type HostEgressProfiles, type EgressReport,
   type RcSession, type RcKind, type RcState,
   type RcCapabilities, offeredKinds, rcAuthHint,
@@ -821,247 +819,6 @@ function LaunchAgentDialog({ sheds, capabilities, refresh, onClose, onLaunched }
   );
 }
 
-/* ---- Preferences (in-app modal; the tray is Phase C) ---------------------- */
-// How an SSH-key approval is confirmed. On Linux "Authenticate" routes through
-// polkit; "Prompt only" needs no gate — a plain Approve button.
-const APPROVAL_METHODS: { id: SshPrefs["method"]; label: string; detail: string }[] = [
-  { id: "biometrics-or-password", label: "Authenticate", detail: "Confirm with your login password." },
-  { id: "prompt", label: "Prompt only", detail: "A plain Approve button — no password." },
-];
-
-// The SSH approval policies, most → least permissive (mirrors SshApprovalPolicy in
-// shed-core). `prompts` gates the Method picker and `usesDuration` gates the
-// Duration field — the SAME policy→behavior mapping as the Swift app.
-const SSH_POLICIES: { id: string; label: string; prompts: boolean; usesDuration: boolean }[] = [
-  { id: "always-allow", label: "Always Allow", prompts: false, usesDuration: false },
-  { id: "per-shed-allow", label: "Per Shed Allow", prompts: true, usesDuration: false },
-  { id: "time-based-allow", label: "Time Based Allow", prompts: true, usesDuration: true },
-  { id: "always-ask", label: "Always Ask", prompts: true, usesDuration: false },
-  { id: "always-deny", label: "Always Deny", prompts: false, usesDuration: false },
-];
-
-const PREF_LABEL = "mb-1.5 font-mono text-[11px] font-semibold uppercase tracking-wider text-shed-text-muted";
-const PREF_GROUP = "mb-5 overflow-hidden rounded-[10px] border border-shed-border bg-shed-surface";
-
-function PreferencesModal({ onClose }: { onClose: () => void }) {
-  const [presets, setPresets] = useState<TerminalPresetInfo[]>([]);
-  const [preset, setPreset] = useState("custom");
-  const [template, setTemplate] = useState("");
-  const [method, setMethod] = useState<SshPrefs["method"]>("biometrics-or-password");
-  const [policy, setPolicy] = useState("time-based-allow");
-  const [ttl, setTtl] = useState("2h");
-  const [launchAtLogin, setLaunchAtLogin] = useState(false);
-  const [loginBusy, setLoginBusy] = useState(false);
-  const sshGen = useRef(0);
-  const ttlAtFocus = useRef(""); // the Duration value when the field gained focus
-
-  useEffect(() => {
-    void fetchTerminalPresets().then(setPresets);
-    void getLoginItem().then(setLaunchAtLogin);
-    void getPrefs().then((p) => {
-      setPreset(p.terminal_preset);
-      setTemplate(p.terminal_template);
-    });
-    // Guard the initial load with the same generation ref as applySsh: if the user
-    // edits a pref before this slow first read resolves, the stale load must not
-    // clobber their change (its optimistic set already bumped sshGen).
-    const mine = ++sshGen.current;
-    void getSshApproval().then((p) => {
-      if (mine !== sshGen.current) return;
-      setMethod(p.method);
-      setPolicy(p.policy);
-      setTtl(p.ttl);
-    });
-  }, []);
-
-  useEscClose(onClose);
-
-  const choosePreset = (id: string) => {
-    setPreset(id);
-    void setTerminalPref(id, id === "custom" ? template : undefined);
-  };
-  const editTemplate = (t: string) => {
-    setTemplate(t);
-    if (preset === "custom") void setTerminalPref("custom", t);
-  };
-  // Launch-at-login: set optimistically, persist via the THROWING setter, then
-  // reconcile from loginitem.status — so a failed/guarded write can't leave the
-  // toggle misrepresenting the real state. Guarded by `loginBusy` so a fast
-  // double-toggle can't race enable()/disable() into the wrong final OS state.
-  const toggleLaunchAtLogin = (v: boolean) => {
-    setLaunchAtLogin(v);
-    setLoginBusy(true);
-    void (async () => {
-      try {
-        await setLoginItem(v);
-      } catch {
-        // fall through to reconcile from the backend truth
-      }
-      setLaunchAtLogin(await getLoginItem()); // getLoginItem swallows → never throws
-      setLoginBusy(false);
-    })();
-  };
-  // Apply one SSH-pref delta: set it optimistically, persist only the changed
-  // field, then reconcile ALL three from the backend — so a rejected/failed write
-  // can't leave the method radio misrepresenting the actual gate strength. A
-  // generation guard drops a superseded reload so fast Duration typing can't be
-  // clobbered by an out-of-order confirm.
-  const applySsh = (delta: { method?: SshPrefs["method"]; policy?: string; ttl?: string }) => {
-    if (delta.method !== undefined) setMethod(delta.method);
-    if (delta.policy !== undefined) setPolicy(delta.policy);
-    if (delta.ttl !== undefined) setTtl(delta.ttl);
-    const mine = ++sshGen.current;
-    void (async () => {
-      await setSshApproval(delta.method, delta.policy, delta.ttl);
-      const p = await getSshApproval();
-      if (mine !== sshGen.current) return; // superseded by a newer change
-      setMethod(p.method);
-      setPolicy(p.policy);
-      setTtl(p.ttl);
-    })();
-  };
-  const policyMeta = SSH_POLICIES.find((p) => p.id === policy);
-
-  return (
-    <Scrim onClose={onClose} mark="prefs">
-      <DialogShell icon={Settings} title="Preferences" sub="Terminal, credential approvals, and launch behavior." onClose={onClose} width={480}>
-        <div>
-          <div className={PREF_LABEL}>General</div>
-          <div className={PREF_GROUP}>
-            <label className="flex items-center gap-3 px-3.5 py-2.5">
-              <span className="text-[13px] text-shed-text">Launch at login</span>
-              <span className="flex-1" />
-              <span className="text-[12px] text-shed-text-muted">Open Shed Desktop when you sign in.</span>
-              <Switch on={launchAtLogin} set={toggleLaunchAtLogin} disabled={loginBusy} />
-            </label>
-          </div>
-
-          <div className={PREF_LABEL}>Terminal</div>
-          <p className="mb-2 text-[12px] text-shed-text-muted">Which terminal opens when you click "Open in Terminal" on a shed.</p>
-          <div className={PREF_GROUP}>
-            {presets.map((p, i) => {
-              const active = preset === p.id;
-              return (
-                <label
-                  key={p.id}
-                  className={cn("flex cursor-pointer items-center gap-3 px-3.5 py-2.5", i && "border-t border-shed-border", !p.available && "opacity-50")}
-                  style={{ background: active ? "var(--shed-accent-subtle)" : undefined }}
-                >
-                  <input
-                    type="radio"
-                    name="terminal-preset"
-                    checked={active}
-                    disabled={!p.available}
-                    onChange={() => choosePreset(p.id)}
-                    style={{ accentColor: "var(--shed-accent)" }}
-                  />
-                  <span className="text-[13px] text-shed-text">{p.label}</span>
-                  {!p.available && <span className="text-[12px] text-shed-text-muted">not installed</span>}
-                  <span className="flex-1" />
-                  {p.detail && <span className="truncate text-[12px] text-shed-text-muted">{p.detail}</span>}
-                </label>
-              );
-            })}
-          </div>
-          {preset === "custom" && (
-            <div className="-mt-3 mb-5">
-              <input
-                value={template}
-                onChange={(e) => editTemplate(e.target.value)}
-                placeholder="e.g. kitty -e {cmd}"
-                className="w-full rounded-[9px] border border-shed-border bg-shed-surface px-3 py-2 font-mono text-[13px] text-shed-text outline-none focus:border-shed-accent"
-              />
-              <p className="mt-1.5 text-[12px] text-shed-text-muted">
-                <code className="font-mono">{"{cmd}"}</code> is the ssh command, <code className="font-mono">{"{shed}"}</code> the shed name.
-              </p>
-            </div>
-          )}
-
-          <div className={PREF_LABEL}>Credential approvals</div>
-          <p className="mb-2 text-[12px] text-shed-text-muted">What happens when the host agent routes an SSH-key approval here.</p>
-          <div className="mb-2 overflow-hidden rounded-[10px] border border-shed-border bg-shed-surface">
-            <label className="flex items-center gap-3 px-3.5 py-2.5">
-              <span className="text-[13px] text-shed-text">Approval policy</span>
-              <span className="flex-1" />
-              <select
-                value={policy}
-                onChange={(e) => applySsh({ policy: e.target.value })}
-                className="rounded-md border border-shed-border bg-shed-inset px-2 py-1 text-[13px] text-shed-text outline-none"
-                data-ssh-policy
-              >
-                {SSH_POLICIES.map((p) => (
-                  <option key={p.id} value={p.id}>{p.label}</option>
-                ))}
-              </select>
-            </label>
-
-            {/* Duration — only the time-based policy carries one (policy.usesDuration). */}
-            {policyMeta?.usesDuration && (
-              <label className="flex items-center gap-3 border-t border-shed-border px-3.5 py-2.5">
-                <span className="text-[13px] text-shed-text">Duration</span>
-                <span className="flex-1" />
-                <input
-                  value={ttl}
-                  // Free text → keep each keystroke LOCAL (optimistic) and persist only
-                  // on blur/Enter, and only when it changed. applySsh resets live SSH
-                  // grants + rewrites prefs.json, so a per-keystroke persist would revoke
-                  // active grants and churn disk mid-typing.
-                  onChange={(e) => setTtl(e.target.value)}
-                  onFocus={() => {
-                    ttlAtFocus.current = ttl;
-                  }}
-                  onBlur={() => {
-                    if (ttl !== ttlAtFocus.current) applySsh({ ttl });
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") e.currentTarget.blur();
-                  }}
-                  placeholder="2h"
-                  className="w-[72px] rounded-md border border-shed-border bg-shed-inset px-2 py-1 text-right font-mono text-[13px] text-shed-text outline-none"
-                  data-ssh-ttl
-                />
-              </label>
-            )}
-          </div>
-
-          {/* Method — only the prompting policies confirm an approval (policy.prompts). */}
-          {policyMeta?.prompts && (
-            <>
-              <div className={PREF_LABEL}>Method</div>
-              <div className="mb-2 overflow-hidden rounded-[10px] border border-shed-border bg-shed-surface">
-                {APPROVAL_METHODS.map((m, i) => {
-                  const active = method === m.id;
-                  return (
-                    <label
-                      key={m.id}
-                      className={cn("flex cursor-pointer items-center gap-3 px-3.5 py-2.5", i && "border-t border-shed-border")}
-                      style={{ background: active ? "var(--shed-accent-subtle)" : undefined }}
-                    >
-                      <input
-                        type="radio"
-                        name="approval-method"
-                        checked={active}
-                        onChange={() => applySsh({ method: m.id })}
-                        style={{ accentColor: "var(--shed-accent)" }}
-                      />
-                      <span className="text-[13px] text-shed-text">{m.label}</span>
-                      <span className="flex-1" />
-                      <span className="truncate text-[12px] text-shed-text-muted">{m.detail}</span>
-                    </label>
-                  );
-                })}
-              </div>
-            </>
-          )}
-          <p className="text-[12px] leading-relaxed text-shed-text-muted">
-            Always Allow / Always Deny decide every SSH sign with no prompt. The others prompt, then remember your approval per the policy. Changing the policy clears live grants. Method is how each approval is confirmed.
-          </p>
-        </div>
-      </DialogShell>
-    </Scrim>
-  );
-}
-
 /* ---- New-shed (create dialog with live SSE progress) ---------------------- */
 const BACKEND_OPTS = [
   { value: "", label: "Default" },
@@ -1289,20 +1046,24 @@ export default function App() {
 
   // Apply the appearance to the root BEFORE the bridge's report effect samples it (a
   // layout effect runs ahead of that passive effect), so `ui.computed_style` reflects
-  // the flip.
+  // the flip. Also mirror the mode into the Rust AppearanceState (which broadcasts
+  // `set-appearance` to every window, so the Preferences window follows) — it fires
+  // on both the manual header toggle and IPC-driven changes, and the Rust side
+  // no-ops (no re-emit) when unchanged, so the listener→effect loop can't echo.
   useLayoutEffect(() => {
     document.documentElement.dataset.mode = mode;
+    void setAppearanceState(mode);
   }, [mode]);
 
-  // Open the modals both from the buttons and from the ui.show_preferences /
-  // ui.show_create / ui.show_launch IPC ops (events); drive dark/light from
-  // ui.set_appearance — so the harness can drive + screenshot each deterministically.
+  // Open the modals both from the buttons and from the ui.show_create /
+  // ui.show_launch IPC ops (events); drive dark/light from ui.set_appearance —
+  // so the harness can drive + screenshot each deterministically. (Preferences is
+  // a dedicated window now — opened via the open_preferences command, no event.)
   useEffect(() => {
     if (typeof window === "undefined" || !("__TAURI_INTERNALS__" in window)) return;
     const uns: Array<() => void> = [];
     let cancelled = false;
     void import("@tauri-apps/api/event").then(async ({ listen }) => {
-      uns.push(await listen("show-preferences", () => setModal("prefs")));
       uns.push(await listen("show-create", () => setModal("create")));
       uns.push(await listen("show-launch", () => setModal("launch")));
       uns.push(
@@ -1403,7 +1164,7 @@ export default function App() {
           <span className="inline-flex items-center gap-2 text-[13px] font-medium text-shed-text-secondary">
             <Dot className="h-2 w-2" style={{ background: connected ? "var(--shed-ok)" : "var(--shed-text-muted)" }} /> host agent · {connected ? "connected" : "connecting…"}
           </span>
-          <button onClick={() => setModal("prefs")} title="Preferences" className="hlink flex h-[34px] w-[34px] items-center justify-center rounded-[9px] text-shed-text-muted">
+          <button onClick={() => void openPreferences()} title="Preferences" className="hlink flex h-[34px] w-[34px] items-center justify-center rounded-[9px] text-shed-text-muted">
             <Settings size={18} />
           </button>
           <button onClick={() => setMode(mode === "light" ? "dark" : "light")} title="Toggle appearance" className="hlink flex h-[34px] w-[34px] items-center justify-center rounded-[9px] text-shed-text-muted">
@@ -1421,7 +1182,6 @@ export default function App() {
           </div>
         </main>
       </div>
-      {modal === "prefs" && <PreferencesModal onClose={() => setModal(null)} />}
       {modal === "create" && <NewShedDialog refresh={refresh} onClose={() => setModal(null)} />}
       {modal === "launch" && <LaunchAgentDialog sheds={sheds} capabilities={rcCapabilities} refresh={refreshRc} onClose={() => setModal(null)} onLaunched={onLaunched} />}
     </div>

--- a/desktop/tauri/ui/src/PreferencesWindow.tsx
+++ b/desktop/tauri/ui/src/PreferencesWindow.tsx
@@ -1,0 +1,475 @@
+/* PreferencesWindow — the dedicated Preferences window (label "preferences"), the
+   Tauri port of the mac PreferencesView's grouped form: General / Terminal / the
+   namespace-gated approval sections (SSH, AWS, Docker) / Per-shed overrides, in
+   the mac section order. A fixed-size decorated window; its own webview + React
+   root so it never mounts `useUiBridge`. It reports `{sections, values, mode}`
+   under the `prefs` key so the harness drives + asserts it via `prefs.dump`. */
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Segmented, Select, Switch } from "@/components/dialog";
+import {
+  inTauri,
+  fetchTerminalPresets, getPrefs, setTerminalPref,
+  getLoginItem, setLoginItem,
+  getSshApproval, setSshApproval,
+  fetchGateNamespaces, useCoordinatorData,
+  getProviderModes, setProviderMode,
+  listShedRules, removeShedRule,
+  getAppearanceState, reportPrefs,
+  type TerminalPresetInfo, type SshPrefs, type ProviderModes, type ShedRule,
+  type PrefsReport,
+} from "@/lib/bridge";
+
+/* The credential namespaces the host agent can delegate (mac CredentialNamespace). */
+const NS_SSH = "ssh-agent";
+const NS_AWS = "aws-credentials";
+const NS_DOCKER = "docker-credentials";
+
+// How an SSH-key approval is confirmed. On Linux "Authenticate" routes through
+// polkit; "Prompt only" needs no gate — a plain Approve button.
+const APPROVAL_METHODS: { id: SshPrefs["method"]; label: string; detail: string }[] = [
+  { id: "biometrics-or-password", label: "Authenticate", detail: "Confirm with your login password." },
+  { id: "prompt", label: "Prompt only", detail: "A plain Approve button — no password." },
+];
+
+// The SSH approval policies, most → least permissive (mirrors SshApprovalPolicy in
+// shed-core). `prompts` gates the Method radios and `usesDuration` gates the
+// Duration field — the SAME policy→behavior mapping as the Swift app.
+const SSH_POLICIES: { id: string; label: string; prompts: boolean; usesDuration: boolean }[] = [
+  { id: "always-allow", label: "Always Allow", prompts: false, usesDuration: false },
+  { id: "per-shed-allow", label: "Per Shed Allow", prompts: true, usesDuration: false },
+  { id: "time-based-allow", label: "Time Based Allow", prompts: true, usesDuration: true },
+  { id: "always-ask", label: "Always Ask", prompts: true, usesDuration: false },
+  { id: "always-deny", label: "Always Deny", prompts: false, usesDuration: false },
+];
+
+/** A titled grouped card: the mac per-section mono label + the rounded container
+    the section's rows live in. The optional Footnote is a separate sibling. */
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <>
+      <div className="mb-1.5 font-mono text-[11px] font-semibold uppercase tracking-wider text-shed-text-muted">{title}</div>
+      <div className="mb-5 overflow-hidden rounded-[10px] border border-shed-border bg-shed-surface">{children}</div>
+    </>
+  );
+}
+
+/** The muted footnote below a grouped card (mac's per-section footer text). */
+function Footnote({ children }: { children: React.ReactNode }) {
+  return <p className="-mt-3.5 mb-5 px-1 text-[12px] leading-relaxed text-shed-text-muted">{children}</p>;
+}
+
+/** An AWS/Docker provider section: a Segmented Allow|Deny + the mac live-note. */
+function ProviderSection({ title, mode, onChange }:
+  { title: string; mode: "approve" | "deny"; onChange: (v: "approve" | "deny") => void }) {
+  return (
+    <>
+      <Section title={title}>
+        <div className="flex items-center gap-3 px-3.5 py-2.5">
+          <span className="text-[13px] text-shed-text">Mode</span>
+          <span className="flex-1" />
+          <span className="w-[170px]">
+            <Segmented
+              options={[["approve", "Allow"], ["deny", "Deny"]]}
+              value={mode}
+              set={(v) => onChange(v as "approve" | "deny")}
+            />
+          </span>
+        </div>
+      </Section>
+      <Footnote>Live — takes effect immediately. Credentials fail closed (deny) when shed-desktop isn't running.</Footnote>
+    </>
+  );
+}
+
+export default function PreferencesWindow() {
+  // Appearance: seeded from the Rust-held app-wide state (the dashboard's mode);
+  // unset (a fresh launch) falls back to the OS scheme (popover parity). Live via
+  // the same `set-appearance` broadcast the dashboard's mode effect triggers.
+  const [mode, setMode] = useState<"light" | "dark">("light");
+  const [presets, setPresets] = useState<TerminalPresetInfo[]>([]);
+  const [preset, setPreset] = useState("custom");
+  const [template, setTemplate] = useState("");
+  const [method, setMethod] = useState<SshPrefs["method"]>("biometrics-or-password");
+  const [policy, setPolicy] = useState("time-based-allow");
+  const [ttl, setTtl] = useState("2h");
+  const [launchAtLogin, setLaunchAtLogin] = useState(false);
+  const [loginBusy, setLoginBusy] = useState(false);
+  const [providerModes, setModes] = useState<ProviderModes>({});
+  const [shedRules, setShedRules] = useState<ShedRule[]>([]);
+  const sshGen = useRef(0);
+  const reloadGen = useRef(0); // bumped per reloadAll; guards every fetch's application
+  const ttlAtFocus = useRef(""); // the Duration value when the field gained focus
+  // Which namespaces the host agent delegates here — gates the approval sections.
+  // Own subscription (separate React root ⇒ separate hook instance from the shell's).
+  const gateNs = useCoordinatorData<string[]>("connected-changed", fetchGateNamespaces, []);
+
+  useEffect(() => {
+    if (!inTauri()) return;
+    let cancelled = false;
+    const uns: Array<() => void> = [];
+    void (async () => {
+      const { listen } = await import("@tauri-apps/api/event");
+      // Listener BEFORE the initial read: `ui.set_appearance` updates the Rust
+      // cell before emitting, so read-after-attach can never be older than a
+      // heard event (no attach race, no flash).
+      uns.push(
+        await listen<{ mode?: unknown }>("set-appearance", (e) => {
+          if (e.payload?.mode === "light" || e.payload?.mode === "dark") setMode(e.payload.mode);
+        }),
+      );
+      const initial = await getAppearanceState();
+      if (!cancelled) {
+        setMode(initial ?? (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"));
+      }
+      if (cancelled) uns.forEach((u) => u());
+    })();
+    return () => {
+      cancelled = true;
+      uns.forEach((u) => u());
+    };
+  }, []);
+  useLayoutEffect(() => {
+    document.documentElement.dataset.mode = mode;
+  }, [mode]);
+
+  // (Re)load every value the window shows. Ran on mount and on `prefs-changed`
+  // (an IPC-driven mutation changed prefs behind the window's back — its own
+  // controls update local state directly).
+  const reloadAll = useCallback(() => {
+    // One generation captured at entry, checked before every async application:
+    // two interleaved prefs-changed reloads can't let an older fetch resolving
+    // last leave stale values (or a stale prefs.dump).
+    const gen = ++reloadGen.current;
+    const fresh = () => gen === reloadGen.current;
+    void fetchTerminalPresets().then((v) => {
+      if (fresh()) setPresets(v);
+    });
+    void getLoginItem().then((v) => {
+      if (fresh()) setLaunchAtLogin(v);
+    });
+    void getPrefs().then((p) => {
+      if (!fresh()) return;
+      setPreset(p.terminal_preset);
+      setTemplate(p.terminal_template);
+    });
+    void getProviderModes().then((v) => {
+      if (fresh()) setModes(v);
+    });
+    void listShedRules().then((v) => {
+      if (fresh()) setShedRules(v);
+    });
+    // SSH keeps its own guard on top: applySsh bumps sshGen on an optimistic
+    // edit, so a slow load must not clobber a newer edit (not just a newer reload).
+    const mine = ++sshGen.current;
+    void getSshApproval().then((p) => {
+      if (mine !== sshGen.current || !fresh()) return;
+      setMethod(p.method);
+      setPolicy(p.policy);
+      setTtl(p.ttl);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!inTauri()) return;
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+    void (async () => {
+      const { listen } = await import("@tauri-apps/api/event");
+      const un = await listen("prefs-changed", reloadAll);
+      if (cancelled) un();
+      else unlisten = un;
+      reloadAll(); // initial load, after the listener is live
+    })();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [reloadAll]);
+
+  const choosePreset = (id: string) => {
+    setPreset(id);
+    void setTerminalPref(id, id === "custom" ? template : undefined);
+  };
+  const editTemplate = (t: string) => {
+    setTemplate(t);
+    if (preset === "custom") void setTerminalPref("custom", t);
+  };
+  // Launch-at-login: set optimistically, persist via the THROWING setter, then
+  // reconcile from loginitem.status — so a failed/guarded write can't leave the
+  // toggle misrepresenting the real state. Guarded by `loginBusy` so a fast
+  // double-toggle can't race enable()/disable() into the wrong final OS state.
+  const toggleLaunchAtLogin = (v: boolean) => {
+    setLaunchAtLogin(v);
+    setLoginBusy(true);
+    void (async () => {
+      try {
+        await setLoginItem(v);
+      } catch {
+        // fall through to reconcile from the backend truth
+      }
+      setLaunchAtLogin(await getLoginItem()); // getLoginItem swallows → never throws
+      setLoginBusy(false);
+    })();
+  };
+  // Apply one SSH-pref delta: set it optimistically, persist only the changed
+  // field, then reconcile ALL three from the backend — so a rejected/failed write
+  // can't leave the method radio misrepresenting the actual gate strength. A
+  // generation guard drops a superseded reload so fast Duration typing can't be
+  // clobbered by an out-of-order confirm.
+  const applySsh = (delta: { method?: SshPrefs["method"]; policy?: string; ttl?: string }) => {
+    if (delta.method !== undefined) setMethod(delta.method);
+    if (delta.policy !== undefined) setPolicy(delta.policy);
+    if (delta.ttl !== undefined) setTtl(delta.ttl);
+    const mine = ++sshGen.current;
+    void (async () => {
+      await setSshApproval(delta.method, delta.policy, delta.ttl);
+      const p = await getSshApproval();
+      if (mine !== sshGen.current) return; // superseded by a newer change
+      setMethod(p.method);
+      setPolicy(p.policy);
+      setTtl(p.ttl);
+    })();
+  };
+  // A provider mode: optimistic, then reconcile from the coordinator (the setter
+  // throws on a rejected namespace; the read-back is the truth either way).
+  const chooseProviderMode = (ns: typeof NS_AWS | typeof NS_DOCKER, decision: "approve" | "deny") => {
+    setModes((m) => ({ ...m, [ns]: decision }));
+    void (async () => {
+      try {
+        await setProviderMode(ns, decision);
+      } catch {
+        // fall through to reconcile from the backend truth
+      }
+      setModes(await getProviderModes());
+    })();
+  };
+  const removeRule = (r: ShedRule) => {
+    void (async () => {
+      await removeShedRule(r.server ?? "", r.shed ?? "");
+      setShedRules(await listShedRules());
+    })();
+  };
+
+  const policyMeta = SSH_POLICIES.find((p) => p.id === policy);
+  const sshGated = gateNs.includes(NS_SSH);
+  const awsGated = gateNs.includes(NS_AWS);
+  const dockerGated = gateNs.includes(NS_DOCKER);
+  const anyGated = sshGated || awsGated || dockerGated;
+
+  // The mac availableTerminalPresets shape: offer the installed presets, plus the
+  // persisted one even if it's (no longer) installed so the picker stays truthful.
+  const presetOpts = presets
+    .filter((p) => p.available || p.id === preset)
+    .map((p) => ({ value: p.id, label: p.available ? p.label : `${p.label} (not installed)` }));
+
+  // The visible section ids, in mac order — reported so the harness asserts
+  // gated visibility as logical content, not pixels.
+  const sections: string[] = [
+    "general",
+    "terminal",
+    ...(anyGated ? [] : ["approvals-empty"]),
+    ...(sshGated ? ["ssh"] : []),
+    ...(awsGated ? ["aws"] : []),
+    ...(dockerGated ? ["docker"] : []),
+    ...(shedRules.length ? ["shed-overrides"] : []),
+  ];
+
+  // Report the rendered snapshot on mount + every value/visibility change, deduped
+  // by content so a re-render without a real change doesn't re-report.
+  const report: PrefsReport = {
+    sections,
+    values: {
+      preset,
+      template,
+      policy,
+      method,
+      ttl,
+      login: launchAtLogin,
+      provider_modes: providerModes,
+      shed_rules_count: shedRules.length,
+    },
+    mode,
+  };
+  const reportJson = JSON.stringify(report);
+  useEffect(() => {
+    if (!inTauri()) return;
+    reportPrefs(report);
+  }, [reportJson]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="h-full overflow-y-auto bg-shed-bg px-5 py-4 text-shed-text">
+      <Section title="General">
+        <label className="flex items-center gap-3 px-3.5 py-2.5">
+          <span className="text-[13px] text-shed-text">Launch at login</span>
+          <span className="flex-1" />
+          <Switch on={launchAtLogin} set={toggleLaunchAtLogin} disabled={loginBusy} />
+        </label>
+      </Section>
+      <Footnote>Open Shed Desktop when you sign in.</Footnote>
+
+      <Section title="Terminal">
+        <label className="flex items-center gap-3 px-3.5 py-2.5">
+          <span className="flex-none text-[13px] text-shed-text">Open sheds in</span>
+          <span className="flex-1" />
+          <span className="w-[200px]">
+            <Select value={preset} onChange={choosePreset} options={presetOpts} />
+          </span>
+        </label>
+        {preset === "custom" && (
+          <div className="border-t border-shed-border px-3.5 py-2.5">
+            <input
+              value={template}
+              onChange={(e) => editTemplate(e.target.value)}
+              placeholder="e.g. ghostty -e {cmd}"
+              className="w-full rounded-[8px] border border-shed-border bg-shed-inset px-2.5 py-1.5 font-mono text-[13px] text-shed-text outline-none focus:border-shed-accent"
+              data-terminal-template
+            />
+          </div>
+        )}
+      </Section>
+      <Footnote>
+        {preset === "custom" ? (
+          <>
+            <code className="font-mono">{"{cmd}"}</code> is replaced with the ssh command,{" "}
+            <code className="font-mono">{"{shed}"}</code> with the shed name.
+          </>
+        ) : (
+          presets.find((p) => p.id === preset)?.detail ||
+          'Which terminal opens when you click "Open in Terminal" on a shed.'
+        )}
+      </Footnote>
+
+      {!anyGated && (
+        <Section title="Approvals">
+          <p className="px-3.5 py-2.5 text-[12px] leading-relaxed text-shed-text-muted">
+            No extensions are delegated to shed-desktop. Set an extension's{" "}
+            <code className="font-mono">approval.policy</code> to{" "}
+            <code className="font-mono">shed-desktop</code> in extensions.yaml to manage it here.
+          </p>
+        </Section>
+      )}
+
+      {sshGated && (
+        <>
+          <Section title="SSH approvals">
+            <label className="flex items-center gap-3 px-3.5 py-2.5">
+              <span className="flex-none text-[13px] text-shed-text">Approval policy</span>
+              <span className="flex-1" />
+              {/* The dialog Select (appearance-none + own caret): WebKitGTK renders a
+                  raw native <select>'s button text illegibly in dark mode. */}
+              <span className="w-[190px]" data-ssh-policy>
+                <Select
+                  value={policy}
+                  onChange={(v) => applySsh({ policy: v })}
+                  options={SSH_POLICIES.map((p) => ({ value: p.id, label: p.label }))}
+                />
+              </span>
+            </label>
+
+            {/* Duration — only the time-based policy carries one (policy.usesDuration). */}
+            {policyMeta?.usesDuration && (
+              <label className="flex items-center gap-3 border-t border-shed-border px-3.5 py-2.5">
+                <span className="text-[13px] text-shed-text">Duration</span>
+                <span className="flex-1" />
+                <input
+                  value={ttl}
+                  // Free text → keep each keystroke LOCAL (optimistic) and persist only
+                  // on blur/Enter, and only when it changed. applySsh resets live SSH
+                  // grants + rewrites prefs.json, so a per-keystroke persist would revoke
+                  // active grants and churn disk mid-typing.
+                  onChange={(e) => setTtl(e.target.value)}
+                  onFocus={() => {
+                    ttlAtFocus.current = ttl;
+                  }}
+                  onBlur={() => {
+                    if (ttl !== ttlAtFocus.current) applySsh({ ttl });
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") e.currentTarget.blur();
+                  }}
+                  placeholder="2h"
+                  className="w-[72px] rounded-md border border-shed-border bg-shed-inset px-2 py-1 text-right font-mono text-[13px] text-shed-text outline-none"
+                  data-ssh-ttl
+                />
+              </label>
+            )}
+
+            {/* Method — only the prompting policies confirm an approval (policy.prompts). */}
+            {policyMeta?.prompts &&
+              APPROVAL_METHODS.map((m) => {
+                const active = method === m.id;
+                return (
+                  <label
+                    key={m.id}
+                    className="flex cursor-pointer items-center gap-3 border-t border-shed-border px-3.5 py-2.5"
+                    style={{ background: active ? "var(--shed-accent-subtle)" : undefined }}
+                  >
+                    <input
+                      type="radio"
+                      name="approval-method"
+                      checked={active}
+                      onChange={() => applySsh({ method: m.id })}
+                      style={{ accentColor: "var(--shed-accent)" }}
+                    />
+                    <span className="text-[13px] text-shed-text">{m.label}</span>
+                    <span className="flex-1" />
+                    <span className="truncate text-[12px] text-shed-text-muted">{m.detail}</span>
+                  </label>
+                );
+              })}
+          </Section>
+          <Footnote>
+            Always Allow / Always Deny decide every SSH sign with no prompt. The others prompt,
+            then remember your approval per the policy. Changing the policy clears live grants.
+            “Method” is the confirmation prompt shown when approving.
+          </Footnote>
+        </>
+      )}
+
+      {awsGated && (
+        <ProviderSection
+          title="AWS credentials"
+          mode={providerModes[NS_AWS] ?? "deny"}
+          onChange={(v) => chooseProviderMode(NS_AWS, v)}
+        />
+      )}
+      {dockerGated && (
+        <ProviderSection
+          title="Docker credentials"
+          mode={providerModes[NS_DOCKER] ?? "deny"}
+          onChange={(v) => chooseProviderMode(NS_DOCKER, v)}
+        />
+      )}
+
+      {shedRules.length > 0 && (
+        <Section title="Per-shed overrides">
+          {shedRules.map((r, i) => (
+              <div
+                key={`${r.server ?? ""}/${r.shed ?? ""}`}
+                className={cn("flex items-center gap-2 px-3.5 py-2", i > 0 && "border-t border-shed-border")}
+              >
+                <span className="text-[13px] text-shed-text">{r.shed}</span>
+                {r.server ? <span className="text-[11px] text-shed-text-muted">{r.server}</span> : null}
+                <span className="flex-1" />
+                <span
+                  className="text-[11px] font-semibold"
+                  style={{ color: r.action === "deny" ? "var(--shed-danger)" : "var(--shed-text-muted)" }}
+                >
+                  {r.action === "deny" ? "auto-deny" : "auto-approve"}
+                </span>
+                <button
+                  onClick={() => removeRule(r)}
+                  title="Remove this override"
+                  className="hlink flex h-6 w-6 flex-none items-center justify-center rounded-md text-shed-text-muted"
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            ))}
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/desktop/tauri/ui/src/components/dialog.tsx
+++ b/desktop/tauri/ui/src/components/dialog.tsx
@@ -27,7 +27,7 @@ export function useEscClose(onClose: () => void, enabled = true) {
 }
 
 /** The backdrop scrim. `mark` stamps a `data-<mark>` attr the harness can look for
-    (parity with the old data-prefs/data-create markers). Backdrop mousedown closes. */
+    (e.g. data-create / data-launch). Backdrop mousedown closes. */
 export function Scrim({ onClose, mark, children }: { onClose: () => void; mark?: string; children: React.ReactNode }) {
   const markAttr = mark ? { [`data-${mark}`]: "" } : {};
   return (

--- a/desktop/tauri/ui/src/lib/bridge.ts
+++ b/desktop/tauri/ui/src/lib/bridge.ts
@@ -419,6 +419,56 @@ export async function setSshApproval(method?: string, policy?: string, ttl?: str
   await invoke("set_ssh_approval", { method, policy, ttl });
 }
 
+/** The AWS/Docker provider approval modes, keyed by the full namespace string
+ *  (`aws-credentials`/`docker-credentials`) → `"approve"` | `"deny"`. A namespace
+ *  absent from the map is Deny (fail-closed default). */
+export type ProviderModes = Record<string, "approve" | "deny">;
+
+export async function getProviderModes(): Promise<ProviderModes> {
+  return (await invoke<ProviderModes>("provider_modes_get")) ?? {};
+}
+
+/** Set an AWS/Docker provider mode. THROWS on a rejected namespace (the coordinator
+ *  only accepts the two providers), unlike the error-swallowing `invoke`. */
+export async function setProviderMode(
+  ns: "aws-credentials" | "docker-credentials",
+  decision: "approve" | "deny",
+): Promise<void> {
+  const core = await import("@tauri-apps/api/core");
+  await core.invoke("set_provider_mode", { ns, decision });
+}
+
+/** A per-shed override rule (the Preferences "Per-shed overrides" list). */
+export type ShedRule = {
+  scope: string;
+  server?: string | null;
+  namespace?: string | null;
+  shed?: string | null;
+  action: "approve" | "deny" | "prompt";
+  gate?: string;
+};
+
+export async function listShedRules(): Promise<ShedRule[]> {
+  return (await invoke<ShedRule[]>("policy_list_shed")) ?? [];
+}
+
+/** Remove one per-shed override rule (its row's remove button). */
+export async function removeShedRule(server: string, shed: string): Promise<void> {
+  await invoke("remove_shed_rule", { server, shed });
+}
+
+/** The app-wide light/dark appearance, read synchronously by the Preferences window
+ *  on mount (`null` = unset → fall back to `prefers-color-scheme`). */
+export async function getAppearanceState(): Promise<"light" | "dark" | null> {
+  return (await invoke<{ mode: "light" | "dark" | null }>("get_appearance_state"))?.mode ?? null;
+}
+
+/** Broadcast a light/dark change app-wide (idempotent — no re-emit when unchanged).
+ *  Invoked from the dashboard's mode effect so every window stays in sync. */
+export async function setAppearanceState(mode: "light" | "dark"): Promise<void> {
+  await invoke("set_appearance_state", { mode });
+}
+
 /** Keep a coordinator-backed slice live: fetch on mount, then re-fetch whenever
  *  the coordinator emits `event` (the TauriEventSink app.emit). `fetch` is held
  *  in a ref so the subscription is set up once (a no-op in a plain browser). */

--- a/desktop/tauri/ui/src/lib/bridge.ts
+++ b/desktop/tauri/ui/src/lib/bridge.ts
@@ -2,8 +2,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 export type Pane = "sheds" | "approvals" | "agents" | "activity" | "egress" | "system";
 
-/** Which modal (if any) is open — reported so the harness can drive + assert it. */
-export type Modal = null | "prefs" | "create" | "launch";
+/** Which modal (if any) is open — reported so the harness can drive + assert it.
+ *  (Preferences is a dedicated window, not a modal — see `reportPrefs`.) */
+export type Modal = null | "create" | "launch";
 
 const PANES: readonly Pane[] = ["sheds", "approvals", "agents", "activity", "egress", "system"];
 
@@ -467,6 +468,31 @@ export async function getAppearanceState(): Promise<"light" | "dark" | null> {
  *  Invoked from the dashboard's mode effect so every window stays in sync. */
 export async function setAppearanceState(mode: "light" | "dark"): Promise<void> {
   await invoke("set_appearance_state", { mode });
+}
+
+/** The Preferences window's rendered snapshot, reported under its own window label
+ *  ("preferences") so the `prefs.dump` op can observe it (UI truth, like the egress
+ *  report): the visible section ids in mac order, the rendered control values, and
+ *  the active light/dark mode. Keys are additive + stable — the harness asserts them. */
+export type PrefsReport = {
+  sections: string[];
+  values: {
+    preset: string;
+    template: string;
+    policy: string;
+    method: string;
+    ttl: string;
+    login: boolean;
+    provider_modes: ProviderModes;
+    shed_rules_count: number;
+  };
+  mode: string;
+};
+
+/** Report the Preferences window's rendered state (`ui_report` keys it under the
+ *  calling window's label, so it can never clobber the dashboard's `main`). */
+export function reportPrefs(snapshot: PrefsReport): void {
+  void invoke("ui_report", { snapshot: { prefs: snapshot } });
 }
 
 /** Keep a coordinator-backed slice live: fetch on mount, then re-fetch whenever

--- a/desktop/tauri/ui/src/preferences.tsx
+++ b/desktop/tauri/ui/src/preferences.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import PreferencesWindow from "./PreferencesWindow";
+import "./index.css";
+
+// The Preferences window — a SEPARATE React root from the dashboard shell (the
+// popover precedent), so it never mounts `useUiBridge` (which reports
+// `pane`/`sheds` and would clobber the `main` snapshot). It reports its own
+// grouped-form snapshot under the `preferences` window key (read by `prefs.dump`).
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <PreferencesWindow />
+  </React.StrictMode>,
+);

--- a/desktop/tauri/ui/vite.config.ts
+++ b/desktop/tauri/ui/vite.config.ts
@@ -15,13 +15,15 @@ export default defineConfig({
     outDir: "dist",
     emptyOutDir: true,
     target: "safari15",
-    // Two entries: the dashboard shell (index.html) + the macOS menu-bar popover
-    // (popover.html → TrayPopover). The popover is a SEPARATE webview so it never
+    // Three entries: the dashboard shell (index.html), the macOS menu-bar popover
+    // (popover.html → TrayPopover), and the Preferences window (preferences.html →
+    // PreferencesWindow). Each extra window is a SEPARATE webview/root so it never
     // mounts the shell's useUiBridge (which would clobber the `main` snapshot).
     rollupOptions: {
       input: {
         main: fileURLToPath(new URL("./index.html", import.meta.url)),
         popover: fileURLToPath(new URL("./popover.html", import.meta.url)),
+        preferences: fileURLToPath(new URL("./preferences.html", import.meta.url)),
       },
     },
   },

--- a/desktop/tools/shedtest/client.py
+++ b/desktop/tools/shedtest/client.py
@@ -371,6 +371,17 @@ class TauriClient(_ApprovalOps, _RcOps, _RustCoreClient):
         UI truth (empty unless the UI is on the agents pane)."""
         return self.call("agents.dump")["sessions"]
 
+    def provider_modes_get(self) -> dict:
+        """The AWS/Docker provider approval modes ({namespace: 'approve'|'deny'}) —
+        the read side of set_provider_mode. A namespace absent from the map is Deny."""
+        return self.call("prefs.provider_modes")
+
+    def set_provider_mode(self, namespace: str, decision: str) -> None:
+        """Set an AWS/Docker provider mode + persist. `namespace` is the full string
+        ('aws-credentials'|'docker-credentials'); `decision` is 'approve'|'deny'. A
+        non-provider namespace is rejected (bad_request)."""
+        self.call("prefs.set_provider", {"namespace": namespace, "decision": decision})
+
     def activate(self) -> None:
         self.call("app.activate")
 

--- a/desktop/tools/shedtest/client.py
+++ b/desktop/tools/shedtest/client.py
@@ -355,8 +355,32 @@ class TauriClient(_ApprovalOps, _RcOps, _RustCoreClient):
         self.call("ui.show_window")
 
     def show_preferences(self) -> None:
-        """Open the in-app Preferences modal (raises the window + emits the event)."""
+        """Open/focus the dedicated Preferences window (a singleton: created lazily
+        on the first open, fronted if already open; closing it hides it). Does NOT
+        raise the dashboard (mac parity). `ui.open_preferences` is an equivalent
+        alias op (the mac op name)."""
         self.call("ui.show_preferences")
+
+    def open_preferences(self) -> None:
+        """The `ui.open_preferences` alias (the mac op name) for show_preferences."""
+        self.call("ui.open_preferences")
+
+    def prefs_dump(self) -> dict:
+        """The Preferences window's drivable state: `{visible, title, prefs}`.
+        `visible`/`title` are Rust-side native window truth (visible False and
+        prefs None before the first open); `prefs` is the window's reported
+        snapshot `{sections, values, mode}`."""
+        return self.call("prefs.dump")
+
+    def prefs_close(self) -> None:
+        """Close (hide) the Preferences window — the close-hides singleton contract."""
+        self.call("prefs.close")
+
+    def remove_shed_rule(self, server: str, shed: str) -> None:
+        """Remove one per-shed override rule + persist the remaining set (the same
+        path as the Preferences row's remove button). `server` is matched verbatim
+        ('' = the single/unnamed server)."""
+        self.call("prefs.remove_shed_rule", {"server": server, "shed": shed})
 
     def show_create(self) -> None:
         """Open the New-Shed dialog (raises the window + emits the event)."""
@@ -390,7 +414,8 @@ class TauriClient(_ApprovalOps, _RcOps, _RustCoreClient):
         return self.call("ui.current_pane").get("pane")
 
     def modal(self) -> str | None:
-        """Which modal (if any) the frontend has open: 'prefs' | 'create' | None."""
+        """Which modal (if any) the frontend has open: 'create' | 'launch' | None.
+        (Preferences is a dedicated window, not a modal — see prefs_dump.)"""
         return self.call("ui.modal").get("modal")
 
     def computed_style(self) -> dict | None:

--- a/desktop/tools/shedtest/test_tauri.py
+++ b/desktop/tools/shedtest/test_tauri.py
@@ -361,20 +361,147 @@ def test_loginitem_probe(tauri):
         tauri.login_item_set(before)
 
 
-def test_preferences_modal_opens(tauri):
-    # A1c-2c(2): ui.show_preferences → the frontend opens the in-app Preferences modal
-    # and reports modal=="prefs", so the harness verifies it ACTUALLY rendered (round-trip:
-    # op → event → React → modal → report), not just that the op acked. The pref LOGIC
-    # is covered by test_terminal_pref_persists above.
-    tauri.wait_until(lambda: tauri.current_pane() is not None, timeout=15, what="frontend ready")
+def _prefs_snapshot(tauri) -> dict:
+    """The Preferences window's reported snapshot, or {} before its first report."""
+    return tauri.prefs_dump().get("prefs") or {}
+
+
+def _prefs_values(tauri) -> dict:
+    return _prefs_snapshot(tauri).get("values") or {}
+
+
+def _prefs_sections(tauri) -> list:
+    return _prefs_snapshot(tauri).get("sections") or []
+
+
+def _open_prefs(tauri) -> None:
+    """Open the Preferences window and wait until it's visible AND has reported."""
     tauri.show_preferences()
-    tauri.wait_until(lambda: tauri.modal() == "prefs", timeout=15, what="preferences modal open")
-    # ...and on the real WebView it paints (the screenshot is TCC-gated on macOS).
-    if platform.system() == "Darwin":
-        return
-    tauri.show_window()
-    png, w, h = tauri.screenshot(scale=1)
-    assert png[:8] == PNG_MAGIC and w > 0 and h > 0
+    tauri.wait_until(lambda: tauri.prefs_dump()["visible"] and _prefs_snapshot(tauri),
+                     timeout=20, what="preferences window visible + reported")
+
+
+def test_preferences_window_opens(tauri):
+    # ui.show_preferences → the DEDICATED Preferences window (mac parity, not a
+    # modal): a fixed-size singleton titled "shed desktop — Preferences" whose
+    # rendered snapshot is reported under its own window label (prefs.dump), whose
+    # close HIDES it, and whose reopen re-fronts the same window.
+    tauri.wait_until(lambda: tauri.current_pane() is not None, timeout=15, what="frontend ready")
+    ssh = tauri.ssh_prefs_get()
+    prefs = tauri.prefs_get()
+    login = tauri.login_item_status()
+    _open_prefs(tauri)
+    assert tauri.prefs_dump()["title"] == "shed desktop — Preferences"
+    # The reported values converge on the backend truth (the window fetches on mount).
+    tauri.wait_until(lambda: _prefs_values(tauri).get("policy") == ssh["policy"],
+                     timeout=15, what="reported ssh policy matches the coordinator")
+    v = tauri.prefs_dump()["prefs"]["values"]
+    assert v["method"] == ssh["method"] and v["ttl"] == ssh["ttl"]
+    assert v["preset"] == prefs["terminal_preset"]
+    assert v["login"] == login
+    # Sections render in mac order; General + Terminal are always present.
+    assert _prefs_sections(tauri)[:2] == ["general", "terminal"]
+    # Defensive: Preferences is no longer a dashboard modal.
+    assert tauri.modal() != "prefs"
+    # Close hides (never destroys)...
+    tauri.prefs_close()
+    tauri.wait_until(lambda: tauri.prefs_dump()["visible"] is False,
+                     timeout=15, what="preferences window hidden after prefs.close")
+    # ...and a reopen (via the mac-named alias op) re-fronts the same window.
+    tauri.open_preferences()
+    tauri.wait_until(lambda: tauri.prefs_dump()["visible"] is True,
+                     timeout=15, what="preferences window re-shown")
+    # On the real WebView it paints (the screenshot is TCC-gated on macOS).
+    if platform.system() != "Darwin":
+        png, w, h = tauri.screenshot(scale=1)
+        assert png[:8] == PNG_MAGIC and w > 0 and h > 0
+    tauri.prefs_close()
+
+
+def test_preferences_theme_sync(tauri):
+    # The prefs window follows the app-wide appearance: ui.set_appearance updates the
+    # Rust AppearanceState + broadcasts set-appearance to every window, so both the
+    # dashboard AND the Preferences window flip together. Restore light after.
+    _open_prefs(tauri)
+    try:
+        tauri.set_appearance("dark")
+        tauri.wait_until(lambda: _prefs_snapshot(tauri).get("mode") == "dark",
+                         timeout=15, what="prefs window mode=dark")
+        tauri.wait_until(lambda: (tauri.computed_style() or {}).get("mode") == "dark",
+                         timeout=15, what="dashboard mode=dark")
+    finally:
+        tauri.set_appearance("light")
+        tauri.wait_until(lambda: _prefs_snapshot(tauri).get("mode") == "light",
+                         timeout=15, what="prefs window mode=light")
+        tauri.prefs_close()
+
+
+def test_preferences_gated_sections(tauri, fake):
+    # The approval sections are namespace-gated (mac parity): they appear only for
+    # the namespaces the host agent delegates (hello_ack gate_namespaces). Narrowing
+    # the fake's delegation to ssh-only (a reconnect re-handshakes) drops the
+    # aws/docker sections; restoring it brings them back.
+    assert fake.wait_connected()
+    _open_prefs(tauri)
+    # The default fake delegates all three → every approval section shows.
+    tauri.wait_until(lambda: {"ssh", "aws", "docker"} <= set(_prefs_sections(tauri)),
+                     timeout=15, what="all three gated sections visible")
+    assert "approvals-empty" not in _prefs_sections(tauri)
+    hellos = fake.hello_count
+    try:
+        fake.gate_namespaces = ["ssh-agent"]
+        fake.drop_connection()
+        assert fake.wait_hello_count(hellos + 1), "client did not re-handshake"
+        tauri.wait_until(
+            lambda: "ssh" in _prefs_sections(tauri)
+            and not {"aws", "docker"} & set(_prefs_sections(tauri)),
+            timeout=20, what="ssh-only delegation drops the aws/docker sections")
+        # Defensive: the prefs surface never reappears as a dashboard modal.
+        assert tauri.modal() != "prefs"
+    finally:
+        fake.gate_namespaces = ["ssh-agent", "aws-credentials", "docker-credentials"]
+        fake.drop_connection()
+        fake.wait_hello_count(hellos + 2)
+        tauri.wait_until(lambda: {"ssh", "aws", "docker"} <= set(_prefs_sections(tauri)),
+                         timeout=20, what="all three gated sections restored")
+        tauri.prefs_close()
+
+
+def test_preferences_shed_rules(tauri, fake):
+    # Per-shed overrides (mac parity): a persisted approval decision installs a
+    # per-shed rule → the section appears in prefs.dump with the rows counted;
+    # removing the rule (prefs.remove_shed_rule — the row button's path) drops it
+    # again. Asserted against ENGINE truth (policy.list) rather than a fixed count:
+    # extra_rules persisted by earlier tests survive the per-test policy.set reset
+    # and get recomposed into the engine by the next rebuild, so the absolute count
+    # isn't ours to pin — the window must simply mirror the engine's shed-rule set.
+    assert fake.wait_connected()
+
+    def engine_shed_rules() -> list[dict]:
+        return [r for r in tauri.policy_list() if r.get("scope") == "shed"]
+
+    def mine() -> list[dict]:
+        return [r for r in engine_shed_rules() if r.get("shed") == "prefs-rules-shed"]
+
+    _open_prefs(tauri)
+    rid = fake.emit_request("ssh-agent", "sign", "prefs-rules-shed")
+    tauri.wait_until(lambda: any(a["id"] == rid for a in tauri.approvals_list()),
+                     timeout=15, what="approval request queued")
+    tauri.approval_decide(rid, "approve", scope="per-shed", persist=True)
+    # The rule lands in the engine, and the window mirrors the engine's rule set.
+    tauri.wait_until(lambda: mine(), timeout=15, what="persisted rule in policy.list")
+    tauri.wait_until(
+        lambda: _prefs_values(tauri).get("shed_rules_count") == len(engine_shed_rules()),
+        timeout=15, what="prefs.dump mirrors the engine's shed rules")
+    assert "shed-overrides" in _prefs_sections(tauri)
+    tauri.remove_shed_rule(mine()[0].get("server") or "", "prefs-rules-shed")
+    tauri.wait_until(lambda: not mine(), timeout=15, what="rule removed from the engine")
+    tauri.wait_until(
+        lambda: _prefs_values(tauri).get("shed_rules_count") == len(engine_shed_rules()),
+        timeout=15, what="prefs.dump mirrors the removal")
+    if not engine_shed_rules():
+        assert "shed-overrides" not in _prefs_sections(tauri)
+    tauri.prefs_close()
 
 
 def test_new_shed_dialog_opens(tauri):

--- a/desktop/tools/shedtest/test_tauri.py
+++ b/desktop/tools/shedtest/test_tauri.py
@@ -308,6 +308,40 @@ def test_ssh_prefs_round_trip_and_partial_update(tauri):
         )
 
 
+def test_provider_mode_round_trip_drives_docker_policy(tauri, fake):
+    # D: the AWS/Docker provider mode is drivable + observable AND actually changes
+    # the coordinator's namespace policy. The fake host-agent delegates docker-
+    # credentials, so a set→emit→response round-trip proves the mode governs the
+    # auto-decision (the approvals-matrix pattern). Restore Deny after (the app +
+    # coordinator are session-scoped, so a left-over Approve would leak).
+    assert fake.wait_connected()
+    try:
+        # Approve → a docker request auto-approves by policy (no prompt/queue).
+        tauri.set_provider_mode("docker-credentials", "approve")
+        tauri.wait_until(
+            lambda: tauri.provider_modes_get().get("docker-credentials") == "approve",
+            timeout=15, what="docker mode == approve")
+        rid = fake.emit_request("docker-credentials", "get_credentials", "prov-approve-shed")
+        resp = fake.wait_response(rid)
+        assert resp and resp["decision"] == "approve" and resp["decided_by"] == "policy"
+
+        # Deny → a docker request auto-denies by policy (fail-closed).
+        tauri.set_provider_mode("docker-credentials", "deny")
+        tauri.wait_until(
+            lambda: tauri.provider_modes_get().get("docker-credentials") == "deny",
+            timeout=15, what="docker mode == deny")
+        rid2 = fake.emit_request("docker-credentials", "get_credentials", "prov-deny-shed")
+        resp2 = fake.wait_response(rid2)
+        assert resp2 and resp2["decision"] == "deny" and resp2["decided_by"] == "policy"
+
+        # A non-provider namespace is rejected (SSH has its own prefs path).
+        with pytest.raises(ShedError) as e:
+            tauri.set_provider_mode("ssh-agent", "approve")
+        assert e.value.code == "bad_request"
+    finally:
+        tauri.set_provider_mode("docker-credentials", "deny")
+
+
 def test_loginitem_probe(tauri):
     # B4: launch-at-login is drivable + observable (the Swift PreferencesView
     # "Launch at login" toggle parity). On Linux (the shipped target) `auto-launch`

--- a/docs/desktop/test-automation.md
+++ b/docs/desktop/test-automation.md
@@ -39,6 +39,14 @@ make -C desktop e2e-swift   # mac: same, Rust core forced off (SHED_DESKTOP_RUST
 make -C desktop e2e-tauri   # tauri: shared suite + test_tauri (needs a display; Xvfb on Linux)
 ```
 
+On the Tauri client, Preferences is a dedicated native window (mac parity), not a dashboard
+modal — `ui.show_preferences` (alias `ui.open_preferences`) opens/focuses the lazy-created
+singleton without raising the dashboard, so `ui.modal` only ever reports `create`, `launch`,
+or `null`. The window's UI truth is `prefs.dump` → `{visible, title, prefs}`: `visible`/`title`
+are the Rust-side native window state, and `prefs` is the window's own reported
+`{sections, values, mode}` snapshot — the surface a test asserts (gated section visibility,
+persisted values, theme) instead of pixels, the same UI-truth pattern as `dashboard.dump`.
+
 ### Simulating a down (unreachable) host
 
 The shared session redirects every configured server to the one in-process mock, so a


### PR DESCRIPTION
Converts the Tauri client's Preferences from a modal into a **dedicated native window** matching the mac app — fixed-size (520×640), titled "shed desktop — Preferences", singleton (reopening focuses it, closing hides it for fast reopen) — and closes the config parity gaps the modal never had.

## What changed

**1. Plumbing (`f6ede26`)** — the shared coordinator gains a real provider-mode surface (`set_provider_mode` validating `aws-credentials`/`docker-credentials`, `provider_modes()` read-back) and `remove_shed_rule`, all in the established actor pattern; provider modes + per-shed `extra_rules` are now persisted in prefs.json (`#[serde(default)]`, corrupt-tolerant, shed-scope-filtered hydration) and hydrated into the coordinator at startup — including `persist: true` approval decisions, which previously created rules that never survived a restart. New managed appearance state backs cross-window theme sync (`ui.set_appearance` updates it in Rust before emitting, killing a listener-attach race).

**2. The window (`7630081`)** — a third webview entry (`preferences.html`, own React root, per-label capability file) following the popover pattern but cross-platform and decorated. All open paths repointed (tray menu, popover footer, dashboard gear, `ui.show_preferences` + new `ui.open_preferences` alias); the modal, the `show-preferences` event, and the `"prefs"` modal state are gone. Full mac-parity grouped form: General, Terminal (dynamic per-preset descriptions), Approvals empty-state, SSH approvals (conditional Duration/Method), **AWS + Docker credentials** (Allow|Deny segmented, live), **Per-shed overrides** (with remove) — visibility driven by the host-agent's gated namespaces. Open/close are FIFO-consistent (whole check-create-or-focus marshalled to the main thread) and all prefs fetches are generation-guarded.

**3. Docs/skills (`2cf66c0`)** — the new drive surface documented; the Linux screenshot recipe fixed (`UV_PROJECT_ENVIRONMENT`, HOST_OUT expansion gotcha); new gremlins (WebKitGTK dark-mode raw `<select>` illegibility, `policy.set` vs `extra_rules`, no per-window capture).

## Drivability (north star)

The window reports under its own label: `prefs.dump → {visible, title, prefs: {sections, values, mode}}` (Rust-side visibility merged in), `prefs.close`, `prefs.set_provider`/`prefs.provider_modes`, `prefs.remove_shed_rule`, plus a `prefs-changed` nudge so IPC-driven mutations refresh the window. `ui.modal` now reports only `create|launch|null`.

## Verification

- shed-app: 75 tests (+4 new: provider set/reject/deny-unset, single-rule removal), workspace clippy clean, rc leg green
- `make e2e-tauri`: 75 passed / 31 skipped (replaced modal test + 4 new window tests: open/values/close/reopen-focus, theme sync, gated sections via fake host-agent re-handshake, shed-rule add/remove)
- `make tauri-build-linux` (WebKitGTK render gate): 77 passed / 29 skipped
- Screenshots (light/dark/fully-gated) eyeballed against the mac Preferences design on the render gate
- Plan hardened by the Codex/Kimi/CodeRabbit panel; per-commit /simplify + review (Cursor as correctness reviewer — the Codex CLI needs an upgrade for its new default model); all findings fixed (window-create/close FIFO race, reloadAll generation guard, shed-scope hydration filter, removal semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QReoPKEdMBFuYDmL51LUDx
