### PR TITLE
feat(host-agent): AWS credential backend — passthrough + STS assume-role + multi-namespace bus (Phase 3 leg 3a.1 sub-plan 2)

### DIFF
--- a/cmd/shed-host-agent/golden_test.go
+++ b/cmd/shed-host-agent/golden_test.go
@@ -233,6 +233,72 @@ func TestGoldenSSHPayloadShapes(t *testing.T) {
 	}
 }
 
+// TestGoldenAWSResolve is the Go half of the aws_resolve golden. It routes each
+// vector's config YAML through the PRODUCTION LoadConfig (so the same DefaultConfig
+// defaulting + yaml merge the daemon uses is exercised), then asserts AWS.Resolve /
+// AWS.Enabled / the applied load defaults against the shared fixture the Rust runner
+// (config.rs:golden_aws_resolve) also reads.
+func TestGoldenAWSResolve(t *testing.T) {
+	var fx struct {
+		ProtocolVersion int `json:"protocol_version"`
+		Vectors         []struct {
+			Name       string `json:"name"`
+			ConfigYAML string `json:"config_yaml"`
+			Queries    []struct {
+				Server          string `json:"server"`
+				Shed            string `json:"shed"`
+				Role            string `json:"role"`
+				Mode            string `json:"mode"`
+				SessionDuration string `json:"session_duration"`
+			} `json:"queries"`
+			Enabled  bool `json:"enabled"`
+			Defaults struct {
+				SourceProfile      string `json:"source_profile"`
+				SessionDuration    string `json:"session_duration"`
+				CacheRefreshBefore string `json:"cache_refresh_before"`
+			} `json:"defaults"`
+		} `json:"vectors"`
+	}
+	readFixture(t, "aws_resolve.json", &fx)
+
+	if fx.ProtocolVersion != 1 {
+		t.Fatalf("aws_resolve.json protocol_version = %d, want 1 (version skew)", fx.ProtocolVersion)
+	}
+	if len(fx.Vectors) == 0 {
+		t.Fatal("aws_resolve.json has no vectors")
+	}
+	for _, v := range fx.Vectors {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte(v.ConfigYAML), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadConfig(path)
+		if err != nil {
+			t.Errorf("%s: LoadConfig: %v", v.Name, err)
+			continue
+		}
+		if got := cfg.AWS.Enabled(); got != v.Enabled {
+			t.Errorf("%s: Enabled() = %v, want %v", v.Name, got, v.Enabled)
+		}
+		if cfg.AWS.SourceProfile != v.Defaults.SourceProfile {
+			t.Errorf("%s: source_profile = %q, want %q", v.Name, cfg.AWS.SourceProfile, v.Defaults.SourceProfile)
+		}
+		if cfg.AWS.SessionDuration != v.Defaults.SessionDuration {
+			t.Errorf("%s: session_duration = %q, want %q", v.Name, cfg.AWS.SessionDuration, v.Defaults.SessionDuration)
+		}
+		if cfg.AWS.CacheRefreshBefore != v.Defaults.CacheRefreshBefore {
+			t.Errorf("%s: cache_refresh_before = %q, want %q", v.Name, cfg.AWS.CacheRefreshBefore, v.Defaults.CacheRefreshBefore)
+		}
+		for _, q := range v.Queries {
+			got := cfg.AWS.Resolve(q.Server, q.Shed)
+			if got.Role != q.Role || got.Mode != q.Mode || got.SessionDuration != q.SessionDuration {
+				t.Errorf("%s: Resolve(%q,%q) = {role:%q mode:%q dur:%q}, want {role:%q mode:%q dur:%q}",
+					v.Name, q.Server, q.Shed, got.Role, got.Mode, got.SessionDuration, q.Role, q.Mode, q.SessionDuration)
+			}
+		}
+	}
+}
+
 func TestGoldenGateNamespaces(t *testing.T) {
 	var fx struct {
 		ProtocolVersion int `json:"protocol_version"`

--- a/cmd/shed-host-agent/golden_test.go
+++ b/cmd/shed-host-agent/golden_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/charliek/shed/internal/ext/protocol"
 )
@@ -295,6 +296,72 @@ func TestGoldenAWSResolve(t *testing.T) {
 				t.Errorf("%s: Resolve(%q,%q) = {role:%q mode:%q dur:%q}, want {role:%q mode:%q dur:%q}",
 					v.Name, q.Server, q.Shed, got.Role, got.Mode, got.SessionDuration, q.Role, q.Mode, q.SessionDuration)
 			}
+		}
+	}
+}
+
+// TestGoldenAWSExpiry is the Go half of the aws_expiry golden. It routes each vector
+// through the PRODUCTION expiry scan (parseSessionExpiry -> parseExpiryValue), the
+// handler's expiration Format layout ("2006-01-02T15:04:05Z", the literal-Z render),
+// and awsExpiryDetail, against the shared fixture the Rust runner
+// (aws_backend.rs:golden_aws_expiry) also reads.
+func TestGoldenAWSExpiry(t *testing.T) {
+	var fx struct {
+		ProtocolVersion int `json:"protocol_version"`
+		ExpiryVectors   []struct {
+			Name         string `json:"name"`
+			INI          string `json:"ini"`
+			Profile      string `json:"profile"`
+			ExpectedUnix *int64 `json:"expected_unix"`
+		} `json:"expiry_vectors"`
+		LiteralZVectors []struct {
+			Unix     int64  `json:"unix"`
+			Expected string `json:"expected"`
+		} `json:"literal_z_vectors"`
+		ExpiryDetailVectors []struct {
+			Unix     *int64 `json:"unix"`
+			Expected string `json:"expected"`
+		} `json:"expiry_detail_vectors"`
+	}
+	readFixture(t, "aws_expiry.json", &fx)
+
+	if fx.ProtocolVersion != 1 {
+		t.Fatalf("aws_expiry.json protocol_version = %d, want 1 (version skew)", fx.ProtocolVersion)
+	}
+	if len(fx.ExpiryVectors) == 0 || len(fx.LiteralZVectors) == 0 || len(fx.ExpiryDetailVectors) == 0 {
+		t.Fatal("aws_expiry.json missing vectors")
+	}
+
+	for _, v := range fx.ExpiryVectors {
+		path := filepath.Join(t.TempDir(), "credentials")
+		if err := os.WriteFile(path, []byte(v.INI), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got := parseSessionExpiry(path, v.Profile)
+		switch {
+		case v.ExpectedUnix == nil:
+			if !got.IsZero() {
+				t.Errorf("%s: expected zero time, got %v", v.Name, got)
+			}
+		case got.IsZero():
+			t.Errorf("%s: expected unix %d, got zero time", v.Name, *v.ExpectedUnix)
+		case got.Unix() != *v.ExpectedUnix:
+			t.Errorf("%s: got unix %d, want %d", v.Name, got.Unix(), *v.ExpectedUnix)
+		}
+	}
+	for _, v := range fx.LiteralZVectors {
+		got := time.Unix(v.Unix, 0).UTC().Format("2006-01-02T15:04:05Z")
+		if got != v.Expected {
+			t.Errorf("literal_z(%d) = %q, want %q", v.Unix, got, v.Expected)
+		}
+	}
+	for _, v := range fx.ExpiryDetailVectors {
+		var exp time.Time // zero value => awsExpiryDetail returns "expires:none"
+		if v.Unix != nil {
+			exp = time.Unix(*v.Unix, 0).UTC()
+		}
+		if got := awsExpiryDetail(exp); got != v.Expected {
+			t.Errorf("awsExpiryDetail(unix=%v) = %q, want %q", v.Unix, got, v.Expected)
 		}
 	}
 }

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -68,6 +68,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +343,379 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-config"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47712fde1909402600ccfbb26e47d482d2e58bb9e9e603d9f17e67cc435a6319"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.2",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7816e98ee912159f45d307e5ee6bfea4a335a55aee15f7f3e32f81a6f3000f1d"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.103.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0469f435f645ad2162cfb463b15bde37115966ee3acf2d87fb4871ee309b8401"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "085faefb253f770655e162b9304321e62a1e71adf7f019ee1f4454228a377b3a"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.108.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c72b08911d8128dd360fe1b22a9fec0fa8b552dde8ec828dcf20ef5ec974e9f"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.2",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.4.2",
+ "hyper 1.10.1",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd22a6ba36e3f113cb8d5b3d1fe0ed31c76ee608ef63322d753bb8d2c9479e77"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea94a9ff8464016338c851e24b472d7131c388c88898a502e781815b2ee6045"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ed1ebe6e0a95ea84570225f5a8208dec4b8f77e61a9b0d6f51773fcb4612f0"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.2",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.2",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea3f68eec3607f02acd24067969ce2abc6ba16aa7d5ce59ca450ed2fb5f78957"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e957a6c6dbce82b7a91f44231c09273159703769f447cbe85e854dfe9cf67f86"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +732,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -417,6 +809,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +841,16 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "camino"
@@ -510,7 +921,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -555,6 +966,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,10 +993,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -619,15 +1067,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -651,10 +1117,16 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
@@ -662,10 +1134,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -706,12 +1190,12 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-traits",
  "pkcs8",
  "rfc6979",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "zeroize",
 ]
@@ -723,7 +1207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -749,7 +1233,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -768,7 +1252,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1081,6 +1565,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.2",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,12 +1602,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1203,6 +1721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,6 +1762,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
@@ -1255,6 +1783,7 @@ dependencies = [
  "hyper 1.10.1",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1628,6 +2157,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,6 +2204,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,7 +2224,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1689,7 +2236,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1703,7 +2250,7 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1853,6 +2400,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2065,6 +2618,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,7 +2676,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -2141,15 +2700,15 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "spki",
  "subtle",
@@ -2199,6 +2758,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,6 +2812,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2858,29 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2362,8 +2965,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2373,8 +2976,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2405,7 +3019,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "uuid",
@@ -2427,6 +3041,10 @@ name = "shed-host-agent"
 version = "0.7.10"
 dependencies = [
  "async-trait",
+ "aws-config",
+ "aws-sdk-sts",
+ "aws-smithy-http-client",
+ "aws-smithy-types",
  "base64 0.22.1",
  "ed25519-dalek",
  "futures-util",
@@ -2440,7 +3058,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "shed-core",
  "ssh-key",
  "tempfile",
@@ -2481,7 +3099,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2575,7 +3193,7 @@ checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
 dependencies = [
  "base64ct",
  "pem-rfc7468",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2594,7 +3212,7 @@ dependencies = [
  "rsa",
  "sec1",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "ssh-cipher",
  "ssh-encoding",
@@ -2754,6 +3372,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,7 +3546,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3078,6 +3738,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3111,6 +3777,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -3456,6 +4128,12 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"

--- a/crates/shed-host-agent/Cargo.toml
+++ b/crates/shed-host-agent/Cargo.toml
@@ -92,6 +92,32 @@ p521 = { version = "0.13", default-features = false, features = ["ecdsa", "pem",
 # base64 StdEncoding for the sign req/resp (public_key / data / blob), matching Go's
 # encoding/base64.StdEncoding.
 base64 = "0.22"
+# --- AWS assume-role backend (aws_backend.rs) ------------------------------------
+# The SDK is bought ONLY for the assume-role source-profile credential CHAIN
+# (SSO / credential_process / static), which Go gets from
+# config.LoadDefaultConfig(WithSharedConfigProfile) — a product-fidelity purchase
+# with zero differential coverage (the differentially-tested passthrough path is
+# hand-rolled and SDK-free). Always-on because the bus is not feature-gated; the
+# headless `--no-default-features` build carries it too.
+#
+# Feature choices (verified by an out-of-repo probe; see the PR's DEP_DELTA):
+#   - `sso` + `credentials-process` re-enable those source-profile providers (they
+#     are default-on but `default-features = false` drops them), so
+#     `profile_name(p).load()` resolves SSO / process / static exactly like Go's chain.
+#   - `behavior-version-latest` pins the SDK behavior version (no per-call opt-in).
+#   - `rt-tokio` gives the async sleep/spawn impl on the workspace's tokio.
+#   - `default-https-client` is deliberately OFF: it defaults to a rustls-aws-lc TLS
+#     stack that pulls the heavy `aws-lc-sys` C build. Instead the backend builds the
+#     HTTPS connector explicitly via `aws-smithy-http-client`'s `rustls-ring`, so the
+#     SDK reuses the SAME ring + rustls 0.23 + hyper 1.x the workspace already
+#     compiles (reqwest/shed-core) — cargo unifies one build, no new C toolchain dep.
+#   - `aws-smithy-types` (already transitive) is named directly only for
+#     `DisplayErrorContext`, to render the full SdkError chain into the
+#     `sts:AssumeRole failed for <arn>: <err>` message (Go's `%w`).
+aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio", "sso", "credentials-process"] }
+aws-sdk-sts = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
+aws-smithy-http-client = { version = "1", default-features = false, features = ["rustls-ring"] }
+aws-smithy-types = "1"
 
 [dev-dependencies]
 # Throwaway socket dirs for the status "not running" exit-code test.

--- a/crates/shed-host-agent/src/aws_backend.rs
+++ b/crates/shed-host-agent/src/aws_backend.rs
@@ -503,9 +503,14 @@ enum OffsetColon {
 /// Returns unix seconds (offset applied) or `None`.
 fn parse_layout(val: &str, sep: char, offset: OffsetColon) -> Option<i64> {
     let (date, time_zone) = val.split_once(sep)?;
-    // Date: YYYY-MM-DD (2-digit month/day; year is the leading run of digits).
+    // Date: YYYY-MM-DD. Go's `time.Parse` "2006" year is FIXED-WIDTH 4 digits — a
+    // 5-digit year is a parse error, not a big year (CodeRabbit review).
     let mut dparts = date.split('-');
-    let y: i64 = dparts.next()?.parse().ok()?;
+    let ystr = dparts.next()?;
+    if ystr.len() != 4 || !ystr.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let y: i64 = ystr.parse().ok()?;
     let mo: u32 = parse_2(dparts.next()?)?;
     let d: u32 = parse_2(dparts.next()?)?;
     if dparts.next().is_some() {
@@ -531,11 +536,31 @@ fn parse_layout(val: &str, sep: char, offset: OffsetColon) -> Option<i64> {
     if tparts.next().is_some() {
         return None;
     }
-    if !(1..=12).contains(&mo) || !(1..=31).contains(&d) || h > 23 || mi > 59 || se > 60 {
+    // Real calendar validation — Go's `time.Parse` rejects Feb 30 / non-leap Feb 29
+    // ("day out of range") and has no leap-second support (`:60` errors), where the
+    // Hinnant `days_from_civil` math would silently normalize (CodeRabbit review).
+    if !(1..=12).contains(&mo) || d < 1 || d > days_in_month(y, mo) || h > 23 || mi > 59 || se > 59
+    {
         return None;
     }
     let days = crate::status::days_from_civil(y, mo, d);
     Some(days * 86_400 + (h as i64) * 3_600 + (mi as i64) * 60 + (se as i64) - offset_secs)
+}
+
+/// Days in a month, Gregorian, with leap-year February (mirrors what Go's
+/// `time.Parse` accepts). `mo` is validated 1..=12 by the caller.
+fn days_in_month(y: i64, mo: u32) -> u32 {
+    match mo {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        _ => {
+            if (y % 4 == 0 && y % 100 != 0) || y % 400 == 0 {
+                29
+            } else {
+                28
+            }
+        }
+    }
 }
 
 /// Split an RFC3339 zone suffix off the time, returning `(time_text, secs_to_subtract)`

--- a/crates/shed-host-agent/src/aws_backend.rs
+++ b/crates/shed-host-agent/src/aws_backend.rs
@@ -1,0 +1,1237 @@
+//! The AWS credential backend — a faithful Rust port of
+//! `cmd/shed-host-agent/aws_backend.go`.
+//!
+//! Two vending modes (selected per shed by [`crate::config::AwsConfig::resolve`]):
+//!
+//! * **assume-role** — `sts:AssumeRole` from the configured source profile into the
+//!   resolved role, cached per `server/shed` until near expiry. The STS call goes
+//!   through the [`AssumeRoler`] seam so unit tests inject fakes; the real
+//!   [`SdkAssumeRoler`] builds its SDK client **lazily on first use**, so a
+//!   passthrough-only config never loads the AssumeRole credential chain.
+//! * **passthrough** — vends the source profile's existing session credentials
+//!   directly, re-reading the shared credentials file on every request (no cache) so
+//!   a fresh `aws sso login` is picked up immediately. This path is **hand-rolled**
+//!   (a tiny INI reader + the expiry-hint scan) — no SDK — which keeps the only
+//!   differentially-tested path SDK-free and makes Go's "profile present but no keys"
+//!   branch naturally reachable.
+//!
+//! **Divergence from Go, documented:** Go's `config.LoadDefaultConfig` returns an
+//! error (surfaced as `loading AWS config for profile "<p>": <err>`); the Rust
+//! `aws_config::from_env()...load()` is **infallible** (credential resolution is
+//! deferred to first use), so a bad source profile surfaces instead as an
+//! `sts:AssumeRole failed for <arn>: <err>` from the `send()`. The lazy-once client
+//! build is preserved (the behavioural property the `passthrough_only_never_builds_client`
+//! test pins); there is simply no load-time error to latch.
+//!
+//! **Wiring:** this whole module is ported in this slice but reached only through the
+//! aws-credentials handler + `main.rs`, which are added in commit 3. Until then it is
+//! unreachable in a non-test build, so a module-wide `allow(dead_code)` keeps the
+//! headless `cargo build --no-default-features` warning-free (the module is fully
+//! exercised under `--all-targets`/tests). Remove this allow when commit 3 wires it.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::bus::BusLog;
+use crate::config::{
+    parse_go_duration_nanos, user_home_dir, AwsConfig, ResolvedAws, AWS_MODE_PASSTHROUGH,
+};
+
+/// A cached (or freshly vended) set of temporary AWS credentials. For passthrough
+/// mode `expiration` may be `None` when the source profile carries no expiry hint
+/// (the guest then discovers expiry on a 403). `expiration` is unix seconds; `None`
+/// mirrors Go's zero `time.Time`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CachedCreds {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    pub session_token: String,
+    pub expiration: Option<i64>,
+}
+
+/// The host-side AWS credential operations (mirror Go's `AWSBackend` interface).
+/// Async + `&self` so the bus handler can hold it as `Arc<dyn AwsBackend>`.
+/// [`Self::status`] NEVER errors — a missing/unreadable credentials file degrades
+/// to a `None` expiry rather than an error the status path can't return.
+#[async_trait]
+pub trait AwsBackend: Send + Sync {
+    /// Return temporary credentials for `shed` on `server`.
+    async fn get_credentials(&self, server: &str, shed: &str) -> Result<CachedCreds, String>;
+
+    /// Return the role label and cache/expiry instant for `shed` on `server`.
+    fn status(&self, server: &str, shed: &str) -> (String, Option<i64>);
+}
+
+/// The inputs to one `sts:AssumeRole` call (mirror `sts.AssumeRoleInput`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssumeRoleParams {
+    pub role_arn: String,
+    pub session_name: String,
+    pub duration_seconds: i32,
+}
+
+/// The credentials one `sts:AssumeRole` returns (mirror `sts.Credentials`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssumedCreds {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    pub session_token: String,
+    pub expiration: Option<i64>,
+}
+
+/// The STS seam: performs one `AssumeRole`. A trait so unit tests inject fakes
+/// without a live STS endpoint (the assume-role path has no live differential —
+/// it is owned by unit tests + goldens). `Ok(Some(creds))` = credentials returned;
+/// **`Ok(None)`** = the call succeeded but the SDK's optional credential fields were
+/// absent → the backend maps this to `sts:AssumeRole returned nil credentials for
+/// <arn>` (never a panic); `Err(msg)` = the call itself failed (the backend wraps it
+/// as `sts:AssumeRole failed for <arn>: <msg>`).
+#[async_trait]
+pub trait AssumeRoler: Send + Sync {
+    async fn assume_role(&self, input: AssumeRoleParams) -> Result<Option<AssumedCreds>, String>;
+}
+
+/// `parse_duration_or` parses a Go-`time.ParseDuration` string, falling back to
+/// `default` (with a warning) when empty, unparseable, or non-positive. A faithful
+/// port of `watcher.go:parseDurationOr`, reusing the crate's Go-duration parser.
+/// In Go this helper lives in `watcher.go` (discovery) — when the discovery port
+/// lands, move it to a shared util module rather than importing it from here.
+pub fn parse_duration_or(raw: &str, default: Duration, label: &str, log: &dyn BusLog) -> Duration {
+    match parse_go_duration_nanos(raw) {
+        Some(nanos) if nanos > 0 => Duration::from_nanos(nanos as u64),
+        _ => {
+            log.warn(&format!(
+                "invalid duration, using default: field={label} value={raw:?} default={default:?}"
+            ));
+            default
+        }
+    }
+}
+
+/// The `server/shed` cache + session key (mirror `config.go:serverShedKey`): keying
+/// by both keeps identical shed names on different servers isolated.
+fn server_shed_key(server: &str, shed: &str) -> String {
+    format!("{server}/{shed}")
+}
+
+/// The concrete AWS backend (mirror Go's `stsBackend`). The STS client itself lives
+/// behind the [`AssumeRoler`] seam and is built lazily there, so a passthrough-only
+/// config never loads the AssumeRole credential chain.
+pub struct StsBackend {
+    cfg: AwsConfig,
+    refresh_before: Duration,
+    session_dur: Duration,
+    assume_roler: Arc<dyn AssumeRoler>,
+    log: Arc<dyn BusLog>,
+    cache: Mutex<HashMap<String, CachedCreds>>,
+    /// Injectable wall clock (unix seconds) for the cache-window logic + session name.
+    now_unix: Box<dyn Fn() -> i64 + Send + Sync>,
+}
+
+/// Build an AWS backend. Validates the duration knobs (warn + default on a bad value)
+/// and reports whether AWS is configured at all; the STS client is created on first
+/// AssumeRole use inside the [`SdkAssumeRoler`]. Mirror `NewSTSBackend`.
+///
+/// Unwired in this slice — the handler + `main.rs` construct it in commit 3 (the
+/// same "ported, wired by a later slice" posture as `minter.rs::refresh_loop`).
+pub fn new_sts_backend(cfg: AwsConfig, log: Arc<dyn BusLog>) -> Result<StsBackend, String> {
+    if !cfg.enabled() {
+        return Err("no AWS credentials configured (set aws.default_role, aws.mode: passthrough, or a per-server/shed role/mode)".to_string());
+    }
+    // NewSTSBackend uses time.ParseDuration directly (fall back only on a PARSE error,
+    // not on non-positive — that stricter check is parse_duration_or, used by
+    // resolve_session_dur). Mirror that split faithfully.
+    let refresh_before = parse_ctor_duration(&cfg.cache_refresh_before);
+    let session_dur = parse_ctor_duration(&cfg.session_duration);
+    if refresh_before.is_none() {
+        log.warn(&format!(
+            "invalid cache_refresh_before, using default: value={:?} default=5m",
+            cfg.cache_refresh_before
+        ));
+    }
+    if session_dur.is_none() {
+        log.warn(&format!(
+            "invalid session_duration, using default: value={:?} default=1h",
+            cfg.session_duration
+        ));
+    }
+    let refresh_before = refresh_before.unwrap_or(Duration::from_secs(300));
+    let session_dur = session_dur.unwrap_or(Duration::from_secs(3600));
+    let source_profile = cfg.source_profile.clone();
+    log.info(&format!(
+        "AWS backend initialized: profile={source_profile:?} default_role={:?} session_duration={session_dur:?} cache_refresh_before={refresh_before:?}",
+        cfg.default_role,
+    ));
+    Ok(StsBackend {
+        refresh_before,
+        session_dur,
+        assume_roler: Arc::new(SdkAssumeRoler::new(&source_profile)),
+        log,
+        cache: Mutex::new(HashMap::new()),
+        now_unix: Box::new(crate::status::now_unix),
+        cfg,
+    })
+}
+
+/// Constructor-time duration parse: `Some(dur)` on a valid non-negative value,
+/// `None` on a parse error (the caller then warns + uses the default). Unlike
+/// [`parse_duration_or`] a zero value is accepted (mirror Go's `time.ParseDuration`
+/// in `NewSTSBackend`, which falls back only on `err != nil`); a negative value —
+/// which Go would keep — falls back here since a `Duration` cannot be negative.
+fn parse_ctor_duration(raw: &str) -> Option<Duration> {
+    match parse_go_duration_nanos(raw) {
+        Some(nanos) if nanos >= 0 => Some(Duration::from_nanos(nanos as u64)),
+        _ => None,
+    }
+}
+
+impl StsBackend {
+    /// Session duration for a resolved policy, falling back to the backend default
+    /// when the override is unset or invalid (mirror `resolveSessionDur`).
+    fn resolve_session_dur(&self, resolved: &ResolvedAws) -> Duration {
+        if resolved.session_duration.is_empty() {
+            return self.session_dur;
+        }
+        parse_duration_or(
+            &resolved.session_duration,
+            self.session_dur,
+            "session_duration",
+            self.log.as_ref(),
+        )
+    }
+
+    /// Vend the source profile's existing session credentials directly, re-reading
+    /// the shared files on every request (no cache, no lock). Mirror
+    /// `getPassthroughCreds` — but hand-rolled over the INI reader, no SDK.
+    fn get_passthrough_creds(&self, server: &str, shed: &str) -> Result<CachedCreds, String> {
+        let profile = &self.cfg.source_profile;
+        let creds_path = shared_credentials_path();
+        let cfg_path = shared_config_path();
+
+        // Go's LoadSharedConfigProfile merges the config + credentials files with the
+        // CREDENTIALS file taking precedence for the static-credential keys. We mirror
+        // that pragmatically: read the profile from the config file as the base, then
+        // overlay the credentials file (credentials wins) for the three keys we need.
+        // The expiry hint is read from the credentials file ONLY (Go parity — the SDK
+        // never surfaces it, so parse_session_expiry hand-scans that file alone).
+        let cfg_section = read_ini_profile(&cfg_path, profile);
+        let creds_section = read_ini_profile(&creds_path, profile);
+
+        // A profile present in NEITHER file → Go's LoadSharedConfigProfile errors.
+        // Outer wrap is Go-parity; the inner text is OURS (documented divergence — Go
+        // wraps the SDK's error text there, asserted as prefix + profile-name).
+        if cfg_section.is_none() && creds_section.is_none() {
+            return Err(format!(
+                "passthrough: loading profile \"{profile}\" from {}: profile not found in the shared credentials or config file",
+                creds_path.display()
+            ));
+        }
+
+        let mut kv = cfg_section.unwrap_or_default();
+        if let Some(creds_kv) = creds_section {
+            for (k, v) in creds_kv {
+                kv.insert(k, v); // credentials file overrides config file
+            }
+        }
+        let access = kv.get("aws_access_key_id").cloned().unwrap_or_default();
+        let secret = kv.get("aws_secret_access_key").cloned().unwrap_or_default();
+        let token = kv.get("aws_session_token").cloned().unwrap_or_default();
+
+        // Exact Go byte strings (aws_backend.go:200-204).
+        if access.is_empty() || secret.is_empty() {
+            return Err(format!(
+                "passthrough: profile \"{profile}\" in {} has no static credentials; run your SSO/SAML login (e.g. `aws sso login`) to refresh",
+                creds_path.display()
+            ));
+        }
+        if token.is_empty() {
+            return Err(format!(
+                "passthrough: profile \"{profile}\" has no aws_session_token; passthrough expects temporary SSO/SAML session credentials, not long-lived keys"
+            ));
+        }
+
+        let expiration = parse_session_expiry(&creds_path, profile);
+        self.log.info(&format!(
+            "vending passthrough credentials: server={server:?} shed={shed:?} profile={profile:?} expires={}",
+            expiry_label(expiration)
+        ));
+        Ok(CachedCreds {
+            access_key_id: access,
+            secret_access_key: secret,
+            session_token: token,
+            expiration,
+        })
+    }
+}
+
+#[async_trait]
+impl AwsBackend for StsBackend {
+    async fn get_credentials(&self, server: &str, shed: &str) -> Result<CachedCreds, String> {
+        let resolved = self.cfg.resolve(server, shed);
+
+        if resolved.mode == AWS_MODE_PASSTHROUGH {
+            return self.get_passthrough_creds(server, shed);
+        }
+
+        let role_arn = resolved.role.clone();
+        if role_arn.is_empty() {
+            return Err(format!(
+                "no role configured for shed \"{shed}\" on server \"{server}\""
+            ));
+        }
+
+        let cache_key = server_shed_key(server, shed);
+        let now = (self.now_unix)();
+
+        // Cache hit iff the entry expires more than refresh_before from now.
+        {
+            let cache = self.cache.lock().unwrap();
+            if let Some(cached) = cache.get(&cache_key) {
+                if let Some(exp) = cached.expiration {
+                    if exp - now > self.refresh_before.as_secs() as i64 {
+                        self.log.debug(&format!(
+                            "returning cached credentials: server={server:?} shed={shed:?} expires={exp}"
+                        ));
+                        return Ok(cached.clone());
+                    }
+                }
+            }
+        }
+
+        let duration_seconds = self.resolve_session_dur(&resolved).as_secs() as i32;
+        // Session names are keyed by server/shed/now so parallel sheds don't collide.
+        let session_name = format!("shed-{server}-{shed}-{now}");
+
+        let params = AssumeRoleParams {
+            role_arn: role_arn.clone(),
+            session_name: session_name.clone(),
+            duration_seconds,
+        };
+        let assumed = match self.assume_roler.assume_role(params).await {
+            Ok(Some(a)) => a,
+            // SDK optional credential fields absent → the exact Go nil-creds error.
+            Ok(None) => {
+                return Err(format!(
+                    "sts:AssumeRole returned nil credentials for {role_arn}"
+                ))
+            }
+            Err(e) => return Err(format!("sts:AssumeRole failed for {role_arn}: {e}")),
+        };
+
+        let creds = CachedCreds {
+            access_key_id: assumed.access_key_id,
+            secret_access_key: assumed.secret_access_key,
+            session_token: assumed.session_token,
+            expiration: assumed.expiration,
+        };
+        let entry = creds.clone(); // clone outside the lock; the guard holds only the insert
+        self.cache.lock().unwrap().insert(cache_key, entry);
+
+        self.log.info(&format!(
+            "assumed role: server={server:?} shed={shed:?} role={role_arn:?} session={session_name:?} expires={}",
+            expiry_label(creds.expiration)
+        ));
+        Ok(creds)
+    }
+
+    fn status(&self, server: &str, shed: &str) -> (String, Option<i64>) {
+        let resolved = self.cfg.resolve(server, shed);
+
+        if resolved.mode == AWS_MODE_PASSTHROUGH {
+            let role = format!("passthrough:{}", self.cfg.source_profile);
+            // Scan the file directly (no token validation) so a missing/unreadable
+            // file degrades to a None expiry rather than an error status can't return.
+            let exp = parse_session_expiry(&shared_credentials_path(), &self.cfg.source_profile);
+            return (role, exp);
+        }
+
+        let cache = self.cache.lock().unwrap();
+        let expiration = cache
+            .get(&server_shed_key(server, shed))
+            .and_then(|cached| cached.expiration);
+        (resolved.role, expiration)
+    }
+}
+
+/// Render an expiration for logs, rendering `None` as `"none"` (mirror `expiryLabel`).
+fn expiry_label(exp: Option<i64>) -> String {
+    match exp {
+        None => "none".to_string(),
+        Some(unix) => aws_literal_z(unix),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared-file path resolution (mirror sharedCredentialsPath / sharedConfigPath)
+// ---------------------------------------------------------------------------
+
+/// The shared credentials file: `AWS_SHARED_CREDENTIALS_FILE` if set, else
+/// `~/.aws/credentials` (Go's `config.DefaultSharedCredentialsFilename`).
+fn shared_credentials_path() -> PathBuf {
+    match std::env::var_os("AWS_SHARED_CREDENTIALS_FILE") {
+        Some(p) if !p.is_empty() => PathBuf::from(p),
+        _ => user_home_dir().join(".aws").join("credentials"),
+    }
+}
+
+/// The shared config file: `AWS_CONFIG_FILE` if set, else `~/.aws/config` (Go's
+/// `config.DefaultSharedConfigFilename`).
+fn shared_config_path() -> PathBuf {
+    match std::env::var_os("AWS_CONFIG_FILE") {
+        Some(p) if !p.is_empty() => PathBuf::from(p),
+        _ => user_home_dir().join(".aws").join("config"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hand-rolled INI reader + expiry scan (mirror parseSessionExpiry / parseExpiryValue)
+// ---------------------------------------------------------------------------
+
+/// Read the first `[profile]` section's `key = value` pairs from an INI-shaped file.
+/// Returns `None` if the file is unreadable OR the section header never appears (so
+/// the caller can distinguish "profile missing" from "profile present but empty");
+/// `Some(map)` (possibly empty) when the section appears. Semantics match Go's
+/// shared-file reader for our needs: `[profile <name>]`-prefix tolerance, `#`/`;`
+/// comments, whitespace trimmed, **first key in line order wins** (and, across a
+/// duplicate section header, the first section's keys win).
+fn read_ini_profile(path: &Path, profile: &str) -> Option<HashMap<String, String>> {
+    let data = std::fs::read_to_string(path).ok()?;
+    let mut found = false;
+    let mut in_section = false;
+    let mut map: HashMap<String, String> = HashMap::new();
+    for raw in data.split('\n') {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if line.starts_with('[') && line.ends_with(']') {
+            let name = line[1..line.len() - 1].trim();
+            let name = name.strip_prefix("profile ").unwrap_or(name); // config-style header
+            in_section = name == profile;
+            if in_section {
+                found = true;
+            }
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        if let Some((k, v)) = line.split_once('=') {
+            // First key in line order wins (or_insert keeps the earliest).
+            map.entry(k.trim().to_string())
+                .or_insert_with(|| v.trim().to_string());
+        }
+    }
+    if found {
+        Some(map)
+    } else {
+        None
+    }
+}
+
+/// Scan the credentials file's `[profile]` section for a session-expiry hint
+/// (`aws_session_expiration` or `x_security_token_expires`). Returns `None` when the
+/// file, profile, or key is missing or unparseable. Only the credentials file (bare
+/// `[name]`) is scanned; hints in `~/.aws/config` are out of scope. A faithful port of
+/// `parseSessionExpiry` (aws_backend.go:282-312): **first matching key in line order
+/// within the first matching section wins.**
+fn parse_session_expiry(creds_path: &Path, profile: &str) -> Option<i64> {
+    let data = std::fs::read_to_string(creds_path).ok()?;
+    let mut in_section = false;
+    for raw in data.split('\n') {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if line.starts_with('[') && line.ends_with(']') {
+            let name = line[1..line.len() - 1].trim();
+            let name = name.strip_prefix("profile ").unwrap_or(name);
+            in_section = name == profile;
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        let Some((key, val)) = line.split_once('=') else {
+            continue;
+        };
+        match key.trim() {
+            "aws_session_expiration" | "x_security_token_expires" => {
+                return parse_expiry_value(val.trim());
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Parse an expiry-hint value defensively across the RFC3339 variants SSO/SAML
+/// helpers emit, normalizing to unix seconds (UTC). Returns `None` on any failure.
+/// Faithful port of `parseExpiryValue` (aws_backend.go:316-329) — the same four Go
+/// layouts, tried in order, with REAL offset arithmetic (non-zero offsets are
+/// golden-pinned). Surrounding single/double quotes are trimmed first. The layouts:
+///
+/// 1. RFC3339 — `2006-01-02T15:04:05Z07:00` (`T` sep, `Z` or `±HH:MM`).
+/// 2. RFC3339Nano — as 1 with fractional seconds.
+/// 3. `2006-01-02T15:04:05Z0700` — `T` sep, `Z` or `±HHMM` numeric offset (NO colon).
+/// 4. `2006-01-02 15:04:05Z07:00` — SPACE separator, `Z` or `±HH:MM`.
+fn parse_expiry_value(val: &str) -> Option<i64> {
+    let val = val.trim().trim_matches(|c| c == '"' || c == '\'');
+    // The three attempts cover Go's four layouts: T+colon (RFC3339 & RFC3339Nano),
+    // T+no-colon (Z0700), space+colon (Z07:00). Optional fractional seconds are
+    // accepted under ALL of them — Go's `time.Parse` accepts a trailing fractional
+    // after the seconds field even when the layout omits it (verified empirically),
+    // then `Unix()` truncates to whole seconds. Tried in order; first parse wins.
+    parse_layout(val, 'T', OffsetColon::Colon)
+        .or_else(|| parse_layout(val, 'T', OffsetColon::NoColon))
+        .or_else(|| parse_layout(val, ' ', OffsetColon::Colon))
+}
+
+/// Whether the numeric zone offset carries a `:` (`±HH:MM`) or not (`±HHMM`). `Z` is
+/// accepted under either.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OffsetColon {
+    Colon,
+    NoColon,
+}
+
+/// Parse one exact layout: `<date><sep><time>[.frac]<zone>`, where `sep` is `'T'` or
+/// `' '`, `zone` is `Z` or a signed offset (`colon`-styled or not). Optional fractional
+/// seconds are validated then dropped (Go truncates to whole seconds on `Unix()`).
+/// Returns unix seconds (offset applied) or `None`.
+fn parse_layout(val: &str, sep: char, offset: OffsetColon) -> Option<i64> {
+    let (date, time_zone) = val.split_once(sep)?;
+    // Date: YYYY-MM-DD (2-digit month/day; year is the leading run of digits).
+    let mut dparts = date.split('-');
+    let y: i64 = dparts.next()?.parse().ok()?;
+    let mo: u32 = parse_2(dparts.next()?)?;
+    let d: u32 = parse_2(dparts.next()?)?;
+    if dparts.next().is_some() {
+        return None;
+    }
+
+    // Split the zone suffix off the time.
+    let (time_part, offset_secs) = split_zone(time_zone, offset)?;
+    // Optional fractional seconds.
+    let (hms, frac) = match time_part.split_once('.') {
+        Some((h, f)) => (h, Some(f)),
+        None => (time_part, None),
+    };
+    if let Some(f) = frac {
+        if f.is_empty() || !f.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+    }
+    let mut tparts = hms.split(':');
+    let h: u32 = parse_2(tparts.next()?)?;
+    let mi: u32 = parse_2(tparts.next()?)?;
+    let se: u32 = parse_2(tparts.next()?)?;
+    if tparts.next().is_some() {
+        return None;
+    }
+    if !(1..=12).contains(&mo) || !(1..=31).contains(&d) || h > 23 || mi > 59 || se > 60 {
+        return None;
+    }
+    let days = crate::status::days_from_civil(y, mo, d);
+    Some(days * 86_400 + (h as i64) * 3_600 + (mi as i64) * 60 + (se as i64) - offset_secs)
+}
+
+/// Split an RFC3339 zone suffix off the time, returning `(time_text, secs_to_subtract)`
+/// where the offset is the value to SUBTRACT to reach UTC (`+05:00` → +18000, since a
+/// +5h local clock is 5h ahead of UTC). `Z` → 0. A missing zone → `None` (every Go
+/// expiry layout requires a zone). `offset` selects the colon style of a `±` offset.
+fn split_zone(time_zone: &str, offset: OffsetColon) -> Option<(&str, i64)> {
+    if let Some(rest) = time_zone.strip_suffix('Z') {
+        return Some((rest, 0));
+    }
+    let bytes = time_zone.as_bytes();
+    let mut idx = None;
+    for (i, &b) in bytes.iter().enumerate() {
+        if (b == b'+' || b == b'-') && i > 0 {
+            idx = Some(i);
+        }
+    }
+    let i = idx?;
+    let (time_part, off) = time_zone.split_at(i);
+    let sign = if off.as_bytes()[0] == b'+' { 1 } else { -1 };
+    let off = &off[1..];
+    let (oh, om) = match offset {
+        OffsetColon::Colon => {
+            let (oh, om) = off.split_once(':')?;
+            (parse_2(oh)? as i64, parse_2(om)? as i64)
+        }
+        OffsetColon::NoColon => {
+            if off.len() != 4 || !off.bytes().all(|b| b.is_ascii_digit()) {
+                return None;
+            }
+            (parse_2(&off[..2])? as i64, parse_2(&off[2..])? as i64)
+        }
+    };
+    if oh > 23 || om > 59 {
+        return None;
+    }
+    Some((time_part, sign * (oh * 3_600 + om * 60)))
+}
+
+/// Parse an exactly-2-digit unsigned field.
+fn parse_2(s: &str) -> Option<u32> {
+    if s.len() != 2 || !s.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    s.parse().ok()
+}
+
+// ---------------------------------------------------------------------------
+// Timestamp render helpers (shared with the aws-credentials handler, commit 3)
+// ---------------------------------------------------------------------------
+
+/// Render a unix instant as `YYYY-MM-DDTHH:MM:SSZ` with a **literal** `Z` — Go's
+/// `time.Time.Format("2006-01-02T15:04:05Z")`, where the bare `Z` is a literal, so
+/// the UTC clock numbers are emitted with a trailing `Z`. Reuses `rfc3339_utc`'s
+/// civil math, which already renders exactly this shape. Used by the handler
+/// (commit 3) for `expiration` / `cached_until`.
+pub(crate) fn aws_literal_z(unix: i64) -> String {
+    crate::status::rfc3339_utc(unix)
+}
+
+/// The audit detail for a credential vend: `expires:none` when there is no expiry
+/// (passthrough without a hint) rather than a misleading `expires:00:00`, else
+/// `expires:HH:MM` in UTC (mirror `awsExpiryDetail`). Used by the handler (commit 3).
+pub(crate) fn aws_expiry_detail(exp: Option<i64>) -> String {
+    match exp {
+        None => "expires:none".to_string(),
+        Some(unix) => {
+            // HH:MM slice of the UTC render (chars 11..16 of `YYYY-MM-DDTHH:MM:SSZ`).
+            let s = aws_literal_z(unix);
+            format!("expires:{}", &s[11..16])
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The real STS-backed AssumeRoler (SDK-owned; no live differential coverage)
+// ---------------------------------------------------------------------------
+
+/// The production [`AssumeRoler`]: builds an `aws-sdk-sts` client **lazily on first
+/// use** from the source profile's credential chain (SSO / credential_process /
+/// static), exactly as Go's `LoadDefaultConfig(WithSharedConfigProfile)`. The TLS
+/// connector is built explicitly over `rustls-ring` so the SDK reuses the workspace's
+/// ring stack (no `aws-lc-sys`). Mirror `stsBackend.stsClient` (the lazy-once build) +
+/// the AssumeRole call.
+///
+/// Unwired in this slice (constructed by `new_sts_backend`, which is itself wired in
+/// commit 3) — see the module-level `allow(dead_code)`.
+pub struct SdkAssumeRoler {
+    source_profile: String,
+    client: tokio::sync::OnceCell<aws_sdk_sts::Client>,
+}
+
+impl SdkAssumeRoler {
+    pub fn new(source_profile: &str) -> Self {
+        Self {
+            source_profile: source_profile.to_string(),
+            client: tokio::sync::OnceCell::new(),
+        }
+    }
+
+    /// Build (once) and return the STS client. Only the assume-role path calls this,
+    /// so a passthrough-only agent never loads the AssumeRole credential chain.
+    async fn client(&self) -> &aws_sdk_sts::Client {
+        self.client
+            .get_or_init(|| async {
+                // Ring-backed rustls HTTPS connector (reuses the workspace's ring —
+                // no aws-lc-sys). See the Cargo.toml AWS block.
+                let http = aws_smithy_http_client::Builder::new()
+                    .tls_provider(aws_smithy_http_client::tls::Provider::Rustls(
+                        aws_smithy_http_client::tls::rustls_provider::CryptoMode::Ring,
+                    ))
+                    .build_https();
+                let sdk_cfg = aws_config::from_env()
+                    .profile_name(&self.source_profile)
+                    .http_client(http)
+                    .load()
+                    .await;
+                aws_sdk_sts::Client::new(&sdk_cfg)
+            })
+            .await
+    }
+
+    /// Test hook mirroring Go's `b.client != nil` check: whether the lazy client has
+    /// been built (proves a passthrough-only path never constructs it).
+    #[cfg(test)]
+    fn client_initialized(&self) -> bool {
+        self.client.get().is_some()
+    }
+}
+
+#[async_trait]
+impl AssumeRoler for SdkAssumeRoler {
+    async fn assume_role(&self, input: AssumeRoleParams) -> Result<Option<AssumedCreds>, String> {
+        let client = self.client().await;
+        let out = client
+            .assume_role()
+            .role_arn(input.role_arn)
+            .role_session_name(input.session_name)
+            .duration_seconds(input.duration_seconds)
+            .send()
+            .await
+            .map_err(|e| {
+                // Render the full SdkError chain (Go's %w), not just the terse Display.
+                format!(
+                    "{}",
+                    aws_smithy_types::error::display::DisplayErrorContext(&e)
+                )
+            })?;
+        // The SDK's optional credential fields → Ok(None) so the backend emits the
+        // exact `sts:AssumeRole returned nil credentials for <arn>` (never a panic).
+        Ok(out.credentials().map(|c| AssumedCreds {
+            access_key_id: c.access_key_id().to_string(),
+            secret_access_key: c.secret_access_key().to_string(),
+            session_token: c.session_token().to_string(),
+            expiration: Some(c.expiration().secs()),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // ---- test doubles -----------------------------------------------------------
+
+    /// A `BusLog` that discards everything (the backend's logging is not asserted).
+    struct SilentLog;
+    impl BusLog for SilentLog {
+        fn info(&self, _: &str) {}
+        fn warn(&self, _: &str) {}
+        fn debug(&self, _: &str) {}
+        fn error(&self, _: &str) {}
+    }
+    fn silent() -> Arc<dyn BusLog> {
+        Arc::new(SilentLog)
+    }
+
+    /// An `AssumeRoler` that panics if called — proves the assume-role seam is never
+    /// reached (cache hit / passthrough).
+    struct PanicRoler;
+    #[async_trait]
+    impl AssumeRoler for PanicRoler {
+        async fn assume_role(
+            &self,
+            _input: AssumeRoleParams,
+        ) -> Result<Option<AssumedCreds>, String> {
+            panic!("assume_role must not be called");
+        }
+    }
+
+    /// A scripted `AssumeRoler`: returns canned outcomes in sequence (repeating the
+    /// last), records each session name, and counts calls.
+    struct FakeRoler {
+        outcomes: Mutex<Vec<Result<Option<AssumedCreds>, String>>>,
+        sessions: Mutex<Vec<String>>,
+        calls: AtomicUsize,
+    }
+    impl FakeRoler {
+        fn new(outcomes: Vec<Result<Option<AssumedCreds>, String>>) -> Arc<Self> {
+            Arc::new(Self {
+                outcomes: Mutex::new(outcomes),
+                sessions: Mutex::new(Vec::new()),
+                calls: AtomicUsize::new(0),
+            })
+        }
+    }
+    #[async_trait]
+    impl AssumeRoler for FakeRoler {
+        async fn assume_role(
+            &self,
+            input: AssumeRoleParams,
+        ) -> Result<Option<AssumedCreds>, String> {
+            self.sessions.lock().unwrap().push(input.session_name);
+            let i = self.calls.fetch_add(1, Ordering::SeqCst);
+            let outcomes = self.outcomes.lock().unwrap();
+            outcomes[i.min(outcomes.len() - 1)].clone()
+        }
+    }
+
+    fn assumed(key: &str, exp: Option<i64>) -> AssumedCreds {
+        AssumedCreds {
+            access_key_id: format!("{key}_KEY"),
+            secret_access_key: format!("{key}_SECRET"),
+            session_token: format!("{key}_TOKEN"),
+            expiration: exp,
+        }
+    }
+
+    /// A backend with an injected roler + fixed clock (mirror the Go tests' direct
+    /// `stsBackend{...}` struct literals). `refresh_before` defaults to 5m.
+    fn backend_fixed(cfg: AwsConfig, roler: Arc<dyn AssumeRoler>, now: i64) -> StsBackend {
+        StsBackend {
+            cfg,
+            refresh_before: Duration::from_secs(300),
+            session_dur: Duration::from_secs(3600),
+            assume_roler: roler,
+            log: silent(),
+            cache: Mutex::new(HashMap::new()),
+            now_unix: Box::new(move || now),
+        }
+    }
+
+    /// Clear the two AWS shared-file env vars (paired with `passthrough_env`).
+    fn cleanup_env() {
+        std::env::remove_var("AWS_SHARED_CREDENTIALS_FILE");
+        std::env::remove_var("AWS_CONFIG_FILE");
+    }
+
+    /// Drive a future to completion on a fresh current-thread runtime. The
+    /// passthrough tests mutate process-global env vars under `env_lock()` and must
+    /// hold that guard for the whole operation; running via `block_on` (rather than
+    /// `#[tokio::test]` + `.await`) keeps the guard out of any `await` point (the
+    /// passthrough path performs no real async work), so it stays a plain `#[test]`.
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
+
+    fn aws_cfg_role(role: &str) -> AwsConfig {
+        AwsConfig {
+            default_role: role.to_string(),
+            source_profile: "default".to_string(),
+            session_duration: "1h".to_string(),
+            cache_refresh_before: "5m".to_string(),
+            ..Default::default()
+        }
+    }
+
+    // ---- assume-role cache + errors ---------------------------------------------
+
+    #[tokio::test]
+    async fn cache_hit_skips_sts_and_is_per_server() {
+        // A pre-seeded cache entry within the refresh window returns without ever
+        // calling the (panicking) seam. Mirror TestCacheHit.
+        let now = 1_000_000_000;
+        let b = StsBackend {
+            cfg: aws_cfg_role("arn:aws:iam::123:role/test"),
+            refresh_before: Duration::from_secs(300),
+            session_dur: Duration::from_secs(3600),
+            assume_roler: Arc::new(PanicRoler),
+            log: silent(),
+            cache: Mutex::new(HashMap::new()),
+            now_unix: Box::new(|| 1_000_000_000),
+        };
+        b.cache.lock().unwrap().insert(
+            "mini2/my-shed".to_string(),
+            CachedCreds {
+                access_key_id: "CACHED_KEY".into(),
+                secret_access_key: "CACHED_SECRET".into(),
+                session_token: "CACHED_TOKEN".into(),
+                expiration: Some(now + 30 * 60), // within refresh window
+            },
+        );
+        let creds = b.get_credentials("mini2", "my-shed").await.unwrap();
+        assert_eq!(creds.access_key_id, "CACHED_KEY");
+        // A different server with the same shed name must NOT share the entry.
+        let (_role, until) = b.status("mini3", "my-shed");
+        assert_eq!(until, None, "mini3/my-shed must not share mini2's cache");
+    }
+
+    #[tokio::test]
+    async fn cache_stale_refetches() {
+        // The cached entry is inside the refresh window (stale) → the seam is called
+        // and its fresh creds returned. Stronger than Go's mock-only TestCacheMiss.
+        let now = 1_000_000_000;
+        let roler = FakeRoler::new(vec![Ok(Some(assumed("FRESH", Some(now + 3600))))]);
+        let mut b = backend_fixed(aws_cfg_role("arn:aws:iam::123:role/test"), roler.clone(), now);
+        b.refresh_before = Duration::from_secs(300);
+        b.cache.lock().unwrap().insert(
+            "mini2/my-shed".to_string(),
+            CachedCreds {
+                access_key_id: "STALE".into(),
+                secret_access_key: "STALE".into(),
+                session_token: "STALE".into(),
+                expiration: Some(now + 60), // 60s < 300s refresh → stale
+            },
+        );
+        let creds = b.get_credentials("mini2", "my-shed").await.unwrap();
+        assert_eq!(creds.access_key_id, "FRESH_KEY");
+        assert_eq!(roler.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn no_role_error_exact() {
+        let b = backend_fixed(AwsConfig::default(), Arc::new(PanicRoler), 0);
+        let err = b
+            .get_credentials("mini2", "unknown-shed")
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err,
+            r#"no role configured for shed "unknown-shed" on server "mini2""#
+        );
+    }
+
+    #[tokio::test]
+    async fn nil_credentials_error() {
+        // The seam succeeds but returns no credentials → the exact nil-creds error.
+        let roler = FakeRoler::new(vec![Ok(None)]);
+        let b = backend_fixed(aws_cfg_role("arn:aws:iam::123:role/x"), roler, 0);
+        let err = b.get_credentials("s", "sh").await.unwrap_err();
+        assert_eq!(
+            err,
+            "sts:AssumeRole returned nil credentials for arn:aws:iam::123:role/x"
+        );
+    }
+
+    #[tokio::test]
+    async fn assume_role_failed_error() {
+        let roler = FakeRoler::new(vec![Err("AccessDenied: nope".to_string())]);
+        let b = backend_fixed(aws_cfg_role("arn:aws:iam::123:role/x"), roler, 0);
+        let err = b.get_credentials("s", "sh").await.unwrap_err();
+        assert_eq!(
+            err,
+            "sts:AssumeRole failed for arn:aws:iam::123:role/x: AccessDenied: nope"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_name_shape() {
+        let now = 1_700_000_000;
+        let roler = FakeRoler::new(vec![Ok(Some(assumed("X", Some(now + 3600))))]);
+        let b = backend_fixed(aws_cfg_role("arn:aws:iam::9:role/x"), roler.clone(), now);
+        b.get_credentials("mini2", "web").await.unwrap();
+        let sessions = roler.sessions.lock().unwrap();
+        assert_eq!(sessions[0], format!("shed-mini2-web-{now}"));
+    }
+
+    // ---- passthrough -------------------------------------------------------------
+
+    /// Write a credentials file + an empty config file under an isolated temp HOME,
+    /// pointing the env vars at them (mirror the Go tests' passthroughEnv). Returns
+    /// the guard TempDir (kept alive) + the credentials path.
+    fn passthrough_env(content: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let creds = dir.path().join("credentials");
+        std::fs::write(&creds, content).unwrap();
+        let cfg = dir.path().join("config");
+        std::fs::write(&cfg, "").unwrap();
+        std::env::set_var("AWS_SHARED_CREDENTIALS_FILE", &creds);
+        std::env::set_var("AWS_CONFIG_FILE", &cfg);
+        (dir, creds)
+    }
+
+    fn passthrough_cfg(profile: &str) -> AwsConfig {
+        AwsConfig {
+            source_profile: profile.to_string(),
+            mode: AWS_MODE_PASSTHROUGH.to_string(),
+            session_duration: "1h".to_string(),
+            cache_refresh_before: "5m".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn passthrough_backend(profile: &str) -> StsBackend {
+        backend_fixed(passthrough_cfg(profile), Arc::new(PanicRoler), 0)
+    }
+
+    #[test]
+    fn passthrough_reads_fixture() {
+        let _g = crate::env_lock();
+        let (_d, _creds) = passthrough_env(
+            "[my-sso]\naws_access_key_id = AKIATEST\naws_secret_access_key = secretXYZ\naws_session_token = tokenXYZ\naws_session_expiration = 2099-01-02T15:04:05Z\n",
+        );
+        let b = passthrough_backend("my-sso");
+        let creds = block_on(b.get_credentials("mini2", "web")).unwrap();
+        assert_eq!(creds.access_key_id, "AKIATEST");
+        assert_eq!(creds.secret_access_key, "secretXYZ");
+        assert_eq!(creds.session_token, "tokenXYZ");
+        // 2099-01-02T15:04:05Z as unix seconds.
+        assert_eq!(creds.expiration, Some(4071049445));
+        // Passthrough must not populate the assume-role cache.
+        assert!(b.cache.lock().unwrap().is_empty());
+        cleanup_env();
+    }
+
+    #[test]
+    fn passthrough_reads_via_env_route() {
+        // The env-var resolution path (AWS_SHARED_CREDENTIALS_FILE) — Go pins this in
+        // its own tests; the differential harness uses the isolated-$HOME route.
+        let _g = crate::env_lock();
+        let (_d, creds_path) =
+            passthrough_env("[p]\naws_access_key_id = A\naws_secret_access_key = S\naws_session_token = T\n");
+        assert_eq!(shared_credentials_path(), creds_path);
+        let creds = block_on(passthrough_backend("p").get_credentials("s", "sh")).unwrap();
+        assert_eq!(creds.access_key_id, "A");
+        assert_eq!(creds.expiration, None); // no hint
+        cleanup_env();
+    }
+
+    #[test]
+    fn passthrough_expiry_variants() {
+        let _g = crate::env_lock();
+        // x_security_token_expires key + non-zero offset (Rust-stronger than Go's Z-only).
+        let (_d, _c) = passthrough_env(
+            "[p]\naws_access_key_id = A\naws_secret_access_key = S\naws_session_token = T\nx_security_token_expires = 2099-06-01T02:00:00+02:00\n",
+        );
+        let creds = block_on(passthrough_backend("p").get_credentials("s", "sh")).unwrap();
+        // +02:00 local == 2099-06-01T00:00:00Z.
+        assert_eq!(creds.expiration, Some(4083955200));
+        cleanup_env();
+
+        // Missing hint → None.
+        let (_d2, _c2) = passthrough_env(
+            "[p]\naws_access_key_id = A\naws_secret_access_key = S\naws_session_token = T\n",
+        );
+        let creds = block_on(passthrough_backend("p").get_credentials("s", "sh")).unwrap();
+        assert_eq!(creds.expiration, None);
+        cleanup_env();
+    }
+
+    #[test]
+    fn passthrough_relogin_pickup() {
+        let _g = crate::env_lock();
+        let (dir, creds_path) =
+            passthrough_env("[p]\naws_access_key_id = A1\naws_secret_access_key = S1\naws_session_token = T1\n");
+        let b = passthrough_backend("p");
+        let first = block_on(b.get_credentials("s", "sh")).unwrap();
+        assert_eq!(first.access_key_id, "A1");
+
+        // Simulate `aws sso login` rewriting the file atomically (tmp + rename).
+        let tmp = dir.path().join("credentials.tmp");
+        std::fs::write(
+            &tmp,
+            "[p]\naws_access_key_id = A2\naws_secret_access_key = S2\naws_session_token = T2\n",
+        )
+        .unwrap();
+        std::fs::rename(&tmp, &creds_path).unwrap();
+
+        let second = block_on(b.get_credentials("s", "sh")).unwrap();
+        assert_eq!(second.access_key_id, "A2");
+        cleanup_env();
+    }
+
+    #[test]
+    fn passthrough_errors() {
+        let _g = crate::env_lock();
+        // Missing profile → wrap prefix + profile name (inner SDK-text divergence).
+        let (_d, _c) = passthrough_env(
+            "[other]\naws_access_key_id = A\naws_secret_access_key = S\naws_session_token = T\n",
+        );
+        let err = block_on(passthrough_backend("absent").get_credentials("s", "sh")).unwrap_err();
+        assert!(
+            err.starts_with(r#"passthrough: loading profile "absent" from "#),
+            "got: {err}"
+        );
+        cleanup_env();
+
+        // No session token → EXACT Go string.
+        let (_d2, _c2) =
+            passthrough_env("[p]\naws_access_key_id = A\naws_secret_access_key = S\n");
+        let err = block_on(passthrough_backend("p").get_credentials("s", "sh")).unwrap_err();
+        assert_eq!(
+            err,
+            "passthrough: profile \"p\" has no aws_session_token; passthrough expects temporary SSO/SAML session credentials, not long-lived keys"
+        );
+        cleanup_env();
+
+        // No static credentials → EXACT Go string (path is home-normalized via env).
+        let (_d3, creds_path) = passthrough_env("[p]\nregion = us-east-1\n");
+        let err = block_on(passthrough_backend("p").get_credentials("s", "sh")).unwrap_err();
+        assert_eq!(
+            err,
+            format!(
+                "passthrough: profile \"p\" in {} has no static credentials; run your SSO/SAML login (e.g. `aws sso login`) to refresh",
+                creds_path.display()
+            )
+        );
+        cleanup_env();
+    }
+
+    #[test]
+    fn passthrough_status() {
+        let _g = crate::env_lock();
+        // With an expiry hint → role + Some(unix).
+        let (_d, _c) = passthrough_env(
+            "[my-sso]\naws_access_key_id = A\naws_secret_access_key = S\naws_session_token = T\naws_session_expiration = 2099-01-02T15:04:05Z\n",
+        );
+        let (role, until) = passthrough_backend("my-sso").status("mini2", "web");
+        assert_eq!(role, "passthrough:my-sso");
+        assert_eq!(until, Some(4071049445));
+        cleanup_env();
+
+        // No hint → role + None.
+        let (_d2, _c2) = passthrough_env(
+            "[my-sso]\naws_access_key_id = A\naws_secret_access_key = S\naws_session_token = T\n",
+        );
+        let (role, until) = passthrough_backend("my-sso").status("mini2", "web");
+        assert_eq!(role, "passthrough:my-sso");
+        assert_eq!(until, None);
+        cleanup_env();
+
+        // Missing file must NOT error (status never errors).
+        std::env::set_var(
+            "AWS_SHARED_CREDENTIALS_FILE",
+            std::env::temp_dir().join("shed-aws-nope-xyz"),
+        );
+        std::env::remove_var("AWS_CONFIG_FILE");
+        let (role, until) = passthrough_backend("my-sso").status("mini2", "web");
+        assert_eq!(role, "passthrough:my-sso");
+        assert_eq!(until, None);
+        cleanup_env();
+    }
+
+    #[test]
+    fn passthrough_only_never_builds_client() {
+        let _g = crate::env_lock();
+        let (_d, _c) = passthrough_env(
+            "[my-sso]\naws_access_key_id = A\naws_secret_access_key = S\naws_session_token = T\n",
+        );
+        // Build the REAL SdkAssumeRoler and prove get_credentials (passthrough) never
+        // constructs its lazy STS client — the Rust analog of Go's b.client == nil.
+        let sdk = Arc::new(SdkAssumeRoler::new("my-sso"));
+        let b = backend_fixed(passthrough_cfg("my-sso"), sdk.clone(), 0);
+        block_on(b.get_credentials("mini2", "web")).unwrap();
+        assert!(!sdk.client_initialized());
+        cleanup_env();
+    }
+
+    // ---- parse_session_expiry matrix + parse_expiry_value layouts ---------------
+
+    fn expiry_from(content: &str, profile: &str) -> Option<i64> {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("credentials");
+        std::fs::write(&path, content).unwrap();
+        parse_session_expiry(&path, profile)
+    }
+
+    #[test]
+    fn parse_session_expiry_matrix() {
+        // (content, profile, wants_some)
+        let cases: &[(&str, &str, bool)] = &[
+            ("[p]\naws_session_expiration = 2099-01-02T15:04:05Z\n", "p", true),
+            ("[p]\nx_security_token_expires = 2099-01-02T15:04:05Z\n", "p", true),
+            ("[p]\naws_session_expiration = \"2099-01-02T15:04:05Z\"\n", "p", true),
+            ("# header\n[p]\n  aws_session_expiration = 2099-01-02T15:04:05Z  \n", "p", true),
+            // duplicate section uses first (second has a bad value).
+            ("[p]\naws_session_expiration = 2099-01-02T15:04:05Z\n[p]\naws_session_expiration = bad\n", "p", true),
+            ("[profile p]\naws_session_expiration = 2099-01-02T15:04:05Z\n", "p", true),
+            ("[a.b]\naws_session_expiration = 2099-01-02T15:04:05Z\n", "a.b", true),
+            ("[p]\naws_access_key_id = A\n", "p", false),
+            ("[other]\naws_session_expiration = 2099-01-02T15:04:05Z\n", "p", false),
+            ("[p]\naws_session_expiration = not-a-time\n", "p", false),
+        ];
+        for (content, profile, wants_some) in cases {
+            let got = expiry_from(content, profile);
+            assert_eq!(got.is_some(), *wants_some, "content={content:?}");
+        }
+    }
+
+    #[test]
+    fn parse_session_expiry_key_order_wins() {
+        // First matching key in LINE ORDER wins: x_security first (value A), then
+        // aws_session (value B) → A's unix.
+        let got = expiry_from(
+            "[p]\nx_security_token_expires = 2099-01-02T15:04:05Z\naws_session_expiration = 2100-01-01T00:00:00Z\n",
+            "p",
+        );
+        assert_eq!(got, Some(4071049445)); // the 2099 value, not the 2100 one
+    }
+
+    #[test]
+    fn parse_session_expiry_duplicate_section_first_wins() {
+        let got = expiry_from(
+            "[p]\naws_session_expiration = 2099-01-02T15:04:05Z\n[p]\naws_session_expiration = 2100-01-01T00:00:00Z\n",
+            "p",
+        );
+        assert_eq!(got, Some(4071049445));
+    }
+
+    #[test]
+    fn parse_expiry_value_layouts() {
+        // Layout 1/2: RFC3339 (Z, +00:00), RFC3339Nano (fractional).
+        assert_eq!(parse_expiry_value("2099-01-02T15:04:05Z"), Some(4071049445));
+        assert_eq!(parse_expiry_value("2099-01-02T15:04:05.123Z"), Some(4071049445));
+        assert_eq!(parse_expiry_value("2099-01-02T15:04:05+00:00"), Some(4071049445));
+        // Non-zero colon offset: +02:00 → 2h earlier in UTC.
+        assert_eq!(parse_expiry_value("2099-01-02T17:04:05+02:00"), Some(4071049445));
+        // Negative offset: -05:00 → 5h later in UTC.
+        assert_eq!(parse_expiry_value("2099-01-02T10:04:05-05:00"), Some(4071049445));
+        // Layout 3: numeric offset, NO colon.
+        assert_eq!(parse_expiry_value("2099-01-02T17:04:05+0200"), Some(4071049445));
+        assert_eq!(parse_expiry_value("2099-01-02T15:04:05Z"), Some(4071049445));
+        // Layout 4: SPACE separator, colon offset.
+        assert_eq!(parse_expiry_value("2099-01-02 17:04:05+02:00"), Some(4071049445));
+        assert_eq!(parse_expiry_value("2099-01-02 15:04:05Z"), Some(4071049445));
+        // Fractional seconds accepted under EVERY layout (Go's time.Parse leniency),
+        // truncated to whole seconds. 15:04:05.5+0200 == 13:04:05Z == 4071042245.
+        assert_eq!(parse_expiry_value("2099-01-02T15:04:05.5+0200"), Some(4071042245));
+        assert_eq!(parse_expiry_value("2099-01-02 15:04:05.25Z"), Some(4071049445));
+        // Quotes trimmed.
+        assert_eq!(parse_expiry_value("\"2099-01-02T15:04:05Z\""), Some(4071049445));
+        // Failures → None.
+        assert_eq!(parse_expiry_value("garbage"), None);
+        assert_eq!(parse_expiry_value(""), None);
+        assert_eq!(parse_expiry_value("2099-01-02T15:04:05"), None); // no zone
+        assert_eq!(parse_expiry_value("2099-13-02T15:04:05Z"), None); // bad month
+    }
+
+    // ---- render helpers ----------------------------------------------------------
+
+    #[test]
+    fn literal_z_render_utc() {
+        assert_eq!(aws_literal_z(0), "1970-01-01T00:00:00Z");
+        assert_eq!(aws_literal_z(1_000_000_000), "2001-09-09T01:46:40Z");
+        assert_eq!(aws_literal_z(4071049445), "2099-01-02T15:04:05Z");
+    }
+
+    #[test]
+    fn expiry_detail_render() {
+        assert_eq!(aws_expiry_detail(None), "expires:none");
+        assert_eq!(aws_expiry_detail(Some(4071049445)), "expires:15:04");
+        assert_eq!(aws_expiry_detail(Some(0)), "expires:00:00");
+    }
+
+    // ---- constructor -------------------------------------------------------------
+
+    #[test]
+    fn new_sts_backend_rejects_unconfigured() {
+        assert!(new_sts_backend(AwsConfig::default(), silent()).is_err());
+    }
+
+    #[test]
+    fn new_sts_backend_accepts_passthrough_only() {
+        assert!(new_sts_backend(passthrough_cfg("my-sso"), silent()).is_ok());
+    }
+
+    // ---- golden runner (Rust half of aws_expiry.json) ---------------------------
+
+    #[test]
+    fn golden_aws_expiry() {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/host-agent-diff/fixtures/aws_expiry.json");
+        let raw = std::fs::read_to_string(&path).expect("read golden fixture");
+        let fx: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(fx["protocol_version"], 1, "version skew");
+
+        for v in fx["expiry_vectors"].as_array().unwrap() {
+            let name = v["name"].as_str().unwrap();
+            let got = expiry_from(v["ini"].as_str().unwrap(), v["profile"].as_str().unwrap());
+            let want = v["expected_unix"].as_i64();
+            assert_eq!(got, want, "expiry vector {name:?}");
+        }
+        for v in fx["literal_z_vectors"].as_array().unwrap() {
+            let got = aws_literal_z(v["unix"].as_i64().unwrap());
+            assert_eq!(got, v["expected"].as_str().unwrap(), "literal_z {v}");
+        }
+        for v in fx["expiry_detail_vectors"].as_array().unwrap() {
+            let got = aws_expiry_detail(v["unix"].as_i64());
+            assert_eq!(got, v["expected"].as_str().unwrap(), "expiry_detail {v}");
+        }
+    }
+}

--- a/crates/shed-host-agent/src/aws_backend.rs
+++ b/crates/shed-host-agent/src/aws_backend.rs
@@ -23,12 +23,9 @@
 //! build is preserved (the behavioural property the `passthrough_only_never_builds_client`
 //! test pins); there is simply no load-time error to latch.
 //!
-//! **Wiring:** this whole module is ported in this slice but reached only through the
-//! aws-credentials handler + `main.rs`, which are added in commit 3. Until then it is
-//! unreachable in a non-test build, so a module-wide `allow(dead_code)` keeps the
-//! headless `cargo build --no-default-features` warning-free (the module is fully
-//! exercised under `--all-targets`/tests). Remove this allow when commit 3 wires it.
-#![allow(dead_code)]
+//! **Wiring:** this module is reached through the aws-credentials bus handler
+//! (`bus.rs`) + `main.rs`, which construct the backend via [`new_sts_backend`] and
+//! dispatch `get_credentials`/`status` to it.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/crates/shed-host-agent/src/bootstrap.rs
+++ b/crates/shed-host-agent/src/bootstrap.rs
@@ -381,7 +381,7 @@ fn parse_rfc3339_to_unix(s: &str) -> Result<Option<i64>, ()> {
     if y == 1 && mo == 1 && d == 1 && h == 0 && mi == 0 && se == 0 && offset_secs == 0 {
         return Ok(None);
     }
-    let days = days_from_civil(y, mo, d);
+    let days = crate::status::days_from_civil(y, mo, d);
     let secs = days * 86_400 + (h as i64) * 3_600 + (mi as i64) * 60 + (se as i64) - offset_secs;
     Ok(Some(secs))
 }
@@ -421,18 +421,6 @@ fn parse_fixed<T: std::str::FromStr>(s: &str, width: usize) -> Result<T, ()> {
         return Err(());
     }
     s.parse().map_err(|_| ())
-}
-
-/// Days from the civil date to the unix epoch (Howard Hinnant's `days_from_civil`; the
-/// inverse of the civil-from-days math in [`crate::status::rfc3339_utc`]).
-fn days_from_civil(y: i64, m: u32, d: u32) -> i64 {
-    let y = if m <= 2 { y - 1 } else { y };
-    let era = if y >= 0 { y } else { y - 399 } / 400;
-    let yoe = y - era * 400; // [0, 399]
-    let mp = if m > 2 { m - 3 } else { m + 9 } as i64; // [0, 11]
-    let doy = (153 * mp + 2) / 5 + d as i64 - 1; // [0, 365]
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
-    era * 146_097 + doe - 719_468
 }
 
 /// serde field deserializer for `Bundle.expires_at`: `None` for absent/null/empty/zero;

--- a/crates/shed-host-agent/src/bus.rs
+++ b/crates/shed-host-agent/src/bus.rs
@@ -48,6 +48,7 @@ use shed_core::tls::pinned_client_config;
 
 use crate::approval::ApprovalGate;
 use crate::audit::{AuditEntry, AuditSink};
+use crate::aws_backend::{aws_expiry_detail, aws_literal_z, AwsBackend};
 use crate::config::{NS_AWS_CREDENTIALS, NS_DOCKER_CREDENTIALS, NS_SSH_AGENT};
 use crate::ssh_backend::SshBackend;
 
@@ -55,6 +56,16 @@ use crate::ssh_backend::SshBackend;
 const SSH_CODE_KEY_NOT_FOUND: &str = "KEY_NOT_FOUND";
 const SSH_CODE_SIGN_FAILED: &str = "SIGN_FAILED";
 const SSH_CODE_INTERNAL: &str = "INTERNAL_ERROR";
+
+/// AWS protocol error codes (`internal/ext/protocol/aws.go`). `ASSUME_ROLE_FAILED` is
+/// scoped to `get_credentials` failures only (gate-deny / backend-error); the shared
+/// unknown-op / invalid-payload dispatch uses `INTERNAL_ERROR` (`AWSCodeInternal`).
+/// Go also defines `ROLE_NOT_FOUND`, but the handler NEVER emits it, so it is
+/// intentionally omitted here.
+const AWS_CODE_ASSUME_ROLE_FAILED: &str = "ASSUME_ROLE_FAILED";
+const AWS_CODE_INTERNAL: &str = "INTERNAL_ERROR";
+/// The gated AWS op — the only one whose audit carries the approval outcome.
+const AWS_OP_GET_CREDENTIALS: &str = "get_credentials";
 
 // ---------------------------------------------------------------------------
 // Constants (mirrors hostclient.go)
@@ -786,31 +797,46 @@ fn build_http_client(pin: Option<&str>) -> Result<reqwest::Client, BusError> {
 // Single-server daemon entry point + ping responder
 // ---------------------------------------------------------------------------
 
-/// The bus's injected seams for the gated credential flow — built in `main.rs` and
-/// threaded through the subscribe loop into `handle_bus_message`/`handle_sign`: the
-/// approval `gate` (selected from `ssh.approval.policy`), the `audit` sink (durable
-/// JSONL + desktop fan-out), the ed25519 sign `backend`, and the discovery
-/// `server_name` (the audit/approval `server` field — empty in single-server mode).
-/// Grouping the seams keeps the two entry points below the argument-count lint and
-/// gives later slices (aws/docker backends, the credential minter) one place to grow.
+/// The bus's injected seams for the gated credential flows — built in `main.rs` and
+/// threaded through the subscribe loops: the ssh approval `gate` (selected from
+/// `ssh.approval.policy`), the `audit` sink (durable JSONL + desktop fan-out; SHARED
+/// across namespaces), the ed25519 sign `backend`, the discovery `server_name` (the
+/// audit/approval `server` field — empty in single-server mode), and the optional
+/// [`AwsHandlers`] (the second bus namespace). Grouping the seams keeps the entry
+/// points below the argument-count lint and gives later slices (docker backend, the
+/// credential minter) one place to grow.
 pub struct BusHandlers {
     pub gate: Arc<dyn ApprovalGate>,
     pub audit: Arc<dyn AuditSink>,
     pub backend: Arc<dyn SshBackend>,
     pub server_name: String,
+    /// The aws-credentials handler's seams, present only when `aws.enabled()` and the
+    /// backend constructed (Go main.go:166-173 — a nil AWS backend means no aws
+    /// handler). `None` ⇒ the aws-credentials namespace is never subscribed.
+    pub aws: Option<AwsHandlers>,
 }
 
-/// Run the single-server message bus: subscribe to `ssh-agent` (open mode — no
-/// token, no pin) and answer inbound requests until `shutdown` flips. `ping` → a
-/// `pong`; `sign` runs the gated ed25519 flow (approval gate → backend → response +
-/// audit). Mirrors the Go daemon's single-server path
-/// (`main.go` → `startWatcherGroup` → `NewSSHHandler(...).Run`). `server_name` is the
-/// audit/approval `server` field — empty in single-server mode (matches Go).
+/// The aws-credentials handler's seams (the second bus namespace). Carries its OWN
+/// per-namespace approval `gate` (selected from `aws.approval.policy`, NEVER ssh's —
+/// panel F6) and the `backend`; the audit sink + `server_name` are shared from
+/// [`BusHandlers`]. Present iff `main.rs` built the AWS backend.
+pub struct AwsHandlers {
+    pub backend: Arc<dyn AwsBackend>,
+    pub gate: Arc<dyn ApprovalGate>,
+}
+
+/// Run the single-server message bus: subscribe to `ssh-agent` (always) and
+/// `aws-credentials` (when the AWS backend is configured) in open mode (no token, no
+/// pin) and answer inbound requests until `shutdown` flips. Each namespace runs its own
+/// subscribe+serve loop (both racing `shutdown`), mirroring the Go daemon's
+/// per-namespace watcher goroutines (`main.go` → `startWatcherGroup` → the per-handler
+/// `.Run`). `server_name` is the audit/approval `server` field — empty in single-server
+/// mode (matches Go).
 ///
 /// KNOWN GAP (for the harness): Go's watcher group also subscribes to
-/// `aws-credentials`, `docker-credentials`, and the egress-audit stream, and answers
-/// the ssh `list`/`status` ops. Those need their backends + the egress route, so they
-/// are deliberately NOT wired here — this slice wires the ssh-agent ping + gated sign.
+/// `docker-credentials` and the egress-audit stream. Those need their backends + the
+/// egress route, so they are deliberately NOT wired here — this slice wires ssh-agent +
+/// (configured) aws-credentials.
 pub async fn run_single_server_bus(
     server_url: String,
     shutdown: watch::Receiver<bool>,
@@ -838,20 +864,57 @@ pub async fn run_single_server_bus(
         }
     };
     log.info(&format!("brokering for single server server={server_url}"));
-    // The known gap for the harness: only ssh-agent is wired this slice; the other
-    // credential namespaces + egress need their backends (later slices).
+
+    // The subscription set: always ssh-agent; aws-credentials when the AWS backend is
+    // configured (Go: a nil AWS backend means no aws handler). docker-credentials + the
+    // egress stream remain later slices. Compute the set once, then log + spawn from it
+    // so a new namespace is a single push (no parallel branches to keep in sync).
+    let mut subscribed: Vec<&'static str> = vec![NS_SSH_AGENT];
+    if handlers.aws.is_some() {
+        subscribed.push(NS_AWS_CREDENTIALS);
+    }
+    let deferred: Vec<&'static str> = BUS_NAMESPACES
+        .iter()
+        .copied()
+        .filter(|ns| !subscribed.contains(ns))
+        .collect();
     log.info(&format!(
-        "message bus subscribing namespace={}; deferred (later slices): {:?}",
-        NS_SSH_AGENT,
-        &BUS_NAMESPACES[1..]
+        "message bus subscribing namespaces={subscribed:?}; deferred (later slices): {deferred:?}"
     ));
 
-    // Subscribe + run the ping responder. On shutdown (or a terminal 409) the
-    // subscribe loop drops its sender, closing `rx` and ending this loop; the
-    // subscription's Drop then aborts the (already-finished) task. The recv is also
-    // raced against shutdown, and `shutdown` is threaded into `handle_bus_message`
-    // so a `respond` to a hung server can't pin this loop past a SIGTERM/SIGINT.
-    let mut sub = client.subscribe(NS_SSH_AGENT, shutdown.clone());
+    // Share the seams across the per-namespace loops. Each namespace subscribes +
+    // serves independently (both racing `shutdown`), so a slow op on one namespace
+    // can't stall the other.
+    let handlers = Arc::new(handlers);
+    let mut tasks: Vec<JoinHandle<()>> = Vec::new();
+    for namespace in subscribed {
+        tasks.push(tokio::spawn(serve_namespace(
+            client.clone(),
+            namespace,
+            shutdown.clone(),
+            handlers.clone(),
+            log.clone(),
+        )));
+    }
+    for t in tasks {
+        let _ = t.await;
+    }
+}
+
+/// Subscribe to one namespace's SSE stream and answer inbound requests until `shutdown`
+/// flips (or the subscription is terminally rejected). On shutdown (or a terminal 409)
+/// the subscribe loop drops its sender, closing `rx` and ending this loop; the recv is
+/// also raced against shutdown, and `shutdown` is threaded into the dispatch so a
+/// `respond` to a hung server can't pin the loop past a SIGTERM/SIGINT. Dispatch is
+/// namespace-aware (see [`dispatch_bus_message`]).
+async fn serve_namespace(
+    client: BusClient,
+    namespace: &'static str,
+    shutdown: watch::Receiver<bool>,
+    handlers: Arc<BusHandlers>,
+    log: Arc<dyn BusLog>,
+) {
+    let mut sub = client.subscribe(namespace, shutdown.clone());
     loop {
         let env = tokio::select! {
             _ = wait_shutdown(shutdown.clone()) => break,
@@ -860,13 +923,42 @@ pub async fn run_single_server_bus(
                 None => break, // sender dropped: shutdown or terminal 409
             },
         };
-        handle_bus_message(&client, NS_SSH_AGENT, &env, &shutdown, &handlers).await;
+        dispatch_bus_message(&client, namespace, &env, &shutdown, &handlers).await;
     }
     let s = sub.status();
     log.info(&format!(
         "message bus stopped namespace={} state={:?} last_error={}",
         s.namespace, s.state, s.last_error
     ));
+}
+
+/// Route one inbound request to its namespace handler: `aws-credentials` → the gated
+/// AWS flow (its OWN per-namespace gate + AWS error codes), every other namespace
+/// (ssh-agent) → [`handle_bus_message`]. The aws branch is reached only when
+/// `handlers.aws` is `Some` (its loop is started only then); a defensive fall-through
+/// to the ssh dispatch keeps a stray aws frame from hanging the shed's request.
+async fn dispatch_bus_message(
+    client: &BusClient,
+    namespace: &str,
+    env: &Envelope,
+    shutdown: &watch::Receiver<bool>,
+    handlers: &BusHandlers,
+) {
+    match (namespace, &handlers.aws) {
+        (NS_AWS_CREDENTIALS, Some(aws)) => {
+            handle_aws_bus_message(
+                client,
+                namespace,
+                env,
+                shutdown,
+                aws,
+                &handlers.audit,
+                &handlers.server_name,
+            )
+            .await
+        }
+        _ => handle_bus_message(client, namespace, env, shutdown, handlers).await,
+    }
 }
 
 /// Answer one inbound bus request, mirroring `ssh_handler.go:handleMessage`'s
@@ -1245,8 +1337,222 @@ async fn handle_sign(
     }
 }
 
+// ---------------------------------------------------------------------------
+// AWS credential handler (a faithful port of aws_handler.go) — the second bus
+// namespace. Uses its own per-namespace gate + the AWS protocol error codes, and the
+// LogEntry audit form (approval + decided_by/scope/ttl) — unlike the ssh positional
+// `list` audit.
+// ---------------------------------------------------------------------------
+
+/// AWS response payload types (serde mirrors of `internal/ext/protocol/aws.go`). Built
+/// as typed structs (not ad-hoc `json!`) so the tag names are pinned in one place; the
+/// `aws_payload_tag_names_match_protocol` test asserts they equal the Go json tags.
+/// `expiration`/`cached_until` use `skip_serializing_if` = Go's `omitempty`.
+#[derive(Serialize)]
+struct AwsCredentialsResponse {
+    access_key_id: String,
+    secret_access_key: String,
+    session_token: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expiration: Option<String>,
+}
+
+/// `AWSPingResponse` — the `ping` op's payload.
+#[derive(Serialize)]
+struct AwsPingResponse {
+    status: String,
+}
+
+/// `AWSStatusResponse` — the `status` op's payload. `cached_until` is omitted (Go
+/// `omitempty`) when there is no known expiry.
+#[derive(Serialize)]
+struct AwsStatusResponse {
+    connected: bool,
+    role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cached_until: Option<String>,
+}
+
+/// `AWSErrorResponse` — an `{error, code}` error payload.
+#[derive(Serialize)]
+struct AwsErrorResponse {
+    error: String,
+    code: String,
+}
+
+/// Build an `{error, code}` AWS error payload (`AWSErrorResponse`).
+fn aws_error(msg: &str, code: &str) -> serde_json::Value {
+    to_payload(&AwsErrorResponse {
+        error: msg.to_string(),
+        code: code.to_string(),
+    })
+}
+
+/// A gated AWS audit entry — the LogEntry form (unlike the ssh positional `list`
+/// audit). The fixed aws-credentials ns + `get_credentials` op, the given result/detail,
+/// the approval method, and the gate outcome's decided_by/scope/ttl. NO `code`/`reason`
+/// (aws_handler.go sets neither on ANY get_credentials audit); `detail` is empty on the
+/// deny path, `err.Error()` on error, and `awsExpiryDetail` on ok.
+fn aws_audit(
+    server_name: &str,
+    shed_name: &str,
+    result: &str,
+    detail: &str,
+    approval: String,
+    outcome: &crate::approval::ApprovalOutcome,
+) -> AuditEntry {
+    AuditEntry {
+        server: server_name.to_string(),
+        shed: shed_name.to_string(),
+        ns: NS_AWS_CREDENTIALS.to_string(),
+        op: AWS_OP_GET_CREDENTIALS.to_string(),
+        result: result.to_string(),
+        detail: detail.to_string(),
+        approval,
+        decided_by: outcome.decided_by.clone(),
+        scope: outcome.scope.clone().unwrap_or_default(),
+        ttl: outcome.ttl.clone().unwrap_or_default(),
+        ..Default::default()
+    }
+}
+
+/// Answer one inbound aws-credentials request, mirroring `aws_handler.go:handleMessage`'s
+/// dispatch. `get_credentials` runs the gated flow (approval gate → backend → response +
+/// audit); `ping` → `{"status":"ok"}`; `status` → `{connected, role, cached_until?}` (no
+/// audit); an unknown op → Go's exact `unknown operation: <op>` `INTERNAL_ERROR`; a
+/// non-object/non-null payload → `{invalid payload, INTERNAL_ERROR}` (the shared
+/// [`parse_operation`], but with AWS codes). The reply plumbing (mint response, echo
+/// `shed`, POST, warn-on-failure) + audit-after-response order match the ssh path.
+async fn handle_aws_bus_message(
+    client: &BusClient,
+    namespace: &str,
+    env: &Envelope,
+    shutdown: &watch::Receiver<bool>,
+    aws: &AwsHandlers,
+    audit: &Arc<dyn AuditSink>,
+    server_name: &str,
+) {
+    let (payload, audit_entry) = aws_dispatch(env, aws, server_name).await;
+    let mut resp = Envelope::new_response(&env.id, namespace, payload);
+    resp.shed = env.shed.clone(); // route the reply back (aws_handler.go: resp.Shed = req.Shed)
+    if let Err(e) = client.respond(namespace, &resp, shutdown).await {
+        client.log.warn(&format!("failed to send aws response: {e}"));
+    }
+    // Audit after responding (aws_handler.go order). Only get_credentials audits; ping/
+    // status/unknown/invalid leave `audit_entry` None.
+    if let Some(entry) = audit_entry {
+        audit.log(entry);
+    }
+}
+
+/// Compute the aws-credentials response payload + optional audit entry for one request,
+/// mirroring `aws_handler.go:handleMessage`'s op dispatch (the network-free core of
+/// [`handle_aws_bus_message`], so unit tests can inspect the payload + audit directly).
+async fn aws_dispatch(
+    env: &Envelope,
+    aws: &AwsHandlers,
+    server_name: &str,
+) -> (serde_json::Value, Option<AuditEntry>) {
+    let shed_name = env.shed.as_ref().map(|s| s.name.as_str()).unwrap_or("");
+    match parse_operation(&env.payload) {
+        Err(()) => (aws_error("invalid payload", AWS_CODE_INTERNAL), None),
+        Ok(op) => match op.as_str() {
+            "get_credentials" => {
+                handle_aws_get_credentials(server_name, shed_name, &aws.gate, &aws.backend).await
+            }
+            "ping" => (
+                to_payload(&AwsPingResponse {
+                    status: "ok".to_string(),
+                }),
+                None,
+            ),
+            "status" => (
+                handle_aws_status(server_name, shed_name, &aws.backend),
+                None,
+            ),
+            other => (
+                aws_error(&format!("unknown operation: {other}"), AWS_CODE_INTERNAL),
+                None,
+            ),
+        },
+    }
+}
+
+/// The gated `get_credentials` flow — a faithful port of
+/// `aws_handler.go:handleGetCredentials`. ORDER matches Go: approval gate FIRST
+/// (deny-all fails closed), THEN the backend vend. Returns the response payload + the
+/// audit entry (all three outcomes — deny/error/ok — audit; the parse-error paths in
+/// [`handle_aws_bus_message`] do not).
+async fn handle_aws_get_credentials(
+    server_name: &str,
+    shed_name: &str,
+    gate: &Arc<dyn ApprovalGate>,
+    backend: &Arc<dyn AwsBackend>,
+) -> (serde_json::Value, Option<AuditEntry>) {
+    let outcome = gate
+        .approve(
+            NS_AWS_CREDENTIALS,
+            AWS_OP_GET_CREDENTIALS,
+            server_name,
+            shed_name,
+            "AWS credentials request",
+        )
+        .await;
+    let approval = gate.method().to_string();
+    if !outcome.approved {
+        // Deny audit: result=denied, approval + decided_by/scope/ttl; NO detail, NO
+        // code, NO reason (aws_handler.go's deny path sets none of those).
+        let entry = aws_audit(server_name, shed_name, "denied", "", approval, &outcome);
+        return (
+            aws_error("approval denied", AWS_CODE_ASSUME_ROLE_FAILED),
+            Some(entry),
+        );
+    }
+
+    match backend.get_credentials(server_name, shed_name).await {
+        Err(e) => {
+            // Error audit: result=error, detail=err.Error(), approval + outcome; NO code.
+            let entry = aws_audit(server_name, shed_name, "error", &e, approval, &outcome);
+            (
+                aws_error("credential request failed", AWS_CODE_ASSUME_ROLE_FAILED),
+                Some(entry),
+            )
+        }
+        Ok(creds) => {
+            // expiration OMITTED when None (Go's zero time.Time → omitempty), else the
+            // literal-Z UTC render (Go's Format("2006-01-02T15:04:05Z")).
+            let resp = AwsCredentialsResponse {
+                access_key_id: creds.access_key_id,
+                secret_access_key: creds.secret_access_key,
+                session_token: creds.session_token,
+                expiration: creds.expiration.map(aws_literal_z),
+            };
+            let detail = aws_expiry_detail(creds.expiration);
+            let entry = aws_audit(server_name, shed_name, "ok", &detail, approval, &outcome);
+            (to_payload(&resp), Some(entry))
+        }
+    }
+}
+
+/// The `status` op — a faithful port of `aws_handler.go:handleStatus`:
+/// `{connected:true, role, cached_until?}`. NO audit (`backend.status` never errors;
+/// `cached_until` renders literal-Z when Some, else the field is omitted).
+fn handle_aws_status(
+    server_name: &str,
+    shed_name: &str,
+    backend: &Arc<dyn AwsBackend>,
+) -> serde_json::Value {
+    let (role, cached_until) = backend.status(server_name, shed_name);
+    to_payload(&AwsStatusResponse {
+        connected: true,
+        role,
+        cached_until: cached_until.map(aws_literal_z),
+    })
+}
+
 /// The credential namespaces (re-exported from `config` for callers wiring the
-/// bus). Only `ssh-agent` is subscribed in this slice.
+/// bus). `ssh-agent` is always subscribed; `aws-credentials` when configured;
+/// `docker-credentials` is a later slice.
 pub const BUS_NAMESPACES: [&str; 3] = [NS_SSH_AGENT, NS_AWS_CREDENTIALS, NS_DOCKER_CREDENTIALS];
 
 #[cfg(test)]
@@ -1364,6 +1670,7 @@ mod tests {
             audit,
             backend,
             server_name: String::new(),
+            aws: None,
         }
     }
 
@@ -2564,6 +2871,356 @@ mod tests {
         assert_eq!(
             BUS_NAMESPACES,
             ["ssh-agent", "aws-credentials", "docker-credentials"]
+        );
+    }
+
+    // ---- AWS credential handler (mirror aws_handler.go) --------------------------
+
+    use crate::aws_backend::CachedCreds;
+
+    /// A scripted AWS backend: `get_credentials` returns a canned Result (and counts
+    /// calls, to prove the gate short-circuits a deny); `status` returns a canned
+    /// `(role, expiry)`.
+    struct FakeAwsBackend {
+        creds: Result<CachedCreds, String>,
+        status: (String, Option<i64>),
+        calls: AtomicUsize,
+    }
+    impl FakeAwsBackend {
+        fn new(creds: Result<CachedCreds, String>, status: (String, Option<i64>)) -> Arc<Self> {
+            Arc::new(Self {
+                creds,
+                status,
+                calls: AtomicUsize::new(0),
+            })
+        }
+        fn creds_ok(creds: CachedCreds) -> Arc<Self> {
+            Self::new(Ok(creds), ("unused".into(), None))
+        }
+        fn creds_err(msg: &str) -> Arc<Self> {
+            Self::new(Err(msg.to_string()), ("unused".into(), None))
+        }
+        fn with_status(role: &str, until: Option<i64>) -> Arc<Self> {
+            Self::new(Err("unused".into()), (role.to_string(), until))
+        }
+    }
+    #[async_trait::async_trait]
+    impl AwsBackend for FakeAwsBackend {
+        async fn get_credentials(&self, _server: &str, _shed: &str) -> Result<CachedCreds, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.creds.clone()
+        }
+        fn status(&self, _server: &str, _shed: &str) -> (String, Option<i64>) {
+            self.status.clone()
+        }
+    }
+
+    fn creds(exp: Option<i64>) -> CachedCreds {
+        CachedCreds {
+            access_key_id: "ASIATESTKEY".into(),
+            secret_access_key: "SECRETKEY".into(),
+            session_token: "SESSIONTOKEN".into(),
+            expiration: exp,
+        }
+    }
+
+    fn aws_handlers(backend: Arc<dyn AwsBackend>, gate: Arc<dyn ApprovalGate>) -> AwsHandlers {
+        AwsHandlers { backend, gate }
+    }
+
+    /// Build an aws-credentials request Envelope carrying `payload` + a fixed shed.
+    fn aws_env(payload: serde_json::Value) -> Envelope {
+        Envelope {
+            id: "aws-req".into(),
+            namespace: "aws-credentials".into(),
+            msg_type: "request".into(),
+            in_reply_to: String::new(),
+            is_final: true,
+            timestamp: "t".into(),
+            payload: Some(payload),
+            shed: Some(ShedInfo {
+                name: "web".into(),
+                backend: "vz".into(),
+                server: "mini2".into(),
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn aws_get_credentials_ok() {
+        // 4071049445 == 2099-01-02T15:04:05Z.
+        let backend: Arc<dyn AwsBackend> = FakeAwsBackend::creds_ok(creds(Some(4071049445)));
+        // Single-server mode: server_name is empty (matches Go's h.server).
+        let (payload, entry) =
+            handle_aws_get_credentials("", "web", &approve_gate(), &backend).await;
+        assert_eq!(payload["access_key_id"], "ASIATESTKEY");
+        assert_eq!(payload["secret_access_key"], "SECRETKEY");
+        assert_eq!(payload["session_token"], "SESSIONTOKEN");
+        assert_eq!(payload["expiration"], "2099-01-02T15:04:05Z");
+        // ok audit: ns/op fixed, detail = awsExpiryDetail, approval, empty outcome.
+        let entry = entry.expect("ok path audits");
+        assert_eq!(entry.ns, "aws-credentials");
+        assert_eq!(entry.op, "get_credentials");
+        assert_eq!(entry.result, "ok");
+        assert_eq!(entry.detail, "expires:15:04");
+        assert_eq!(entry.approval, "approve-all");
+        assert_eq!(entry.shed, "web");
+        assert_eq!(entry.server, "");
+        // aws_handler.go sets NO code/reason on ANY get_credentials audit.
+        assert_eq!(entry.code, "");
+        assert_eq!(entry.reason, "");
+    }
+
+    #[tokio::test]
+    async fn aws_expiration_omitted_when_zero() {
+        // No expiry hint → the expiration key is ABSENT (Go omitempty), audit expires:none.
+        let backend: Arc<dyn AwsBackend> = FakeAwsBackend::creds_ok(creds(None));
+        let (payload, entry) =
+            handle_aws_get_credentials("", "web", &approve_gate(), &backend).await;
+        assert!(
+            payload.get("expiration").is_none(),
+            "expiration key must be absent for a None expiry, got {payload}"
+        );
+        assert_eq!(payload["access_key_id"], "ASIATESTKEY");
+        assert_eq!(entry.expect("ok path audits").detail, "expires:none");
+    }
+
+    #[test]
+    fn aws_expiry_detail_format() {
+        // The handler's audit detail helper (aws_backend::aws_expiry_detail): none / HH:MM.
+        assert_eq!(aws_expiry_detail(None), "expires:none");
+        assert_eq!(aws_expiry_detail(Some(4071049445)), "expires:15:04");
+    }
+
+    #[tokio::test]
+    async fn aws_ping() {
+        // ping → {"status":"ok"}, no audit.
+        let aws = aws_handlers(FakeAwsBackend::creds_err("unused"), approve_gate());
+        let (payload, entry) = aws_dispatch(&aws_env(serde_json::json!({"operation":"ping"})), &aws, "").await;
+        assert_eq!(payload, serde_json::json!({"status": "ok"}));
+        assert!(entry.is_none(), "ping does not audit");
+    }
+
+    #[tokio::test]
+    async fn aws_backend_error_maps_assume_role_failed() {
+        let backend: Arc<dyn AwsBackend> =
+            FakeAwsBackend::creds_err("sts:AssumeRole failed for arn:aws:iam::9:role/x: boom");
+        let (payload, entry) =
+            handle_aws_get_credentials("srv", "web", &approve_gate(), &backend).await;
+        // The guest gets the generic mapping; ASSUME_ROLE_FAILED is get_credentials-scoped.
+        assert_eq!(payload["error"], "credential request failed");
+        assert_eq!(payload["code"], "ASSUME_ROLE_FAILED");
+        // error audit: result=error, detail=raw backend error, approval; NO code.
+        let entry = entry.expect("error path audits");
+        assert_eq!(entry.result, "error");
+        assert_eq!(
+            entry.detail,
+            "sts:AssumeRole failed for arn:aws:iam::9:role/x: boom"
+        );
+        assert_eq!(entry.approval, "approve-all");
+        assert_eq!(entry.code, "");
+        assert_eq!(entry.reason, "");
+    }
+
+    #[tokio::test]
+    async fn aws_status_role_and_cached_until() {
+        // Some(expiry) → cached_until rendered literal-Z; status never audits.
+        let aws = aws_handlers(
+            FakeAwsBackend::with_status("passthrough:shed-test", Some(4071049445)),
+            approve_gate(),
+        );
+        let (payload, entry) =
+            aws_dispatch(&aws_env(serde_json::json!({"operation":"status"})), &aws, "").await;
+        assert_eq!(
+            payload,
+            serde_json::json!({"connected": true, "role": "passthrough:shed-test", "cached_until": "2099-01-02T15:04:05Z"})
+        );
+        assert!(entry.is_none(), "status does not audit");
+        // None → cached_until omitted (Go covers only the nil case; Rust covers both).
+        let aws = aws_handlers(
+            FakeAwsBackend::with_status("arn:aws:iam::9:role/x", None),
+            approve_gate(),
+        );
+        let (payload, _) =
+            aws_dispatch(&aws_env(serde_json::json!({"operation":"status"})), &aws, "").await;
+        assert_eq!(
+            payload,
+            serde_json::json!({"connected": true, "role": "arn:aws:iam::9:role/x"})
+        );
+        assert!(payload.get("cached_until").is_none());
+    }
+
+    #[tokio::test]
+    async fn aws_denied_by_gate() {
+        // A deny-all gate rejects before the backend is hit; the denied audit carries NO
+        // detail/code/reason and the empty deny-all outcome.
+        let backend = FakeAwsBackend::creds_ok(creds(Some(4071049445)));
+        let dyn_backend: Arc<dyn AwsBackend> = backend.clone();
+        let (payload, entry) =
+            handle_aws_get_credentials("srv", "web", &deny_gate(), &dyn_backend).await;
+        assert_eq!(payload["error"], "approval denied");
+        assert_eq!(payload["code"], "ASSUME_ROLE_FAILED");
+        let entry = entry.expect("deny path audits");
+        assert_eq!(entry.result, "denied");
+        assert_eq!(entry.approval, "deny-all");
+        assert_eq!(entry.detail, "");
+        assert_eq!(entry.code, "");
+        assert_eq!(entry.reason, "");
+        assert_eq!(entry.decided_by, ""); // deny-all's empty outcome
+        assert_eq!(
+            backend.calls.load(Ordering::SeqCst),
+            0,
+            "backend must not be consulted when the gate denies"
+        );
+    }
+
+    #[tokio::test]
+    async fn aws_unknown_op_exact_string() {
+        let aws = aws_handlers(FakeAwsBackend::creds_err("unused"), approve_gate());
+        let (payload, entry) =
+            aws_dispatch(&aws_env(serde_json::json!({"operation": "delete"})), &aws, "").await;
+        assert_eq!(payload["error"], "unknown operation: delete");
+        assert_eq!(payload["code"], "INTERNAL_ERROR");
+        assert!(entry.is_none());
+    }
+
+    #[tokio::test]
+    async fn aws_invalid_payload_internal_error() {
+        // A non-object payload → {invalid payload, INTERNAL_ERROR} (AWS code, shared parse).
+        let aws = aws_handlers(FakeAwsBackend::creds_err("unused"), approve_gate());
+        let (payload, entry) = aws_dispatch(&aws_env(serde_json::json!([1, 2, 3])), &aws, "").await;
+        assert_eq!(payload["error"], "invalid payload");
+        assert_eq!(payload["code"], "INTERNAL_ERROR");
+        assert!(entry.is_none());
+    }
+
+    #[tokio::test]
+    async fn aws_uses_aws_gate_not_ssh() {
+        // One BusHandlers: ssh gate = deny-all, aws gate = approve-all. Routed through the
+        // real dispatcher ([`dispatch_bus_message`]) + the wire, an aws get_credentials is
+        // APPROVED (uses aws.gate → the mock only matches a vended-key body) while an ssh
+        // sign is DENIED (uses the ssh gate → the mock only matches an "approval denied"
+        // body). Each mock's `.assert()` fails if the wrong gate was consulted, proving
+        // per-namespace gate selection (F6).
+        let handlers = BusHandlers {
+            gate: deny_gate(),                                  // ssh gate: deny-all
+            audit: noop_audit(),
+            backend: empty_backend(),
+            server_name: String::new(),
+            aws: Some(AwsHandlers {
+                backend: FakeAwsBackend::creds_ok(creds(None)), // aws gate: approve-all
+                gate: approve_gate(),
+            }),
+        };
+
+        // aws-credentials → the approve-all aws gate vends the key (never "approval denied").
+        let server = MockServer::start_async().await;
+        let aws_ok = server
+            .mock_async(|w, t| {
+                w.method(POST)
+                    .path("/api/plugins/listeners/aws-credentials/respond")
+                    .matches(|req| {
+                        let body = req
+                            .body
+                            .as_ref()
+                            .map(|b| String::from_utf8_lossy(b).to_string())
+                            .unwrap_or_default();
+                        body.contains("ASIATESTKEY") && !body.contains("approval denied")
+                    });
+                t.status(204);
+            })
+            .await;
+        let client = open_client(&server.base_url());
+        dispatch_bus_message(
+            &client,
+            "aws-credentials",
+            &aws_env(serde_json::json!({"operation": "get_credentials"})),
+            &never_shutdown(),
+            &handlers,
+        )
+        .await;
+        aws_ok.assert_async().await;
+
+        // ssh-agent → the deny-all ssh gate rejects the sign (never a signature response).
+        let ssh_server = MockServer::start_async().await;
+        let ssh_denied = ssh_server
+            .mock_async(|w, t| {
+                w.method(POST)
+                    .path("/api/plugins/listeners/ssh-agent/respond")
+                    .matches(|req| {
+                        let body = req
+                            .body
+                            .as_ref()
+                            .map(|b| String::from_utf8_lossy(b).to_string())
+                            .unwrap_or_default();
+                        body.contains("approval denied") && body.contains("SIGN_FAILED")
+                    });
+                t.status(204);
+            })
+            .await;
+        let ssh_client = open_client(&ssh_server.base_url());
+        dispatch_bus_message(
+            &ssh_client,
+            "ssh-agent",
+            &sign_env(&b64(&fixed_ed25519_pub()), &b64(b"data"), 0),
+            &never_shutdown(),
+            &handlers,
+        )
+        .await;
+        ssh_denied.assert_async().await;
+    }
+
+    #[test]
+    fn aws_payload_tag_names_match_protocol() {
+        // Golden-consistency: the serde tag names equal the Go json tags in aws.go.
+        assert_eq!(
+            serde_json::to_value(AwsCredentialsResponse {
+                access_key_id: "a".into(),
+                secret_access_key: "b".into(),
+                session_token: "c".into(),
+                expiration: Some("2099-01-02T15:04:05Z".into()),
+            })
+            .unwrap(),
+            serde_json::json!({"access_key_id":"a","secret_access_key":"b","session_token":"c","expiration":"2099-01-02T15:04:05Z"})
+        );
+        assert_eq!(
+            serde_json::to_value(AwsCredentialsResponse {
+                access_key_id: "a".into(),
+                secret_access_key: "b".into(),
+                session_token: "c".into(),
+                expiration: None,
+            })
+            .unwrap(),
+            serde_json::json!({"access_key_id":"a","secret_access_key":"b","session_token":"c"})
+        );
+        assert_eq!(
+            serde_json::to_value(AwsStatusResponse {
+                connected: true,
+                role: "passthrough:p".into(),
+                cached_until: Some("2099-01-02T15:04:05Z".into()),
+            })
+            .unwrap(),
+            serde_json::json!({"connected":true,"role":"passthrough:p","cached_until":"2099-01-02T15:04:05Z"})
+        );
+        assert_eq!(
+            serde_json::to_value(AwsStatusResponse {
+                connected: true,
+                role: "passthrough:p".into(),
+                cached_until: None,
+            })
+            .unwrap(),
+            serde_json::json!({"connected":true,"role":"passthrough:p"})
+        );
+        assert_eq!(
+            serde_json::to_value(AwsPingResponse {
+                status: "ok".into()
+            })
+            .unwrap(),
+            serde_json::json!({"status":"ok"})
+        );
+        assert_eq!(
+            aws_error("boom", "INTERNAL_ERROR"),
+            serde_json::json!({"error":"boom","code":"INTERNAL_ERROR"})
         );
     }
 }

--- a/crates/shed-host-agent/src/config.rs
+++ b/crates/shed-host-agent/src/config.rs
@@ -8,6 +8,7 @@
 //! indentation-aware nested-map/scalar reader (`yaml_lite`) rather than a YAML
 //! crate dependency — the repo intentionally avoids serde_yaml/serde_norway.
 
+use std::collections::BTreeMap;
 use std::io;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -158,6 +159,14 @@ pub struct HostAgentConfig {
     /// started — mirroring Go's `cfg.Discovery != nil` gate in `main.go`. This
     /// minimal reader does not yet parse the discovery contents, only its presence.
     pub has_discovery: bool,
+    /// The layered AWS credential policy (`aws.{source_profile,default_role,mode,
+    /// session_duration,cache_refresh_before,servers…}`), mirroring Go's `AWSConfig`.
+    /// The `aws.approval.policy` gate is kept in `aws_policy` above (unchanged); this
+    /// field carries only the resolution/vending knobs. Consumed by the AWS backend
+    /// (commit 2) + the in-crate golden/unit tests; unused by production code in this
+    /// slice, hence the `dead_code` allow.
+    #[allow(dead_code)]
+    pub aws: AwsConfig,
 }
 
 impl HostAgentConfig {
@@ -213,6 +222,7 @@ impl HostAgentConfig {
             ),
             server,
             has_discovery: root.has_key("discovery"),
+            aws: AwsConfig::from_node(&root),
         }
     }
 
@@ -264,6 +274,207 @@ impl HostAgentConfig {
             .filter(|ns| self.effective_policy(ns) == POLICY_SHED_DESKTOP)
             .map(str::to_string)
             .collect()
+    }
+}
+
+/// AWS credential vending modes (mirror Go's `AWSMode*` in `config.go`). `mode`
+/// selects how the agent obtains the creds it vends for a shed: `assume-role`
+/// (default) does `sts:AssumeRole` from the source profile into the resolved role;
+/// `passthrough` vends the source profile's existing session credentials directly
+/// (SSO/SAML setups with no assumable role). An empty mode means assume-role.
+pub const AWS_MODE_ASSUME_ROLE: &str = "assume-role";
+pub const AWS_MODE_PASSTHROUGH: &str = "passthrough";
+
+/// `normalize_aws_mode` maps an empty mode to the assume-role default (Go's
+/// `normalizeAWSMode`).
+fn normalize_aws_mode(mode: &str) -> &str {
+    if mode.is_empty() {
+        AWS_MODE_ASSUME_ROLE
+    } else {
+        mode
+    }
+}
+
+/// The layered AWS config (`aws.*`), a faithful port of Go's `AWSConfig`. The
+/// top-level fields are the defaults; `servers` carries per-server (and per-shed)
+/// overrides layered over them. `source_profile` and `cache_refresh_before` are
+/// process-global and are not overridable per server. The `aws.approval.policy`
+/// gate lives on `HostAgentConfig.aws_policy`, not here.
+///
+/// Consumed by the AWS backend (commit 2) + the in-crate golden/unit tests; unused
+/// by production code in this slice, hence the `dead_code` allows.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct AwsConfig {
+    pub source_profile: String,
+    pub default_role: String,
+    /// `""` (= assume-role) | `assume-role` | `passthrough`.
+    pub mode: String,
+    pub session_duration: String,
+    pub cache_refresh_before: String,
+    pub servers: BTreeMap<String, AwsServerConfig>,
+}
+
+/// Per-server AWS overrides (Go's `AWSServerConfig`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct AwsServerConfig {
+    pub default_role: String,
+    pub mode: String,
+    pub session_duration: String,
+    pub sheds: BTreeMap<String, AwsShedConfig>,
+}
+
+/// Per-shed AWS overrides (Go's `ShedAWSConfig`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct AwsShedConfig {
+    pub role: String,
+    pub mode: String,
+    pub session_duration: String,
+}
+
+/// The effective AWS policy for a single `(server, shed)` pair (Go's `ResolvedAWS`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct ResolvedAws {
+    /// Assumed-role ARN (`""` => no role configured).
+    pub role: String,
+    /// `AWS_MODE_ASSUME_ROLE` | `AWS_MODE_PASSTHROUGH` (never `""`).
+    pub mode: String,
+    /// `""` => fall back to the backend default.
+    pub session_duration: String,
+}
+
+#[allow(dead_code)]
+impl AwsConfig {
+    /// Build the AWS slice from the parsed config tree, applying the same load
+    /// defaults Go's `DefaultConfig`/`LoadConfig` do (`config.go:439-443`): an
+    /// empty/absent `source_profile` → `"default"`, `session_duration` → `"1h"`,
+    /// `cache_refresh_before` → `"5m"`. These are applied whether or not an `aws:`
+    /// block is present, matching Go (the defaults sit on `DefaultConfig` and the
+    /// YAML merge only overwrites keys it names).
+    ///
+    /// `aws.sheds` (Go's removed global per-shed map) is intentionally NOT read: it
+    /// is parse-and-ignore for resolution. Go's `AWSConfig.validate` rejects it with
+    /// a migration message; that rejection is sub-plan 5.
+    fn from_node(root: &yaml_lite::Node) -> AwsConfig {
+        use yaml_lite::Node;
+        let aws = root.as_map().and_then(|m| m.get("aws")).and_then(Node::as_map);
+        let scalar = |key: &str| -> String {
+            aws.and_then(|m| m.get(key))
+                .and_then(Node::as_scalar)
+                .unwrap_or("")
+                .to_string()
+        };
+        let default_if_empty = |v: String, d: &str| if v.is_empty() { d.to_string() } else { v };
+
+        let mut servers = BTreeMap::new();
+        if let Some(servers_map) = aws.and_then(|m| m.get("servers")).and_then(Node::as_map) {
+            for (name, entry) in servers_map {
+                let Some(fields) = entry.as_map() else { continue };
+                let sfield = |k: &str| {
+                    fields
+                        .get(k)
+                        .and_then(Node::as_scalar)
+                        .unwrap_or("")
+                        .to_string()
+                };
+                let mut sheds = BTreeMap::new();
+                if let Some(sheds_map) = fields.get("sheds").and_then(Node::as_map) {
+                    for (sname, sentry) in sheds_map {
+                        let Some(sf) = sentry.as_map() else { continue };
+                        let g = |k: &str| sf.get(k).and_then(Node::as_scalar).unwrap_or("").to_string();
+                        sheds.insert(
+                            sname.clone(),
+                            AwsShedConfig {
+                                role: g("role"),
+                                mode: g("mode"),
+                                session_duration: g("session_duration"),
+                            },
+                        );
+                    }
+                }
+                servers.insert(
+                    name.clone(),
+                    AwsServerConfig {
+                        default_role: sfield("default_role"),
+                        mode: sfield("mode"),
+                        session_duration: sfield("session_duration"),
+                        sheds,
+                    },
+                );
+            }
+        }
+
+        AwsConfig {
+            source_profile: default_if_empty(scalar("source_profile"), "default"),
+            default_role: scalar("default_role"),
+            mode: scalar("mode"),
+            session_duration: default_if_empty(scalar("session_duration"), "1h"),
+            cache_refresh_before: default_if_empty(scalar("cache_refresh_before"), "5m"),
+            servers,
+        }
+    }
+
+    /// Layer AWS overrides for a `(server, shed)` pair, most specific wins:
+    /// top-level defaults → `servers[server]` → `servers[server].sheds[shed]`. Role,
+    /// mode, and session_duration each layer independently; an empty mode means "no
+    /// override" while layering and is normalized to `AWS_MODE_ASSUME_ROLE` at the
+    /// end (so a child that only sets a role under a passthrough parent stays
+    /// passthrough). A faithful port of Go's `AWSConfig.Resolve` (config.go:317-343).
+    pub fn resolve(&self, server: &str, shed: &str) -> ResolvedAws {
+        let mut role = self.default_role.clone();
+        let mut mode = self.mode.clone();
+        let mut session_duration = self.session_duration.clone();
+        if let Some(sv) = self.servers.get(server) {
+            if !sv.default_role.is_empty() {
+                role = sv.default_role.clone();
+            }
+            if !sv.mode.is_empty() {
+                mode = sv.mode.clone();
+            }
+            if !sv.session_duration.is_empty() {
+                session_duration = sv.session_duration.clone();
+            }
+            if let Some(sc) = sv.sheds.get(shed) {
+                if !sc.role.is_empty() {
+                    role = sc.role.clone();
+                }
+                if !sc.mode.is_empty() {
+                    mode = sc.mode.clone();
+                }
+                if !sc.session_duration.is_empty() {
+                    session_duration = sc.session_duration.clone();
+                }
+            }
+        }
+        ResolvedAws {
+            role,
+            mode: normalize_aws_mode(&mode).to_string(),
+            session_duration,
+        }
+    }
+
+    /// Report whether the AWS handler should start at all: true if any resolution
+    /// path selects passthrough mode or configures a non-empty role. An explicit
+    /// assume-role with no role anywhere is "AWS off" (false). A faithful port of
+    /// Go's `AWSConfig.Enabled` (config.go:356-371).
+    pub fn enabled(&self) -> bool {
+        if self.mode == AWS_MODE_PASSTHROUGH || !self.default_role.is_empty() {
+            return true;
+        }
+        for sv in self.servers.values() {
+            if sv.mode == AWS_MODE_PASSTHROUGH || !sv.default_role.is_empty() {
+                return true;
+            }
+            for s in sv.sheds.values() {
+                if s.mode == AWS_MODE_PASSTHROUGH || !s.role.is_empty() {
+                    return true;
+                }
+            }
+        }
+        false
     }
 }
 
@@ -580,5 +791,415 @@ discovery:
             expand_tilde("~/x/y"),
             home.join("x/y").to_string_lossy().into_owned()
         );
+    }
+
+    // ---- AWS config slice (mirror aws_backend_test.go / config_test.go) ----------
+
+    fn sheds(entries: &[(&str, AwsShedConfig)]) -> BTreeMap<String, AwsShedConfig> {
+        entries
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    fn servers(entries: &[(&str, AwsServerConfig)]) -> BTreeMap<String, AwsServerConfig> {
+        entries
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    fn shed_role(role: &str) -> AwsShedConfig {
+        AwsShedConfig {
+            role: role.to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// Mirrors `aws_backend_test.go:TestAWSResolve` — layering matrix, role + mode
+    /// only (session_duration layering is exercised by the golden).
+    #[test]
+    fn aws_resolve_matrix() {
+        struct Case {
+            name: &'static str,
+            cfg: AwsConfig,
+            server: &'static str,
+            shed: &'static str,
+            want_role: &'static str,
+            want_mode: &'static str,
+        }
+        let cases = vec![
+            Case {
+                name: "default role",
+                cfg: AwsConfig {
+                    default_role: "arn:aws:iam::123:role/default".into(),
+                    ..Default::default()
+                },
+                server: "mini2",
+                shed: "my-shed",
+                want_role: "arn:aws:iam::123:role/default",
+                want_mode: AWS_MODE_ASSUME_ROLE,
+            },
+            Case {
+                name: "per-server override",
+                cfg: AwsConfig {
+                    default_role: "arn:aws:iam::123:role/default".into(),
+                    servers: servers(&[(
+                        "mini2",
+                        AwsServerConfig {
+                            default_role: "arn:aws:iam::123:role/mini2".into(),
+                            ..Default::default()
+                        },
+                    )]),
+                    ..Default::default()
+                },
+                server: "mini2",
+                shed: "my-shed",
+                want_role: "arn:aws:iam::123:role/mini2",
+                want_mode: AWS_MODE_ASSUME_ROLE,
+            },
+            Case {
+                name: "per-server-per-shed override wins",
+                cfg: AwsConfig {
+                    default_role: "arn:aws:iam::123:role/default".into(),
+                    servers: servers(&[(
+                        "mini2",
+                        AwsServerConfig {
+                            default_role: "arn:aws:iam::123:role/mini2".into(),
+                            sheds: sheds(&[("web", shed_role("arn:aws:iam::123:role/web"))]),
+                            ..Default::default()
+                        },
+                    )]),
+                    ..Default::default()
+                },
+                server: "mini2",
+                shed: "web",
+                want_role: "arn:aws:iam::123:role/web",
+                want_mode: AWS_MODE_ASSUME_ROLE,
+            },
+            Case {
+                name: "same shed name on different server is isolated",
+                cfg: AwsConfig {
+                    default_role: "arn:aws:iam::123:role/default".into(),
+                    servers: servers(&[(
+                        "mini2",
+                        AwsServerConfig {
+                            sheds: sheds(&[("web", shed_role("arn:aws:iam::123:role/mini2-web"))]),
+                            ..Default::default()
+                        },
+                    )]),
+                    ..Default::default()
+                },
+                server: "mini3",
+                shed: "web",
+                want_role: "arn:aws:iam::123:role/default",
+                want_mode: AWS_MODE_ASSUME_ROLE,
+            },
+            Case {
+                name: "no config normalizes to assume-role",
+                cfg: AwsConfig::default(),
+                server: "mini2",
+                shed: "my-shed",
+                want_role: "",
+                want_mode: AWS_MODE_ASSUME_ROLE,
+            },
+            Case {
+                name: "top-level passthrough",
+                cfg: AwsConfig {
+                    mode: AWS_MODE_PASSTHROUGH.into(),
+                    ..Default::default()
+                },
+                server: "mini2",
+                shed: "my-shed",
+                want_role: "",
+                want_mode: AWS_MODE_PASSTHROUGH,
+            },
+            Case {
+                name: "server-level passthrough ignores role",
+                cfg: AwsConfig {
+                    default_role: "arn:aws:iam::123:role/default".into(),
+                    servers: servers(&[(
+                        "mini2",
+                        AwsServerConfig {
+                            mode: AWS_MODE_PASSTHROUGH.into(),
+                            ..Default::default()
+                        },
+                    )]),
+                    ..Default::default()
+                },
+                server: "mini2",
+                shed: "web",
+                want_role: "arn:aws:iam::123:role/default",
+                want_mode: AWS_MODE_PASSTHROUGH,
+            },
+            Case {
+                name: "child role under passthrough parent stays passthrough",
+                cfg: AwsConfig {
+                    servers: servers(&[(
+                        "mini2",
+                        AwsServerConfig {
+                            mode: AWS_MODE_PASSTHROUGH.into(),
+                            sheds: sheds(&[("web", shed_role("arn:aws:iam::123:role/web"))]),
+                            ..Default::default()
+                        },
+                    )]),
+                    ..Default::default()
+                },
+                server: "mini2",
+                shed: "web",
+                want_role: "arn:aws:iam::123:role/web",
+                want_mode: AWS_MODE_PASSTHROUGH,
+            },
+            Case {
+                name: "child assume-role overrides passthrough parent",
+                cfg: AwsConfig {
+                    mode: AWS_MODE_PASSTHROUGH.into(),
+                    servers: servers(&[(
+                        "mini2",
+                        AwsServerConfig {
+                            sheds: sheds(&[(
+                                "scoped",
+                                AwsShedConfig {
+                                    mode: AWS_MODE_ASSUME_ROLE.into(),
+                                    role: "arn:aws:iam::123:role/scoped".into(),
+                                    ..Default::default()
+                                },
+                            )]),
+                            ..Default::default()
+                        },
+                    )]),
+                    ..Default::default()
+                },
+                server: "mini2",
+                shed: "scoped",
+                want_role: "arn:aws:iam::123:role/scoped",
+                want_mode: AWS_MODE_ASSUME_ROLE,
+            },
+        ];
+        for c in cases {
+            let got = c.cfg.resolve(c.server, c.shed);
+            assert_eq!(got.role, c.want_role, "{}: role", c.name);
+            assert_eq!(got.mode, c.want_mode, "{}: mode", c.name);
+        }
+    }
+
+    /// Mirrors `aws_backend_test.go:TestAWSEnabled`.
+    #[test]
+    fn aws_enabled_matrix() {
+        let cases: Vec<(&str, AwsConfig, bool)> = vec![
+            ("empty", AwsConfig::default(), false),
+            (
+                "explicit assume-role, no role",
+                AwsConfig {
+                    mode: AWS_MODE_ASSUME_ROLE.into(),
+                    ..Default::default()
+                },
+                false,
+            ),
+            (
+                "default role",
+                AwsConfig {
+                    default_role: "x".into(),
+                    ..Default::default()
+                },
+                true,
+            ),
+            (
+                "top-level passthrough",
+                AwsConfig {
+                    mode: AWS_MODE_PASSTHROUGH.into(),
+                    ..Default::default()
+                },
+                true,
+            ),
+            (
+                "server default role",
+                AwsConfig {
+                    servers: servers(&[(
+                        "m",
+                        AwsServerConfig {
+                            default_role: "x".into(),
+                            ..Default::default()
+                        },
+                    )]),
+                    ..Default::default()
+                },
+                true,
+            ),
+            (
+                "server passthrough",
+                AwsConfig {
+                    servers: servers(&[(
+                        "m",
+                        AwsServerConfig {
+                            mode: AWS_MODE_PASSTHROUGH.into(),
+                            ..Default::default()
+                        },
+                    )]),
+                    ..Default::default()
+                },
+                true,
+            ),
+            (
+                "shed role",
+                AwsConfig {
+                    servers: servers(&[(
+                        "m",
+                        AwsServerConfig {
+                            sheds: sheds(&[("s", shed_role("x"))]),
+                            ..Default::default()
+                        },
+                    )]),
+                    ..Default::default()
+                },
+                true,
+            ),
+            (
+                "shed passthrough",
+                AwsConfig {
+                    servers: servers(&[(
+                        "m",
+                        AwsServerConfig {
+                            sheds: sheds(&[(
+                                "s",
+                                AwsShedConfig {
+                                    mode: AWS_MODE_PASSTHROUGH.into(),
+                                    ..Default::default()
+                                },
+                            )]),
+                            ..Default::default()
+                        },
+                    )]),
+                    ..Default::default()
+                },
+                true,
+            ),
+        ];
+        for (name, cfg, want) in cases {
+            assert_eq!(cfg.enabled(), want, "{name}");
+        }
+    }
+
+    /// Mirrors `aws_backend_test.go:TestMixedModeResolve`.
+    #[test]
+    fn aws_mixed_mode_resolve() {
+        let cfg = AwsConfig {
+            default_role: "arn:aws:iam::111:role/dev".into(),
+            servers: servers(&[(
+                "mini2",
+                AwsServerConfig {
+                    sheds: sheds(&[
+                        (
+                            "sso-app",
+                            AwsShedConfig {
+                                mode: AWS_MODE_PASSTHROUGH.into(),
+                                ..Default::default()
+                            },
+                        ),
+                        ("scoped-app", shed_role("arn:aws:iam::111:role/scoped")),
+                    ]),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        };
+        assert_eq!(cfg.resolve("mini2", "sso-app").mode, AWS_MODE_PASSTHROUGH);
+        let scoped = cfg.resolve("mini2", "scoped-app");
+        assert_eq!(scoped.mode, AWS_MODE_ASSUME_ROLE);
+        assert_eq!(scoped.role, "arn:aws:iam::111:role/scoped");
+    }
+
+    /// Mirrors the parse halves of `config_test.go:TestLoadConfigAWS` +
+    /// `TestLoadConfigDefaults` (Validate parity is sub-plan 5).
+    #[test]
+    fn aws_load_and_defaults() {
+        // TestLoadConfigAWS: explicit values + nested per-shed overrides parse.
+        let cfg = HostAgentConfig::parse(
+            "\
+server: http://localhost:8080
+aws:
+  source_profile: staging
+  default_role: arn:aws:iam::123456789012:role/dev
+  session_duration: 2h
+  cache_refresh_before: 10m
+  approval:
+    policy: approve-all
+  servers:
+    mini2:
+      sheds:
+        sso-app:
+          mode: passthrough
+        my-service:
+          role: arn:aws:iam::123456789012:role/my-service
+",
+        );
+        let aws = &cfg.aws;
+        assert_eq!(aws.source_profile, "staging");
+        assert_eq!(aws.default_role, "arn:aws:iam::123456789012:role/dev");
+        assert_eq!(aws.session_duration, "2h");
+        assert_eq!(aws.cache_refresh_before, "10m");
+        // The aws.approval.policy gate still resolves via the existing accessor.
+        assert_eq!(cfg.effective_policy(NS_AWS_CREDENTIALS), "approve-all");
+        let sheds = &aws.servers["mini2"].sheds;
+        assert_eq!(sheds["sso-app"].mode, AWS_MODE_PASSTHROUGH);
+        assert_eq!(sheds["my-service"].role, "arn:aws:iam::123456789012:role/my-service");
+
+        // TestLoadConfigDefaults: with no aws block the load defaults apply.
+        let defaults = HostAgentConfig::parse("server: http://localhost:8080\n");
+        assert_eq!(defaults.aws.source_profile, "default");
+        assert_eq!(defaults.aws.session_duration, "1h");
+        assert_eq!(defaults.aws.cache_refresh_before, "5m");
+    }
+
+    /// The Rust half of the `aws_resolve` golden — reads the SAME shared fixture the
+    /// Go runner reads (`cmd/shed-host-agent/golden_test.go:TestGoldenAWSResolve`),
+    /// so the two impls can't drift together on the layering / defaults / enabled
+    /// semantics. Lives in-crate (the `load_discovered_servers` precedent) because
+    /// this is a binary crate with no lib.
+    #[test]
+    fn golden_aws_resolve() {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/host-agent-diff/fixtures/aws_resolve.json");
+        let raw = std::fs::read_to_string(&path).expect("read golden fixture");
+        let fx: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(fx["protocol_version"], 1, "version skew");
+        let vectors = fx["vectors"].as_array().unwrap();
+        assert!(!vectors.is_empty(), "fixture has no vectors");
+        for v in vectors {
+            let name = v["name"].as_str().unwrap();
+            let cfg = HostAgentConfig::parse(v["config_yaml"].as_str().unwrap());
+            let aws = &cfg.aws;
+            assert_eq!(
+                aws.enabled(),
+                v["enabled"].as_bool().unwrap(),
+                "enabled {name:?}"
+            );
+            let d = &v["defaults"];
+            assert_eq!(
+                aws.source_profile,
+                d["source_profile"].as_str().unwrap(),
+                "source_profile {name:?}"
+            );
+            assert_eq!(
+                aws.session_duration,
+                d["session_duration"].as_str().unwrap(),
+                "session_duration {name:?}"
+            );
+            assert_eq!(
+                aws.cache_refresh_before,
+                d["cache_refresh_before"].as_str().unwrap(),
+                "cache_refresh_before {name:?}"
+            );
+            for q in v["queries"].as_array().unwrap() {
+                let r = aws.resolve(q["server"].as_str().unwrap(), q["shed"].as_str().unwrap());
+                assert_eq!(r.role, q["role"].as_str().unwrap(), "role {name:?}");
+                assert_eq!(r.mode, q["mode"].as_str().unwrap(), "mode {name:?}");
+                assert_eq!(
+                    r.session_duration,
+                    q["session_duration"].as_str().unwrap(),
+                    "session_duration {name:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/shed-host-agent/src/config.rs
+++ b/crates/shed-host-agent/src/config.rs
@@ -82,7 +82,10 @@ fn parse_approval_timeout(raw: &str) -> Duration {
 /// malformed string (unknown unit, missing number, etc.). A faithful subset — the
 /// caller only needs positivity + magnitude, so the signed result lets it detect a
 /// non-positive value and fall back to the default.
-fn parse_go_duration_nanos(s: &str) -> Option<i128> {
+///
+/// `pub(crate)` so `aws_backend`'s `parse_duration_or` (the AWS session-duration /
+/// cache-refresh knobs) reuses the same Go-`time.ParseDuration` subset.
+pub(crate) fn parse_go_duration_nanos(s: &str) -> Option<i128> {
     let s = s.trim();
     if s.is_empty() {
         return None;
@@ -163,9 +166,7 @@ pub struct HostAgentConfig {
     /// session_duration,cache_refresh_before,servers…}`), mirroring Go's `AWSConfig`.
     /// The `aws.approval.policy` gate is kept in `aws_policy` above (unchanged); this
     /// field carries only the resolution/vending knobs. Consumed by the AWS backend
-    /// (commit 2) + the in-crate golden/unit tests; unused by production code in this
-    /// slice, hence the `dead_code` allow.
-    #[allow(dead_code)]
+    /// (`aws_backend.rs`).
     pub aws: AwsConfig,
 }
 
@@ -301,10 +302,9 @@ fn normalize_aws_mode(mode: &str) -> &str {
 /// process-global and are not overridable per server. The `aws.approval.policy`
 /// gate lives on `HostAgentConfig.aws_policy`, not here.
 ///
-/// Consumed by the AWS backend (commit 2) + the in-crate golden/unit tests; unused
-/// by production code in this slice, hence the `dead_code` allows.
+/// Built by [`AwsConfig::from_node`] (called from `HostAgentConfig::parse`) and
+/// consumed by the AWS backend (`aws_backend.rs`).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[allow(dead_code)]
 pub struct AwsConfig {
     pub source_profile: String,
     pub default_role: String,
@@ -317,7 +317,6 @@ pub struct AwsConfig {
 
 /// Per-server AWS overrides (Go's `AWSServerConfig`).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[allow(dead_code)]
 pub struct AwsServerConfig {
     pub default_role: String,
     pub mode: String,
@@ -327,7 +326,6 @@ pub struct AwsServerConfig {
 
 /// Per-shed AWS overrides (Go's `ShedAWSConfig`).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[allow(dead_code)]
 pub struct AwsShedConfig {
     pub role: String,
     pub mode: String,
@@ -335,6 +333,11 @@ pub struct AwsShedConfig {
 }
 
 /// The effective AWS policy for a single `(server, shed)` pair (Go's `ResolvedAWS`).
+/// Only [`AwsConfig::resolve`] constructs it, and `resolve` is reached only through
+/// the AWS backend, which `main.rs` wires in commit 3 — so under a plain
+/// `cargo build --no-default-features` (no test targets) it is not yet reachable.
+/// The allow keeps that headless build warning-free until the wiring lands (same
+/// ported-but-unwired posture as `minter.rs`); it is live under `--all-targets`/tests.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(dead_code)]
 pub struct ResolvedAws {
@@ -346,14 +349,24 @@ pub struct ResolvedAws {
     pub session_duration: String,
 }
 
+// `from_node` is live (called by `HostAgentConfig::parse`); `resolve`/`enabled` are
+// reached only through the AWS backend, which `main.rs` wires in commit 3, so under a
+// plain `cargo build --no-default-features` (no test targets) they are not yet
+// reachable. The block-level allow keeps that headless build warning-free until the
+// wiring lands (ported-but-unwired posture); all three are live under `--all-targets`.
 #[allow(dead_code)]
 impl AwsConfig {
     /// Build the AWS slice from the parsed config tree, applying the same load
     /// defaults Go's `DefaultConfig`/`LoadConfig` do (`config.go:439-443`): an
     /// empty/absent `source_profile` → `"default"`, `session_duration` → `"1h"`,
-    /// `cache_refresh_before` → `"5m"`. These are applied whether or not an `aws:`
-    /// block is present, matching Go (the defaults sit on `DefaultConfig` and the
-    /// YAML merge only overwrites keys it names).
+    /// `cache_refresh_before` → `"5m"`. For an ABSENT key (or absent `aws:` block)
+    /// this matches Go exactly (the defaults sit on `DefaultConfig` and the YAML
+    /// merge only overwrites keys the document names). For an EXPLICITLY-EMPTY
+    /// scalar (`source_profile: ""`) Go keeps the empty string — it would call STS
+    /// with profile `""` — while this port re-applies the default; `yaml_lite`
+    /// cannot even represent the distinction (a bare `key:` parses as an empty
+    /// map). Known divergence, same class as the other `yaml_lite` permissiveness
+    /// gaps, closed by the config-port sub-plan (cursor review, 2026-07-11).
     ///
     /// `aws.sheds` (Go's removed global per-shed map) is intentionally NOT read: it
     /// is parse-and-ignore for resolution. Go's `AWSConfig.validate` rejects it with

--- a/crates/shed-host-agent/src/config.rs
+++ b/crates/shed-host-agent/src/config.rs
@@ -333,13 +333,9 @@ pub struct AwsShedConfig {
 }
 
 /// The effective AWS policy for a single `(server, shed)` pair (Go's `ResolvedAWS`).
-/// Only [`AwsConfig::resolve`] constructs it, and `resolve` is reached only through
-/// the AWS backend, which `main.rs` wires in commit 3 — so under a plain
-/// `cargo build --no-default-features` (no test targets) it is not yet reachable.
-/// The allow keeps that headless build warning-free until the wiring lands (same
-/// ported-but-unwired posture as `minter.rs`); it is live under `--all-targets`/tests.
+/// Constructed by [`AwsConfig::resolve`] and consumed by the AWS backend
+/// (`aws_backend.rs`), which `main.rs` wires into the bus.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
 pub struct ResolvedAws {
     /// Assumed-role ARN (`""` => no role configured).
     pub role: String,
@@ -350,11 +346,8 @@ pub struct ResolvedAws {
 }
 
 // `from_node` is live (called by `HostAgentConfig::parse`); `resolve`/`enabled` are
-// reached only through the AWS backend, which `main.rs` wires in commit 3, so under a
-// plain `cargo build --no-default-features` (no test targets) they are not yet
-// reachable. The block-level allow keeps that headless build warning-free until the
-// wiring lands (ported-but-unwired posture); all three are live under `--all-targets`.
-#[allow(dead_code)]
+// reached through the AWS backend + `main.rs`, wired into the bus (`new_sts_backend`
+// calls `enabled`; the backend's get_credentials/status call `resolve`).
 impl AwsConfig {
     /// Build the AWS slice from the parsed config tree, applying the same load
     /// defaults Go's `DefaultConfig`/`LoadConfig` do (`config.go:439-443`): an

--- a/crates/shed-host-agent/src/main.rs
+++ b/crates/shed-host-agent/src/main.rs
@@ -390,19 +390,23 @@ fn run_daemon(config_path: &str, log_file: &str) -> i32 {
             // hand its `Arc` to the bus.
             let backend: Arc<dyn ssh_backend::SshBackend> = ssh_backend;
 
-            // Select the ssh approval gate from the effective policy (empty →
-            // deny-all, fail-closed). shed-desktop delegates to the desktop server;
-            // any policy this slice doesn't implement (deny-all, biometrics) fails
-            // closed to deny-all — the touch-id gates are a later slice.
-            let ssh_policy = cfg.effective_policy(config::NS_SSH_AGENT);
-            let gate: Arc<dyn approval::ApprovalGate> = match ssh_policy.as_str() {
-                config::POLICY_APPROVE_ALL => Arc::new(approval::ApproveAllGate),
-                #[cfg(feature = "desktop-forwarding")]
-                config::POLICY_SHED_DESKTOP => {
-                    Arc::new(desktop::DesktopGate::new(desktop_server.clone()))
+            // Select each namespace's approval gate from its own effective policy (empty
+            // → deny-all, fail-closed). shed-desktop delegates to the desktop server; any
+            // policy this slice doesn't implement (deny-all, biometrics) fails closed to
+            // deny-all — the touch-id gates are a later slice. The closure gives ssh and
+            // aws their OWN per-namespace gate (never a shared one), from
+            // `<ns>.approval.policy`.
+            let select_gate = |policy: &str| -> Arc<dyn approval::ApprovalGate> {
+                match policy {
+                    config::POLICY_APPROVE_ALL => Arc::new(approval::ApproveAllGate),
+                    #[cfg(feature = "desktop-forwarding")]
+                    config::POLICY_SHED_DESKTOP => {
+                        Arc::new(desktop::DesktopGate::new(desktop_server.clone()))
+                    }
+                    _ => Arc::new(approval::DenyAllGate),
                 }
-                _ => Arc::new(approval::DenyAllGate),
             };
+            let gate = select_gate(&cfg.effective_policy(config::NS_SSH_AGENT));
 
             #[cfg(feature = "desktop-forwarding")]
             let audit: Arc<dyn audit::AuditSink> = Arc::new(audit::JsonlAuditSink::new(
@@ -412,11 +416,34 @@ fn run_daemon(config_path: &str, log_file: &str) -> i32 {
             #[cfg(not(feature = "desktop-forwarding"))]
             let audit: Arc<dyn audit::AuditSink> = Arc::new(audit::JsonlAuditSink::new(&cfg));
 
+            // The AWS credential backend (optional; Go main.go:166-173 parity): build it
+            // from `aws.*`. A construction error — including `new_sts_backend`'s "no AWS
+            // credentials configured…" not-enabled case — warns and leaves `aws` None, so
+            // the aws-credentials namespace is simply never subscribed. Its gate is the
+            // aws-credentials per-namespace gate (from `aws.approval.policy`), distinct
+            // from ssh's.
+            let aws = match aws_backend::new_sts_backend(cfg.aws.clone(), bus_log.clone()) {
+                Ok(sts) => {
+                    let backend_dyn: Arc<dyn aws_backend::AwsBackend> = Arc::new(sts);
+                    let aws_gate =
+                        select_gate(&cfg.effective_policy(config::NS_AWS_CREDENTIALS));
+                    Some(bus::AwsHandlers {
+                        backend: backend_dyn,
+                        gate: aws_gate,
+                    })
+                }
+                Err(e) => {
+                    bus_log.warn(&format!("AWS handler disabled error={e}"));
+                    None
+                }
+            };
+
             let handlers = bus::BusHandlers {
                 gate,
                 audit,
                 backend,
                 server_name: String::new(),
+                aws,
             };
             tasks.push(tokio::spawn(async move {
                 bus::run_single_server_bus(server_url, rx, bus_log, handlers).await;

--- a/crates/shed-host-agent/src/main.rs
+++ b/crates/shed-host-agent/src/main.rs
@@ -15,6 +15,7 @@
 //! off, matching the Go daemon's `cfg.Discovery == nil` gate.
 
 mod approval;
+mod aws_backend;
 mod audit;
 // The SSH-bootstrap minter (bootstrap exchange + credential source) and the
 // control-token provider. This slice's only consumer is `token.get` on surface A, so

--- a/crates/shed-host-agent/src/status.rs
+++ b/crates/shed-host-agent/src/status.rs
@@ -160,6 +160,20 @@ pub(crate) fn rfc3339_utc(unix_secs: i64) -> String {
     format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
 }
 
+/// Days from the civil date to the unix epoch (Howard Hinnant's `days_from_civil`;
+/// the inverse of the civil-from-days math in [`rfc3339_utc`] above). Lives in this
+/// always-on module so both `bootstrap` (desktop-gated) and `aws_backend` (always-on,
+/// bus-side) can reuse one implementation without a cross-gate dependency.
+pub(crate) fn days_from_civil(y: i64, m: u32, d: u32) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400; // [0, 399]
+    let mp = if m > 2 { m - 3 } else { m + 9 } as i64; // [0, 11]
+    let doy = (153 * mp + 2) / 5 + d as i64 - 1; // [0, 365]
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
+    era * 146_097 + doe - 719_468
+}
+
 // ---------------------------------------------------------------------------
 // Status socket server (channel 4)
 // ---------------------------------------------------------------------------

--- a/tests/host-agent-diff/README.md
+++ b/tests/host-agent-diff/README.md
@@ -151,19 +151,22 @@ identities (real-signing ed25519, canned blobs for rsa/ecdsa).
   normal path resolves immediately either way; a pathological full-backlog peer could hang
   the Rust side longer. Low severity, tracked for the config/lifecycle slice.
 
-- **Bus subscription set: ssh-agent-only (Rust) vs egress + docker/aws (Go).** In
-  single-server mode (no `discovery:` block) both daemons connect to `server:` and
-  subscribe to `ssh-agent`, so the **ping/pong** differential (`test_bus_ping_pong.py`)
-  compares apples to apples. But the *set of endpoints each impl touches* differs by
-  design this slice: the Go daemon also GETs `/api/egress/stream` (its always-on egress
-  subscriber) and subscribes to `docker-credentials` (its Docker backend is non-nil even
-  unconfigured; `aws-credentials` too when configured), whereas the Rust slice-1b daemon
-  wires **ssh-agent only** (egress + the aws/docker backends are later slices). The
-  synthetic bus tolerates the extra Go subscribes (records them, holds the streams open,
-  never pushes) and 501s the egress GET (Go backs off 5m, DEBUG-quiet) — so the
-  asymmetry is absorbed by the harness, not diffed. The differential asserts only the
-  **ssh-agent response envelope**, never which routes each daemon hit. This flips to a
-  full match when the later slices wire the Rust egress + aws/docker paths.
+- **Bus subscription set: ssh-agent + (configured) aws-credentials on both; docker +
+  egress remain Go-only.** In single-server mode (no `discovery:` block) both daemons
+  connect to `server:` and subscribe to `ssh-agent`; when `aws.*` is configured (mode
+  passthrough, or a role) both ALSO subscribe `aws-credentials` — so the ssh ping/pong
+  (`test_bus_ping_pong.py`) AND the AWS passthrough cells (`test_aws_backend.py`)
+  compare apples to apples, each `wait_for_subscribe`-ing its namespace on both impls.
+  A residual asymmetry remains by design this slice: the Go daemon also GETs
+  `/api/egress/stream` (its always-on egress subscriber) and subscribes to
+  `docker-credentials` (its Docker backend is non-nil even unconfigured), whereas the
+  Rust daemon wires **ssh-agent + aws-credentials only** (egress + the docker backend
+  are later slices). The synthetic bus tolerates the extra Go subscribes (records them,
+  holds the streams open, never pushes) and 501s the egress GET (Go backs off 5m,
+  DEBUG-quiet) — so the asymmetry is absorbed by the harness, not diffed. The
+  differential asserts only the compared **response envelope** for the namespace under
+  test, never which routes each daemon hit. This flips to a full match when the later
+  slices wire the Rust egress + docker paths.
 
 - **Event replay ring.** The surface-A handshake (`hello`→`hello_ack`), the non-hello
   drop, single-consumer supersede, event fan-out + approval correlation (via the gated
@@ -210,7 +213,8 @@ owned by a different mechanism (golden/unit) or later slice, not the live diff.
 | approval | native Touch-ID (biometrics) | **out-of-scope** | separate manual sign-off (needs live biometric) |
 | bus | subscribe → ping → respond (open) ping/pong (masked canonical-equal) | **enforced** | live surface B (`test_bus_ping_pong.py`) |
 | bus | secure (TLS-pin) subscribe/respond, 401/409, reconnect | **xfail** | live surface B — secure needs the TLS pin from a `discovery:` config (later slice); the pin/reconnect/401/409 logic is already `bus.rs`-unit-tested |
-| bus | aws-credentials / docker-credentials subscription | **xfail** | live surface B — later slices; slice 1b wires **ssh-agent only** (see "Known contract gaps") |
+| bus | aws-credentials subscription (when configured) | **enforced** | live surface B (`test_aws_backend.py`: both impls `wait_for_subscribe("aws-credentials")`) |
+| bus | docker-credentials subscription | **xfail** | live surface B — later slice; the Rust daemon wires ssh-agent + aws-credentials (see "Known contract gaps") |
 | status | single-server `LiveStatus.servers[]` per-namespace state (incl. 409-rejected) | **xfail** | supervisor slice — Go surfaces `HostClient.Status()` via supervisor health; the Rust bus records the state + logs it, but `servers[]` stays empty until the supervisor lands |
 | egress | events / 401 / 404-501, 5m vs 30s backoff | **xfail** | live ("no reconnect in window") + unit (consts) |
 | ssh backend · local-keys | `list` (masked canonical-equal + durable non-gated audit line) | **enforced** | live (`test_ssh_backend.py`) |
@@ -224,7 +228,9 @@ owned by a different mechanism (golden/unit) or later slice, not the live diff.
 | ssh backend · mode resolution | unknown `ssh.mode` → exit 1 (single-server AND `discovery:` config shapes) | **enforced** | live (`test_ssh_mode_error.py`) |
 | ssh backend | response payload shapes (`list`/`sign`/`status`/`error`: tag names, b64 pass-through, `rest:""`, empty-list `[]` not `null`) | **enforced** | golden (Go + Rust runners on `ssh_payload_shapes.json`) |
 | ssh backend | agent-client wire (framing/failure/oversize/wedged bounds), flag-bit matrix, resolve matrix, missing/encrypted skip, unknown-op/invalid-payload strings, list-error audit | **enforced (unit)** | Rust unit (`ssh_backend*.rs`, `bus.rs`) + fake-seam self-test (`test_fake_ssh_agent.py`) |
-| aws backend | passthrough, cache-hit/expiry | **xfail** (live) | live; assume-role → **out-of-scope** (golden+unit, no Go STS seam) |
+| aws backend · passthrough | `get_credentials` (success + no-expiry-hint + no-static error; payload + audit diffed, error detail home-normalized), `status` (`passthrough:<profile>` + `cached_until`), `ping`, unknown-op, re-login pickup (atomic rewrite) | **enforced** | live (`test_aws_backend.py`) |
+| aws backend · assume-role | cache hit/stale, role resolution + layering, STS/nil-creds errors, session-name shape | **out-of-scope** | golden (`aws_resolve`/`aws_expiry` runners) + Rust unit (`AssumeRoler` fake) — no Go STS seam to drive live |
+| aws backend | response payload shapes (`get_credentials`/`status`/`ping`/`error`: tag names, `expiration`/`cached_until` omitempty) + per-namespace gate selection | **enforced (unit)** | Rust unit (`bus.rs`: `aws_*`, incl. `aws_uses_aws_gate_not_ssh`, `aws_payload_tag_names_match_protocol`) |
 | docker backend | allowlist / allow_all / helper / inline, not-found vs not-allowed | **xfail** | live (helper transcript) + golden (resolution matrix) |
 | minter | control-scope argv + success `token.response` | **enforced** | live (`test_token_get.py`: `token`/`expires_at` compared + argv == expected vector, `<scope>` == `control`) |
 | minter | host-key-mismatch terminal; single-flight; refresh cadence | **enforced (unit)** | unit parity (`minter.rs` / `bootstrap.rs`, incl. real-runner shell-shim tests) |

--- a/tests/host-agent-diff/conftest.py
+++ b/tests/host-agent-diff/conftest.py
@@ -330,6 +330,7 @@ def daemon(binaries, tmp_path_factory):
         shed_config: str | None = None,
         known_hosts: str | None = None,
         ssh_shim_bundle: str | None = None,
+        install_aws_credentials: str | None = None,
     ):
         root = tmp_path_factory.mktemp(f"daemon-{impl}")
         home = root / "home"
@@ -363,6 +364,19 @@ def daemon(binaries, tmp_path_factory):
                 key_dst = ssh_dir / dst_name
                 key_dst.write_bytes((FIXTURES_DIR / stem).read_bytes())
                 os.chmod(key_dst, 0o600)
+
+        # Install the AWS shared-credentials fixture into this daemon's isolated
+        # `<HOME>/.aws/{credentials,config}` BEFORE launch, so a passthrough vend reads
+        # the SAME profile on both impls (Go `~/.aws/credentials` default + Rust
+        # `user_home_dir().join(".aws")`, both keyed off `$HOME`). The config file is
+        # written EMPTY (Go's `LoadSharedConfigProfile` merges config + credentials; the
+        # credentials file carries the static keys). Hermetic by construction — no
+        # AWS_SHARED_CREDENTIALS_FILE env plumbing needed (that route is unit-covered).
+        if install_aws_credentials is not None:
+            aws_dir = home / ".aws"
+            aws_dir.mkdir(exist_ok=True)
+            (aws_dir / "credentials").write_text(install_aws_credentials)
+            (aws_dir / "config").write_text("")
 
         # The minter reads `<HOME>/.shed/{config.yaml,known_hosts}` (the shed CLI
         # config it resolves servers from + the host-key pin). Both impls read the

--- a/tests/host-agent-diff/fixtures/aws_expiry.json
+++ b/tests/host-agent-diff/fixtures/aws_expiry.json
@@ -2,34 +2,183 @@
   "_comment": "Language-neutral goldens for the AWS expiry-hint scan + timestamp render helpers. The Go runner (cmd/shed-host-agent/golden_test.go:TestGoldenAWSExpiry) routes each vector through the REAL parseSessionExpiry/parseExpiryValue + the handler's expiration Format + awsExpiryDetail; the Rust runner (crates/shed-host-agent/src/aws_backend.rs:golden_aws_expiry) routes through parse_session_expiry/parse_expiry_value + aws_literal_z + aws_expiry_detail. expiry_vectors: INI text + profile -> expected unix seconds (or null). literal_z_vectors: unix -> literal-Z UTC string. expiry_detail_vectors: unix (or null) -> audit detail.",
   "protocol_version": 1,
   "expiry_vectors": [
-    {"name": "rfc3339_z", "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05Z\n", "profile": "p", "expected_unix": 4071049445},
-    {"name": "x_security_token_expires", "ini": "[p]\nx_security_token_expires = 2099-01-02T15:04:05Z\n", "profile": "p", "expected_unix": 4071049445},
-    {"name": "rfc3339_nano_fractional", "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05.123Z\n", "profile": "p", "expected_unix": 4071049445},
-    {"name": "offset_colon_positive", "ini": "[p]\naws_session_expiration = 2099-01-02T17:04:05+02:00\n", "profile": "p", "expected_unix": 4071049445},
-    {"name": "offset_colon_negative", "ini": "[p]\naws_session_expiration = 2099-01-02T10:04:05-05:00\n", "profile": "p", "expected_unix": 4071049445},
-    {"name": "offset_nocolon_z0700", "ini": "[p]\naws_session_expiration = 2099-01-02T17:04:05+0200\n", "profile": "p", "expected_unix": 4071049445},
-    {"name": "space_separator_colon_offset", "ini": "[p]\naws_session_expiration = 2099-01-02 17:04:05+02:00\n", "profile": "p", "expected_unix": 4071049445},
-    {"name": "space_separator_z", "ini": "[p]\naws_session_expiration = 2099-01-02 15:04:05Z\n", "profile": "p", "expected_unix": 4071049445},
-    {"name": "fractional_under_nocolon_offset", "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05.5+0200\n", "profile": "p", "expected_unix": 4071042245},
-    {"name": "quoted_value", "ini": "[p]\naws_session_expiration = \"2099-01-02T15:04:05Z\"\n", "profile": "p", "expected_unix": 4071049445},
-    {"name": "comment_and_whitespace", "ini": "# header\n[p]\n  aws_session_expiration = 2099-01-02T15:04:05Z  \n", "profile": "p", "expected_unix": 4071049445},
-    {"name": "config_style_profile_prefix", "ini": "[profile p]\naws_session_expiration = 2099-01-02T15:04:05Z\n", "profile": "p", "expected_unix": 4071049445},
-    {"name": "profile_with_dot", "ini": "[a.b]\naws_session_expiration = 2099-01-02T15:04:05Z\n", "profile": "a.b", "expected_unix": 4071049445},
-    {"name": "duplicate_section_first_wins", "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05Z\n[p]\naws_session_expiration = 2100-01-01T00:00:00Z\n", "profile": "p", "expected_unix": 4071049445},
-    {"name": "key_order_first_line_wins", "ini": "[p]\nx_security_token_expires = 2099-01-02T15:04:05Z\naws_session_expiration = 2100-01-01T00:00:00Z\n", "profile": "p", "expected_unix": 4071049445},
-    {"name": "missing_key", "ini": "[p]\naws_access_key_id = A\n", "profile": "p", "expected_unix": null},
-    {"name": "missing_profile", "ini": "[other]\naws_session_expiration = 2099-01-02T15:04:05Z\n", "profile": "p", "expected_unix": null},
-    {"name": "unparseable_value", "ini": "[p]\naws_session_expiration = not-a-time\n", "profile": "p", "expected_unix": null},
-    {"name": "no_zone_rejected", "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05\n", "profile": "p", "expected_unix": null}
+    {
+      "name": "rfc3339_z",
+      "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05Z\n",
+      "profile": "p",
+      "expected_unix": 4071049445
+    },
+    {
+      "name": "x_security_token_expires",
+      "ini": "[p]\nx_security_token_expires = 2099-01-02T15:04:05Z\n",
+      "profile": "p",
+      "expected_unix": 4071049445
+    },
+    {
+      "name": "rfc3339_nano_fractional",
+      "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05.123Z\n",
+      "profile": "p",
+      "expected_unix": 4071049445
+    },
+    {
+      "name": "offset_colon_positive",
+      "ini": "[p]\naws_session_expiration = 2099-01-02T17:04:05+02:00\n",
+      "profile": "p",
+      "expected_unix": 4071049445
+    },
+    {
+      "name": "offset_colon_negative",
+      "ini": "[p]\naws_session_expiration = 2099-01-02T10:04:05-05:00\n",
+      "profile": "p",
+      "expected_unix": 4071049445
+    },
+    {
+      "name": "offset_nocolon_z0700",
+      "ini": "[p]\naws_session_expiration = 2099-01-02T17:04:05+0200\n",
+      "profile": "p",
+      "expected_unix": 4071049445
+    },
+    {
+      "name": "space_separator_colon_offset",
+      "ini": "[p]\naws_session_expiration = 2099-01-02 17:04:05+02:00\n",
+      "profile": "p",
+      "expected_unix": 4071049445
+    },
+    {
+      "name": "space_separator_z",
+      "ini": "[p]\naws_session_expiration = 2099-01-02 15:04:05Z\n",
+      "profile": "p",
+      "expected_unix": 4071049445
+    },
+    {
+      "name": "fractional_under_nocolon_offset",
+      "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05.5+0200\n",
+      "profile": "p",
+      "expected_unix": 4071042245
+    },
+    {
+      "name": "quoted_value",
+      "ini": "[p]\naws_session_expiration = \"2099-01-02T15:04:05Z\"\n",
+      "profile": "p",
+      "expected_unix": 4071049445
+    },
+    {
+      "name": "comment_and_whitespace",
+      "ini": "# header\n[p]\n  aws_session_expiration = 2099-01-02T15:04:05Z  \n",
+      "profile": "p",
+      "expected_unix": 4071049445
+    },
+    {
+      "name": "config_style_profile_prefix",
+      "ini": "[profile p]\naws_session_expiration = 2099-01-02T15:04:05Z\n",
+      "profile": "p",
+      "expected_unix": 4071049445
+    },
+    {
+      "name": "profile_with_dot",
+      "ini": "[a.b]\naws_session_expiration = 2099-01-02T15:04:05Z\n",
+      "profile": "a.b",
+      "expected_unix": 4071049445
+    },
+    {
+      "name": "duplicate_section_first_wins",
+      "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05Z\n[p]\naws_session_expiration = 2100-01-01T00:00:00Z\n",
+      "profile": "p",
+      "expected_unix": 4071049445
+    },
+    {
+      "name": "key_order_first_line_wins",
+      "ini": "[p]\nx_security_token_expires = 2099-01-02T15:04:05Z\naws_session_expiration = 2100-01-01T00:00:00Z\n",
+      "profile": "p",
+      "expected_unix": 4071049445
+    },
+    {
+      "name": "missing_key",
+      "ini": "[p]\naws_access_key_id = A\n",
+      "profile": "p",
+      "expected_unix": null
+    },
+    {
+      "name": "missing_profile",
+      "ini": "[other]\naws_session_expiration = 2099-01-02T15:04:05Z\n",
+      "profile": "p",
+      "expected_unix": null
+    },
+    {
+      "name": "unparseable_value",
+      "ini": "[p]\naws_session_expiration = not-a-time\n",
+      "profile": "p",
+      "expected_unix": null
+    },
+    {
+      "name": "no_zone_rejected",
+      "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05\n",
+      "profile": "p",
+      "expected_unix": null
+    },
+    {
+      "name": "calendar_invalid_feb30",
+      "ini": "[p]\naws_session_expiration = 2099-02-30T15:04:05Z\n",
+      "profile": "p",
+      "expected_unix": null
+    },
+    {
+      "name": "calendar_invalid_apr31",
+      "ini": "[p]\naws_session_expiration = 2099-04-31T15:04:05Z\n",
+      "profile": "p",
+      "expected_unix": null
+    },
+    {
+      "name": "calendar_nonleap_feb29",
+      "ini": "[p]\naws_session_expiration = 2099-02-29T15:04:05Z\n",
+      "profile": "p",
+      "expected_unix": null
+    },
+    {
+      "name": "calendar_leap_feb29_ok",
+      "ini": "[p]\naws_session_expiration = 2096-02-29T15:04:05Z\n",
+      "profile": "p",
+      "expected_unix": 3981366245
+    },
+    {
+      "name": "leap_second_rejected",
+      "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:60Z\n",
+      "profile": "p",
+      "expected_unix": null
+    },
+    {
+      "name": "five_digit_year_rejected",
+      "ini": "[p]\naws_session_expiration = 12345-01-02T15:04:05Z\n",
+      "profile": "p",
+      "expected_unix": null
+    }
   ],
   "literal_z_vectors": [
-    {"unix": 0, "expected": "1970-01-01T00:00:00Z"},
-    {"unix": 1000000000, "expected": "2001-09-09T01:46:40Z"},
-    {"unix": 4071049445, "expected": "2099-01-02T15:04:05Z"}
+    {
+      "unix": 0,
+      "expected": "1970-01-01T00:00:00Z"
+    },
+    {
+      "unix": 1000000000,
+      "expected": "2001-09-09T01:46:40Z"
+    },
+    {
+      "unix": 4071049445,
+      "expected": "2099-01-02T15:04:05Z"
+    }
   ],
   "expiry_detail_vectors": [
-    {"unix": null, "expected": "expires:none"},
-    {"unix": 4071049445, "expected": "expires:15:04"},
-    {"unix": 0, "expected": "expires:00:00"}
+    {
+      "unix": null,
+      "expected": "expires:none"
+    },
+    {
+      "unix": 4071049445,
+      "expected": "expires:15:04"
+    },
+    {
+      "unix": 0,
+      "expected": "expires:00:00"
+    }
   ]
 }

--- a/tests/host-agent-diff/fixtures/aws_expiry.json
+++ b/tests/host-agent-diff/fixtures/aws_expiry.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "Language-neutral goldens for the AWS expiry-hint scan + timestamp render helpers. The Go runner (cmd/shed-host-agent/golden_test.go:TestGoldenAWSExpiry) routes each vector through the REAL parseSessionExpiry/parseExpiryValue + the handler's expiration Format + awsExpiryDetail; the Rust runner (crates/shed-host-agent/src/aws_backend.rs:golden_aws_expiry) routes through parse_session_expiry/parse_expiry_value + aws_literal_z + aws_expiry_detail. expiry_vectors: INI text + profile -> expected unix seconds (or null). literal_z_vectors: unix -> literal-Z UTC string. expiry_detail_vectors: unix (or null) -> audit detail.",
+  "protocol_version": 1,
+  "expiry_vectors": [
+    {"name": "rfc3339_z", "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05Z\n", "profile": "p", "expected_unix": 4071049445},
+    {"name": "x_security_token_expires", "ini": "[p]\nx_security_token_expires = 2099-01-02T15:04:05Z\n", "profile": "p", "expected_unix": 4071049445},
+    {"name": "rfc3339_nano_fractional", "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05.123Z\n", "profile": "p", "expected_unix": 4071049445},
+    {"name": "offset_colon_positive", "ini": "[p]\naws_session_expiration = 2099-01-02T17:04:05+02:00\n", "profile": "p", "expected_unix": 4071049445},
+    {"name": "offset_colon_negative", "ini": "[p]\naws_session_expiration = 2099-01-02T10:04:05-05:00\n", "profile": "p", "expected_unix": 4071049445},
+    {"name": "offset_nocolon_z0700", "ini": "[p]\naws_session_expiration = 2099-01-02T17:04:05+0200\n", "profile": "p", "expected_unix": 4071049445},
+    {"name": "space_separator_colon_offset", "ini": "[p]\naws_session_expiration = 2099-01-02 17:04:05+02:00\n", "profile": "p", "expected_unix": 4071049445},
+    {"name": "space_separator_z", "ini": "[p]\naws_session_expiration = 2099-01-02 15:04:05Z\n", "profile": "p", "expected_unix": 4071049445},
+    {"name": "fractional_under_nocolon_offset", "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05.5+0200\n", "profile": "p", "expected_unix": 4071042245},
+    {"name": "quoted_value", "ini": "[p]\naws_session_expiration = \"2099-01-02T15:04:05Z\"\n", "profile": "p", "expected_unix": 4071049445},
+    {"name": "comment_and_whitespace", "ini": "# header\n[p]\n  aws_session_expiration = 2099-01-02T15:04:05Z  \n", "profile": "p", "expected_unix": 4071049445},
+    {"name": "config_style_profile_prefix", "ini": "[profile p]\naws_session_expiration = 2099-01-02T15:04:05Z\n", "profile": "p", "expected_unix": 4071049445},
+    {"name": "profile_with_dot", "ini": "[a.b]\naws_session_expiration = 2099-01-02T15:04:05Z\n", "profile": "a.b", "expected_unix": 4071049445},
+    {"name": "duplicate_section_first_wins", "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05Z\n[p]\naws_session_expiration = 2100-01-01T00:00:00Z\n", "profile": "p", "expected_unix": 4071049445},
+    {"name": "key_order_first_line_wins", "ini": "[p]\nx_security_token_expires = 2099-01-02T15:04:05Z\naws_session_expiration = 2100-01-01T00:00:00Z\n", "profile": "p", "expected_unix": 4071049445},
+    {"name": "missing_key", "ini": "[p]\naws_access_key_id = A\n", "profile": "p", "expected_unix": null},
+    {"name": "missing_profile", "ini": "[other]\naws_session_expiration = 2099-01-02T15:04:05Z\n", "profile": "p", "expected_unix": null},
+    {"name": "unparseable_value", "ini": "[p]\naws_session_expiration = not-a-time\n", "profile": "p", "expected_unix": null},
+    {"name": "no_zone_rejected", "ini": "[p]\naws_session_expiration = 2099-01-02T15:04:05\n", "profile": "p", "expected_unix": null}
+  ],
+  "literal_z_vectors": [
+    {"unix": 0, "expected": "1970-01-01T00:00:00Z"},
+    {"unix": 1000000000, "expected": "2001-09-09T01:46:40Z"},
+    {"unix": 4071049445, "expected": "2099-01-02T15:04:05Z"}
+  ],
+  "expiry_detail_vectors": [
+    {"unix": null, "expected": "expires:none"},
+    {"unix": 4071049445, "expected": "expires:15:04"},
+    {"unix": 0, "expected": "expires:00:00"}
+  ]
+}

--- a/tests/host-agent-diff/fixtures/aws_resolve.json
+++ b/tests/host-agent-diff/fixtures/aws_resolve.json
@@ -1,0 +1,84 @@
+{
+  "_comment": "Golden fixture for the AWS config slice — input host-agent config YAML (block-style only, the yaml_lite subset) -> per-(server,shed) Resolve() results + Enabled() verdict + the applied load defaults (source_profile/session_duration/cache_refresh_before). Read by BOTH the Go runner (cmd/shed-host-agent/golden_test.go:TestGoldenAWSResolve, via the production LoadConfig->AWS.Resolve/Enabled path) and the Rust runner (crates/shed-host-agent/src/config.rs tests::golden_aws_resolve, via HostAgentConfig::parse().aws) so the two impls cannot drift together on the layering / mode-normalization / enabled / load-defaults semantics. Mirrors TestAWSResolve / TestMixedModeResolve / TestAWSEnabled / TestLoadConfigAWS / TestLoadConfigDefaults.",
+  "protocol_version": 1,
+  "vectors": [
+    {
+      "name": "top-level only; defaults applied when keys absent; session_duration falls back to top-level default",
+      "config_yaml": "aws:\n  default_role: arn:aws:iam::123:role/default\n",
+      "queries": [
+        {"server": "mini2", "shed": "web", "role": "arn:aws:iam::123:role/default", "mode": "assume-role", "session_duration": "1h"},
+        {"server": "mini3", "shed": "api", "role": "arn:aws:iam::123:role/default", "mode": "assume-role", "session_duration": "1h"}
+      ],
+      "enabled": true,
+      "defaults": {"source_profile": "default", "session_duration": "1h", "cache_refresh_before": "5m"}
+    },
+    {
+      "name": "per-server role override; defaults overridden by explicit keys; same shed name on other server isolated",
+      "config_yaml": "aws:\n  source_profile: staging\n  default_role: arn:aws:iam::123:role/default\n  session_duration: 2h\n  cache_refresh_before: 10m\n  servers:\n    mini2:\n      default_role: arn:aws:iam::123:role/mini2\n",
+      "queries": [
+        {"server": "mini2", "shed": "web", "role": "arn:aws:iam::123:role/mini2", "mode": "assume-role", "session_duration": "2h"},
+        {"server": "mini3", "shed": "web", "role": "arn:aws:iam::123:role/default", "mode": "assume-role", "session_duration": "2h"}
+      ],
+      "enabled": true,
+      "defaults": {"source_profile": "staging", "session_duration": "2h", "cache_refresh_before": "10m"}
+    },
+    {
+      "name": "per-server + per-shed session_duration layering (shed wins over server wins over top-level default)",
+      "config_yaml": "aws:\n  default_role: arn:aws:iam::123:role/default\n  servers:\n    mini2:\n      session_duration: 3h\n      sheds:\n        web:\n          role: arn:aws:iam::123:role/web\n          session_duration: 30m\n        api:\n          role: arn:aws:iam::123:role/api\n",
+      "queries": [
+        {"server": "mini2", "shed": "web", "role": "arn:aws:iam::123:role/web", "mode": "assume-role", "session_duration": "30m"},
+        {"server": "mini2", "shed": "api", "role": "arn:aws:iam::123:role/api", "mode": "assume-role", "session_duration": "3h"},
+        {"server": "mini2", "shed": "other", "role": "arn:aws:iam::123:role/default", "mode": "assume-role", "session_duration": "3h"}
+      ],
+      "enabled": true,
+      "defaults": {"source_profile": "default", "session_duration": "1h", "cache_refresh_before": "5m"}
+    },
+    {
+      "name": "mixed passthrough/assume-role per shed; role present under passthrough is ignored for mode",
+      "config_yaml": "aws:\n  default_role: arn:aws:iam::111:role/dev\n  servers:\n    mini2:\n      sheds:\n        sso-app:\n          mode: passthrough\n        scoped-app:\n          role: arn:aws:iam::111:role/scoped\n",
+      "queries": [
+        {"server": "mini2", "shed": "sso-app", "role": "arn:aws:iam::111:role/dev", "mode": "passthrough", "session_duration": "1h"},
+        {"server": "mini2", "shed": "scoped-app", "role": "arn:aws:iam::111:role/scoped", "mode": "assume-role", "session_duration": "1h"}
+      ],
+      "enabled": true,
+      "defaults": {"source_profile": "default", "session_duration": "1h", "cache_refresh_before": "5m"}
+    },
+    {
+      "name": "empty-mode inheritance: child role under passthrough parent stays passthrough",
+      "config_yaml": "aws:\n  servers:\n    mini2:\n      mode: passthrough\n      sheds:\n        web:\n          role: arn:aws:iam::123:role/web\n",
+      "queries": [
+        {"server": "mini2", "shed": "web", "role": "arn:aws:iam::123:role/web", "mode": "passthrough", "session_duration": "1h"}
+      ],
+      "enabled": true,
+      "defaults": {"source_profile": "default", "session_duration": "1h", "cache_refresh_before": "5m"}
+    },
+    {
+      "name": "child assume-role overrides passthrough parent; sibling with no override inherits passthrough",
+      "config_yaml": "aws:\n  mode: passthrough\n  servers:\n    mini2:\n      sheds:\n        scoped:\n          mode: assume-role\n          role: arn:aws:iam::123:role/scoped\n",
+      "queries": [
+        {"server": "mini2", "shed": "scoped", "role": "arn:aws:iam::123:role/scoped", "mode": "assume-role", "session_duration": "1h"},
+        {"server": "mini2", "shed": "other", "role": "", "mode": "passthrough", "session_duration": "1h"}
+      ],
+      "enabled": true,
+      "defaults": {"source_profile": "default", "session_duration": "1h", "cache_refresh_before": "5m"}
+    },
+    {
+      "name": "enabled-false: explicit assume-role with no role anywhere is AWS off",
+      "config_yaml": "aws:\n  mode: assume-role\n",
+      "queries": [
+        {"server": "mini2", "shed": "web", "role": "", "mode": "assume-role", "session_duration": "1h"}
+      ],
+      "enabled": false,
+      "defaults": {"source_profile": "default", "session_duration": "1h", "cache_refresh_before": "5m"}
+    },
+    {
+      "name": "no aws block at all: defaults applied, empty mode normalizes to assume-role, disabled",
+      "config_yaml": "server: http://localhost:8080\n",
+      "queries": [
+        {"server": "mini2", "shed": "web", "role": "", "mode": "assume-role", "session_duration": "1h"}
+      ],
+      "enabled": false,
+      "defaults": {"source_profile": "default", "session_duration": "1h", "cache_refresh_before": "5m"}
+    }
+  ]
+}

--- a/tests/host-agent-diff/synthetic_bus.py
+++ b/tests/host-agent-diff/synthetic_bus.py
@@ -143,16 +143,24 @@ class SyntheticBus:
     def await_response(self, ns: str, timeout: float = 5.0) -> dict:
         """Block until the daemon POSTs a response Envelope for `{ns}` and return the
         first one (or raise on timeout). Deadline-driven."""
+        return self.await_response_at(ns, 0, timeout)
+
+    def await_response_at(self, ns: str, index: int, timeout: float = 5.0) -> dict:
+        """Block until the daemon has POSTed at least `index + 1` responses for `{ns}`
+        and return the one at `index` (arrival order). Deadline-driven. Lets a test that
+        drives two sequential requests (e.g. the re-login pickup) read the SECOND
+        response without racing the first."""
         deadline = time.monotonic() + timeout
         with self._cond:
-            while not self._responses.get(ns):
+            while len(self._responses.get(ns, [])) <= index:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     raise AssertionError(
-                        f"no response POSTed for {ns!r} within {timeout}s"
+                        f"fewer than {index + 1} responses POSTed for {ns!r} within "
+                        f"{timeout}s (got {len(self._responses.get(ns, []))})"
                     )
                 self._cond.wait(remaining)
-            return self._responses[ns][0]
+            return self._responses[ns][index]
 
     def subscribed_namespaces(self) -> list[str]:
         """A snapshot of the namespaces subscribed so far (sorted)."""

--- a/tests/host-agent-diff/test_aws_backend.py
+++ b/tests/host-agent-diff/test_aws_backend.py
@@ -1,0 +1,334 @@
+"""The AWS credential backend differential — surface-B `get_credentials`/`status`/
+`ping`/unknown over the aws-credentials namespace, in **passthrough** mode, asserted
+equal across the Go `cmd/shed-host-agent` and the Rust `crates/shed-host-agent`.
+
+**Passthrough only, by design.** The hand-rolled INI reader + expiry-hint scan is the
+only differentially-tested path (both impls read the same `<HOME>/.aws/credentials`
+profile with no SDK involved). The **assume-role** path is owned by unit tests (the
+`AssumeRoler` fake) + the `aws_expiry`/`aws_resolve` goldens — there is no Go STS seam
+to drive live, so it is reclassified out-of-scope for the live diff (README table).
+
+**Hermetic by construction.** The `daemon` fixture writes the fixture profile into each
+impl's isolated `<HOME>/.aws/credentials` (+ an empty `<HOME>/.aws/config`), so no real
+`~/.aws` is read and the two impls resolve the SAME profile off `$HOME`. The env-var
+resolution route (`AWS_SHARED_CREDENTIALS_FILE`) is covered by Rust unit tests instead.
+
+**Subscription-set.** Each scenario `wait_for_subscribe("aws-credentials")` before
+pushing, so BOTH impls are proven to subscribe the aws-credentials namespace when the
+AWS backend is configured (the Rust side now wires it; docker + egress asymmetry
+remains — see the README).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from normalize import canonical, mask_audit_entry, mask_bus_response
+from synthetic_bus import SyntheticBus
+
+# The fixed passthrough profile the fixtures carry (throwaway, non-secret constants).
+PROFILE = "shed-test"
+AWS_KEY = "ASIATESTKEY00000001"
+AWS_SECRET = "testSecretAccessKey00000001"
+AWS_TOKEN = "testSessionTokenABCDEF00000001"
+# The re-login rewrite carries a distinct key so the pickup is observable.
+AWS_KEY_2 = "ASIATESTKEY00000002"
+AWS_SECRET_2 = "testSecretAccessKey00000002"
+AWS_TOKEN_2 = "testSessionTokenABCDEF00000002"
+
+# A fixed expiry hint → a deterministic wire `expiration` + `cached_until` on both impls.
+EXPIRY = "2030-01-01T00:00:00Z"
+
+# --- fixture profiles (INI text written to <HOME>/.aws/credentials) -------------------
+
+CREDS_WITH_EXPIRY = (
+    f"[{PROFILE}]\n"
+    f"aws_access_key_id = {AWS_KEY}\n"
+    f"aws_secret_access_key = {AWS_SECRET}\n"
+    f"aws_session_token = {AWS_TOKEN}\n"
+    f"aws_session_expiration = {EXPIRY}\n"
+)
+
+CREDS_NO_EXPIRY = (
+    f"[{PROFILE}]\n"
+    f"aws_access_key_id = {AWS_KEY}\n"
+    f"aws_secret_access_key = {AWS_SECRET}\n"
+    f"aws_session_token = {AWS_TOKEN}\n"
+)
+
+# A profile present but with NO static credentials (region only) → the exact
+# no-static-credentials error, which embeds the shared-credentials PATH. Chosen for the
+# error cell because it (a) is an EXACT Go string ported byte-for-byte to Rust and (b)
+# carries the per-impl `<HOME>/.aws/credentials` path, so it genuinely exercises the
+# home-normalization the plan requires (the no-session-token branch carries no path).
+CREDS_NO_STATIC = f"[{PROFILE}]\nregion = us-east-1\n"
+
+CREDS_RELOGIN = (
+    f"[{PROFILE}]\n"
+    f"aws_access_key_id = {AWS_KEY_2}\n"
+    f"aws_secret_access_key = {AWS_SECRET_2}\n"
+    f"aws_session_token = {AWS_TOKEN_2}\n"
+    f"aws_session_expiration = {EXPIRY}\n"
+)
+
+# --- config (block style; `{server}` filled, `{audit_log}` survives to the fixture) ---
+
+AWS_CONFIG = """\
+server: {server}
+ssh:
+  approval:
+    policy: approve-all
+aws:
+  source_profile: shed-test
+  mode: passthrough
+  approval:
+    policy: approve-all
+logging:
+  enabled: true
+  path: {audit_log}
+"""
+
+
+def _aws_config(bus_url: str) -> str:
+    return AWS_CONFIG.replace("{server}", bus_url)
+
+
+# The `shed` block every request carries; echoed onto the response.
+SHED = {"name": "web", "backend": "vz", "server": "mini2"}
+EXPECTED_SHED = dict(SHED)
+
+
+def _req(req_id: str, operation: str) -> dict:
+    return {
+        "id": req_id,
+        "namespace": "aws-credentials",
+        "type": "request",
+        "final": True,
+        "timestamp": "2026-07-10T00:00:00Z",
+        "payload": {"operation": operation},
+        "shed": SHED,
+    }
+
+
+# --- D3.6 introspection: RAW captured pairs saved for the orchestrator ----------------
+
+INTROSPECTION_PATH = Path(
+    "/private/tmp/claude-501/-Users-charliek-projects-shed/"
+    "97fd8aef-9216-431e-8aed-653022afed7c/scratchpad/aws-commit3-introspection.txt"
+)
+_introspection: dict = {}
+
+
+def _record_introspection(section: str, data: dict) -> None:
+    """Merge a RAW captured pair (response envelope + audit) into the introspection file
+    and rewrite it (tests run serially, so accumulation is safe)."""
+    _introspection[section] = data
+    INTROSPECTION_PATH.write_text(json.dumps(_introspection, indent=2, sort_keys=True))
+
+
+# =====================================================================================
+# passthrough cells
+# =====================================================================================
+
+
+@pytest.mark.differential
+def test_aws_passthrough_get_credentials(daemon, differential):
+    captured: dict = {}
+
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _aws_config(bus.url), install_aws_credentials=CREDS_WITH_EXPIRY) as d:
+                bus.wait_for_subscribe("aws-credentials", timeout=10.0)
+                bus.push_request("aws-credentials", _req("cred-1", "get_credentials"))
+                resp = bus.await_response("aws-credentials", timeout=10.0)
+                audit = d.read_audit_jsonl(expect=1, timeout=10.0)[0]
+                captured[impl] = {"response": resp, "audit": dict(audit)}
+                return {
+                    "response": canonical(mask_bus_response(resp)),
+                    "audit": canonical(mask_audit_entry(audit)),
+                }
+
+    result = differential(scenario)
+    resp = result["response"]
+    assert resp["in_reply_to"] == "cred-1"
+    assert resp["shed"] == EXPECTED_SHED
+    # The full response payload is deterministic → diffed byte-for-byte incl. expiration.
+    assert resp["payload"] == {
+        "access_key_id": AWS_KEY,
+        "secret_access_key": AWS_SECRET,
+        "session_token": AWS_TOKEN,
+        "expiration": EXPIRY,
+    }
+    # The gated get_credentials audit (LogEntry form): approve-all → no decided_by/scope/
+    # ttl; detail = awsExpiryDetail (HH:MM UTC); NO code (asserted absent below).
+    assert result["audit"] == {
+        "ts": "<ts>",
+        "shed": "web",
+        "ns": "aws-credentials",
+        "op": "get_credentials",
+        "result": "ok",
+        "detail": "expires:00:00",
+        "approval": "approve-all",
+    }
+    assert "code" not in result["audit"], "get_credentials audit must carry NO code"
+    _record_introspection("get_credentials", captured["rust"])
+
+
+@pytest.mark.differential
+def test_aws_passthrough_no_expiry_hint(daemon, differential):
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _aws_config(bus.url), install_aws_credentials=CREDS_NO_EXPIRY) as d:
+                bus.wait_for_subscribe("aws-credentials", timeout=10.0)
+                bus.push_request("aws-credentials", _req("cred-2", "get_credentials"))
+                resp = bus.await_response("aws-credentials", timeout=10.0)
+                audit = d.read_audit_jsonl(expect=1, timeout=10.0)[0]
+                return {
+                    "response": canonical(mask_bus_response(resp)),
+                    "audit": canonical(mask_audit_entry(audit)),
+                }
+
+    result = differential(scenario)
+    # No expiry hint → the expiration key is ABSENT on the wire (Go omitempty == Rust
+    # skip_serializing_if), and the audit detail is expires:none.
+    assert "expiration" not in result["response"]["payload"], (
+        f"expiration must be absent without a hint: {result['response']['payload']}"
+    )
+    assert result["response"]["payload"] == {
+        "access_key_id": AWS_KEY,
+        "secret_access_key": AWS_SECRET,
+        "session_token": AWS_TOKEN,
+    }
+    assert result["audit"]["result"] == "ok"
+    assert result["audit"]["detail"] == "expires:none"
+
+
+@pytest.mark.differential
+def test_aws_passthrough_error(daemon, differential):
+    captured: dict = {}
+
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _aws_config(bus.url), install_aws_credentials=CREDS_NO_STATIC) as d:
+                bus.wait_for_subscribe("aws-credentials", timeout=10.0)
+                bus.push_request("aws-credentials", _req("err-1", "get_credentials"))
+                resp = bus.await_response("aws-credentials", timeout=10.0)
+                audit = d.read_audit_jsonl(expect=1, timeout=10.0)[0]
+                captured[impl] = {"response": resp, "audit": dict(audit)}
+                # Home-normalize the per-impl `<HOME>/.aws/credentials` path embedded in
+                # the error detail before diffing (each impl has its own isolated $HOME;
+                # follow the minter argv home-normalize precedent).
+                norm = dict(audit)
+                norm["detail"] = norm["detail"].replace(d.home, "<HOME>")
+                return {
+                    "response": canonical(mask_bus_response(resp)),
+                    "audit": canonical(mask_audit_entry(norm)),
+                }
+
+    result = differential(scenario)
+    resp = result["response"]
+    assert resp["in_reply_to"] == "err-1"
+    # A backend error maps to the generic guest-facing payload (ASSUME_ROLE_FAILED is
+    # scoped to get_credentials failures — gate-deny + backend-error).
+    assert resp["payload"] == {"error": "credential request failed", "code": "ASSUME_ROLE_FAILED"}
+    audit = result["audit"]
+    assert audit["result"] == "error"
+    assert audit["ns"] == "aws-credentials"
+    assert audit["op"] == "get_credentials"
+    assert audit["approval"] == "approve-all"
+    assert "code" not in audit, "error audit sets NO code"
+    # The detail is the EXACT Go no-static-credentials string, home-normalized.
+    assert audit["detail"] == (
+        'passthrough: profile "shed-test" in <HOME>/.aws/credentials has no static '
+        "credentials; run your SSO/SAML login (e.g. `aws sso login`) to refresh"
+    )
+    _record_introspection("error", captured["rust"])
+
+
+@pytest.mark.differential
+def test_aws_status(daemon, differential):
+    captured: dict = {}
+
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _aws_config(bus.url), install_aws_credentials=CREDS_WITH_EXPIRY) as d:
+                bus.wait_for_subscribe("aws-credentials", timeout=10.0)
+                bus.push_request("aws-credentials", _req("st-1", "status"))
+                resp = bus.await_response("aws-credentials", timeout=10.0)
+                captured[impl] = {"response": resp}
+                return canonical(mask_bus_response(resp))
+
+    result = differential(scenario)
+    assert result["in_reply_to"] == "st-1"
+    # role = passthrough:<source_profile>; cached_until = the scanned expiry hint (UTC).
+    assert result["payload"] == {
+        "connected": True,
+        "role": f"passthrough:{PROFILE}",
+        "cached_until": EXPIRY,
+    }
+    _record_introspection("status", captured["rust"])
+
+
+@pytest.mark.differential
+def test_aws_ping(daemon, differential):
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _aws_config(bus.url), install_aws_credentials=CREDS_WITH_EXPIRY) as d:
+                bus.wait_for_subscribe("aws-credentials", timeout=10.0)
+                bus.push_request("aws-credentials", _req("ping-1", "ping"))
+                resp = bus.await_response("aws-credentials", timeout=10.0)
+                return canonical(mask_bus_response(resp))
+
+    result = differential(scenario)
+    assert result["in_reply_to"] == "ping-1"
+    assert result["payload"] == {"status": "ok"}
+
+
+@pytest.mark.differential
+def test_aws_unknown_op(daemon, differential):
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _aws_config(bus.url), install_aws_credentials=CREDS_WITH_EXPIRY) as d:
+                bus.wait_for_subscribe("aws-credentials", timeout=10.0)
+                bus.push_request("aws-credentials", _req("unk-1", "delete"))
+                resp = bus.await_response("aws-credentials", timeout=10.0)
+                return canonical(mask_bus_response(resp))
+
+    result = differential(scenario)
+    assert result["in_reply_to"] == "unk-1"
+    # Go's exact `unknown operation: <op>` INTERNAL_ERROR (AWSCodeInternal).
+    assert result["payload"] == {"error": "unknown operation: delete", "code": "INTERNAL_ERROR"}
+
+
+@pytest.mark.differential
+def test_aws_relogin_pickup(daemon, differential):
+    """A fresh `aws sso login` (an atomic tmp+rename rewrite of the credentials file
+    between two get_credentials) is picked up immediately: passthrough re-reads the file
+    every call (no cache), so the second vend reflects the new keys on BOTH impls."""
+
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _aws_config(bus.url), install_aws_credentials=CREDS_WITH_EXPIRY) as d:
+                bus.wait_for_subscribe("aws-credentials", timeout=10.0)
+                bus.push_request("aws-credentials", _req("relogin-1", "get_credentials"))
+                first = bus.await_response_at("aws-credentials", 0, timeout=10.0)
+
+                # Simulate `aws sso login` rewriting the file ATOMICALLY (tmp + os.replace).
+                creds_path = Path(d.home) / ".aws" / "credentials"
+                tmp = creds_path.with_name("credentials.tmp")
+                tmp.write_text(CREDS_RELOGIN)
+                os.replace(tmp, creds_path)
+
+                bus.push_request("aws-credentials", _req("relogin-2", "get_credentials"))
+                second = bus.await_response_at("aws-credentials", 1, timeout=10.0)
+                return {
+                    "first": mask_bus_response(first)["payload"]["access_key_id"],
+                    "second": mask_bus_response(second)["payload"]["access_key_id"],
+                }
+
+    result = differential(scenario)
+    assert result == {"first": AWS_KEY, "second": AWS_KEY_2}


### PR DESCRIPTION
Sub-plan 2 of the **3a.1 completion program** (stacked on #257 — retarget to main when it merges): port the host-agent's **AWS credential backend** to Rust — `aws_backend.go` (assume-role via STS + passthrough + cache + expiry-hint scan), `aws_handler.go` (the `aws-credentials` namespace), and the `AWSConfig` layered-resolve slice of `config.go` — making the Rust daemon's bus **multi-namespace** for the first time.

Plan: `~/.claude/plans/monorepo-phase3-host-agent-aws-backend.md`, panel-reviewed (Kimi K2.6 + CodeRabbit + Cursor [Codex usage-limited]); every commit ran the full gate (cargo workspace tests + clippy default **and** headless + Go `make check` + `make test-host-agent-diff`) → `/simplify` → external review.

## The panel-shaped dependency decision

The panel converged on splitting the SDK question: **passthrough — the only differentially-tested path — is hand-rolled** (a minimal INI profile reader; no SDK), while **assume-role buys `aws-config` + `aws-sdk-sts`** solely for the source-profile credential chain (SSO/credential-process — Go-parity for real-world profiles; zero differential coverage, documented as SDK-owned behavior on both sides). `default-https-client` stays **off**: the HTTPS connector is wired explicitly through `aws-smithy-http-client`'s rustls-ring, so the SDK reuses the workspace's existing ring/rustls/hyper — **no `aws-lc-sys`, no C toolchain**. Cost: +45 marginal workspace crates, +4.2s wall clean-build (methodology in commit message / DEP_DELTA notes).

## Commits

1. `67e3f5d` — **config slice**: `AwsConfig` layered `resolve()` (top-level → server → shed, empty-mode = no override, normalize at end), `enabled()`, LoadConfig defaults; `aws_resolve` golden (8 vectors) whose Go runner routes through the **real `LoadConfig`**.
2. `f8f754a` — **backend**: hand-rolled passthrough (Go's exact no-static/no-token error strings reachable; credentials-over-config merge; re-read every call), `parse_session_expiry`/`parse_expiry_value` with all 4 Go layouts and **real offset arithmetic** (the `aws_expiry` golden pins non-zero-offset vectors — Go's own tests only cover `+00:00`), assume-role behind an async `AssumeRoler` seam (cache windows, session-name shape, nil-credentials guard, lazy-once SDK client that passthrough-only configs never build), literal-Z timestamp rendering (`2006-01-02T15:04:05Z` — bare Z is a literal; verified empirically by two panelists).
3. (this commit) — **handler + multi-namespace bus + harness flip**: per-namespace approval gates, subscription only-when-configured, `aws_handler.go`-exact payloads/audits (audit `code` key ABSENT — pinned), 7 new live passthrough cells (harness 43 → 50), README reclassification (assume-role = golden+unit, no Go STS seam).

## Evidence

- All 21 Go AWS tests have named Rust mirrors (+ Rust-only strengtheners: non-zero offsets, nil-credentials, per-namespace-gate proof, status-Some branch).
- Live diff introspection (raw JSON): get_credentials payload byte-deterministic with `expiration: 2030-01-01T00:00:00Z`; audit `expires:00:00`; error-path audit carries Go's exact string with home-normalized path; no `code` key.
- Residual Go-vs-Rust bus subscription asymmetry is now **docker + egress only**.

## Review trail

Panel findings all incorporated (see plan §Panel disposition): offset-arithmetic golden gap (CodeRabbit), SSO features load-bearing (Cursor), per-namespace gate (CodeRabbit/Kimi), audit field-absence pinning, HOME-route fixtures, atomic re-login rewrite. Post-commit cursor review of the config slice: no real bugs; its one doc-note finding (explicitly-empty scalar defaults divergence — unrepresentable in `yaml_lite`) is corrected and tracked for the config-port sub-plan.

No server/guest changes; Go host-agent unchanged and shipped-capable; nothing AWS enters shed-core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED6csoQ3peM3GHc4c1CtqY
