### PR TITLE
feat(host-agent): Docker credential backend — allowlist/helpers/inline auths + unconditional subscribe (Phase 3 leg 3a.1 sub-plan 3)

### DIFF
--- a/cmd/shed-host-agent/golden_test.go
+++ b/cmd/shed-host-agent/golden_test.go
@@ -13,6 +13,7 @@ package main
 // the package is fine for a Go test and does not affect `go list ./...`.
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -455,6 +456,156 @@ func TestGoldenGateNamespaces(t *testing.T) {
 		if !equalStrings(got, v.Gate) {
 			t.Errorf("desktopGateNamespaces(ssh=%q,aws=%q,docker=%q) = %v, want %v",
 				v.SSH, v.AWS, v.Docker, got, v.Gate)
+		}
+	}
+}
+
+// TestGoldenDockerNormalize is the Go half of the docker_normalize golden. It routes
+// each vector through the PRODUCTION normalizeRegistry + lookupConfigMap (the same
+// canonicalization + 3-way config-map search the backend uses), against the shared
+// fixture the Rust runner (docker_backend.rs:tests::golden_docker_normalize) also
+// reads, so the one-occurrence strip / strip-order / raw->normalized->scan lookup
+// semantics cannot drift together.
+func TestGoldenDockerNormalize(t *testing.T) {
+	var fx struct {
+		ProtocolVersion  int `json:"protocol_version"`
+		NormalizeVectors []struct {
+			Input    string `json:"input"`
+			Expected string `json:"expected"`
+		} `json:"normalize_vectors"`
+		LookupVectors []struct {
+			Name     string            `json:"name"`
+			Map      map[string]string `json:"map"`
+			Raw      string            `json:"raw"`
+			Expected *string           `json:"expected"`
+		} `json:"lookup_vectors"`
+	}
+	readFixture(t, "docker_normalize.json", &fx)
+
+	if fx.ProtocolVersion != 1 {
+		t.Fatalf("docker_normalize.json protocol_version = %d, want 1 (version skew)", fx.ProtocolVersion)
+	}
+	if len(fx.NormalizeVectors) == 0 || len(fx.LookupVectors) == 0 {
+		t.Fatal("docker_normalize.json missing vectors")
+	}
+
+	for _, v := range fx.NormalizeVectors {
+		if got := normalizeRegistry(v.Input); got != v.Expected {
+			t.Errorf("normalizeRegistry(%q) = %q, want %q", v.Input, got, v.Expected)
+		}
+	}
+	for _, v := range fx.LookupVectors {
+		normalized := normalizeRegistry(v.Raw)
+		got, ok := lookupConfigMap(v.Map, v.Raw, normalized)
+		switch {
+		case v.Expected == nil:
+			if ok {
+				t.Errorf("%s: lookupConfigMap(raw=%q) = %q, want miss", v.Name, v.Raw, got)
+			}
+		case !ok:
+			t.Errorf("%s: lookupConfigMap(raw=%q) = miss, want %q", v.Name, v.Raw, *v.Expected)
+		case got != *v.Expected:
+			t.Errorf("%s: lookupConfigMap(raw=%q) = %q, want %q", v.Name, v.Raw, got, *v.Expected)
+		}
+	}
+}
+
+// TestGoldenDockerInlineAuth is the Go half of the docker_inline_auth golden. It
+// base64-STANDARD-encodes each vector's `plain` (matching the Rust runner's own
+// STANDARD encode), routes it through the PRODUCTION decodeInlineAuth, and asserts the
+// username/secret split (valid) or the exact error string (invalid). The
+// malformed-base64 case is intentionally absent (its runtime suffix is impl-dependent
+// — see the fixture comment).
+func TestGoldenDockerInlineAuth(t *testing.T) {
+	var fx struct {
+		ProtocolVersion int `json:"protocol_version"`
+		ValidVectors    []struct {
+			Name      string `json:"name"`
+			ServerURL string `json:"server_url"`
+			Plain     string `json:"plain"`
+			Username  string `json:"username"`
+			Secret    string `json:"secret"`
+		} `json:"valid_vectors"`
+		InvalidVectors []struct {
+			Name          string `json:"name"`
+			ServerURL     string `json:"server_url"`
+			Plain         string `json:"plain"`
+			ExpectedError string `json:"expected_error"`
+		} `json:"invalid_vectors"`
+	}
+	readFixture(t, "docker_inline_auth.json", &fx)
+
+	if fx.ProtocolVersion != 1 {
+		t.Fatalf("docker_inline_auth.json protocol_version = %d, want 1 (version skew)", fx.ProtocolVersion)
+	}
+	if len(fx.ValidVectors) == 0 || len(fx.InvalidVectors) == 0 {
+		t.Fatal("docker_inline_auth.json missing vectors")
+	}
+
+	for _, v := range fx.ValidVectors {
+		encoded := base64.StdEncoding.EncodeToString([]byte(v.Plain))
+		cred, err := decodeInlineAuth(v.ServerURL, encoded)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", v.Name, err)
+			continue
+		}
+		if cred.Username != v.Username || cred.Secret != v.Secret {
+			t.Errorf("%s: decodeInlineAuth = {user:%q secret:%q}, want {user:%q secret:%q}",
+				v.Name, cred.Username, cred.Secret, v.Username, v.Secret)
+		}
+		if cred.ServerURL != v.ServerURL {
+			t.Errorf("%s: ServerURL = %q, want %q", v.Name, cred.ServerURL, v.ServerURL)
+		}
+	}
+	for _, v := range fx.InvalidVectors {
+		encoded := base64.StdEncoding.EncodeToString([]byte(v.Plain))
+		_, err := decodeInlineAuth(v.ServerURL, encoded)
+		if err == nil {
+			t.Errorf("%s: expected error, got nil", v.Name)
+			continue
+		}
+		if err.Error() != v.ExpectedError {
+			t.Errorf("%s: error = %q, want %q", v.Name, err.Error(), v.ExpectedError)
+		}
+	}
+}
+
+// TestGoldenDockerPathAugment is the Go half of the docker_path_augment golden. It
+// routes each vector through the PRODUCTION augmentPATH (over os.Environ()-shaped
+// []string) and extracts the effective (last-wins) PATH value via pathValue, against
+// the shared fixture the Rust runner (docker_backend.rs:tests::golden_docker_path_augment)
+// also reads. go_only vectors (multiple PATH= entries / no PATH= entry) exercise the
+// Go []string-env branches the Rust map-env has no equivalent for; the Rust runner
+// skips them.
+func TestGoldenDockerPathAugment(t *testing.T) {
+	var fx struct {
+		ProtocolVersion int `json:"protocol_version"`
+		Vectors         []struct {
+			Name         string   `json:"name"`
+			GoOnly       bool     `json:"go_only"`
+			Path         string   `json:"path"`
+			Env          []string `json:"env"`
+			ExtraDirs    []string `json:"extra_dirs"`
+			ExpectedPath string   `json:"expected_path"`
+		} `json:"vectors"`
+	}
+	readFixture(t, "docker_path_augment.json", &fx)
+
+	if fx.ProtocolVersion != 1 {
+		t.Fatalf("docker_path_augment.json protocol_version = %d, want 1 (version skew)", fx.ProtocolVersion)
+	}
+	if len(fx.Vectors) == 0 {
+		t.Fatal("docker_path_augment.json has no vectors")
+	}
+
+	for _, v := range fx.Vectors {
+		env := v.Env
+		if env == nil {
+			env = []string{"PATH=" + v.Path}
+		}
+		got := augmentPATH(env, v.ExtraDirs)
+		if pv := pathValue(t, got); pv != v.ExpectedPath {
+			t.Errorf("%s: augmentPATH PATH = %q, want %q", v.Name, pv, v.ExpectedPath)
 		}
 	}
 }

--- a/cmd/shed-host-agent/golden_test.go
+++ b/cmd/shed-host-agent/golden_test.go
@@ -366,6 +366,67 @@ func TestGoldenAWSExpiry(t *testing.T) {
 	}
 }
 
+// TestGoldenDockerResolve is the Go half of the docker_resolve golden. It routes each
+// vector's config YAML through the PRODUCTION LoadConfig (so the same DefaultConfig
+// defaulting + yaml merge the daemon uses is exercised — Docker gets NO load-defaults,
+// unlike AWS), then asserts Docker.Resolve's allow_all + registries + registry_count
+// against the shared fixture the Rust runner (config.rs:golden_docker_resolve) also
+// reads. Go has no Resolve layering test, so this golden is the drift guard for the
+// Option<Vec<String>> replace / Option<bool> force / flow-list-parse semantics.
+func TestGoldenDockerResolve(t *testing.T) {
+	var fx struct {
+		ProtocolVersion int `json:"protocol_version"`
+		Vectors         []struct {
+			Name       string `json:"name"`
+			ConfigYAML string `json:"config_yaml"`
+			Queries    []struct {
+				Server        string   `json:"server"`
+				Shed          string   `json:"shed"`
+				AllowAll      bool     `json:"allow_all"`
+				Registries    []string `json:"registries"`
+				RegistryCount int      `json:"registry_count"`
+			} `json:"queries"`
+		} `json:"vectors"`
+	}
+	readFixture(t, "docker_resolve.json", &fx)
+
+	if fx.ProtocolVersion != 1 {
+		t.Fatalf("docker_resolve.json protocol_version = %d, want 1 (version skew)", fx.ProtocolVersion)
+	}
+	if len(fx.Vectors) == 0 {
+		t.Fatal("docker_resolve.json has no vectors")
+	}
+	for _, v := range fx.Vectors {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte(v.ConfigYAML), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadConfig(path)
+		if err != nil {
+			t.Errorf("%s: LoadConfig: %v", v.Name, err)
+			continue
+		}
+		for _, q := range v.Queries {
+			got := cfg.Docker.Resolve(q.Server, q.Shed)
+			if got.AllowAll != q.AllowAll {
+				t.Errorf("%s: Resolve(%q,%q).AllowAll = %v, want %v",
+					v.Name, q.Server, q.Shed, got.AllowAll, q.AllowAll)
+			}
+			// equalStrings treats a nil slice and an empty slice as equal — Go's
+			// Resolve returns a nil Registries for the inherited-empty case, the
+			// fixture decodes `[]` to a non-nil empty slice.
+			if !equalStrings(got.Registries, q.Registries) {
+				t.Errorf("%s: Resolve(%q,%q).Registries = %v, want %v",
+					v.Name, q.Server, q.Shed, got.Registries, q.Registries)
+			}
+			if len(got.Registries) != q.RegistryCount {
+				t.Errorf("%s: Resolve(%q,%q) registry_count = %d, want %d",
+					v.Name, q.Server, q.Shed, len(got.Registries), q.RegistryCount)
+			}
+		}
+	}
+}
+
 func TestGoldenGateNamespaces(t *testing.T) {
 	var fx struct {
 		ProtocolVersion int `json:"protocol_version"`

--- a/crates/shed-host-agent/src/approval.rs
+++ b/crates/shed-host-agent/src/approval.rs
@@ -33,6 +33,13 @@ pub struct ApprovalOutcome {
     pub scope: Option<String>,
     /// TTL applied (e.g. `4h`). `None` → omitted from audit.
     pub ttl: Option<String>,
+    /// The deny reason — the faithful port of Go's `(ApprovalOutcome, error)`: on a
+    /// deny, Go carries an `error` alongside the outcome whose `Error()` some handlers
+    /// record as the audit `reason` (the docker `get` deny path,
+    /// `docker_handler.go:115`). The seam folds that string in here so a single value
+    /// carries the decision + its deny reason. Empty on approve. The ssh/aws deny
+    /// audits set no `reason`, so they ignore it; only the docker `get` deny reads it.
+    pub reason: String,
 }
 
 impl ApprovalOutcome {
@@ -45,6 +52,9 @@ impl ApprovalOutcome {
             decided_by: String::new(),
             scope: None,
             ttl: None,
+            // No specific reason — this is the generic fail-closed (no consumer /
+            // timeout / disconnect); the deny-all gate builds its own reason below.
+            reason: String::new(),
         }
     }
 }
@@ -94,6 +104,7 @@ impl ApprovalGate for ApproveAllGate {
             decided_by: String::new(),
             scope: None,
             ttl: None,
+            reason: String::new(),
         }
     }
     fn method(&self) -> &str {
@@ -116,7 +127,12 @@ impl ApprovalGate for DenyAllGate {
         _shed: &str,
         _detail: &str,
     ) -> ApprovalOutcome {
-        ApprovalOutcome::denied_no_decision()
+        // The deny-all reason is Go's `denyAllGate.Approve` error string verbatim
+        // (`approval.go:36`) — the docker `get` deny audit records it as `reason`.
+        ApprovalOutcome {
+            reason: "denied: approval policy is deny-all".to_string(),
+            ..ApprovalOutcome::denied_no_decision()
+        }
     }
     fn method(&self) -> &str {
         POLICY_DENY_ALL
@@ -152,6 +168,9 @@ mod tests {
         assert_eq!(out.decided_by, "");
         assert_eq!(out.scope, None);
         assert_eq!(out.ttl, None);
+        // The deny-all reason is Go's verbatim error string (recorded as the docker
+        // get deny audit `reason`).
+        assert_eq!(out.reason, "denied: approval policy is deny-all");
         assert_eq!(g.method(), "deny-all");
     }
 
@@ -162,5 +181,8 @@ mod tests {
         assert_eq!(out.decided_by, "");
         assert!(out.scope.is_none());
         assert!(out.ttl.is_none());
+        // The generic fail-closed carries no specific reason (the deny-all gate sets
+        // its own; the desktop no-decision paths leave it empty — sub-plan 5).
+        assert_eq!(out.reason, "");
     }
 }

--- a/crates/shed-host-agent/src/bus.rs
+++ b/crates/shed-host-agent/src/bus.rs
@@ -1014,17 +1014,49 @@ async fn handle_bus_message(
             ),
         },
     };
+    // The reply plumbing + audit-after-response tail is shared with the aws (and
+    // later docker) namespaces (`respond_and_audit`). A non-gated op or a
+    // parse-error path leaves `audit_entry` None (Go emits no audit for those).
+    respond_and_audit(
+        client,
+        namespace,
+        env,
+        shutdown,
+        &handlers.audit,
+        payload,
+        audit_entry,
+        what,
+    )
+    .await;
+}
+
+/// The shared reply-plumbing + audit tail for a bus namespace handler, extracted
+/// byte-for-byte from the ssh and aws handlers (the rule-of-three the docker slice
+/// justifies). Mint the response envelope, echo `shed` so shed-server routes the
+/// reply back to the originating shed (`*_handler.go: resp.Shed = req.Shed`), POST it
+/// racing `shutdown` (see [`BusClient::respond`]) and warn on failure with a
+/// namespace-specific `what`, then — matching Go's sendResponse/sendError-then-Log
+/// order — write the audit entry if one is present. `audit` is the SHARED sink taken
+/// by reference; `what` absorbs the ssh-vs-aws warn-message difference.
+#[allow(clippy::too_many_arguments)]
+async fn respond_and_audit(
+    client: &BusClient,
+    namespace: &str,
+    env: &Envelope,
+    shutdown: &watch::Receiver<bool>,
+    audit: &Arc<dyn AuditSink>,
+    payload: serde_json::Value,
+    audit_entry: Option<AuditEntry>,
+    what: &str,
+) {
     let mut resp = Envelope::new_response(&env.id, namespace, payload);
-    resp.shed = env.shed.clone(); // route the reply back (ssh_handler.go: resp.Shed = req.Shed)
-                                  // `shutdown` is threaded through so the POST races teardown (see `respond`).
+    resp.shed = env.shed.clone(); // route the reply back (resp.Shed = req.Shed)
     if let Err(e) = client.respond(namespace, &resp, shutdown).await {
         client.log.warn(&format!("failed to send {what}: {e}"));
     }
-    // Audit after responding — the durable log + desktop fan-out (ssh_handler.go
-    // order). A non-gated op or a parse-error path leaves `audit_entry` None (Go
-    // emits no audit for those).
+    // Audit after responding — the durable log + desktop fan-out.
     if let Some(entry) = audit_entry {
-        handlers.audit.log(entry);
+        audit.log(entry);
     }
 }
 
@@ -1433,16 +1465,20 @@ async fn handle_aws_bus_message(
     server_name: &str,
 ) {
     let (payload, audit_entry) = aws_dispatch(env, aws, server_name).await;
-    let mut resp = Envelope::new_response(&env.id, namespace, payload);
-    resp.shed = env.shed.clone(); // route the reply back (aws_handler.go: resp.Shed = req.Shed)
-    if let Err(e) = client.respond(namespace, &resp, shutdown).await {
-        client.log.warn(&format!("failed to send aws response: {e}"));
-    }
-    // Audit after responding (aws_handler.go order). Only get_credentials audits; ping/
-    // status/unknown/invalid leave `audit_entry` None.
-    if let Some(entry) = audit_entry {
-        audit.log(entry);
-    }
+    // Shared reply-plumbing + audit tail (`respond_and_audit`). Only get_credentials
+    // audits; ping/status/unknown/invalid leave `audit_entry` None. `what` preserves
+    // the aws warn message (`failed to send aws response: ...`).
+    respond_and_audit(
+        client,
+        namespace,
+        env,
+        shutdown,
+        audit,
+        payload,
+        audit_entry,
+        "aws response",
+    )
+    .await;
 }
 
 /// Compute the aws-credentials response payload + optional audit entry for one request,

--- a/crates/shed-host-agent/src/bus.rs
+++ b/crates/shed-host-agent/src/bus.rs
@@ -29,9 +29,11 @@
 //! **`status`** (`{connected, mode, key_count}`) ops, and `ping` → `pong`. An unknown
 //! operation gets Go's exact `unknown operation: <op>` `INTERNAL_ERROR` envelope, and
 //! a payload that isn't a JSON object gets `{invalid payload, INTERNAL_ERROR}` — so the
-//! shed's request never hangs. The other credential backends (aws/docker) are LATER
-//! slices.
+//! shed's request never hangs. The `aws-credentials` and `docker-credentials` namespaces
+//! are wired alongside (each its own per-namespace gate); only egress remains a later
+//! slice.
 
+use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -50,6 +52,9 @@ use crate::approval::ApprovalGate;
 use crate::audit::{AuditEntry, AuditSink};
 use crate::aws_backend::{aws_expiry_detail, aws_literal_z, AwsBackend};
 use crate::config::{NS_AWS_CREDENTIALS, NS_DOCKER_CREDENTIALS, NS_SSH_AGENT};
+use crate::docker_backend::{
+    DockerBackend, DOCKER_CODE_INTERNAL, DOCKER_CODE_NOT_ALLOWED, DOCKER_CODE_NOT_FOUND,
+};
 use crate::ssh_backend::SshBackend;
 
 /// SSH protocol error codes (`internal/ext/protocol/ssh.go`).
@@ -66,6 +71,21 @@ const AWS_CODE_ASSUME_ROLE_FAILED: &str = "ASSUME_ROLE_FAILED";
 const AWS_CODE_INTERNAL: &str = "INTERNAL_ERROR";
 /// The gated AWS op — the only one whose audit carries the approval outcome.
 const AWS_OP_GET_CREDENTIALS: &str = "get_credentials";
+
+/// Docker operations (`internal/ext/protocol/docker.go`) used for the audit `op` field
+/// / gate op. The remaining ops (`ping`/`status`) match as literals in `docker_dispatch`.
+const DOCKER_OP_GET: &str = "get";
+const DOCKER_OP_LIST: &str = "list";
+/// The audit-only code for a request the approval gate rejected — distinct from
+/// `REGISTRY_NOT_ALLOWED` (an allowlist deny). The guest receives
+/// `REGISTRY_NOT_ALLOWED` for BOTH (preserving its behavior); this code only
+/// disambiguates the cause on host/admin surfaces (mirror Go's `auditCodeApprovalDenied`,
+/// `docker_handler.go:32`).
+const DOCKER_AUDIT_CODE_APPROVAL_DENIED: &str = "APPROVAL_DENIED";
+/// The docker `get` audit result for an allowed registry that had no credential
+/// (`CREDENTIALS_NOT_FOUND`): NOT a failure — the guest pulls anonymously — so it is
+/// recorded distinctly from a real error (mirror Go's `auditResultAnonymous`).
+const DOCKER_AUDIT_RESULT_ANONYMOUS: &str = "anonymous";
 
 // ---------------------------------------------------------------------------
 // Constants (mirrors hostclient.go)
@@ -814,6 +834,13 @@ pub struct BusHandlers {
     /// backend constructed (Go main.go:166-173 — a nil AWS backend means no aws
     /// handler). `None` ⇒ the aws-credentials namespace is never subscribed.
     pub aws: Option<AwsHandlers>,
+    /// The docker-credentials handler's seams. Unlike `aws`, this is `Some` in the
+    /// COMMON case even when unconfigured: `new_docker_backend` errors ONLY when an
+    /// explicit `config_path` is unstat-able (Go `NewDockerBackend`, main.go:175-180),
+    /// so `main.rs` all but always sets it — the docker-credentials namespace is
+    /// subscribed for every server (denying everything under an empty allowlist). `None`
+    /// only on that explicit-config_path error.
+    pub docker: Option<DockerHandlers>,
 }
 
 /// The aws-credentials handler's seams (the second bus namespace). Carries its OWN
@@ -825,18 +852,29 @@ pub struct AwsHandlers {
     pub gate: Arc<dyn ApprovalGate>,
 }
 
-/// Run the single-server message bus: subscribe to `ssh-agent` (always) and
-/// `aws-credentials` (when the AWS backend is configured) in open mode (no token, no
-/// pin) and answer inbound requests until `shutdown` flips. Each namespace runs its own
-/// subscribe+serve loop (both racing `shutdown`), mirroring the Go daemon's
-/// per-namespace watcher goroutines (`main.go` → `startWatcherGroup` → the per-handler
-/// `.Run`). `server_name` is the audit/approval `server` field — empty in single-server
-/// mode (matches Go).
+/// The docker-credentials handler's seams (the third bus namespace). Carries its OWN
+/// per-namespace approval `gate` (selected from `docker.approval.policy`, NEVER ssh's or
+/// aws's) and the `backend`; the audit sink + `server_name` are shared from
+/// [`BusHandlers`]. Present in the common case (the constructor near-always yields a live
+/// backend — see [`BusHandlers::docker`]).
+pub struct DockerHandlers {
+    pub backend: Arc<dyn DockerBackend>,
+    pub gate: Arc<dyn ApprovalGate>,
+}
+
+/// Run the single-server message bus: subscribe to `ssh-agent` (always),
+/// `aws-credentials` (when the AWS backend is configured), and `docker-credentials`
+/// (when the docker backend constructed — the COMMON case, even unconfigured) in open
+/// mode (no token, no pin) and answer inbound requests until `shutdown` flips. Each
+/// namespace runs its own subscribe+serve loop (both racing `shutdown`), mirroring the
+/// Go daemon's per-namespace watcher goroutines (`main.go` → `startWatcherGroup` → the
+/// per-handler `.Run`). `server_name` is the audit/approval `server` field — empty in
+/// single-server mode (matches Go).
 ///
-/// KNOWN GAP (for the harness): Go's watcher group also subscribes to
-/// `docker-credentials` and the egress-audit stream. Those need their backends + the
-/// egress route, so they are deliberately NOT wired here — this slice wires ssh-agent +
-/// (configured) aws-credentials.
+/// KNOWN GAP (for the harness): Go's watcher group also GETs the egress-audit stream
+/// (`/api/egress/stream`). That needs the egress route, so it is deliberately NOT wired
+/// here — after this slice the Rust daemon wires ssh-agent + (configured) aws-credentials
+/// + docker-credentials, and ONLY egress remains asymmetric.
 pub async fn run_single_server_bus(
     server_url: String,
     shutdown: watch::Receiver<bool>,
@@ -866,12 +904,17 @@ pub async fn run_single_server_bus(
     log.info(&format!("brokering for single server server={server_url}"));
 
     // The subscription set: always ssh-agent; aws-credentials when the AWS backend is
-    // configured (Go: a nil AWS backend means no aws handler). docker-credentials + the
-    // egress stream remain later slices. Compute the set once, then log + spawn from it
-    // so a new namespace is a single push (no parallel branches to keep in sync).
+    // configured (Go: a nil AWS backend means no aws handler); docker-credentials when
+    // the docker backend constructed — effectively unconditional, since the constructor
+    // near-always yields `Some` (Go's `NewDockerBackend` is non-nil even unconfigured).
+    // Only the egress stream remains a later slice. Compute the set once, then log + spawn
+    // from it so a new namespace is a single push (no parallel branches to keep in sync).
     let mut subscribed: Vec<&'static str> = vec![NS_SSH_AGENT];
     if handlers.aws.is_some() {
         subscribed.push(NS_AWS_CREDENTIALS);
+    }
+    if handlers.docker.is_some() {
+        subscribed.push(NS_DOCKER_CREDENTIALS);
     }
     let deferred: Vec<&'static str> = BUS_NAMESPACES
         .iter()
@@ -933,10 +976,11 @@ async fn serve_namespace(
 }
 
 /// Route one inbound request to its namespace handler: `aws-credentials` → the gated
-/// AWS flow (its OWN per-namespace gate + AWS error codes), every other namespace
-/// (ssh-agent) → [`handle_bus_message`]. The aws branch is reached only when
-/// `handlers.aws` is `Some` (its loop is started only then); a defensive fall-through
-/// to the ssh dispatch keeps a stray aws frame from hanging the shed's request.
+/// AWS flow, `docker-credentials` → the docker flow (each with its OWN per-namespace
+/// gate + its own error codes), every other namespace (ssh-agent) → [`handle_bus_message`].
+/// The aws/docker branches are reached only when their handlers are `Some` (their loops
+/// are started only then); a defensive fall-through to the ssh dispatch keeps a stray
+/// frame from hanging the shed's request.
 async fn dispatch_bus_message(
     client: &BusClient,
     namespace: &str,
@@ -944,14 +988,26 @@ async fn dispatch_bus_message(
     shutdown: &watch::Receiver<bool>,
     handlers: &BusHandlers,
 ) {
-    match (namespace, &handlers.aws) {
-        (NS_AWS_CREDENTIALS, Some(aws)) => {
+    match (namespace, &handlers.aws, &handlers.docker) {
+        (NS_AWS_CREDENTIALS, Some(aws), _) => {
             handle_aws_bus_message(
                 client,
                 namespace,
                 env,
                 shutdown,
                 aws,
+                &handlers.audit,
+                &handlers.server_name,
+            )
+            .await
+        }
+        (NS_DOCKER_CREDENTIALS, _, Some(docker)) => {
+            handle_docker_bus_message(
+                client,
+                namespace,
+                env,
+                shutdown,
+                docker,
                 &handlers.audit,
                 &handlers.server_name,
             )
@@ -1586,9 +1642,332 @@ fn handle_aws_status(
     })
 }
 
+// ---------------------------------------------------------------------------
+// Docker credential handler (a faithful port of docker_handler.go) — the third bus
+// namespace. Uses its own per-namespace gate + the Docker protocol error codes. The
+// get audit is a LogEntry form that — unlike ssh/aws — SETS code+reason and splits
+// `result` into anonymous-vs-error (the CREDENTIALS_NOT_FOUND → anonymous-pull case);
+// the list audit is the ssh-style positional form (success only, `approval:"none"`).
+// ---------------------------------------------------------------------------
+
+/// Docker response payload types (serde mirrors of `internal/ext/protocol/docker.go`).
+/// Built as typed structs (not ad-hoc `json!`) so the tag names are pinned in one place;
+/// `docker_payload_tag_names_match_protocol` asserts they equal the Go json tags.
+#[derive(Serialize)]
+struct DockerGetResponse {
+    server_url: String,
+    username: String,
+    secret: String,
+}
+
+/// `DockerListResponse` — the `list` op's payload. `registries` is a registry→username
+/// map (Go `map[string]string`; a `BTreeMap` here so the wire is deterministic).
+#[derive(Serialize)]
+struct DockerListResponse {
+    registries: BTreeMap<String, String>,
+}
+
+/// `DockerPingResponse` — the `ping` op's payload.
+#[derive(Serialize)]
+struct DockerPingResponse {
+    status: String,
+}
+
+/// `DockerStatusResponse` — the `status` op's payload.
+#[derive(Serialize)]
+struct DockerStatusResponse {
+    connected: bool,
+    allow_all: bool,
+    registry_count: usize,
+}
+
+/// `DockerErrorResponse` — an `{error, code}` error payload.
+#[derive(Serialize)]
+struct DockerErrorResponse {
+    error: String,
+    code: String,
+}
+
+/// The `get` request payload (`DockerGetRequest`). `operation` is already dispatched on;
+/// only `server_url` is needed. `#[serde(default)]` so an absent field zero-fills (Go
+/// `json.Unmarshal`); a wrong-typed `server_url` fails the decode (Go too).
+#[derive(Deserialize)]
+struct DockerGetRequestPayload {
+    #[serde(default)]
+    server_url: String,
+}
+
+/// Build an `{error, code}` Docker error payload (`DockerErrorResponse`).
+fn docker_error(msg: &str, code: &str) -> serde_json::Value {
+    to_payload(&DockerErrorResponse {
+        error: msg.to_string(),
+        code: code.to_string(),
+    })
+}
+
+/// A Docker `get` audit entry — the LogEntry form carrying the gate outcome AND
+/// `code`/`reason` (unlike ssh/aws get audits, which set neither). Fixed
+/// docker-credentials ns + `get` op; `detail` is always the requested `server_url`; a
+/// `code`/`reason` of `""` is omitted by the sink (Go omitempty), so the ok path passes
+/// `""` for both. Mirrors `docker_handler.go`'s three `LogEntry` calls.
+#[allow(clippy::too_many_arguments)]
+fn docker_get_audit(
+    server_name: &str,
+    shed_name: &str,
+    result: &str,
+    detail: &str,
+    code: &str,
+    reason: &str,
+    approval: String,
+    outcome: &crate::approval::ApprovalOutcome,
+) -> AuditEntry {
+    AuditEntry {
+        server: server_name.to_string(),
+        shed: shed_name.to_string(),
+        ns: NS_DOCKER_CREDENTIALS.to_string(),
+        op: DOCKER_OP_GET.to_string(),
+        result: result.to_string(),
+        detail: detail.to_string(),
+        code: code.to_string(),
+        reason: reason.to_string(),
+        approval,
+        decided_by: outcome.decided_by.clone(),
+        scope: outcome.scope.clone().unwrap_or_default(),
+        ttl: outcome.ttl.clone().unwrap_or_default(),
+        ..Default::default()
+    }
+}
+
+/// A Docker `list` audit entry — Go's positional `AuditLogger.Log` form (like ssh's
+/// `list`, NOT the LogEntry form): fixed docker-credentials ns + `list` op, the given
+/// result/detail, `approval:"none"`, and NO decided_by/scope/ttl/code/reason. `list`
+/// audits ONLY on success (the error path returns audit-silent).
+fn docker_list_audit(server_name: &str, shed_name: &str, detail: &str) -> AuditEntry {
+    AuditEntry {
+        server: server_name.to_string(),
+        shed: shed_name.to_string(),
+        ns: NS_DOCKER_CREDENTIALS.to_string(),
+        op: DOCKER_OP_LIST.to_string(),
+        result: "ok".to_string(),
+        detail: detail.to_string(),
+        approval: "none".to_string(),
+        ..Default::default()
+    }
+}
+
+/// Answer one inbound docker-credentials request, mirroring `docker_handler.go:handleMessage`'s
+/// dispatch. `get` runs the gated flow (approval gate → backend → response + audit);
+/// `list` → the UNGATED registry listing (success audits positionally, error is
+/// audit-silent); `ping` → `{"status":"ok"}`; `status` → `{connected, allow_all,
+/// registry_count}`; an unknown op → Go's exact `unknown operation: <op>` `INTERNAL_ERROR`;
+/// a non-object/non-null payload → `{invalid payload, INTERNAL_ERROR}` (the shared
+/// [`parse_operation`], but with Docker codes). The reply plumbing + audit-after-response
+/// order match the ssh/aws paths (`respond_and_audit`).
+async fn handle_docker_bus_message(
+    client: &BusClient,
+    namespace: &str,
+    env: &Envelope,
+    shutdown: &watch::Receiver<bool>,
+    docker: &DockerHandlers,
+    audit: &Arc<dyn AuditSink>,
+    server_name: &str,
+) {
+    let (payload, audit_entry) = docker_dispatch(env, docker, server_name).await;
+    respond_and_audit(
+        client,
+        namespace,
+        env,
+        shutdown,
+        audit,
+        payload,
+        audit_entry,
+        "docker response",
+    )
+    .await;
+}
+
+/// Compute the docker-credentials response payload + optional audit entry for one request
+/// (the network-free core of [`handle_docker_bus_message`], so unit tests inspect the
+/// payload + audit directly). `get`/`list` audit per Go; `ping`/`status`/unknown/invalid
+/// do not.
+async fn docker_dispatch(
+    env: &Envelope,
+    docker: &DockerHandlers,
+    server_name: &str,
+) -> (serde_json::Value, Option<AuditEntry>) {
+    let shed_name = env.shed.as_ref().map(|s| s.name.as_str()).unwrap_or("");
+    match parse_operation(&env.payload) {
+        Err(()) => (docker_error("invalid payload", DOCKER_CODE_INTERNAL), None),
+        Ok(op) => match op.as_str() {
+            DOCKER_OP_GET => {
+                handle_docker_get(env, server_name, shed_name, &docker.gate, &docker.backend).await
+            }
+            DOCKER_OP_LIST => {
+                handle_docker_list(server_name, shed_name, &docker.backend).await
+            }
+            "ping" => (
+                to_payload(&DockerPingResponse {
+                    status: "ok".to_string(),
+                }),
+                None,
+            ),
+            "status" => (
+                handle_docker_status(server_name, shed_name, &docker.backend),
+                None,
+            ),
+            other => (
+                docker_error(&format!("unknown operation: {other}"), DOCKER_CODE_INTERNAL),
+                None,
+            ),
+        },
+    }
+}
+
+/// The gated `get` flow — a faithful port of `docker_handler.go:handleGet`. ORDER matches
+/// Go: parse request → **approval gate** → backend. On gate-deny the guest gets
+/// `{approval denied, REGISTRY_NOT_ALLOWED}` while the audit carries `code:APPROVAL_DENIED,
+/// result:denied` (the two-code disambiguation). On a backend error the guest gets the
+/// original code (`DockerCredError.code`, or `INTERNAL_ERROR` when empty) and the audit
+/// splits `result` into `anonymous` (CREDENTIALS_NOT_FOUND — the guest pulls anonymously)
+/// vs `error`, with `code`+`reason`(err msg)+`detail`(server_url). On success →
+/// `DockerGetResponse` + an ok audit (detail = server_url, NO code/reason).
+async fn handle_docker_get(
+    env: &Envelope,
+    server_name: &str,
+    shed_name: &str,
+    gate: &Arc<dyn ApprovalGate>,
+    backend: &Arc<dyn DockerBackend>,
+) -> (serde_json::Value, Option<AuditEntry>) {
+    // Parse the get request (a wrong-typed `server_url` → invalid get request; no audit).
+    let req: DockerGetRequestPayload =
+        match serde_json::from_value(env.payload.clone().unwrap_or_default()) {
+            Ok(r) => r,
+            Err(_) => return (docker_error("invalid get request", DOCKER_CODE_INTERNAL), None),
+        };
+
+    // Approval gate FIRST (deny-all fails closed). The reason names the registry so the
+    // desktop approval card shows what is being requested (Go's `fmt.Sprintf`).
+    let outcome = gate
+        .approve(
+            NS_DOCKER_CREDENTIALS,
+            DOCKER_OP_GET,
+            server_name,
+            shed_name,
+            &format!("Docker credentials for {}", req.server_url),
+        )
+        .await;
+    let approval = gate.method().to_string();
+    if !outcome.approved {
+        // Deny audit: code=APPROVAL_DENIED (audit-only), reason=the gate deny reason,
+        // detail=server_url + the outcome. The guest still receives REGISTRY_NOT_ALLOWED.
+        let entry = docker_get_audit(
+            server_name,
+            shed_name,
+            "denied",
+            &req.server_url,
+            DOCKER_AUDIT_CODE_APPROVAL_DENIED,
+            &outcome.reason,
+            approval,
+            &outcome,
+        );
+        return (
+            docker_error("approval denied", DOCKER_CODE_NOT_ALLOWED),
+            Some(entry),
+        );
+    }
+
+    match backend
+        .get_credentials(server_name, shed_name, &req.server_url)
+        .await
+    {
+        Ok(cred) => {
+            let resp = DockerGetResponse {
+                server_url: cred.server_url,
+                username: cred.username,
+                secret: cred.secret,
+            };
+            // ok audit: detail=server_url, NO code/reason (Go passes neither).
+            let entry = docker_get_audit(
+                server_name,
+                shed_name,
+                "ok",
+                &req.server_url,
+                "",
+                "",
+                approval,
+                &outcome,
+            );
+            (to_payload(&resp), Some(entry))
+        }
+        Err(e) => {
+            // An empty backend code maps to INTERNAL_ERROR (Go's bare-`fmt.Errorf` cases).
+            let code = if e.code.is_empty() {
+                DOCKER_CODE_INTERNAL
+            } else {
+                e.code.as_str()
+            };
+            // CREDENTIALS_NOT_FOUND for an allowed registry is an anonymous pull, not a
+            // failure → audit `anonymous`; everything else (deny, helper fault) → `error`.
+            let result = if code == DOCKER_CODE_NOT_FOUND {
+                DOCKER_AUDIT_RESULT_ANONYMOUS
+            } else {
+                "error"
+            };
+            // The guest receives the original code; the audit enriches with code+reason.
+            let entry = docker_get_audit(
+                server_name,
+                shed_name,
+                result,
+                &req.server_url,
+                code,
+                &e.msg,
+                approval,
+                &outcome,
+            );
+            (docker_error("credential request failed", code), Some(entry))
+        }
+    }
+}
+
+/// The `list` op — a faithful port of `docker_handler.go:handleList`. UNGATED (Go never
+/// invokes the approval gate on `list`). Success → `DockerListResponse{registries}` + a
+/// positional audit (`count:N`, `approval:none`). A backend error → `{list failed,
+/// INTERNAL_ERROR}` and returns with **NO audit** (Go returns early; only success audits).
+async fn handle_docker_list(
+    server_name: &str,
+    shed_name: &str,
+    backend: &Arc<dyn DockerBackend>,
+) -> (serde_json::Value, Option<AuditEntry>) {
+    match backend.list_credentials(server_name, shed_name).await {
+        Ok(registries) => {
+            let count = registries.len();
+            let payload = to_payload(&DockerListResponse { registries });
+            let entry = docker_list_audit(server_name, shed_name, &format!("count:{count}"));
+            (payload, Some(entry))
+        }
+        // Error path: audit-silent (matches Go's early return, no LogEntry).
+        Err(_) => (docker_error("list failed", DOCKER_CODE_INTERNAL), None),
+    }
+}
+
+/// The `status` op — a faithful port of `docker_handler.go:handleStatus`:
+/// `{connected:true, allow_all, registry_count}`. `Status` never errors. NO audit.
+fn handle_docker_status(
+    server_name: &str,
+    shed_name: &str,
+    backend: &Arc<dyn DockerBackend>,
+) -> serde_json::Value {
+    let (allow_all, registry_count) = backend.status(server_name, shed_name);
+    to_payload(&DockerStatusResponse {
+        connected: true,
+        allow_all,
+        registry_count,
+    })
+}
+
 /// The credential namespaces (re-exported from `config` for callers wiring the
 /// bus). `ssh-agent` is always subscribed; `aws-credentials` when configured;
-/// `docker-credentials` is a later slice.
+/// `docker-credentials` in the common case (even unconfigured).
 pub const BUS_NAMESPACES: [&str; 3] = [NS_SSH_AGENT, NS_AWS_CREDENTIALS, NS_DOCKER_CREDENTIALS];
 
 #[cfg(test)]
@@ -1707,6 +2086,7 @@ mod tests {
             backend,
             server_name: String::new(),
             aws: None,
+            docker: None,
         }
     }
 
@@ -3147,6 +3527,7 @@ mod tests {
                 backend: FakeAwsBackend::creds_ok(creds(None)), // aws gate: approve-all
                 gate: approve_gate(),
             }),
+            docker: None,
         };
 
         // aws-credentials → the approve-all aws gate vends the key (never "approval denied").
@@ -3256,6 +3637,419 @@ mod tests {
         );
         assert_eq!(
             aws_error("boom", "INTERNAL_ERROR"),
+            serde_json::json!({"error":"boom","code":"INTERNAL_ERROR"})
+        );
+    }
+
+    // ---- Docker credential handler (mirror docker_handler.go) --------------------
+
+    use crate::docker_backend::{DockerCredError, DockerCredential};
+
+    /// A scripted Docker backend: `get_credentials` returns a canned Result (and counts
+    /// calls, to prove the gate short-circuits a deny); `list_credentials`/`status`
+    /// return canned values.
+    struct FakeDockerBackend {
+        get: Result<DockerCredential, DockerCredError>,
+        list: Result<BTreeMap<String, String>, String>,
+        status: (bool, usize),
+        get_calls: AtomicUsize,
+    }
+    impl FakeDockerBackend {
+        fn new(
+            get: Result<DockerCredential, DockerCredError>,
+            list: Result<BTreeMap<String, String>, String>,
+            status: (bool, usize),
+        ) -> Arc<Self> {
+            Arc::new(Self {
+                get,
+                list,
+                status,
+                get_calls: AtomicUsize::new(0),
+            })
+        }
+        fn get_ok(cred: DockerCredential) -> Arc<Self> {
+            Self::new(Ok(cred), Ok(BTreeMap::new()), (false, 0))
+        }
+        fn get_err(e: DockerCredError) -> Arc<Self> {
+            Self::new(Err(e), Ok(BTreeMap::new()), (false, 0))
+        }
+        fn with_list(list: BTreeMap<String, String>) -> Arc<Self> {
+            Self::new(Err(unused_err()), Ok(list), (false, 0))
+        }
+        fn list_err() -> Arc<Self> {
+            Self::new(Err(unused_err()), Err("boom".to_string()), (false, 0))
+        }
+        fn with_status(allow_all: bool, count: usize) -> Arc<Self> {
+            Self::new(Err(unused_err()), Ok(BTreeMap::new()), (allow_all, count))
+        }
+    }
+    #[async_trait::async_trait]
+    impl DockerBackend for FakeDockerBackend {
+        async fn get_credentials(
+            &self,
+            _server: &str,
+            _shed: &str,
+            _server_url: &str,
+        ) -> Result<DockerCredential, DockerCredError> {
+            self.get_calls.fetch_add(1, Ordering::SeqCst);
+            self.get.clone()
+        }
+        async fn list_credentials(
+            &self,
+            _server: &str,
+            _shed: &str,
+        ) -> Result<BTreeMap<String, String>, String> {
+            self.list.clone()
+        }
+        fn status(&self, _server: &str, _shed: &str) -> (bool, usize) {
+            self.status
+        }
+    }
+
+    fn unused_err() -> DockerCredError {
+        DockerCredError {
+            msg: "unused".to_string(),
+            code: "UNUSED".to_string(),
+        }
+    }
+    fn cred(server_url: &str, username: &str, secret: &str) -> DockerCredential {
+        DockerCredential {
+            server_url: server_url.to_string(),
+            username: username.to_string(),
+            secret: secret.to_string(),
+        }
+    }
+    fn docker_handlers(backend: Arc<dyn DockerBackend>, gate: Arc<dyn ApprovalGate>) -> DockerHandlers {
+        DockerHandlers { backend, gate }
+    }
+    /// A docker-credentials request Envelope carrying `payload` + a fixed shed.
+    fn docker_env(payload: serde_json::Value) -> Envelope {
+        Envelope {
+            id: "docker-req".into(),
+            namespace: "docker-credentials".into(),
+            msg_type: "request".into(),
+            in_reply_to: String::new(),
+            is_final: true,
+            timestamp: "t".into(),
+            payload: Some(payload),
+            shed: Some(ShedInfo {
+                name: "web".into(),
+                backend: "vz".into(),
+                server: "mini2".into(),
+            }),
+        }
+    }
+    fn docker_get_env(server_url: &str) -> Envelope {
+        docker_env(serde_json::json!({"operation": "get", "server_url": server_url}))
+    }
+
+    #[tokio::test]
+    async fn docker_get_ok() {
+        let backend: Arc<dyn DockerBackend> = FakeDockerBackend::get_ok(cred("ghcr.io", "u", "s"));
+        let (payload, entry) =
+            docker_dispatch(&docker_get_env("ghcr.io"), &docker_handlers(backend, approve_gate()), "").await;
+        assert_eq!(payload["server_url"], "ghcr.io");
+        assert_eq!(payload["username"], "u");
+        assert_eq!(payload["secret"], "s");
+        // ok audit: ns/op fixed, detail=server_url, approval; NO code/reason.
+        let entry = entry.expect("ok path audits");
+        assert_eq!(entry.ns, "docker-credentials");
+        assert_eq!(entry.op, "get");
+        assert_eq!(entry.result, "ok");
+        assert_eq!(entry.detail, "ghcr.io");
+        assert_eq!(entry.approval, "approve-all");
+        assert_eq!(entry.shed, "web");
+        assert_eq!(entry.code, "");
+        assert_eq!(entry.reason, "");
+    }
+
+    #[tokio::test]
+    async fn docker_get_error_maps_code() {
+        // The guest receives the backend's raw code (REGISTRY_NOT_ALLOWED here).
+        let backend: Arc<dyn DockerBackend> = FakeDockerBackend::get_err(DockerCredError {
+            msg: "registry not allowed".into(),
+            code: DOCKER_CODE_NOT_ALLOWED.into(),
+        });
+        let (payload, _entry) =
+            docker_dispatch(&docker_get_env("blocked.io"), &docker_handlers(backend, approve_gate()), "").await;
+        assert_eq!(payload["error"], "credential request failed");
+        assert_eq!(payload["code"], "REGISTRY_NOT_ALLOWED");
+    }
+
+    async fn docker_get_audit_case(code: &str, msg: &str) -> AuditEntry {
+        let backend: Arc<dyn DockerBackend> = FakeDockerBackend::get_err(DockerCredError {
+            msg: msg.into(),
+            code: code.into(),
+        });
+        let (_p, entry) = docker_dispatch(
+            &docker_get_env("https://index.docker.io/v1/"),
+            &docker_handlers(backend, approve_gate()),
+            "",
+        )
+        .await;
+        entry.expect("get error path audits")
+    }
+
+    #[tokio::test]
+    async fn docker_get_audit_anonymous_on_not_found() {
+        // CREDENTIALS_NOT_FOUND for an allowed registry → audit result "anonymous"
+        // (guest pulls anonymously), code+reason+detail set.
+        let e = docker_get_audit_case(DOCKER_CODE_NOT_FOUND, "no credentials found").await;
+        assert_eq!(e.result, "anonymous");
+        assert_eq!(e.code, "CREDENTIALS_NOT_FOUND");
+        assert_eq!(e.reason, "no credentials found");
+        assert_eq!(e.detail, "https://index.docker.io/v1/");
+        assert_eq!(e.op, "get");
+    }
+
+    #[tokio::test]
+    async fn docker_get_audit_error_on_not_allowed() {
+        // An allowlist deny (a backend REGISTRY_NOT_ALLOWED) stays "error", not anonymous.
+        let e = docker_get_audit_case(DOCKER_CODE_NOT_ALLOWED, "registry not allowed").await;
+        assert_eq!(e.result, "error");
+        assert_eq!(e.code, "REGISTRY_NOT_ALLOWED");
+        assert_eq!(e.reason, "registry not allowed");
+    }
+
+    #[tokio::test]
+    async fn docker_get_audit_error_on_helper_failed() {
+        let e = docker_get_audit_case("HELPER_FAILED", "boom").await;
+        assert_eq!(e.result, "error");
+        assert_eq!(e.code, "HELPER_FAILED");
+        assert_eq!(e.reason, "boom");
+    }
+
+    #[tokio::test]
+    async fn docker_get_denied_guest_not_allowed_audit_approval_denied() {
+        // A deny-all gate: the guest still receives REGISTRY_NOT_ALLOWED (back-compat)
+        // while the audit carries APPROVAL_DENIED + result denied (two-code
+        // disambiguation) + the deny reason. The backend is never consulted.
+        let backend = FakeDockerBackend::get_ok(cred("ghcr.io", "u", "s"));
+        let dyn_backend: Arc<dyn DockerBackend> = backend.clone();
+        let (payload, entry) =
+            docker_dispatch(&docker_get_env("ghcr.io"), &docker_handlers(dyn_backend, deny_gate()), "").await;
+        assert_eq!(payload["error"], "approval denied");
+        assert_eq!(payload["code"], "REGISTRY_NOT_ALLOWED");
+        let entry = entry.expect("deny path audits");
+        assert_eq!(entry.result, "denied");
+        assert_eq!(entry.code, "APPROVAL_DENIED");
+        assert_eq!(entry.reason, "denied: approval policy is deny-all");
+        assert_eq!(entry.detail, "ghcr.io");
+        assert_eq!(entry.approval, "deny-all");
+        assert_eq!(entry.decided_by, ""); // deny-all's empty outcome
+        assert_eq!(
+            backend.get_calls.load(Ordering::SeqCst),
+            0,
+            "backend must not be consulted when the gate denies"
+        );
+    }
+
+    #[tokio::test]
+    async fn docker_ping() {
+        let backend: Arc<dyn DockerBackend> = FakeDockerBackend::get_ok(cred("x", "y", "z"));
+        let (payload, entry) =
+            docker_dispatch(&docker_env(serde_json::json!({"operation":"ping"})), &docker_handlers(backend, approve_gate()), "").await;
+        assert_eq!(payload, serde_json::json!({"status": "ok"}));
+        assert!(entry.is_none(), "ping does not audit");
+    }
+
+    #[tokio::test]
+    async fn docker_status_connected() {
+        let backend: Arc<dyn DockerBackend> = FakeDockerBackend::with_status(true, 3);
+        let (payload, entry) =
+            docker_dispatch(&docker_env(serde_json::json!({"operation":"status"})), &docker_handlers(backend, approve_gate()), "").await;
+        assert_eq!(
+            payload,
+            serde_json::json!({"connected": true, "allow_all": true, "registry_count": 3})
+        );
+        assert!(entry.is_none(), "status does not audit");
+    }
+
+    #[tokio::test]
+    async fn docker_list_ok() {
+        let mut m = BTreeMap::new();
+        m.insert("gcr.io".to_string(), "user1".to_string());
+        m.insert("ghcr.io".to_string(), "user2".to_string());
+        let backend: Arc<dyn DockerBackend> = FakeDockerBackend::with_list(m);
+        let (payload, entry) =
+            docker_dispatch(&docker_env(serde_json::json!({"operation":"list"})), &docker_handlers(backend, approve_gate()), "").await;
+        assert_eq!(payload["registries"]["gcr.io"], "user1");
+        assert_eq!(payload["registries"]["ghcr.io"], "user2");
+        // Positional audit: op=list, ok, detail="count:2", approval=none, NO outcome/code.
+        let entry = entry.expect("list success audits");
+        assert_eq!(entry.op, "list");
+        assert_eq!(entry.ns, "docker-credentials");
+        assert_eq!(entry.result, "ok");
+        assert_eq!(entry.detail, "count:2");
+        assert_eq!(entry.approval, "none");
+        assert_eq!(entry.decided_by, "");
+        assert_eq!(entry.code, "");
+    }
+
+    #[tokio::test]
+    async fn docker_list_error_has_no_audit() {
+        // A backend list error → {list failed, INTERNAL_ERROR} + NO audit (Go returns
+        // early; list audits ONLY on success).
+        let backend: Arc<dyn DockerBackend> = FakeDockerBackend::list_err();
+        let (payload, entry) =
+            docker_dispatch(&docker_env(serde_json::json!({"operation":"list"})), &docker_handlers(backend, approve_gate()), "").await;
+        assert_eq!(payload["error"], "list failed");
+        assert_eq!(payload["code"], "INTERNAL_ERROR");
+        assert!(entry.is_none(), "list error path is audit-silent");
+    }
+
+    fn dummy_docker() -> Arc<dyn DockerBackend> {
+        FakeDockerBackend::get_ok(cred("x", "y", "z"))
+    }
+
+    #[tokio::test]
+    async fn docker_omitted_payload_invalid() {
+        // An OMITTED payload (Go nil json.RawMessage) → {invalid payload, INTERNAL_ERROR}.
+        let mut env = docker_env(serde_json::json!({"operation":"ping"}));
+        env.payload = None;
+        let (payload, entry) =
+            docker_dispatch(&env, &docker_handlers(dummy_docker(), approve_gate()), "").await;
+        assert_eq!(payload["error"], "invalid payload");
+        assert_eq!(payload["code"], "INTERNAL_ERROR");
+        assert!(entry.is_none());
+    }
+
+    #[tokio::test]
+    async fn docker_null_payload_unknown_op_empty() {
+        // Explicit null payload → zero op → "unknown operation: " (INTERNAL_ERROR).
+        let mut env = docker_env(serde_json::json!({"operation":"ping"}));
+        env.payload = Some(serde_json::Value::Null);
+        let (payload, entry) =
+            docker_dispatch(&env, &docker_handlers(dummy_docker(), approve_gate()), "").await;
+        assert_eq!(payload["error"], "unknown operation: ");
+        assert_eq!(payload["code"], "INTERNAL_ERROR");
+        assert!(entry.is_none());
+    }
+
+    #[tokio::test]
+    async fn docker_missing_op_unknown_op_empty() {
+        // Object with no `operation` → zero op → "unknown operation: ".
+        let (payload, entry) =
+            docker_dispatch(&docker_env(serde_json::json!({})), &docker_handlers(dummy_docker(), approve_gate()), "").await;
+        assert_eq!(payload["error"], "unknown operation: ");
+        assert_eq!(payload["code"], "INTERNAL_ERROR");
+        assert!(entry.is_none());
+    }
+
+    #[tokio::test]
+    async fn docker_unknown_op_exact_string() {
+        let (payload, entry) = docker_dispatch(
+            &docker_env(serde_json::json!({"operation":"delete"})),
+            &docker_handlers(dummy_docker(), approve_gate()),
+            "",
+        )
+        .await;
+        assert_eq!(payload["error"], "unknown operation: delete");
+        assert_eq!(payload["code"], "INTERNAL_ERROR");
+        assert!(entry.is_none());
+    }
+
+    #[tokio::test]
+    async fn docker_array_or_scalar_op_invalid() {
+        // A non-object payload (array or scalar) OR a non-string `operation` → the shared
+        // parse_operation error → {invalid payload, INTERNAL_ERROR}.
+        for payload in [
+            serde_json::json!([1, 2, 3]),
+            serde_json::json!("hi"),
+            serde_json::json!({"operation": 123}),
+        ] {
+            let (resp, entry) =
+                docker_dispatch(&docker_env(payload), &docker_handlers(dummy_docker(), approve_gate()), "").await;
+            assert_eq!(resp["error"], "invalid payload");
+            assert_eq!(resp["code"], "INTERNAL_ERROR");
+            assert!(entry.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn docker_uses_docker_gate_not_ssh_or_aws() {
+        // One BusHandlers: ssh gate = deny-all, docker gate = approve-all. Routed through
+        // the real dispatcher over the wire, a docker `get` is APPROVED (uses docker.gate,
+        // never the ssh gate) → the mock only matches a vended-credential body. Proves
+        // per-namespace gate selection.
+        let docker_backend: Arc<dyn DockerBackend> = FakeDockerBackend::get_ok(cred("ghcr.io", "u", "s"));
+        let handlers = BusHandlers {
+            gate: deny_gate(), // ssh gate: deny-all
+            audit: noop_audit(),
+            backend: empty_backend(),
+            server_name: String::new(),
+            aws: None,
+            docker: Some(DockerHandlers {
+                backend: docker_backend,
+                gate: approve_gate(), // docker gate: approve-all
+            }),
+        };
+        let server = MockServer::start_async().await;
+        let ok = server
+            .mock_async(|w, t| {
+                w.method(POST)
+                    .path("/api/plugins/listeners/docker-credentials/respond")
+                    .matches(|req| {
+                        let body = req
+                            .body
+                            .as_ref()
+                            .map(|b| String::from_utf8_lossy(b).to_string())
+                            .unwrap_or_default();
+                        body.contains("\"secret\":\"s\"") && !body.contains("approval denied")
+                    });
+                t.status(204);
+            })
+            .await;
+        let client = open_client(&server.base_url());
+        dispatch_bus_message(
+            &client,
+            "docker-credentials",
+            &docker_get_env("ghcr.io"),
+            &never_shutdown(),
+            &handlers,
+        )
+        .await;
+        ok.assert_async().await;
+    }
+
+    #[test]
+    fn docker_payload_tag_names_match_protocol() {
+        // Golden-consistency: the guest-wire serde tag names equal the Go json tags in
+        // docker.go (distinct from the Capitalized helper-protocol struct in
+        // docker_backend.rs, whose roundtrip is guarded there).
+        assert_eq!(
+            serde_json::to_value(DockerGetResponse {
+                server_url: "a".into(),
+                username: "b".into(),
+                secret: "c".into(),
+            })
+            .unwrap(),
+            serde_json::json!({"server_url":"a","username":"b","secret":"c"})
+        );
+        let mut m = BTreeMap::new();
+        m.insert("ghcr.io".to_string(), "u".to_string());
+        assert_eq!(
+            serde_json::to_value(DockerListResponse { registries: m }).unwrap(),
+            serde_json::json!({"registries":{"ghcr.io":"u"}})
+        );
+        assert_eq!(
+            serde_json::to_value(DockerPingResponse {
+                status: "ok".into()
+            })
+            .unwrap(),
+            serde_json::json!({"status":"ok"})
+        );
+        assert_eq!(
+            serde_json::to_value(DockerStatusResponse {
+                connected: true,
+                allow_all: false,
+                registry_count: 2,
+            })
+            .unwrap(),
+            serde_json::json!({"connected":true,"allow_all":false,"registry_count":2})
+        );
+        assert_eq!(
+            docker_error("boom", "INTERNAL_ERROR"),
             serde_json::json!({"error":"boom","code":"INTERNAL_ERROR"})
         );
     }

--- a/crates/shed-host-agent/src/bus.rs
+++ b/crates/shed-host-agent/src/bus.rs
@@ -1177,12 +1177,13 @@ struct SshErrorResponse {
     code: String,
 }
 
-/// Serialize an SSH response payload struct to a `serde_json::Value`. The response
-/// structs are all plain `String`/`bool`/`usize`/`Vec<struct>` fields, so `to_value` is
-/// infallible; `.expect` fails loud on the impossible rather than silently emitting a
+/// Serialize a bus response payload struct (ssh/aws/docker) to a
+/// `serde_json::Value`. The response structs are all plain
+/// `String`/`bool`/`usize`/map/`Vec<struct>` fields, so `to_value` is infallible;
+/// `.expect` fails loud on the impossible rather than silently emitting a
 /// divergent shape (the typed structs are the single source of the wire field/tag names).
 fn to_payload<T: Serialize>(value: &T) -> serde_json::Value {
-    serde_json::to_value(value).expect("serialize ssh response payload")
+    serde_json::to_value(value).expect("serialize bus response payload")
 }
 
 /// Build an `{error, code}` SSH error payload (`SSHErrorResponse`). shed-server parses

--- a/crates/shed-host-agent/src/config.rs
+++ b/crates/shed-host-agent/src/config.rs
@@ -806,6 +806,17 @@ pub(crate) mod yaml_lite {
     /// whitespace-only) inner yields an empty sequence — the `[]` deny-all case —
     /// as does a trailing empty element from a dangling comma (the shipped flow
     /// lists never carry one).
+    ///
+    /// **Known divergence (CodeRabbit review, tracked for the config-port
+    /// sub-plan):** a MALFORMED flow list (`registries: [only-this` — unterminated
+    /// bracket) fails the `ends_with(']')` detector and degrades to a scalar,
+    /// which the Option-typed readers treat as an ABSENT key → inherit. Go's
+    /// yaml.Unmarshal hard-fails and the daemon refuses to start, so an operator
+    /// typo in a lockdown line is loud there and silently fail-open here. The
+    /// permissive-`yaml_lite`-vs-strict-Go class (incl. this case) is closed by
+    /// the config-port slice's validation parity (malformed YAML → exit 1).
+    /// Quoted items containing commas also split naively (documented flow-list
+    /// scope; registry hostnames cannot contain commas).
     fn parse_flow_seq(inner: &str) -> Node {
         let items = inner
             .split(',')

--- a/crates/shed-host-agent/src/config.rs
+++ b/crates/shed-host-agent/src/config.rs
@@ -552,7 +552,6 @@ pub struct DockerShedConfig {
 /// `ResolvedDocker`). `registry_count` in the backend's `Status` is just
 /// `registries.len()`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)] // Constructed only by `resolve` (also staged below) until the backend/bus land.
 pub struct ResolvedDocker {
     pub registries: Vec<String>,
     pub allow_all: bool,
@@ -628,8 +627,9 @@ impl DockerConfig {
     /// `Some(vec![])` replaces with empty (child denies all); an unset (`None`)
     /// `registries`/`allow_all` inherits. A faithful port of Go's
     /// `DockerConfig.Resolve` (`config.go:233-254`, the `sv.Registries != nil` /
-    /// `sv.AllowAll != nil` checks).
-    #[allow(dead_code)] // Consumed by the backend Status/get (commit 2) + bus wiring (commit 3); today only the config unit tests + docker_resolve golden reach it. Staged like the AWS slice.
+    /// `sv.AllowAll != nil` checks). Consumed by the Docker backend's
+    /// `get_credentials`/`list_credentials`/`status` (`docker_backend.rs`, commit 2)
+    /// + the config unit tests + the `docker_resolve` golden.
     pub fn resolve(&self, server: &str, shed: &str) -> ResolvedDocker {
         let mut registries = self.registries.clone();
         let mut allow_all = self.allow_all;

--- a/crates/shed-host-agent/src/config.rs
+++ b/crates/shed-host-agent/src/config.rs
@@ -168,6 +168,14 @@ pub struct HostAgentConfig {
     /// field carries only the resolution/vending knobs. Consumed by the AWS backend
     /// (`aws_backend.rs`).
     pub aws: AwsConfig,
+    /// The layered Docker registry-credential policy (`docker.{registries,
+    /// allow_all,config_path,servers…}`), mirroring Go's `DockerConfig`. The
+    /// `docker.approval.policy` gate is kept in `docker_policy` above (unchanged);
+    /// this field carries only the allowlist/config-path knobs. Consumed by the
+    /// Docker backend (`docker_backend.rs`, commit 2) + `main.rs` bus wiring
+    /// (commit 3); in commit 1 only the config tests + the docker_resolve golden
+    /// read it.
+    pub docker: DockerConfig,
 }
 
 impl HostAgentConfig {
@@ -224,6 +232,7 @@ impl HostAgentConfig {
             server,
             has_discovery: root.has_key("discovery"),
             aws: AwsConfig::from_node(&root),
+            docker: DockerConfig::from_node(&root),
         }
     }
 
@@ -484,6 +493,178 @@ impl AwsConfig {
     }
 }
 
+/// The layered Docker registry-credential config (`docker.*`), a faithful port of
+/// Go's `DockerConfig` (`config.go:198-254`). The top-level fields are the defaults;
+/// `servers` carries per-server (and per-shed) overrides layered over them.
+/// `config_path` (the Docker `config.json` override) is process-global. The
+/// `docker.approval.policy` gate lives on `HostAgentConfig.docker_policy`, not here.
+///
+/// Unlike [`AwsConfig`], Docker has **no `enabled()` method and no load-defaults**:
+/// Go's `DockerConfig` carries no `Enabled()` and `DefaultConfig` sets no Docker
+/// fields, so an absent/empty `docker:` block yields an empty-registries,
+/// `allow_all: false`, empty-`config_path` config that STILL constructs a live
+/// backend (which then denies every registry). That asymmetry — AWS gates itself
+/// off when unconfigured, Docker stays on — is the crux of the Docker slice and is
+/// carried by the constructor (commit 2), not by this config type.
+///
+/// Built by [`DockerConfig::from_node`] (called from `HostAgentConfig::parse`) and
+/// consumed by the Docker backend (`docker_backend.rs`, commit 2) + `main.rs` bus
+/// wiring (commit 3).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DockerConfig {
+    /// Registry hostnames to allow by default. A plain `Vec` (Go's top-level
+    /// `[]string`): absent → empty, which — with `allow_all: false` — denies all.
+    pub registries: Vec<String>,
+    /// Bypass the allowlist entirely (Go's top-level `bool` default).
+    pub allow_all: bool,
+    /// Override the Docker `config.json` path (`~/`-expansion is applied by the
+    /// backend constructor, mirroring Go's `NewDockerBackend`, not here — Go's
+    /// `LoadConfig` likewise stores it raw).
+    pub config_path: String,
+    /// Per-server overrides, each optionally with per-shed nesting.
+    pub servers: BTreeMap<String, DockerServerConfig>,
+}
+
+/// Per-server Docker overrides (Go's `DockerServerConfig`). `registries` and
+/// `allow_all` are BOTH optional so an unset value **inherits** the parent rather
+/// than forcing empty/false. `registries: Option<Vec<String>>` is the load-bearing
+/// choice (mirroring Go's `sv.Registries != nil` replace check): `None` = inherit,
+/// `Some(vec![])` = **replace-with-empty** (the child DENIES ALL — a security
+/// lockdown a plain `Vec` would silently fold into "inherit"), `Some(vec![..])` =
+/// replace. `allow_all: Option<bool>` mirrors Go's `*bool`: `None` = inherit,
+/// `Some(false)` = force-off, `Some(true)` = force-on.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DockerServerConfig {
+    pub registries: Option<Vec<String>>,
+    pub allow_all: Option<bool>,
+    pub sheds: BTreeMap<String, DockerShedConfig>,
+}
+
+/// Per-shed Docker overrides (Go's `DockerShedConfig`). Same `Option` inherit/
+/// replace/force semantics as [`DockerServerConfig`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DockerShedConfig {
+    pub registries: Option<Vec<String>>,
+    pub allow_all: Option<bool>,
+}
+
+/// The effective Docker policy for a single `(server, shed)` pair (Go's
+/// `ResolvedDocker`). `registry_count` in the backend's `Status` is just
+/// `registries.len()`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // Constructed only by `resolve` (also staged below) until the backend/bus land.
+pub struct ResolvedDocker {
+    pub registries: Vec<String>,
+    pub allow_all: bool,
+}
+
+impl DockerConfig {
+    /// Build the Docker slice from the parsed config tree. Reads a **list**
+    /// (`registries`, via [`yaml_lite::Node::as_scalar_list`]: absent key → `None`,
+    /// present `[]` → `Some(vec![])`, present `[a,b]` → `Some(vec![a,b])`) and a
+    /// **pointer bool** (`allow_all`: absent → `None`, present → `Some(_)`),
+    /// mirroring Go's `[]string`/`*bool` fields. The exact `AwsConfig::from_node`
+    /// walk, but sequence-aware.
+    ///
+    /// No load-defaults are applied (Go's `DefaultConfig` sets no Docker fields):
+    /// an absent `docker:` block yields `DockerConfig::default()` — empty
+    /// registries, `allow_all: false`, empty `config_path` — the unconfigured
+    /// deny-all backend.
+    fn from_node(root: &yaml_lite::Node) -> DockerConfig {
+        use yaml_lite::Node;
+        let docker = root
+            .as_map()
+            .and_then(|m| m.get("docker"))
+            .and_then(Node::as_map);
+
+        let mut servers = BTreeMap::new();
+        if let Some(servers_map) = docker.and_then(|m| m.get("servers")).and_then(Node::as_map) {
+            for (name, entry) in servers_map {
+                let Some(fields) = entry.as_map() else {
+                    continue;
+                };
+                let mut sheds = BTreeMap::new();
+                if let Some(sheds_map) = fields.get("sheds").and_then(Node::as_map) {
+                    for (sname, sentry) in sheds_map {
+                        let Some(sf) = sentry.as_map() else { continue };
+                        sheds.insert(
+                            sname.clone(),
+                            DockerShedConfig {
+                                registries: sf.get("registries").and_then(Node::as_scalar_list),
+                                allow_all: opt_bool(sf.get("allow_all")),
+                            },
+                        );
+                    }
+                }
+                servers.insert(
+                    name.clone(),
+                    DockerServerConfig {
+                        registries: fields.get("registries").and_then(Node::as_scalar_list),
+                        allow_all: opt_bool(fields.get("allow_all")),
+                        sheds,
+                    },
+                );
+            }
+        }
+
+        DockerConfig {
+            registries: docker
+                .and_then(|m| m.get("registries"))
+                .and_then(Node::as_scalar_list)
+                .unwrap_or_default(),
+            allow_all: opt_bool(docker.and_then(|m| m.get("allow_all"))).unwrap_or(false),
+            config_path: docker
+                .and_then(|m| m.get("config_path"))
+                .and_then(Node::as_scalar)
+                .unwrap_or("")
+                .to_string(),
+            servers,
+        }
+    }
+
+    /// Layer Docker overrides for a `(server, shed)` pair, most specific wins:
+    /// top-level defaults → `servers[server]` → `servers[server].sheds[shed]`. A
+    /// **`Some` registries list REPLACES** (does not merge) the inherited one —
+    /// `Some(vec![])` replaces with empty (child denies all); an unset (`None`)
+    /// `registries`/`allow_all` inherits. A faithful port of Go's
+    /// `DockerConfig.Resolve` (`config.go:233-254`, the `sv.Registries != nil` /
+    /// `sv.AllowAll != nil` checks).
+    #[allow(dead_code)] // Consumed by the backend Status/get (commit 2) + bus wiring (commit 3); today only the config unit tests + docker_resolve golden reach it. Staged like the AWS slice.
+    pub fn resolve(&self, server: &str, shed: &str) -> ResolvedDocker {
+        let mut registries = self.registries.clone();
+        let mut allow_all = self.allow_all;
+        if let Some(sv) = self.servers.get(server) {
+            if let Some(r) = &sv.registries {
+                registries = r.clone();
+            }
+            if let Some(a) = sv.allow_all {
+                allow_all = a;
+            }
+            if let Some(sc) = sv.sheds.get(shed) {
+                if let Some(r) = &sc.registries {
+                    registries = r.clone();
+                }
+                if let Some(a) = sc.allow_all {
+                    allow_all = a;
+                }
+            }
+        }
+        ResolvedDocker {
+            registries,
+            allow_all,
+        }
+    }
+}
+
+/// Read an optional YAML bool leaf, mirroring Go's `*bool` decode: an absent node
+/// → `None` (inherit), a present scalar → `Some(scalar == "true")` (so
+/// `allow_all: false` is `Some(false)` — force-off — not inherit). A present
+/// non-scalar (e.g. a map) → `None`.
+fn opt_bool(node: Option<&yaml_lite::Node>) -> Option<bool> {
+    node.and_then(yaml_lite::Node::as_scalar)
+        .map(|s| s == "true")
+}
+
 /// A deliberately tiny indentation-based reader. Handles exactly what the
 /// host-agent config's relevant subset contains: nested maps and scalar leaves.
 /// Inline `{}` is an empty map; comments (`#`) and blank lines are skipped. A port
@@ -495,13 +676,20 @@ pub(crate) mod yaml_lite {
     pub enum Node {
         Map(HashMap<String, Node>),
         Scalar(String),
+        /// A flow-style sequence (`[a, b, c]`) of scalar (or, in principle, nested)
+        /// nodes. Added for the Docker `registries` allowlist, which the shipped
+        /// config + `config_test.go` express as a flow list. Only flow-style `[..]`
+        /// is parsed — block-style `- item` lists are NOT supported by this minimal
+        /// reader (the line/colon model has no natural place for them; every fixture
+        /// that needs a list uses the flow form).
+        Sequence(Vec<Node>),
     }
 
     impl Node {
         pub fn as_scalar(&self) -> Option<&str> {
             match self {
                 Node::Scalar(s) => Some(s),
-                Node::Map(_) => None,
+                _ => None,
             }
         }
 
@@ -513,7 +701,36 @@ pub(crate) mod yaml_lite {
         pub fn as_map(&self) -> Option<&HashMap<String, Node>> {
             match self {
                 Node::Map(m) => Some(m),
-                Node::Scalar(_) => None,
+                _ => None,
+            }
+        }
+
+        /// The underlying slice when this node is a `Sequence`. Only the config
+        /// unit tests reach it directly today (the Docker `registries` reader uses
+        /// [`Node::as_scalar_list`]); kept as a first-class accessor because the
+        /// sequence node is reusable by later config slices.
+        #[allow(dead_code)]
+        pub fn as_seq(&self) -> Option<&[Node]> {
+            match self {
+                Node::Sequence(v) => Some(v),
+                _ => None,
+            }
+        }
+
+        /// A `Sequence` flattened to its scalar items (non-scalar items are
+        /// dropped) — the convenience the Docker `registries` allowlist reader
+        /// wants. `None` when this node is not a sequence, which lets the reader
+        /// distinguish an ABSENT key (`get` → `None`) from a present empty list
+        /// (`[]` → `Some(vec![])`) — the load-bearing nil-vs-empty distinction
+        /// Go's `[]string != nil` replace check depends on.
+        pub fn as_scalar_list(&self) -> Option<Vec<String>> {
+            match self {
+                Node::Sequence(v) => Some(
+                    v.iter()
+                        .filter_map(|n| n.as_scalar().map(str::to_string))
+                        .collect(),
+                ),
+                _ => None,
             }
         }
 
@@ -523,7 +740,7 @@ pub(crate) mod yaml_lite {
         pub fn has_key(&self, key: &str) -> bool {
             match self {
                 Node::Map(m) => m.contains_key(key),
-                Node::Scalar(_) => false,
+                _ => false,
             }
         }
 
@@ -545,7 +762,7 @@ pub(crate) mod yaml_lite {
     struct Line {
         indent: usize,
         key: String,
-        value: Option<String>, // None → a nested block follows
+        value: Option<Node>, // None → a nested block follows; Some → a leaf (scalar or sequence)
     }
 
     pub fn parse(text: &str) -> Node {
@@ -566,8 +783,11 @@ pub(crate) mod yaml_lite {
                 }
                 let value = if rest.is_empty() || rest == "{}" {
                     None
+                } else if rest.starts_with('[') && rest.ends_with(']') {
+                    // A flow-style sequence `[a, b, c]` (or empty `[]`).
+                    Some(parse_flow_seq(&rest[1..rest.len() - 1]))
                 } else {
-                    Some(unquote(&rest))
+                    Some(Node::Scalar(unquote(&rest)))
                 };
                 Some(Line {
                     indent,
@@ -578,6 +798,22 @@ pub(crate) mod yaml_lite {
             .collect();
         let mut index = 0;
         build(&lines, &mut index, -1)
+    }
+
+    /// Parse the comma-separated inner content of a flow-style list (the text
+    /// between `[` and `]`) into a `Node::Sequence` of scalars. Items are trimmed
+    /// and unquoted; empty items are dropped by the filter, so an empty (or
+    /// whitespace-only) inner yields an empty sequence — the `[]` deny-all case —
+    /// as does a trailing empty element from a dangling comma (the shipped flow
+    /// lists never carry one).
+    fn parse_flow_seq(inner: &str) -> Node {
+        let items = inner
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| Node::Scalar(unquote(s)))
+            .collect();
+        Node::Sequence(items)
     }
 
     fn build(lines: &[Line], index: &mut usize, parent_indent: isize) -> Node {
@@ -598,8 +834,8 @@ pub(crate) mod yaml_lite {
             }
             let key = lines[*index].key.clone();
             match lines[*index].value.clone() {
-                Some(value) => {
-                    map.insert(key, Node::Scalar(value));
+                Some(node) => {
+                    map.insert(key, node);
                     *index += 1;
                 }
                 None => {
@@ -1204,6 +1440,280 @@ aws:
                     r.session_duration,
                     q["session_duration"].as_str().unwrap(),
                     "session_duration {name:?}"
+                );
+            }
+        }
+    }
+
+    // ---- yaml_lite flow-list sequence (the Docker registries prerequisite) -------
+
+    /// The new `Node::Sequence` flow-list parser: `[a, b]`, empty `[]`, single item,
+    /// quoted items, and internal whitespace, plus the absent-vs-empty distinction
+    /// the Docker registries reader depends on.
+    #[test]
+    fn yaml_lite_sequence_flow_list() {
+        use yaml_lite::Node;
+        let root = yaml_lite::parse(
+            "\
+a: [x, y, z]
+b: []
+c: [only]
+d: [\"q1\", 'q2']
+e: [ spaced ,  items ]
+f: scalar
+g:
+  nested: [deep]
+",
+        );
+        let m = root.as_map().unwrap();
+        // Multi-item flow list.
+        assert_eq!(
+            m["a"].as_scalar_list().unwrap(),
+            vec!["x".to_string(), "y".to_string(), "z".to_string()]
+        );
+        // Empty list is Some(empty) — present, not absent.
+        assert_eq!(m["b"].as_scalar_list().unwrap(), Vec::<String>::new());
+        assert!(matches!(&m["b"], Node::Sequence(v) if v.is_empty()));
+        // Single item.
+        assert_eq!(m["c"].as_scalar_list().unwrap(), vec!["only".to_string()]);
+        // Quoted items are unquoted.
+        assert_eq!(
+            m["d"].as_scalar_list().unwrap(),
+            vec!["q1".to_string(), "q2".to_string()]
+        );
+        // Internal whitespace is trimmed.
+        assert_eq!(
+            m["e"].as_scalar_list().unwrap(),
+            vec!["spaced".to_string(), "items".to_string()]
+        );
+        // A scalar is NOT a sequence.
+        assert!(m["f"].as_scalar_list().is_none());
+        assert_eq!(m["f"].as_scalar(), Some("scalar"));
+        // Nested block still parses; the leaf inside it is a sequence.
+        assert_eq!(
+            m["g"].as_map().unwrap()["nested"].as_scalar_list().unwrap(),
+            vec!["deep".to_string()]
+        );
+        // as_seq exposes the raw nodes.
+        assert_eq!(m["a"].as_seq().unwrap().len(), 3);
+        // An ABSENT key is None — the inherit signal (distinct from present `[]`).
+        assert!(m.get("absent").is_none());
+    }
+
+    // ---- Docker config slice (mirror config_discovery_test.go / config_test.go) ---
+
+    /// Mirrors `config_discovery_test.go:TestDockerResolve`, extended to a full
+    /// matrix over the `Option` inherit/replace/force semantics — Rust-stronger:
+    /// Go has no `Resolve` layering test beyond the three subtests folded in here
+    /// (absent→inherit, per-server pointer override, per-shed replace+force-false),
+    /// plus the `Some(vec![])`→replace-with-empty (deny-all lockdown) and the
+    /// `allow_all` `Option<bool>` None/false/true cases the golden also pins.
+    #[test]
+    fn docker_resolve_matrix() {
+        // (shed-name, registries-override, allow_all-override) — a type alias keeps
+        // the `sv` helper below under clippy::type_complexity.
+        type ShedSpec<'a> = (&'a str, Option<Vec<&'a str>>, Option<bool>);
+        fn sv(
+            registries: Option<Vec<&str>>,
+            allow_all: Option<bool>,
+            sheds: &[ShedSpec],
+        ) -> DockerServerConfig {
+            DockerServerConfig {
+                registries: registries.map(|v| v.iter().map(|s| s.to_string()).collect()),
+                allow_all,
+                sheds: sheds
+                    .iter()
+                    .map(|(name, r, a)| {
+                        (
+                            name.to_string(),
+                            DockerShedConfig {
+                                registries: r
+                                    .as_ref()
+                                    .map(|v| v.iter().map(|s| s.to_string()).collect()),
+                                allow_all: *a,
+                            },
+                        )
+                    })
+                    .collect(),
+            }
+        }
+        let want = |registries: &[&str], allow_all: bool| ResolvedDocker {
+            registries: registries.iter().map(|s| s.to_string()).collect(),
+            allow_all,
+        };
+
+        // The TestDockerResolve config: top-level [ghcr.io]/allow_all=false, server
+        // mini2 forces allow_all=true, shed mini2/web replaces registries + forces
+        // allow_all back to false.
+        let cfg = DockerConfig {
+            registries: vec!["ghcr.io".to_string()],
+            allow_all: false,
+            config_path: String::new(),
+            servers: [(
+                "mini2".to_string(),
+                sv(
+                    None,
+                    Some(true),
+                    &[("web", Some(vec!["reg.example.com"]), Some(false))],
+                ),
+            )]
+            .into_iter()
+            .collect(),
+        };
+        // defaults when no server override
+        assert_eq!(cfg.resolve("mini3", "anything"), want(&["ghcr.io"], false));
+        // per-server allow_all pointer override, registries inherited
+        assert_eq!(cfg.resolve("mini2", "api"), want(&["ghcr.io"], true));
+        // per-shed replaces registries + forces allow_all false
+        assert_eq!(
+            cfg.resolve("mini2", "web"),
+            want(&["reg.example.com"], false)
+        );
+
+        // Some(vec![]) at the server tier → replace-with-empty (deny-all lockdown),
+        // even though the top level allows ghcr.io. A sibling server inherits.
+        let locked = DockerConfig {
+            registries: vec!["ghcr.io".to_string(), "index.docker.io".to_string()],
+            allow_all: false,
+            config_path: String::new(),
+            servers: [("locked".to_string(), sv(Some(vec![]), None, &[]))]
+                .into_iter()
+                .collect(),
+        };
+        assert_eq!(locked.resolve("locked", "x"), want(&[], false));
+        assert_eq!(
+            locked.resolve("other", "x"),
+            want(&["ghcr.io", "index.docker.io"], false)
+        );
+
+        // Some(vec![]) at the SHED tier under an allow_all=true server → deny-all
+        // lockdown for that one shed; the sibling shed inherits allow_all=true.
+        let shed_lock = DockerConfig {
+            registries: vec![],
+            allow_all: true,
+            config_path: String::new(),
+            servers: [(
+                "mini2".to_string(),
+                sv(None, None, &[("locked", Some(vec![]), Some(false))]),
+            )]
+            .into_iter()
+            .collect(),
+        };
+        assert_eq!(shed_lock.resolve("mini2", "locked"), want(&[], false));
+        assert_eq!(shed_lock.resolve("mini2", "other"), want(&[], true));
+
+        // Unconfigured (default) → empty registries, allow_all false (deny-all).
+        assert_eq!(
+            DockerConfig::default().resolve("any", "any"),
+            want(&[], false)
+        );
+    }
+
+    /// Mirrors the Docker parse rows of `config_test.go` (`TestLoadConfig:62`,
+    /// `TestExampleConfigIsValid:276-281`): flow-list `registries` parse + the
+    /// `docker.approval.policy` gate (still via the existing accessor). Validate
+    /// biometric-reject parity is sub-plan 5.
+    #[test]
+    fn docker_load_parse() {
+        // Single-item flow list + shed-desktop policy (TestLoadConfig header).
+        let cfg = HostAgentConfig::parse(
+            "\
+docker:
+  registries: [ghcr.io]
+  approval:
+    policy: shed-desktop
+",
+        );
+        assert_eq!(cfg.docker.registries, vec!["ghcr.io".to_string()]);
+        assert_eq!(cfg.effective_policy(NS_DOCKER_CREDENTIALS), "shed-desktop");
+        assert!(!cfg.docker.allow_all);
+
+        // Two-item flow list + allow_all + config_path + per-server/shed nesting.
+        let cfg = HostAgentConfig::parse(
+            "\
+docker:
+  registries: [index.docker.io, ghcr.io]
+  allow_all: false
+  config_path: /custom/config.json
+  approval:
+    policy: approve-all
+  servers:
+    mini2:
+      allow_all: true
+      sheds:
+        web:
+          registries: [reg.example.com]
+",
+        );
+        assert_eq!(
+            cfg.docker.registries,
+            vec!["index.docker.io".to_string(), "ghcr.io".to_string()]
+        );
+        assert_eq!(cfg.docker.config_path, "/custom/config.json");
+        assert_eq!(cfg.effective_policy(NS_DOCKER_CREDENTIALS), "approve-all");
+        assert_eq!(cfg.docker.servers["mini2"].allow_all, Some(true));
+        assert_eq!(
+            cfg.docker.servers["mini2"].sheds["web"].registries,
+            Some(vec!["reg.example.com".to_string()])
+        );
+        // A resolve through the parsed tree honors the pointer + replace semantics.
+        assert_eq!(
+            cfg.docker.resolve("mini2", "web"),
+            ResolvedDocker {
+                registries: vec!["reg.example.com".to_string()],
+                allow_all: true,
+            }
+        );
+    }
+
+    /// Mirrors `config_test.go:TestLoadConfigDefaults:179` — an absent `docker:`
+    /// block leaves the gate at deny-all and the resolution config empty (the
+    /// unconfigured deny-all backend). No load-defaults are applied to Docker.
+    #[test]
+    fn docker_policy_default_deny_all() {
+        let cfg = HostAgentConfig::parse("server: http://localhost:8080\n");
+        assert_eq!(cfg.effective_policy(NS_DOCKER_CREDENTIALS), POLICY_DENY_ALL);
+        assert_eq!(cfg.docker, DockerConfig::default());
+        assert!(cfg.docker.registries.is_empty());
+        assert!(!cfg.docker.allow_all);
+        assert!(cfg.docker.config_path.is_empty());
+    }
+
+    /// The Rust half of the `docker_resolve` golden — reads the SAME shared fixture
+    /// the Go runner reads (`cmd/shed-host-agent/golden_test.go:TestGoldenDockerResolve`,
+    /// via the production `LoadConfig`→`Docker.Resolve` path), so the two impls can't
+    /// drift together on the `Option<Vec<String>>` replace / `Option<bool>` force /
+    /// flow-list-parse semantics. Go has NO `Resolve` layering test, so this golden
+    /// is Rust-stronger. In-crate (the `aws_resolve` precedent — binary crate, no lib).
+    #[test]
+    fn golden_docker_resolve() {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/host-agent-diff/fixtures/docker_resolve.json");
+        let raw = std::fs::read_to_string(&path).expect("read golden fixture");
+        let fx: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(fx["protocol_version"], 1, "version skew");
+        let vectors = fx["vectors"].as_array().unwrap();
+        assert!(!vectors.is_empty(), "fixture has no vectors");
+        for v in vectors {
+            let name = v["name"].as_str().unwrap();
+            let cfg = HostAgentConfig::parse(v["config_yaml"].as_str().unwrap());
+            for q in v["queries"].as_array().unwrap() {
+                let r = cfg
+                    .docker
+                    .resolve(q["server"].as_str().unwrap(), q["shed"].as_str().unwrap());
+                let want_registries: Vec<String> = q["registries"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|s| s.as_str().unwrap().to_string())
+                    .collect();
+                assert_eq!(r.allow_all, q["allow_all"].as_bool().unwrap(), "allow_all {name:?}");
+                assert_eq!(r.registries, want_registries, "registries {name:?}");
+                // registry_count is the backend Status verdict (registries.len()).
+                assert_eq!(
+                    r.registries.len() as u64,
+                    q["registry_count"].as_u64().unwrap(),
+                    "registry_count {name:?}"
                 );
             }
         }

--- a/crates/shed-host-agent/src/desktop.rs
+++ b/crates/shed-host-agent/src/desktop.rs
@@ -135,6 +135,11 @@ fn decision_to_outcome(dec: DesktopDecision) -> ApprovalOutcome {
         decided_by,
         scope: dec.scope,
         ttl: dec.ttl,
+        // The desktop deny reason ("approval denied by shed-desktop" etc.) is
+        // sub-plan 5 (docker.approval desktop parity); this slice's only reason
+        // consumer is the docker deny-all path. Left empty here — ssh/aws never read
+        // it, and docker-desktop deny isn't wired/tested yet.
+        reason: String::new(),
     }
 }
 

--- a/crates/shed-host-agent/src/docker_backend.rs
+++ b/crates/shed-host-agent/src/docker_backend.rs
@@ -1,0 +1,1445 @@
+//! The Docker registry-credential backend — a faithful Rust port of
+//! `cmd/shed-host-agent/docker_backend.go`.
+//!
+//! Resolves Docker registry credentials on the host by reading the host's Docker
+//! `config.json` and, when a credential helper is configured, shelling out to
+//! `docker-credential-<helper> get`. The allowlist policy is resolved **per
+//! `(server, shed)` request** from [`crate::config::DockerConfig`] (not fixed at
+//! construction), so the same backend serves every shed with the shed's own policy.
+//!
+//! **Resolution order (`get_credentials`, mirror `docker_backend.go:128`):**
+//! 1. `normalize_registry(server_url)`.
+//! 2. **Allowlist check FIRST** — a not-allowed registry is refused
+//!    (`REGISTRY_NOT_ALLOWED`) *before* `config.json` is even read, so a blocked
+//!    registry with a perfectly good local credential is still denied.
+//! 3. `read_config()`.
+//! 4. `credHelpers[reg]` → exec the per-registry helper and **return its result
+//!    directly** (a per-registry helper error PROPAGATES — no fallback).
+//! 5. `credsStore` (default helper) → exec, and **on error FALL THROUGH** to inline
+//!    auths (the credsStore-vs-credHelpers asymmetry: only credsStore failure is
+//!    swallowed).
+//! 6. Inline `auths[reg].auth` → `decode_inline_auth`.
+//! 7. None → `CREDENTIALS_NOT_FOUND`.
+//!
+//! **The unconfigured-backend asymmetry (the crux of this slice):** unlike the AWS
+//! backend (which errors when `!enabled()`), [`new_docker_backend`] returns an error
+//! **only** when an explicit `config_path` is set but cannot be stat'd. An empty /
+//! absent `docker:` block (or a missing default `~/.docker/config.json`) yields a
+//! **live backend, no error** — one that then denies every registry (empty
+//! allowlist). So the docker-credentials bus namespace is subscribed for every server
+//! in the common case, even unconfigured. See [`new_docker_backend`].
+//!
+//! **The helper-exec seam** ([`HelperExecutor`]) is the live-diffable process-spawning
+//! boundary. The production [`RealHelperExecutor`] resolves the helper to an ABSOLUTE
+//! path first (Go's `lookHelperPath`: `PATH` via [`look_path`], then the extra
+//! well-known dirs with an executable-bit check), APPENDS the extra dirs to the
+//! child's `PATH` ([`augment_path`]), pipes the raw `server_url` on stdin, and parses
+//! the helper's `{"ServerURL","Username","Secret"}` reply — all under a 5 s timeout
+//! with `kill_on_drop` so a wedged helper can never hang a mint. Unit tests inject a
+//! fake executor; the real one is exercised by the shell-shim `exec_helper_*` tests.
+//!
+//! **Wiring:** this module is reached through the docker-credentials bus handler
+//! (`bus.rs`) + `main.rs` (commit 3), which construct the backend via
+//! [`new_docker_backend`] and dispatch `get`/`list`/`status` to it. Ported here in
+//! commit 2, wired later — the "ported, wired by a later slice" posture the AWS
+//! backend established.
+//!
+//! Everything here is unwired in this commit (the handler + `main.rs` land in commit
+//! 3), so the module carries a blanket `allow(dead_code)`; commit 3 removes it once
+//! the bus references `new_docker_backend` / the `DockerBackend` trait (the AWS slice
+//! carried the same allow in its commit 2, then dropped it on wiring).
+#![allow(dead_code)]
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use serde::Deserialize;
+use tokio::io::AsyncWriteExt as _;
+
+use crate::bus::BusLog;
+use crate::config::{expand_tilde, user_home_dir, DockerConfig};
+
+// The Docker wire error codes (mirror `internal/ext/protocol/docker.go`). Duplicated
+// here as string constants because the Rust daemon does not link the Go protocol
+// package; the handler (commit 3) maps these onto `DockerErrorResponse.code`.
+const DOCKER_CODE_NOT_FOUND: &str = "CREDENTIALS_NOT_FOUND";
+const DOCKER_CODE_NOT_ALLOWED: &str = "REGISTRY_NOT_ALLOWED";
+const DOCKER_CODE_HELPER_FAILED: &str = "HELPER_FAILED";
+const DOCKER_CODE_INTERNAL: &str = "INTERNAL_ERROR";
+
+/// The list separator for `PATH`. The daemon targets macOS/Linux only (vsock/UDS), so
+/// the unix `:` is correct; Go uses `os.PathListSeparator` for the same reason.
+const PATH_LIST_SEP: &str = ":";
+
+/// The default per-exec helper timeout (Go `5*time.Second`). A field on
+/// [`RealHelperExecutor`] so tests can shorten it (the minter `DEFAULT_TIMEOUT`
+/// precedent).
+const DEFAULT_HELPER_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A single Docker registry credential (mirror Go's `DockerCredential`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DockerCredential {
+    pub server_url: String,
+    pub username: String,
+    pub secret: String,
+}
+
+/// A backend error carrying the wire `code` the handler maps (mirror Go's
+/// `dockerError`). `Display` renders only `msg` (Go's `Error()`); `code` may be empty
+/// for the plain-error cases Go builds with a bare `fmt.Errorf` (the inline-auth
+/// decode failures) — the handler maps an empty code to `INTERNAL_ERROR`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DockerCredError {
+    pub msg: String,
+    pub code: String,
+}
+
+impl DockerCredError {
+    fn new(msg: impl Into<String>, code: &str) -> Self {
+        Self {
+            msg: msg.into(),
+            code: code.to_string(),
+        }
+    }
+
+    /// A plain error with no wire code (mirror Go's bare `fmt.Errorf` — no
+    /// `dockerError`), which the handler maps to `INTERNAL_ERROR`.
+    fn plain(msg: impl Into<String>) -> Self {
+        Self {
+            msg: msg.into(),
+            code: String::new(),
+        }
+    }
+}
+
+impl std::fmt::Display for DockerCredError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+impl std::error::Error for DockerCredError {}
+
+/// The host-side Docker credential operations (mirror Go's `DockerBackend`
+/// interface). Async + `&self` so the bus handler can hold it as
+/// `Arc<dyn DockerBackend>`. [`Self::status`] NEVER errors.
+#[async_trait]
+pub trait DockerBackend: Send + Sync {
+    /// Credentials for `server_url`, applying the allowlist resolved for
+    /// `(server, shed)`.
+    async fn get_credentials(
+        &self,
+        server: &str,
+        shed: &str,
+        server_url: &str,
+    ) -> Result<DockerCredential, DockerCredError>;
+
+    /// Map of allowed registry hostnames → usernames (or a placeholder label) for the
+    /// policy resolved for `(server, shed)`.
+    async fn list_credentials(
+        &self,
+        server: &str,
+        shed: &str,
+    ) -> Result<BTreeMap<String, String>, String>;
+
+    /// The allowlist mode and registry count resolved for `(server, shed)`.
+    fn status(&self, server: &str, shed: &str) -> (bool, usize);
+}
+
+/// The credential-helper exec seam (mirror Go's `helperExecutor`) — the
+/// live-diffable process-spawning boundary. A trait so unit tests inject a fake
+/// without real binaries. `Send + Sync` for `Arc<dyn HelperExecutor>`.
+#[async_trait]
+pub trait HelperExecutor: Send + Sync {
+    async fn exec_helper(
+        &self,
+        helper_name: &str,
+        server_url: &str,
+    ) -> Result<DockerCredential, DockerCredError>;
+}
+
+/// The relevant parts of `~/.docker/config.json` (mirror Go's `dockerConfig`). Every
+/// field defaults so a missing key yields an empty map/string rather than a decode
+/// error (Go's `json.Unmarshal` zero-values). Tags mirror Go's exact json tags.
+#[derive(Debug, Default, Deserialize)]
+struct DockerConfigFile {
+    #[serde(default, rename = "credHelpers")]
+    cred_helpers: BTreeMap<String, String>,
+    #[serde(default, rename = "credsStore")]
+    creds_store: String,
+    #[serde(default)]
+    auths: BTreeMap<String, DockerAuthEntry>,
+}
+
+/// One `auths` entry (mirror Go's `dockerAuthEntry`). `auth` is base64(user:pass).
+#[derive(Debug, Default, Deserialize)]
+struct DockerAuthEntry {
+    #[serde(default)]
+    auth: String,
+}
+
+/// The credential-helper protocol reply (mirror the anonymous struct in Go's
+/// `execHelper`). The tags are the **Capitalized** docker-credential-helper protocol
+/// names, pinned with **explicit** per-field renames — NOT `rename_all =
+/// "PascalCase"`, which would emit `ServerUrl` and silently drop the `ServerURL`
+/// field. This is a distinct struct from the guest wire's snake_case
+/// `DockerGetResponse`; `docker_helper_struct_roundtrip_serverurl` guards the drift.
+#[derive(Debug, Default, Deserialize)]
+struct HelperCredential {
+    #[serde(default, rename = "ServerURL")]
+    server_url: String,
+    #[serde(default, rename = "Username")]
+    username: String,
+    #[serde(default, rename = "Secret")]
+    secret: String,
+}
+
+/// Credential-helper install locations that may be absent from the inherited PATH —
+/// notably under a bare launchd PATH (`brew services`). Docker Desktop symlinks its
+/// helper into `/usr/local/bin`; Homebrew installs into `/opt/homebrew/bin` (Apple
+/// Silicon) or `/usr/local/bin` (Intel). Mirror Go's `extraHelperDirs`.
+fn extra_helper_dirs() -> Vec<String> {
+    vec![
+        "/usr/local/bin".to_string(),
+        "/opt/homebrew/bin".to_string(),
+    ]
+}
+
+/// The concrete Docker backend (mirror Go's `dockerHelperBackend`). `config_path` is
+/// `None` when no config file was resolved (Go's empty-string sentinel). The helper
+/// dirs live on the [`RealHelperExecutor`] behind the [`HelperExecutor`] seam — the
+/// exec path that reads them — not on the backend (Go merges the two because its
+/// backend IS its own executor; the Rust seam split puts them where they are used).
+pub struct DockerHelperBackend {
+    config_path: Option<String>,
+    cfg: DockerConfig,
+    executor: Arc<dyn HelperExecutor>,
+    log: Arc<dyn BusLog>,
+}
+
+/// Build a Docker backend that reads from the host's Docker credential store (mirror
+/// `NewDockerBackend`, `docker_backend.go:88`). Returns an error **only** if an
+/// explicit `config_path` is specified but cannot be stat'd; a missing default config
+/// is NOT an error — the crux of the unconfigured-non-nil asymmetry (see the module
+/// docs). `config_path`'s `~/` prefix is tilde-expanded here (Go's `LoadConfig`
+/// stores it raw; the constructor expands).
+///
+/// Unwired in this slice — the handler + `main.rs` construct it in commit 3 (the same
+/// "ported, wired by a later slice" posture as the AWS backend).
+pub fn new_docker_backend(
+    cfg: DockerConfig,
+    log: Arc<dyn BusLog>,
+) -> Result<DockerHelperBackend, String> {
+    let mut config_path = cfg.config_path.clone();
+    if config_path.is_empty() {
+        config_path = find_docker_config();
+    } else {
+        // `expand_tilde` returns a non-`~/` path unchanged, so this covers both the
+        // tilde and the plain-absolute explicit-path cases (Go's `expandTilde`).
+        config_path = expand_tilde(&config_path);
+    }
+
+    // Error ONLY when an explicit config_path was set but is unstat'able. A default
+    // path (from find_docker_config) that is missing is fine — find_docker_config
+    // already returned "" for it, so config_path is non-empty here only when it exists
+    // or when it was explicit. Stat guards the explicit case.
+    if !cfg.config_path.is_empty() && !config_path.is_empty() {
+        if let Err(e) = std::fs::metadata(&config_path) {
+            return Err(format!("docker config not found at {config_path}: {e}"));
+        }
+    }
+
+    let registry_info = if cfg.allow_all {
+        "all (allow_all)".to_string()
+    } else if !cfg.registries.is_empty() {
+        cfg.registries.join(", ")
+    } else {
+        "none".to_string()
+    };
+    log.info(&format!(
+        "Docker backend initialized: config={config_path:?} registries={registry_info}"
+    ));
+
+    Ok(DockerHelperBackend {
+        config_path: if config_path.is_empty() {
+            None
+        } else {
+            Some(config_path)
+        },
+        cfg,
+        executor: Arc::new(RealHelperExecutor::new(extra_helper_dirs())),
+        log,
+    })
+}
+
+impl DockerHelperBackend {
+    /// Read + parse the Docker `config.json` (mirror `readConfig`,
+    /// `docker_backend.go:216`): no path → empty config; file missing (`NotFound`) →
+    /// empty config, **no error**; other read error → error (raw); parse error →
+    /// `"parsing <path>: <e>"`. Returns a plain `String` error the callers wrap.
+    fn read_config(&self) -> Result<DockerConfigFile, String> {
+        let Some(path) = &self.config_path else {
+            return Ok(DockerConfigFile::default());
+        };
+        let data = match std::fs::read(path) {
+            Ok(d) => d,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(DockerConfigFile::default());
+            }
+            Err(e) => return Err(e.to_string()),
+        };
+        serde_json::from_slice(&data).map_err(|e| format!("parsing {path}: {e}"))
+    }
+}
+
+#[async_trait]
+impl DockerBackend for DockerHelperBackend {
+    async fn get_credentials(
+        &self,
+        server: &str,
+        shed: &str,
+        server_url: &str,
+    ) -> Result<DockerCredential, DockerCredError> {
+        let normalized = normalize_registry(server_url);
+
+        // (2) Allowlist check FIRST — before reading config.json — so a blocked
+        // registry is refused even when the config is missing or unreadable, and even
+        // when a perfectly good local credential exists for it.
+        let resolved = self.cfg.resolve(server, shed);
+        if !resolved.allow_all && !normalize_registry_set(&resolved.registries).contains(&normalized)
+        {
+            return Err(DockerCredError::new(
+                format!("registry {server_url:?} not in allowlist"),
+                DOCKER_CODE_NOT_ALLOWED,
+            ));
+        }
+
+        // (3) read config.json.
+        let cfg = self
+            .read_config()
+            .map_err(|e| DockerCredError::new(format!("reading docker config: {e}"), DOCKER_CODE_INTERNAL))?;
+
+        // (4) credHelpers first (per-registry helper). Look up both raw + normalized
+        // forms since config keys may be "https://index.docker.io/v1/" while the guest
+        // sends "index.docker.io". A per-registry helper error PROPAGATES.
+        if let Some(helper) = lookup_config_map(&cfg.cred_helpers, server_url, &normalized) {
+            return self.executor.exec_helper(helper, server_url).await;
+        }
+
+        // (5) credsStore (default helper). On error FALL THROUGH to inline auths (the
+        // asymmetry: only credsStore failure is swallowed).
+        if !cfg.creds_store.is_empty() {
+            match self.executor.exec_helper(&cfg.creds_store, server_url).await {
+                Ok(cred) => return Ok(cred),
+                Err(e) => {
+                    self.log.debug(&format!(
+                        "default credsStore helper failed, trying auths fallback: helper={} error={}",
+                        cfg.creds_store, e
+                    ));
+                }
+            }
+        }
+
+        // (6) inline auths.
+        if let Some(entry) = lookup_config_map(&cfg.auths, server_url, &normalized) {
+            if !entry.auth.is_empty() {
+                return decode_inline_auth(server_url, &entry.auth);
+            }
+        }
+
+        // (7) none.
+        Err(DockerCredError::new(
+            format!("no credentials found for {server_url:?}"),
+            DOCKER_CODE_NOT_FOUND,
+        ))
+    }
+
+    async fn list_credentials(
+        &self,
+        server: &str,
+        shed: &str,
+    ) -> Result<BTreeMap<String, String>, String> {
+        let cfg = self
+            .read_config()
+            .map_err(|e| format!("reading docker config: {e}"))?;
+
+        let resolved = self.cfg.resolve(server, shed);
+        let allow_all = resolved.allow_all;
+        let allowed = normalize_registry_set(&resolved.registries);
+
+        let mut result = BTreeMap::new();
+
+        // From credHelpers (labelled, never exec'd).
+        for server_url in cfg.cred_helpers.keys() {
+            if allow_all || allowed.contains(&normalize_registry(server_url)) {
+                result.insert(server_url.clone(), "(credential helper)".to_string());
+            }
+        }
+
+        // From inline auths (username decoded when possible, else a placeholder).
+        for (server_url, auth) in &cfg.auths {
+            if allow_all || allowed.contains(&normalize_registry(server_url)) {
+                if !auth.auth.is_empty() {
+                    if let Ok(cred) = decode_inline_auth(server_url, &auth.auth) {
+                        result.insert(server_url.clone(), cred.username);
+                        continue;
+                    }
+                }
+                result.insert(server_url.clone(), "(auth entry)".to_string());
+            }
+        }
+
+        Ok(result)
+    }
+
+    fn status(&self, server: &str, shed: &str) -> (bool, usize) {
+        let resolved = self.cfg.resolve(server, shed);
+        (
+            resolved.allow_all,
+            normalize_registry_set(&resolved.registries).len(),
+        )
+    }
+}
+
+/// Build a normalized lookup set from a registries list (mirror
+/// `normalizeRegistrySet`). Deduplicates by normalized form, so `status`'s count is
+/// the number of DISTINCT normalized registries.
+fn normalize_registry_set(registries: &[String]) -> HashSet<String> {
+    registries.iter().map(|r| normalize_registry(r)).collect()
+}
+
+/// Strip protocol prefix and trailing slash / `/v1` / `/v2` — in that order — to
+/// produce a canonical hostname for allowlist matching (mirror `normalizeRegistry`,
+/// `docker_backend.go:375`).
+///
+/// Uses `strip_prefix`/`strip_suffix` (a **single** occurrence each), NOT
+/// `trim_*_matches`, to match Go's `TrimPrefix`/`TrimSuffix`: `ghcr.io//` → `ghcr.io/`
+/// (one trailing slash stripped, not all). The trailing `/` is stripped BEFORE `/v1`,
+/// so `https://index.docker.io/v1/` → `index.docker.io/v1/` → `index.docker.io/v1` →
+/// `index.docker.io`.
+fn normalize_registry(s: &str) -> String {
+    let s = s.strip_prefix("https://").unwrap_or(s);
+    let s = s.strip_prefix("http://").unwrap_or(s);
+    let s = s.strip_suffix('/').unwrap_or(s);
+    let s = s.strip_suffix("/v1").unwrap_or(s);
+    let s = s.strip_suffix("/v2").unwrap_or(s);
+    s.to_string()
+}
+
+/// Search a Docker config map using the raw key, then the normalized key (if it
+/// differs), then a normalize-every-key scan (mirror `lookupConfigMap`,
+/// `docker_backend.go:387`). This is what lets a config key stored as
+/// `https://index.docker.io/v1/` match a guest `index.docker.io` request (and vice
+/// versa). Generic over the value type (credHelpers = `String`, auths =
+/// `DockerAuthEntry`).
+fn lookup_config_map<'a, V>(
+    m: &'a BTreeMap<String, V>,
+    raw: &str,
+    normalized: &str,
+) -> Option<&'a V> {
+    if let Some(v) = m.get(raw) {
+        return Some(v);
+    }
+    if raw != normalized {
+        if let Some(v) = m.get(normalized) {
+            return Some(v);
+        }
+    }
+    for (k, v) in m {
+        if normalize_registry(k) == normalized {
+            return Some(v);
+        }
+    }
+    None
+}
+
+/// Decode a base64(user:pass) inline auth (mirror `decodeInlineAuth`,
+/// `docker_backend.go:406`). Uses the **padded STANDARD** base64 engine (Go's
+/// `StdEncoding` requires padding). The password may contain colons (split on the
+/// FIRST colon only). Both failure modes return a **plain** (codeless) error mirroring
+/// Go's bare `fmt.Errorf`:
+/// * decode error → `"decoding auth for <url>: <e>"` — the PREFIX is exact-ported and
+///   unit-pinned; the SUFFIX (`<e>`) is an impl-dependent divergence (Go's `illegal
+///   base64 data at input byte N` vs the Rust `base64` crate's text), so the
+///   malformed-base64 case is EXCLUDED from `docker_inline_auth.json` and never
+///   live-diffed.
+/// * no colon → `"invalid auth format for <url>"` — prefix-only, no runtime text,
+///   golden-fixtured.
+fn decode_inline_auth(server_url: &str, encoded: &str) -> Result<DockerCredential, DockerCredError> {
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|e| DockerCredError::plain(format!("decoding auth for {server_url}: {e}")))?;
+    let decoded = String::from_utf8_lossy(&decoded);
+    let Some((username, secret)) = decoded.split_once(':') else {
+        return Err(DockerCredError::plain(format!(
+            "invalid auth format for {server_url}"
+        )));
+    };
+    Ok(DockerCredential {
+        server_url: server_url.to_string(),
+        username: username.to_string(),
+        secret: secret.to_string(),
+    })
+}
+
+/// Return the Docker `config.json` path: `$DOCKER_CONFIG/config.json` if that exists,
+/// else `~/.docker/config.json` if that exists, else `""` (mirror `findDockerConfig`,
+/// `docker_backend.go:356`).
+fn find_docker_config() -> String {
+    if let Some(dir) = std::env::var_os("DOCKER_CONFIG") {
+        if !dir.is_empty() {
+            let p = Path::new(&dir).join("config.json");
+            if std::fs::metadata(&p).is_ok() {
+                return p.to_string_lossy().into_owned();
+            }
+        }
+    }
+    let p = user_home_dir().join(".docker").join("config.json");
+    if std::fs::metadata(&p).is_ok() {
+        return p.to_string_lossy().into_owned();
+    }
+    String::new()
+}
+
+/// Resolve a credential-helper binary to an ABSOLUTE path (mirror `lookHelperPath`,
+/// `docker_backend.go:306`): the inherited `PATH` first (via [`look_path`]), then each
+/// extra dir with a regular-file + executable-bit (`mode & 0o111 != 0`) check.
+///
+/// Absolute-path resolution is required because a bare-name spawn resolves against the
+/// process PATH at construction — augmenting the child's `PATH` afterward only affects
+/// the tools the helper ITSELF shells out to. Missing → an error naming the searched
+/// dirs. Returns a plain `String`; the caller wraps it with `HELPER_FAILED`.
+fn look_helper_path(bin: &str, extra_dirs: &[String]) -> Result<PathBuf, String> {
+    if let Some(p) = look_path(bin) {
+        return Ok(p);
+    }
+    for dir in extra_dirs {
+        let candidate = Path::new(dir).join(bin);
+        if is_executable_file(&candidate) {
+            return Ok(candidate);
+        }
+    }
+    Err(format!(
+        "{bin:?} not found on PATH or in {}",
+        extra_dirs.join(", ")
+    ))
+}
+
+/// The `exec.LookPath` subset [`look_helper_path`] needs: search the process `$PATH`
+/// for an executable regular file named `bin`, returning the first hit's `dir/bin`.
+fn look_path(bin: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        if dir.as_os_str().is_empty() {
+            continue;
+        }
+        let candidate = dir.join(bin);
+        if is_executable_file(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Whether `p` is a regular file (not a directory) with any executable bit set
+/// (`mode & 0o111 != 0`) — the `lookHelperPath` `findExecutable` check. Unix-only
+/// (the daemon targets macOS/Linux).
+fn is_executable_file(p: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt as _;
+    match std::fs::metadata(p) {
+        Ok(meta) => !meta.is_dir() && meta.permissions().mode() & 0o111 != 0,
+        Err(_) => false,
+    }
+}
+
+/// Return `current` (a `PATH`-shaped value) with `extra_dirs` APPENDED (skipping any
+/// already present), joined by the list separator (mirror `augmentPATH`,
+/// `docker_backend.go:323`, for the single-`PATH`-value case). An empty `current`
+/// yields just the extra dirs with NO leading separator (an empty leading element
+/// means "current directory", a footgun).
+///
+/// **Deliberate APPEND** (not prepend — contrast the minter/ssh shim which PREpends):
+/// the extra dirs are a fallback for a sparse launchd PATH, not an override. Go's
+/// last-of-duplicate-`PATH=`-wins logic is an artifact of its `[]string` env; the Rust
+/// `Command` env is a map, so that sub-behavior is inherently absent — the
+/// multiple-`PATH=`-entry and no-`PATH=`-entry Go subtests are labelled Go-only in the
+/// golden (see `augment_path_go_only_note`).
+fn augment_path(current: &str, extra_dirs: &[String]) -> String {
+    let mut dirs: Vec<String> = if current.is_empty() {
+        Vec::new()
+    } else {
+        current.split(PATH_LIST_SEP).map(str::to_string).collect()
+    };
+    let mut seen: HashSet<String> = dirs.iter().cloned().collect();
+    for d in extra_dirs {
+        if seen.insert(d.clone()) {
+            dirs.push(d.clone());
+        }
+    }
+    dirs.join(PATH_LIST_SEP)
+}
+
+/// The production [`HelperExecutor`]: shells `docker-credential-<helper> get` via
+/// `tokio::process`, with the raw `server_url` on stdin and the extra dirs APPENDED to
+/// the child's PATH. Holds `helper_dirs` (Go stores them on the backend; the Rust seam
+/// split puts them on the exec path that reads them) + an injectable `timeout`.
+pub struct RealHelperExecutor {
+    helper_dirs: Vec<String>,
+    timeout: Duration,
+}
+
+impl RealHelperExecutor {
+    fn new(helper_dirs: Vec<String>) -> Self {
+        Self {
+            helper_dirs,
+            timeout: DEFAULT_HELPER_TIMEOUT,
+        }
+    }
+
+    /// A real executor over explicit dirs + a shortened timeout, for the shell-shim
+    /// `exec_helper_*` tests (Go injects `helperDirs` on the struct + shortens the
+    /// 5 s constant).
+    #[cfg(test)]
+    fn with_dirs(helper_dirs: Vec<String>, timeout: Duration) -> Self {
+        Self {
+            helper_dirs,
+            timeout,
+        }
+    }
+}
+
+#[async_trait]
+impl HelperExecutor for RealHelperExecutor {
+    async fn exec_helper(
+        &self,
+        helper_name: &str,
+        server_url: &str,
+    ) -> Result<DockerCredential, DockerCredError> {
+        let bin = format!("docker-credential-{helper_name}");
+
+        // Resolve to an absolute path FIRST (a not-found here is the common cause of a
+        // silent "no credentials found" under a bare launchd PATH — the caller logs it
+        // loudly). Classified as HELPER_FAILED with the `<bin> not found: <e>` wrap.
+        let helper_path = match look_helper_path(&bin, &self.helper_dirs) {
+            Ok(p) => p,
+            Err(e) => {
+                return Err(DockerCredError::new(
+                    format!("{bin} not found: {e}"),
+                    DOCKER_CODE_HELPER_FAILED,
+                ));
+            }
+        };
+
+        // Augment PATH so any tools the helper itself shells out to are also found
+        // under a bare launchd PATH; the rest of the parent env (HOME etc.) is
+        // inherited by not clearing it (Go rebuilds os.Environ() with an augmented
+        // PATH — equivalent to inherit-all + override-PATH).
+        let augmented = augment_path(
+            &std::env::var("PATH").unwrap_or_default(),
+            &self.helper_dirs,
+        );
+
+        let mut cmd = tokio::process::Command::new(&helper_path);
+        cmd.arg("get");
+        cmd.env("PATH", augmented);
+        cmd.stdin(Stdio::piped());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        // On drop (including the timeout branch) the child is killed, so a wedged
+        // helper can never hang a mint past the deadline (minter WaitDelay precedent).
+        cmd.kill_on_drop(true);
+
+        let mut child = cmd.spawn().map_err(|e| {
+            DockerCredError::new(format!("{bin} failed: {e}"), DOCKER_CODE_HELPER_FAILED)
+        })?;
+        let mut stdin = child.stdin.take().expect("piped stdin");
+
+        // stdin = the raw server_url (NOT JSON), then EOF; the output is tiny so a
+        // sequential write-then-collect can't deadlock on a full pipe.
+        let server_url_owned = server_url.to_string();
+        let collect = async move {
+            let _ = stdin.write_all(server_url_owned.as_bytes()).await;
+            let _ = stdin.shutdown().await;
+            drop(stdin);
+            child.wait_with_output().await
+        };
+
+        let output = match tokio::time::timeout(self.timeout, collect).await {
+            // The timeout error text is unit-owned (impl-dependent), never diffed.
+            Err(_) => {
+                return Err(DockerCredError::new(
+                    format!("{bin} failed: timed out after {:?}", self.timeout),
+                    DOCKER_CODE_HELPER_FAILED,
+                ));
+            }
+            Ok(Ok(output)) => output,
+            Ok(Err(e)) => {
+                return Err(DockerCredError::new(
+                    format!("{bin} failed: {e}"),
+                    DOCKER_CODE_HELPER_FAILED,
+                ));
+            }
+        };
+
+        if !output.status.success() {
+            // A located helper that exits non-zero is expected control flow (for
+            // credsStore, get_credentials falls back to inline auths). stderr is
+            // logged locally by the caller path but NEVER propagated to the guest; the
+            // exit-status SUFFIX is impl-dependent (`exit status 1` vs `exit status:
+            // 1`), unit-owned, never diffed.
+            return Err(DockerCredError::new(
+                format!("{bin} failed: {}", output.status),
+                DOCKER_CODE_HELPER_FAILED,
+            ));
+        }
+
+        let cred: HelperCredential = serde_json::from_slice(&output.stdout).map_err(|e| {
+            DockerCredError::new(
+                format!("parsing {bin} output: {e}"),
+                DOCKER_CODE_HELPER_FAILED,
+            )
+        })?;
+
+        Ok(DockerCredential {
+            server_url: cred.server_url,
+            username: cred.username,
+            secret: cred.secret,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // ---- test doubles -----------------------------------------------------------
+
+    struct SilentLog;
+    impl BusLog for SilentLog {
+        fn info(&self, _: &str) {}
+        fn warn(&self, _: &str) {}
+        fn debug(&self, _: &str) {}
+        fn error(&self, _: &str) {}
+    }
+    fn silent() -> Arc<dyn BusLog> {
+        Arc::new(SilentLog)
+    }
+
+    /// A fake [`HelperExecutor`] returning a canned outcome and recording each call
+    /// (mirror Go's `mockExecutor` + the `callLog` on `mockDockerBackend`).
+    struct FakeExecutor {
+        outcome: Result<DockerCredential, DockerCredError>,
+        calls: Mutex<Vec<(String, String)>>,
+    }
+    impl FakeExecutor {
+        fn ok(cred: DockerCredential) -> Arc<Self> {
+            Arc::new(Self {
+                outcome: Ok(cred),
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+        fn err(e: DockerCredError) -> Arc<Self> {
+            Arc::new(Self {
+                outcome: Err(e),
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+    }
+    #[async_trait]
+    impl HelperExecutor for FakeExecutor {
+        async fn exec_helper(
+            &self,
+            helper_name: &str,
+            server_url: &str,
+        ) -> Result<DockerCredential, DockerCredError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((helper_name.to_string(), server_url.to_string()));
+            self.outcome.clone()
+        }
+    }
+
+    /// An executor that panics if called — proves a path never reaches the exec seam
+    /// (inline-auth / not-found / not-allowed).
+    struct PanicExecutor;
+    #[async_trait]
+    impl HelperExecutor for PanicExecutor {
+        async fn exec_helper(
+            &self,
+            _helper_name: &str,
+            _server_url: &str,
+        ) -> Result<DockerCredential, DockerCredError> {
+            panic!("exec_helper must not be called");
+        }
+    }
+    fn panic_exec() -> Arc<dyn HelperExecutor> {
+        Arc::new(PanicExecutor)
+    }
+
+    fn cred(user: &str, secret: &str) -> DockerCredential {
+        DockerCredential {
+            server_url: "registry.example.com".to_string(),
+            username: user.to_string(),
+            secret: secret.to_string(),
+        }
+    }
+
+    fn b64(plain: &str) -> String {
+        base64::engine::general_purpose::STANDARD.encode(plain.as_bytes())
+    }
+
+    /// Write `config.json` into a fresh temp dir and build a backend over it with the
+    /// given cfg + executor (mirror the Go tests' direct `dockerHelperBackend{...}`
+    /// struct literals). Returns the guard TempDir (kept alive) + the backend.
+    fn backend_with(
+        config_json: &str,
+        cfg: DockerConfig,
+        executor: Arc<dyn HelperExecutor>,
+    ) -> (tempfile::TempDir, DockerHelperBackend) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, config_json).unwrap();
+        let b = DockerHelperBackend {
+            config_path: Some(path.to_string_lossy().into_owned()),
+            cfg,
+            executor,
+            log: silent(),
+        };
+        (dir, b)
+    }
+
+    fn cfg_registries(regs: &[&str]) -> DockerConfig {
+        DockerConfig {
+            registries: regs.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    fn cfg_allow_all() -> DockerConfig {
+        DockerConfig {
+            allow_all: true,
+            ..Default::default()
+        }
+    }
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
+
+    // ---- normalize_registry (TestNormalizeRegistry) -----------------------------
+
+    #[test]
+    fn normalize_registry_matrix() {
+        let cases = [
+            ("us-docker.pkg.dev", "us-docker.pkg.dev"),
+            ("https://us-docker.pkg.dev", "us-docker.pkg.dev"),
+            ("https://index.docker.io/v1/", "index.docker.io"),
+            ("https://index.docker.io/v1", "index.docker.io"),
+            ("http://localhost:5000", "localhost:5000"),
+            ("ghcr.io", "ghcr.io"),
+            ("ghcr.io/", "ghcr.io"),
+            // One-occurrence strip: only ONE trailing slash removed.
+            ("ghcr.io//", "ghcr.io/"),
+            // /v2 strip + strip-order (trailing `/` before `/v2`).
+            ("https://reg.io/v2", "reg.io"),
+            ("reg.io/v2/", "reg.io"),
+        ];
+        for (input, want) in cases {
+            assert_eq!(normalize_registry(input), want, "normalize {input:?}");
+        }
+    }
+
+    // ---- decode_inline_auth (TestDecodeInlineAuth*) -----------------------------
+
+    #[test]
+    fn decode_inline_auth_basic() {
+        let c = decode_inline_auth("registry.example.com", &b64("myuser:mypass")).unwrap();
+        assert_eq!(c.username, "myuser");
+        assert_eq!(c.secret, "mypass");
+        assert_eq!(c.server_url, "registry.example.com");
+    }
+
+    #[test]
+    fn decode_inline_auth_colon_in_password() {
+        let c = decode_inline_auth("registry.example.com", &b64("user:pass:word:extra")).unwrap();
+        assert_eq!(c.username, "user");
+        assert_eq!(c.secret, "pass:word:extra");
+    }
+
+    #[test]
+    fn decode_inline_auth_no_colon_errors() {
+        let e = decode_inline_auth("registry.example.com", &b64("nocolon")).unwrap_err();
+        assert_eq!(e.msg, "invalid auth format for registry.example.com");
+        assert!(e.code.is_empty(), "no-colon is a plain (codeless) error");
+    }
+
+    // ---- get_credentials --------------------------------------------------------
+
+    #[test]
+    fn get_allowlist_denies_blocked_even_with_cred() {
+        // blocked.io has a perfectly good local credential — the allowlist must still
+        // refuse it (deny checked BEFORE any lookup). allowed.io succeeds.
+        let json = format!(
+            r#"{{"auths":{{"allowed.io":{{"auth":"{}"}},"blocked.io":{{"auth":"{}"}}}}}}"#,
+            b64("user:pass"),
+            b64("user:secret")
+        );
+        let (_d, b) = backend_with(&json, cfg_registries(&["allowed.io"]), panic_exec());
+
+        let c = block_on(b.get_credentials("srv", "shed", "allowed.io")).unwrap();
+        assert_eq!(c.username, "user");
+
+        let e = block_on(b.get_credentials("srv", "shed", "blocked.io")).unwrap_err();
+        assert_eq!(e.code, DOCKER_CODE_NOT_ALLOWED);
+    }
+
+    #[test]
+    fn get_allow_all_bypasses() {
+        let json = format!(r#"{{"auths":{{"any-registry.io":{{"auth":"{}"}}}}}}"#, b64("user:pass"));
+        let (_d, b) = backend_with(&json, cfg_allow_all(), panic_exec());
+        let c = block_on(b.get_credentials("srv", "shed", "any-registry.io")).unwrap();
+        assert_eq!(c.username, "user");
+    }
+
+    #[test]
+    fn get_via_cred_helper() {
+        let json = r#"{"credHelpers":{"us-docker.pkg.dev":"gcloud"}}"#;
+        let exec = FakeExecutor::ok(DockerCredential {
+            server_url: "us-docker.pkg.dev".into(),
+            username: "_json_key".into(),
+            secret: "gcloud-token".into(),
+        });
+        let (_d, b) = backend_with(json, cfg_registries(&["us-docker.pkg.dev"]), exec.clone());
+        let c = block_on(b.get_credentials("srv", "shed", "us-docker.pkg.dev")).unwrap();
+        assert_eq!(c.username, "_json_key");
+        assert_eq!(c.secret, "gcloud-token");
+        // The helper was exec'd with the registry's helper name + raw server_url.
+        assert_eq!(
+            exec.calls.lock().unwrap().as_slice(),
+            &[("gcloud".to_string(), "us-docker.pkg.dev".to_string())]
+        );
+    }
+
+    #[test]
+    fn get_via_creds_store() {
+        let json = r#"{"credsStore":"osxkeychain"}"#;
+        let exec = FakeExecutor::ok(cred("kc-user", "kc-secret"));
+        let (_d, b) = backend_with(json, cfg_allow_all(), exec);
+        let c = block_on(b.get_credentials("srv", "shed", "registry.example.com")).unwrap();
+        assert_eq!(c.username, "kc-user");
+    }
+
+    #[test]
+    fn get_cred_helper_wins_over_store_and_auths() {
+        // credHelpers must win over credsStore and inline auths.
+        let json = format!(
+            r#"{{"credHelpers":{{"registry.example.com":"custom-helper"}},"credsStore":"osxkeychain","auths":{{"registry.example.com":{{"auth":"{}"}}}}}}"#,
+            b64("inline:creds")
+        );
+        let exec = FakeExecutor::ok(cred("helper-user", "helper-secret"));
+        let (_d, b) = backend_with(&json, cfg_allow_all(), exec);
+        let c = block_on(b.get_credentials("srv", "shed", "registry.example.com")).unwrap();
+        assert_eq!(c.username, "helper-user");
+    }
+
+    #[test]
+    fn get_creds_store_failure_falls_through_to_auths() {
+        // A credsStore helper FAILURE is swallowed → falls through to the inline auth.
+        let json = format!(
+            r#"{{"credsStore":"osxkeychain","auths":{{"registry.example.com":{{"auth":"{}"}}}}}}"#,
+            b64("inline-user:inline-secret")
+        );
+        let exec = FakeExecutor::err(DockerCredError::new("boom", DOCKER_CODE_HELPER_FAILED));
+        let (_d, b) = backend_with(&json, cfg_allow_all(), exec);
+        let c = block_on(b.get_credentials("srv", "shed", "registry.example.com")).unwrap();
+        assert_eq!(c.username, "inline-user");
+        assert_eq!(c.secret, "inline-secret");
+    }
+
+    #[test]
+    fn get_cred_helper_failure_propagates() {
+        // A per-registry credHelper FAILURE PROPAGATES (no fallback to the present
+        // inline auth) — the asymmetry vs credsStore.
+        let json = format!(
+            r#"{{"credHelpers":{{"registry.example.com":"custom-helper"}},"auths":{{"registry.example.com":{{"auth":"{}"}}}}}}"#,
+            b64("inline-user:inline-secret")
+        );
+        let exec = FakeExecutor::err(DockerCredError::new("helper boom", DOCKER_CODE_HELPER_FAILED));
+        let (_d, b) = backend_with(&json, cfg_allow_all(), exec);
+        let e = block_on(b.get_credentials("srv", "shed", "registry.example.com")).unwrap_err();
+        assert_eq!(e.code, DOCKER_CODE_HELPER_FAILED);
+        assert_eq!(e.msg, "helper boom");
+    }
+
+    #[test]
+    fn get_not_found_code() {
+        let (_d, b) = backend_with("{}", cfg_allow_all(), panic_exec());
+        let e = block_on(b.get_credentials("srv", "shed", "unknown.io")).unwrap_err();
+        assert_eq!(e.code, DOCKER_CODE_NOT_FOUND);
+    }
+
+    #[test]
+    fn get_missing_config_surfaces_not_found() {
+        // Misnamed in Go: a missing config FILE → empty config (NO read error) → the
+        // allow_all path finds nothing → CREDENTIALS_NOT_FOUND (not a read error).
+        let b = DockerHelperBackend {
+            config_path: Some("/nonexistent/config.json".to_string()),
+            cfg: cfg_allow_all(),
+            executor: panic_exec(),
+            log: silent(),
+        };
+        let e = block_on(b.get_credentials("srv", "shed", "any.io")).unwrap_err();
+        assert_eq!(e.code, DOCKER_CODE_NOT_FOUND);
+    }
+
+    // ---- list_credentials (TestListCredentials) ---------------------------------
+
+    #[test]
+    fn list_respects_allowlist() {
+        let json = format!(
+            r#"{{"credHelpers":{{"gcr.io":"gcloud","blocked.io":"helper"}},"auths":{{"ghcr.io":{{"auth":"{}"}}}}}}"#,
+            b64("user:token")
+        );
+        let (_d, b) = backend_with(&json, cfg_registries(&["gcr.io", "ghcr.io"]), panic_exec());
+        let result = block_on(b.list_credentials("srv", "shed")).unwrap();
+        assert!(result.contains_key("gcr.io"));
+        assert!(result.contains_key("ghcr.io"));
+        assert_eq!(result.get("ghcr.io").map(String::as_str), Some("user")); // decoded username
+        assert!(!result.contains_key("blocked.io"));
+    }
+
+    // ---- find_docker_config + constructor ---------------------------------------
+
+    #[test]
+    fn find_docker_config_env_var() {
+        let _g = crate::env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, "{}").unwrap();
+        std::env::set_var("DOCKER_CONFIG", dir.path());
+        let got = find_docker_config();
+        std::env::remove_var("DOCKER_CONFIG");
+        assert_eq!(got, path.to_string_lossy());
+    }
+
+    #[test]
+    fn docker_config_env_missing_falls_back_to_home() {
+        // DOCKER_CONFIG unset → $HOME/.docker/config.json (when it exists there).
+        let _g = crate::env_lock();
+        std::env::remove_var("DOCKER_CONFIG");
+        let home = tempfile::tempdir().unwrap();
+        let docker_dir = home.path().join(".docker");
+        std::fs::create_dir_all(&docker_dir).unwrap();
+        let path = docker_dir.join("config.json");
+        std::fs::write(&path, "{}").unwrap();
+        std::env::set_var("HOME", home.path());
+        let got = find_docker_config();
+        std::env::remove_var("HOME");
+        assert_eq!(got, path.to_string_lossy());
+    }
+
+    #[test]
+    fn find_docker_config_missing_returns_empty() {
+        // Neither DOCKER_CONFIG nor ~/.docker/config.json present → "".
+        let _g = crate::env_lock();
+        std::env::remove_var("DOCKER_CONFIG");
+        let home = tempfile::tempdir().unwrap(); // empty home, no .docker
+        std::env::set_var("HOME", home.path());
+        let got = find_docker_config();
+        std::env::remove_var("HOME");
+        assert_eq!(got, "");
+    }
+
+    #[test]
+    fn new_docker_backend_absent_config_constructs() {
+        // An absent docker: block + a missing default file → a LIVE backend, no error
+        // (the unconfigured-non-nil crux). It then denies every registry.
+        let _g = crate::env_lock();
+        std::env::remove_var("DOCKER_CONFIG");
+        let home = tempfile::tempdir().unwrap(); // no ~/.docker/config.json
+        std::env::set_var("HOME", home.path());
+        let b = new_docker_backend(DockerConfig::default(), silent());
+        std::env::remove_var("HOME");
+        let b = b.expect("unconfigured backend still constructs");
+        // Denies every registry (empty allowlist, allow_all false).
+        let e = block_on(b.get_credentials("srv", "shed", "any.io")).unwrap_err();
+        assert_eq!(e.code, DOCKER_CODE_NOT_ALLOWED);
+    }
+
+    #[test]
+    fn explicit_missing_config_path_errors() {
+        // An EXPLICIT config_path that can't be stat'd → construction ERRORS.
+        let cfg = DockerConfig {
+            config_path: "/definitely/not/here/config.json".to_string(),
+            ..Default::default()
+        };
+        assert!(new_docker_backend(cfg, silent()).is_err());
+    }
+
+    #[test]
+    fn config_path_tilde_expands() {
+        // A `~/`-prefixed explicit path expands to $HOME; when the file exists there,
+        // construction succeeds and reads it.
+        let _g = crate::env_lock();
+        let home = tempfile::tempdir().unwrap();
+        let path = home.path().join("mydocker.json");
+        std::fs::write(&path, "{}").unwrap();
+        std::env::set_var("HOME", home.path());
+        let cfg = DockerConfig {
+            config_path: "~/mydocker.json".to_string(),
+            ..Default::default()
+        };
+        let got = new_docker_backend(cfg, silent());
+        std::env::remove_var("HOME");
+        let b = got.expect("tilde path resolves to an existing file");
+        assert_eq!(b.config_path.as_deref(), Some(path.to_string_lossy().as_ref()));
+    }
+
+    // ---- status + read_config + error -------------------------------------------
+
+    #[test]
+    fn status_count_and_allow_all() {
+        let b = DockerHelperBackend {
+            config_path: None,
+            cfg: cfg_registries(&["a.io", "b.io"]),
+            executor: panic_exec(),
+            log: silent(),
+        };
+        let (allow_all, count) = b.status("srv", "shed");
+        assert!(!allow_all);
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn read_config_empty_when_no_path() {
+        let b = DockerHelperBackend {
+            config_path: None,
+            cfg: DockerConfig::default(),
+            executor: panic_exec(),
+            log: silent(),
+        };
+        let cfg = b.read_config().unwrap();
+        assert!(cfg.cred_helpers.is_empty());
+        assert!(cfg.creds_store.is_empty());
+        assert!(cfg.auths.is_empty());
+    }
+
+    #[test]
+    fn read_config_missing_file_is_empty_no_error() {
+        // config_path SET but the file is NotFound → empty config, no error (distinct
+        // from the empty-path branch above).
+        let b = DockerHelperBackend {
+            config_path: Some("/nonexistent/config.json".to_string()),
+            cfg: DockerConfig::default(),
+            executor: panic_exec(),
+            log: silent(),
+        };
+        let cfg = b.read_config().unwrap();
+        assert!(cfg.cred_helpers.is_empty());
+        assert!(cfg.auths.is_empty());
+    }
+
+    #[test]
+    fn docker_cred_error_display() {
+        let e = DockerCredError::new("test error", "TEST_CODE");
+        assert_eq!(e.to_string(), "test error");
+        assert_eq!(e.code, "TEST_CODE");
+    }
+
+    // ---- look_helper_path (TestLookHelperPath) ----------------------------------
+
+    fn write_exec(dir: &Path, name: &str, body: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt as _;
+        let p = dir.join(name);
+        std::fs::write(&p, body).unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+        p
+    }
+
+    #[test]
+    fn look_helper_found_in_extra_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = "docker-credential-faketest-look";
+        let p = write_exec(dir.path(), bin, "#!/bin/sh\n");
+        let got = look_helper_path(bin, &[dir.path().to_string_lossy().into_owned()]).unwrap();
+        assert_eq!(got, p);
+    }
+
+    #[test]
+    fn look_helper_missing_names_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let dirs = vec![dir.path().to_string_lossy().into_owned()];
+        let e = look_helper_path("docker-credential-does-not-exist", &dirs).unwrap_err();
+        assert!(e.contains(dir.path().to_string_lossy().as_ref()), "err {e:?} names dir");
+    }
+
+    #[test]
+    fn look_helper_skips_non_executable() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().unwrap();
+        let name = "docker-credential-faketest-plain";
+        let p = dir.path().join(name);
+        std::fs::write(&p, "x").unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(look_helper_path(name, &[dir.path().to_string_lossy().into_owned()]).is_err());
+    }
+
+    #[test]
+    fn look_helper_skips_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let name = "docker-credential-faketest-dir";
+        std::fs::create_dir(dir.path().join(name)).unwrap();
+        assert!(look_helper_path(name, &[dir.path().to_string_lossy().into_owned()]).is_err());
+    }
+
+    // ---- augment_path (TestAugmentPATH) -----------------------------------------
+
+    #[test]
+    fn augment_path_appends_missing() {
+        let got = augment_path(
+            "/usr/bin:/bin",
+            &["/usr/local/bin".into(), "/opt/homebrew/bin".into()],
+        );
+        assert_eq!(got, "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin");
+    }
+
+    #[test]
+    fn augment_path_no_duplicate() {
+        // A dir already present is not duplicated (append-missing semantics).
+        let got = augment_path("/usr/local/bin:/usr/bin", &["/usr/local/bin".into()]);
+        assert_eq!(got, "/usr/local/bin:/usr/bin");
+    }
+
+    #[test]
+    fn augment_path_empty_yields_only_extras() {
+        // An empty PATH value yields JUST the extra dirs — no leading separator (an
+        // empty leading element means "current directory", a footgun).
+        let got = augment_path("", &["/opt/homebrew/bin".into()]);
+        assert_eq!(got, "/opt/homebrew/bin");
+    }
+
+    #[test]
+    fn augment_path_go_only_note() {
+        // Go's TestAugmentPATH additionally covers a NO-`PATH=`-entry env and a
+        // multiple-`PATH=`-entry env (last-wins augmented). Both are artifacts of Go's
+        // `[]string` env; the Rust `Command` env is a MAP keyed by name, so there is no
+        // "no PATH entry" (the caller passes "") and no "duplicate PATH entry" — those
+        // subtests have no Rust runtime equivalent and are labelled go_only in
+        // docker_path_augment.json. This asserts the single-value augmentation the Rust
+        // seam DOES have: a value already containing the extra keeps a single copy.
+        let got = augment_path("/a:/opt/homebrew/bin:/b", &["/opt/homebrew/bin".into()]);
+        assert_eq!(got, "/a:/opt/homebrew/bin:/b");
+    }
+
+    // ---- exec_helper (real subprocess; skip if no /bin/sh) ----------------------
+
+    fn have_sh() -> bool {
+        Path::new("/bin/sh").exists()
+    }
+
+    #[test]
+    fn exec_helper_resolves_via_extra_dir() {
+        if !have_sh() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        // Fake helper: drains stdin (the server_url) and emits a credential JSON.
+        let script = "#!/bin/sh\ncat >/dev/null\n\
+            printf '%s' '{\"ServerURL\":\"registry.example.com\",\"Username\":\"fake-user\",\"Secret\":\"fake-secret\"}'\n";
+        write_exec(dir.path(), "docker-credential-faketest", script);
+        // dir is NOT on PATH, so this exercises the extra-dir fallback.
+        let exec = RealHelperExecutor::with_dirs(
+            vec![dir.path().to_string_lossy().into_owned()],
+            Duration::from_secs(5),
+        );
+        let c = block_on(exec.exec_helper("faketest", "registry.example.com")).unwrap();
+        assert_eq!(c.username, "fake-user");
+        assert_eq!(c.secret, "fake-secret");
+        assert_eq!(c.server_url, "registry.example.com");
+    }
+
+    #[test]
+    fn exec_helper_missing_binary_helper_failed() {
+        let dir = tempfile::tempdir().unwrap(); // empty dir, binary nowhere
+        let exec = RealHelperExecutor::with_dirs(
+            vec![dir.path().to_string_lossy().into_owned()],
+            Duration::from_secs(5),
+        );
+        let e = block_on(exec.exec_helper("definitely-missing", "registry.example.com")).unwrap_err();
+        assert_eq!(e.code, DOCKER_CODE_HELPER_FAILED);
+    }
+
+    #[test]
+    fn exec_helper_nonzero_exit_and_bad_json_helper_failed() {
+        if !have_sh() {
+            return;
+        }
+        // Non-zero exit → HELPER_FAILED.
+        let dir = tempfile::tempdir().unwrap();
+        write_exec(dir.path(), "docker-credential-failexit", "#!/bin/sh\ncat >/dev/null\nexit 1\n");
+        let exec = RealHelperExecutor::with_dirs(
+            vec![dir.path().to_string_lossy().into_owned()],
+            Duration::from_secs(5),
+        );
+        let e = block_on(exec.exec_helper("failexit", "registry.example.com")).unwrap_err();
+        assert_eq!(e.code, DOCKER_CODE_HELPER_FAILED);
+
+        // Exit 0 but non-JSON stdout → HELPER_FAILED (parse error).
+        let dir2 = tempfile::tempdir().unwrap();
+        write_exec(dir2.path(), "docker-credential-badjson", "#!/bin/sh\ncat >/dev/null\nprintf 'not json'\n");
+        let exec2 = RealHelperExecutor::with_dirs(
+            vec![dir2.path().to_string_lossy().into_owned()],
+            Duration::from_secs(5),
+        );
+        let e2 = block_on(exec2.exec_helper("badjson", "registry.example.com")).unwrap_err();
+        assert_eq!(e2.code, DOCKER_CODE_HELPER_FAILED);
+        assert!(e2.msg.starts_with("parsing docker-credential-badjson output: "), "got {e2:?}");
+    }
+
+    #[test]
+    fn exec_helper_times_out_promptly() {
+        if !have_sh() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        write_exec(dir.path(), "docker-credential-sleeper", "#!/bin/sh\nsleep 30\n");
+        let exec = RealHelperExecutor::with_dirs(
+            vec![dir.path().to_string_lossy().into_owned()],
+            Duration::from_millis(300),
+        );
+        let start = std::time::Instant::now();
+        let e = block_on(exec.exec_helper("sleeper", "registry.example.com")).unwrap_err();
+        assert_eq!(e.code, DOCKER_CODE_HELPER_FAILED);
+        assert!(start.elapsed() < Duration::from_secs(5), "did not abort promptly");
+    }
+
+    // ---- lookup_config_map (3-way) ----------------------------------------------
+
+    #[test]
+    fn lookup_config_map_3way() {
+        let mut m: BTreeMap<String, String> = BTreeMap::new();
+        m.insert("https://index.docker.io/v1/".to_string(), "helperA".to_string());
+        m.insert("ghcr.io".to_string(), "helperB".to_string());
+
+        let lookup = |raw: &str| -> Option<String> {
+            let n = normalize_registry(raw);
+            lookup_config_map(&m, raw, &n).cloned()
+        };
+
+        // Exact raw match.
+        assert_eq!(lookup("ghcr.io"), Some("helperB".to_string()));
+        // Scan-all-keys: guest sends the normalized host, key is the full docker form.
+        assert_eq!(lookup("index.docker.io"), Some("helperA".to_string()));
+        // Normalized-key path: guest sends the full docker form, key is normalized.
+        let mut m2: BTreeMap<String, String> = BTreeMap::new();
+        m2.insert("index.docker.io".to_string(), "helperC".to_string());
+        let n = normalize_registry("https://index.docker.io/v1/");
+        assert_eq!(
+            lookup_config_map(&m2, "https://index.docker.io/v1/", &n).cloned(),
+            Some("helperC".to_string())
+        );
+        // Miss.
+        assert_eq!(lookup("nope.io"), None);
+    }
+
+    // ---- helper struct serde roundtrip (tag-drift guard) ------------------------
+
+    #[test]
+    fn docker_helper_struct_roundtrip_serverurl() {
+        // The Capitalized docker-credential-helper protocol tags must survive a
+        // deserialize independently of the guest wire's snake_case struct. A struct
+        // emitting `ServerUrl` (the rename_all="PascalCase" bug) would drop this.
+        let json = r#"{"ServerURL":"reg.io","Username":"u","Secret":"s"}"#;
+        let c: HelperCredential = serde_json::from_str(json).unwrap();
+        assert_eq!(c.server_url, "reg.io");
+        assert_eq!(c.username, "u");
+        assert_eq!(c.secret, "s");
+        // The snake_case guest tags must NOT populate this struct.
+        let wrong = r#"{"server_url":"reg.io","username":"u","secret":"s"}"#;
+        let c2: HelperCredential = serde_json::from_str(wrong).unwrap();
+        assert!(c2.server_url.is_empty(), "snake_case must not fill ServerURL");
+    }
+
+    // ---- golden runners (Rust half) ---------------------------------------------
+
+    fn fixture(name: &str) -> serde_json::Value {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/host-agent-diff/fixtures")
+            .join(name);
+        let raw = std::fs::read_to_string(&path).expect("read golden fixture");
+        serde_json::from_str(&raw).unwrap()
+    }
+
+    #[test]
+    fn golden_docker_normalize() {
+        let fx = fixture("docker_normalize.json");
+        assert_eq!(fx["protocol_version"], 1, "version skew");
+        for v in fx["normalize_vectors"].as_array().unwrap() {
+            let got = normalize_registry(v["input"].as_str().unwrap());
+            assert_eq!(got, v["expected"].as_str().unwrap(), "normalize {v}");
+        }
+        for v in fx["lookup_vectors"].as_array().unwrap() {
+            let mut m: BTreeMap<String, String> = BTreeMap::new();
+            for (k, val) in v["map"].as_object().unwrap() {
+                m.insert(k.clone(), val.as_str().unwrap().to_string());
+            }
+            let raw = v["raw"].as_str().unwrap();
+            let n = normalize_registry(raw);
+            let got = lookup_config_map(&m, raw, &n).cloned();
+            let want = v["expected"].as_str().map(str::to_string);
+            assert_eq!(got, want, "lookup {}", v["name"]);
+        }
+    }
+
+    #[test]
+    fn golden_docker_inline_auth() {
+        let fx = fixture("docker_inline_auth.json");
+        assert_eq!(fx["protocol_version"], 1, "version skew");
+        for v in fx["valid_vectors"].as_array().unwrap() {
+            let url = v["server_url"].as_str().unwrap();
+            let encoded = b64(v["plain"].as_str().unwrap());
+            let c = decode_inline_auth(url, &encoded).unwrap();
+            assert_eq!(c.username, v["username"].as_str().unwrap(), "user {}", v["name"]);
+            assert_eq!(c.secret, v["secret"].as_str().unwrap(), "secret {}", v["name"]);
+            assert_eq!(c.server_url, url);
+        }
+        for v in fx["invalid_vectors"].as_array().unwrap() {
+            let url = v["server_url"].as_str().unwrap();
+            let encoded = b64(v["plain"].as_str().unwrap());
+            let e = decode_inline_auth(url, &encoded).unwrap_err();
+            assert_eq!(e.msg, v["expected_error"].as_str().unwrap(), "err {}", v["name"]);
+        }
+    }
+
+    #[test]
+    fn golden_docker_path_augment() {
+        let fx = fixture("docker_path_augment.json");
+        assert_eq!(fx["protocol_version"], 1, "version skew");
+        for v in fx["vectors"].as_array().unwrap() {
+            // Go-only vectors (env-array-shaped: no-PATH-entry / duplicate-PATH) have no
+            // Rust runtime equivalent — the Rust Command env is a map. Skip them.
+            if v["go_only"].as_bool().unwrap_or(false) {
+                continue;
+            }
+            let extras: Vec<String> = v["extra_dirs"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|d| d.as_str().unwrap().to_string())
+                .collect();
+            let got = augment_path(v["path"].as_str().unwrap(), &extras);
+            assert_eq!(got, v["expected_path"].as_str().unwrap(), "augment {}", v["name"]);
+        }
+    }
+}

--- a/crates/shed-host-agent/src/docker_backend.rs
+++ b/crates/shed-host-agent/src/docker_backend.rs
@@ -44,11 +44,9 @@
 //! commit 2, wired later — the "ported, wired by a later slice" posture the AWS
 //! backend established.
 //!
-//! Everything here is unwired in this commit (the handler + `main.rs` land in commit
-//! 3), so the module carries a blanket `allow(dead_code)`; commit 3 removes it once
-//! the bus references `new_docker_backend` / the `DockerBackend` trait (the AWS slice
-//! carried the same allow in its commit 2, then dropped it on wiring).
-#![allow(dead_code)]
+//! Wired in commit 3b: the bus references `new_docker_backend` / the `DockerBackend`
+//! trait + the `DOCKER_CODE_*` codes (the AWS slice carried a blanket `allow(dead_code)`
+//! in its commit 2, then dropped it on wiring — done here likewise).
 
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -67,10 +65,15 @@ use crate::config::{expand_tilde, user_home_dir, DockerConfig};
 // The Docker wire error codes (mirror `internal/ext/protocol/docker.go`). Duplicated
 // here as string constants because the Rust daemon does not link the Go protocol
 // package; the handler (commit 3) maps these onto `DockerErrorResponse.code`.
-const DOCKER_CODE_NOT_FOUND: &str = "CREDENTIALS_NOT_FOUND";
-const DOCKER_CODE_NOT_ALLOWED: &str = "REGISTRY_NOT_ALLOWED";
+// NOT_FOUND / NOT_ALLOWED / INTERNAL are `pub(crate)` — the bus handler maps them onto
+// the guest wire (the anonymous-vs-error audit split keys on NOT_FOUND; deny returns
+// NOT_ALLOWED; unknown-op/invalid-payload/list-error/empty-code use INTERNAL).
+// HELPER_FAILED is only ever set by the executor here, so it stays private (the handler
+// forwards `DockerCredError.code` verbatim, never naming it).
+pub(crate) const DOCKER_CODE_NOT_FOUND: &str = "CREDENTIALS_NOT_FOUND";
+pub(crate) const DOCKER_CODE_NOT_ALLOWED: &str = "REGISTRY_NOT_ALLOWED";
 const DOCKER_CODE_HELPER_FAILED: &str = "HELPER_FAILED";
-const DOCKER_CODE_INTERNAL: &str = "INTERNAL_ERROR";
+pub(crate) const DOCKER_CODE_INTERNAL: &str = "INTERNAL_ERROR";
 
 /// The list separator for `PATH`. The daemon targets macOS/Linux only (vsock/UDS), so
 /// the unix `:` is correct; Go uses `os.PathListSeparator` for the same reason.

--- a/crates/shed-host-agent/src/main.rs
+++ b/crates/shed-host-agent/src/main.rs
@@ -28,6 +28,7 @@ mod bus;
 mod config;
 #[cfg(feature = "desktop-forwarding")]
 mod controltoken;
+mod docker_backend;
 #[cfg(feature = "desktop-forwarding")]
 mod desktop;
 #[cfg(feature = "desktop-forwarding")]

--- a/crates/shed-host-agent/src/main.rs
+++ b/crates/shed-host-agent/src/main.rs
@@ -439,12 +439,36 @@ fn run_daemon(config_path: &str, log_file: &str) -> i32 {
                 }
             };
 
+            // The Docker credential backend (Go main.go:175-180 parity). The ASYMMETRY
+            // vs aws: there is NO `enabled()` gate — `new_docker_backend` errors ONLY
+            // when an explicit `config_path` is unstat-able, so an absent/empty `docker:`
+            // block still constructs a live backend (denying every registry under an
+            // empty allowlist) and the docker-credentials namespace is subscribed for
+            // every server. `None` only on that explicit-config_path error. Its gate is
+            // the docker-credentials per-namespace gate (from `docker.approval.policy`).
+            let docker = match docker_backend::new_docker_backend(cfg.docker.clone(), bus_log.clone()) {
+                Ok(backend) => {
+                    let backend_dyn: Arc<dyn docker_backend::DockerBackend> = Arc::new(backend);
+                    let docker_gate =
+                        select_gate(&cfg.effective_policy(config::NS_DOCKER_CREDENTIALS));
+                    Some(bus::DockerHandlers {
+                        backend: backend_dyn,
+                        gate: docker_gate,
+                    })
+                }
+                Err(e) => {
+                    bus_log.warn(&format!("Docker handler disabled error={e}"));
+                    None
+                }
+            };
+
             let handlers = bus::BusHandlers {
                 gate,
                 audit,
                 backend,
                 server_name: String::new(),
                 aws,
+                docker,
             };
             tasks.push(tokio::spawn(async move {
                 bus::run_single_server_bus(server_url, rx, bus_log, handlers).await;

--- a/tests/host-agent-diff/README.md
+++ b/tests/host-agent-diff/README.md
@@ -151,22 +151,23 @@ identities (real-signing ed25519, canned blobs for rsa/ecdsa).
   normal path resolves immediately either way; a pathological full-backlog peer could hang
   the Rust side longer. Low severity, tracked for the config/lifecycle slice.
 
-- **Bus subscription set: ssh-agent + (configured) aws-credentials on both; docker +
-  egress remain Go-only.** In single-server mode (no `discovery:` block) both daemons
-  connect to `server:` and subscribe to `ssh-agent`; when `aws.*` is configured (mode
-  passthrough, or a role) both ALSO subscribe `aws-credentials` — so the ssh ping/pong
-  (`test_bus_ping_pong.py`) AND the AWS passthrough cells (`test_aws_backend.py`)
-  compare apples to apples, each `wait_for_subscribe`-ing its namespace on both impls.
-  A residual asymmetry remains by design this slice: the Go daemon also GETs
-  `/api/egress/stream` (its always-on egress subscriber) and subscribes to
-  `docker-credentials` (its Docker backend is non-nil even unconfigured), whereas the
-  Rust daemon wires **ssh-agent + aws-credentials only** (egress + the docker backend
-  are later slices). The synthetic bus tolerates the extra Go subscribes (records them,
-  holds the streams open, never pushes) and 501s the egress GET (Go backs off 5m,
-  DEBUG-quiet) — so the asymmetry is absorbed by the harness, not diffed. The
-  differential asserts only the compared **response envelope** for the namespace under
-  test, never which routes each daemon hit. This flips to a full match when the later
-  slices wire the Rust egress + docker paths.
+- **Bus subscription set: ssh-agent + (configured) aws-credentials + docker-credentials
+  on both; ONLY egress remains Go-only.** In single-server mode (no `discovery:` block)
+  both daemons connect to `server:` and subscribe to `ssh-agent`; when `aws.*` is
+  configured (mode passthrough, or a role) both ALSO subscribe `aws-credentials`; and
+  both subscribe `docker-credentials` in the common case — the Docker backend is non-nil
+  even unconfigured (its constructor errors ONLY on an explicit-but-unstat-able
+  `config_path`), so the namespace is subscribed for every server. Each cell
+  `wait_for_subscribe`-es its namespace on both impls (`test_bus_ping_pong.py`,
+  `test_aws_backend.py`, `test_docker_backend.py`), so they compare apples to apples.
+  The **one** residual asymmetry remaining by design: the Go daemon also GETs
+  `/api/egress/stream` (its always-on egress subscriber), whereas the Rust daemon does
+  not yet (egress is the last unwired namespace, its own slice). The synthetic bus
+  tolerates the extra Go subscribe (501s the egress GET — Go backs off 5m, DEBUG-quiet)
+  — so the asymmetry is absorbed by the harness, not diffed. The differential asserts
+  only the compared **response envelope** for the namespace under test, never which
+  routes each daemon hit. This flips to a full match when the egress slice wires the Rust
+  egress path.
 
 - **Event replay ring.** The surface-A handshake (`hello`→`hello_ack`), the non-hello
   drop, single-consumer supersede, event fan-out + approval correlation (via the gated
@@ -214,7 +215,7 @@ owned by a different mechanism (golden/unit) or later slice, not the live diff.
 | bus | subscribe → ping → respond (open) ping/pong (masked canonical-equal) | **enforced** | live surface B (`test_bus_ping_pong.py`) |
 | bus | secure (TLS-pin) subscribe/respond, 401/409, reconnect | **xfail** | live surface B — secure needs the TLS pin from a `discovery:` config (later slice); the pin/reconnect/401/409 logic is already `bus.rs`-unit-tested |
 | bus | aws-credentials subscription (when configured) | **enforced** | live surface B (`test_aws_backend.py`: both impls `wait_for_subscribe("aws-credentials")`) |
-| bus | docker-credentials subscription | **xfail** | live surface B — later slice; the Rust daemon wires ssh-agent + aws-credentials (see "Known contract gaps") |
+| bus | docker-credentials subscription (even unconfigured) | **enforced** | live surface B (`test_docker_backend.py`: both impls `wait_for_subscribe("docker-credentials")`, incl. the unconfigured cell) |
 | status | single-server `LiveStatus.servers[]` per-namespace state (incl. 409-rejected) | **xfail** | supervisor slice — Go surfaces `HostClient.Status()` via supervisor health; the Rust bus records the state + logs it, but `servers[]` stays empty until the supervisor lands |
 | egress | events / 401 / 404-501, 5m vs 30s backoff | **xfail** | live ("no reconnect in window") + unit (consts) |
 | ssh backend · local-keys | `list` (masked canonical-equal + durable non-gated audit line) | **enforced** | live (`test_ssh_backend.py`) |
@@ -231,7 +232,8 @@ owned by a different mechanism (golden/unit) or later slice, not the live diff.
 | aws backend · passthrough | `get_credentials` (success + no-expiry-hint + no-static error; payload + audit diffed, error detail home-normalized), `status` (`passthrough:<profile>` + `cached_until`), `ping`, unknown-op, re-login pickup (atomic rewrite) | **enforced** | live (`test_aws_backend.py`) |
 | aws backend · assume-role | cache hit/stale, role resolution + layering, STS/nil-creds errors, session-name shape | **out-of-scope** | golden (`aws_resolve`/`aws_expiry` runners) + Rust unit (`AssumeRoler` fake) — no Go STS seam to drive live |
 | aws backend | response payload shapes (`get_credentials`/`status`/`ping`/`error`: tag names, `expiration`/`cached_until` omitempty) + per-namespace gate selection | **enforced (unit)** | Rust unit (`bus.rs`: `aws_*`, incl. `aws_uses_aws_gate_not_ssh`, `aws_payload_tag_names_match_protocol`) |
-| docker backend | allowlist / allow_all / helper / inline, not-found vs not-allowed | **xfail** | live (helper transcript) + golden (resolution matrix) |
+| docker backend | `get` inline-auth (payload+audit) / helper (transcript diffed + payload + ok audit) / not-allowed (backend REGISTRY_NOT_ALLOWED) / approval-deny (guest REGISTRY_NOT_ALLOWED + audit APPROVAL_DENIED, the two-code split) / not-found→anonymous (guest CREDENTIALS_NOT_FOUND + audit anonymous) / `list` (positional `count:N`) / `status` / `ping` / unknown-op / **unconfigured** (still subscribes + denies) | **enforced** | live (`test_docker_backend.py`, fake `docker-credential-testhelper` seam + self-test) |
+| docker backend | `resolve` layering (Option registries/allow_all, flow-list), `normalize_registry` (one-occurrence strip), inline-auth decode, PATH augment (append), helper-exec seam (abs-resolve, 5s timeout, PascalCase-avoidance tag guard) | **enforced (golden+unit)** | golden (`docker_resolve`/`docker_normalize`/`docker_inline_auth`/`docker_path_augment` runners) + Rust unit (`docker_backend.rs`, `bus.rs` docker handler incl. `docker_uses_docker_gate_not_ssh_or_aws`, `docker_payload_tag_names_match_protocol`) |
 | minter | control-scope argv + success `token.response` | **enforced** | live (`test_token_get.py`: `token`/`expires_at` compared + argv == expected vector, `<scope>` == `control`) |
 | minter | host-key-mismatch terminal; single-flight; refresh cadence | **enforced (unit)** | unit parity (`minter.rs` / `bootstrap.rs`, incl. real-runner shell-shim tests) |
 | minter | `load_discovered_servers` shape (ssh_port=0-vs-22, empty-host skip, sort) | **enforced (golden)** | Go + Rust golden runners on `fixtures/load_discovered_servers.json` |

--- a/tests/host-agent-diff/conftest.py
+++ b/tests/host-agent-diff/conftest.py
@@ -153,6 +153,10 @@ def _clean_env(socket_dir, home, path_prepend=None, ssh_auth_sock=None) -> dict:
     env["HOME"] = str(home)
     env.pop("SSH_AUTH_SOCK", None)
     env.pop("XDG_RUNTIME_DIR", None)
+    # Strip DOCKER_CONFIG so `find_docker_config` resolves the isolated
+    # `<HOME>/.docker/config.json` on BOTH impls (a dev-Mac DOCKER_CONFIG would
+    # otherwise leak a real Docker config into the differential — non-hermetic).
+    env.pop("DOCKER_CONFIG", None)
     if path_prepend is not None:
         env["PATH"] = str(path_prepend) + os.pathsep + env.get("PATH", "")
     if ssh_auth_sock is not None:
@@ -237,6 +241,7 @@ class DaemonHandle:
         log_path,
         audit_log_path,
         ssh_argv_file=None,
+        docker_transcript_file=None,
     ):
         self.impl = impl
         self.binary = binary
@@ -249,6 +254,13 @@ class DaemonHandle:
         # appends its argv (one element per line) to this file — the daemon's exact
         # `ssh` invocation, captured for the differential's argv comparison.
         self.ssh_argv_file = Path(ssh_argv_file) if ssh_argv_file else None
+        # When launched with a fake `docker-credential-testhelper` (the docker helper
+        # cells), the helper appends one JSONL record per invocation — `{"argv":[...],
+        # "stdin":"<server_url>"}`, argv+stdin ONLY, never PATH/env — captured for the
+        # exec-seam transcript diff.
+        self.docker_transcript_file = (
+            Path(docker_transcript_file) if docker_transcript_file else None
+        )
         # The DURABLE audit JSONL (`logging.path`), distinct from the operational log
         # above. Populated by gated ops (the sign flow); a fan-out `event` is sent
         # AFTER the file line is written on both impls (Rust `JsonlAuditSink::log`,
@@ -286,16 +298,16 @@ class DaemonHandle:
             f"{self.impl}: shim ssh argv file {self.ssh_argv_file} empty within {timeout}s"
         )
 
-    def read_audit_jsonl(self, expect: int = 1, timeout: float = 5.0) -> list:
-        """Poll the durable audit file until it holds `expect` non-empty JSONL lines
-        (a deadline poll, never a fixed sleep) and return them parsed. Raises on
-        timeout or on a line that isn't a JSON object. Robust against the small window
-        between the desktop `event` and the file flush landing on disk."""
+    def _poll_jsonl(self, path: Path, what: str, expect: int, timeout: float) -> list:
+        """Poll `path` until it holds `expect` non-empty JSONL lines (a deadline poll,
+        never a fixed sleep) and return them parsed. Raises on timeout or on a line
+        that isn't valid JSON. Robust against the small window between the triggering
+        event and the file flush landing on disk."""
         deadline = time.monotonic() + timeout
         last: list = []
         while time.monotonic() < deadline:
             try:
-                raw = self.audit_log_path.read_text()
+                raw = path.read_text()
             except OSError:
                 raw = ""
             last = [line for line in raw.splitlines() if line.strip()]
@@ -305,9 +317,22 @@ class DaemonHandle:
                 return [_json.loads(line) for line in last]
             time.sleep(0.02)
         raise AssertionError(
-            f"{self.impl}: audit file {self.audit_log_path} held {len(last)} line(s), "
+            f"{self.impl}: {what} {path} held {len(last)} line(s), "
             f"expected {expect} within {timeout}s; contents={last!r}"
         )
+
+    def read_docker_transcript(self, expect: int = 1, timeout: float = 5.0) -> list:
+        """Poll the fake docker-helper's transcript until it holds `expect` non-empty
+        JSONL lines and return them parsed (each `{"argv":[...], "stdin":"..."}`)."""
+        assert self.docker_transcript_file is not None, (
+            "daemon was not launched with docker_helper_bundle"
+        )
+        return self._poll_jsonl(self.docker_transcript_file, "docker transcript", expect, timeout)
+
+    def read_audit_jsonl(self, expect: int = 1, timeout: float = 5.0) -> list:
+        """Poll the durable audit file (`logging.path`) until it holds `expect`
+        non-empty JSONL lines and return them parsed."""
+        return self._poll_jsonl(self.audit_log_path, "audit file", expect, timeout)
 
 
 @pytest.fixture
@@ -331,6 +356,8 @@ def daemon(binaries, tmp_path_factory):
         known_hosts: str | None = None,
         ssh_shim_bundle: str | None = None,
         install_aws_credentials: str | None = None,
+        install_docker_config: str | None = None,
+        docker_helper_bundle: str | None = None,
     ):
         root = tmp_path_factory.mktemp(f"daemon-{impl}")
         home = root / "home"
@@ -378,6 +405,17 @@ def daemon(binaries, tmp_path_factory):
             (aws_dir / "credentials").write_text(install_aws_credentials)
             (aws_dir / "config").write_text("")
 
+        # Install the Docker `config.json` fixture into this daemon's isolated
+        # `<HOME>/.docker/config.json` BEFORE launch, so a `get`/`list` reads the SAME
+        # config on both impls (`find_docker_config` resolves `$HOME/.docker/config.json`
+        # with DOCKER_CONFIG stripped by `_clean_env`). Hermetic by construction — no
+        # DOCKER_CONFIG env plumbing. When None (the UNCONFIGURED cell), no file is
+        # written, so the default path is absent → the backend denies every registry.
+        if install_docker_config is not None:
+            docker_dir = home / ".docker"
+            docker_dir.mkdir(exist_ok=True)
+            (docker_dir / "config.json").write_text(install_docker_config)
+
         # The minter reads `<HOME>/.shed/{config.yaml,known_hosts}` (the shed CLI
         # config it resolves servers from + the host-key pin). Both impls read the
         # SAME isolated HOME.
@@ -401,6 +439,25 @@ def daemon(binaries, tmp_path_factory):
             ssh_argv_file = root / "ssh-argv.txt"
             _write_ssh_shim(shim_dir / "ssh", ssh_argv_file, ssh_shim_bundle)
             path_prepend = shim_dir
+
+        # Install a fake `docker-credential-testhelper` (a python3 script, 0755 + shebang)
+        # into a PATH-PREPENDED `helper-bin` dir — `look_helper_path` resolves via PATH
+        # (`which`-equivalent) FIRST, so the front-of-PATH shim wins on both impls. It
+        # captures its argv + stdin (the server_url) to a per-impl transcript JSONL,
+        # then prints the fixed bundle. The two cells are mutually exclusive with the ssh
+        # shim (both want `path_prepend`).
+        docker_transcript_file = None
+        if docker_helper_bundle is not None:
+            assert ssh_shim_bundle is None, "ssh shim + docker helper both want path_prepend"
+            helper_dir = root / "helper-bin"
+            helper_dir.mkdir()
+            docker_transcript_file = root / "docker-helper-transcript.jsonl"
+            _write_docker_helper(
+                helper_dir / "docker-credential-testhelper",
+                docker_transcript_file,
+                docker_helper_bundle,
+            )
+            path_prepend = helper_dir
 
         # The socket dir must be SHORT: an AF_UNIX bind path caps at ~104 bytes
         # (macOS) / ~108 (Linux), and pytest's nested tmp tree blows past that. A
@@ -453,6 +510,7 @@ def daemon(binaries, tmp_path_factory):
             log_path,
             audit_log,
             ssh_argv_file=ssh_argv_file,
+            docker_transcript_file=docker_transcript_file,
         )
         try:
             yield handle
@@ -499,6 +557,25 @@ def _write_ssh_shim(path: Path, argv_file: Path, bundle_json: str) -> None:
         f'for a in "$@"; do printf \'%s\\n\' "$a" >> "{argv_file}"; done\n'
         f"printf '%s' '{bundle_json}'\n"
         "exit 0\n"
+    )
+    path.write_text(script)
+    os.chmod(path, 0o755)
+
+
+def _write_docker_helper(path: Path, transcript_file: Path, bundle_json: str) -> None:
+    """Write an executable `#!/usr/bin/env python3` fake `docker-credential-testhelper`
+    that (a) reads stdin (the raw `server_url`), (b) appends ONE JSONL record of its
+    argv + stdin — argv+stdin ONLY, NEVER the augmented PATH/env (per-impl/host-dependent;
+    APPEND parity is the `augment_path` golden's job) — to `transcript_file`, and (c)
+    prints the fixed `bundle_json` to stdout, exit 0. The deterministic exec seam both
+    daemons run over."""
+    script = (
+        "#!/usr/bin/env python3\n"
+        "import sys, json\n"
+        "stdin = sys.stdin.read()\n"
+        f"with open({str(transcript_file)!r}, 'a') as f:\n"
+        "    f.write(json.dumps({'argv': sys.argv[1:], 'stdin': stdin}) + '\\n')\n"
+        f"sys.stdout.write({bundle_json!r})\n"
     )
     path.write_text(script)
     os.chmod(path, 0o755)

--- a/tests/host-agent-diff/fixtures/docker_inline_auth.json
+++ b/tests/host-agent-diff/fixtures/docker_inline_auth.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Golden fixture for decodeInlineAuth (docker_backend.go:406 / docker_backend.rs:decode_inline_auth): base64(user:pass) -> {username, secret} split on the FIRST colon (password may contain colons). Each runner base64-STANDARD-encodes `plain` itself (padded StdEncoding — identical bytes both sides), then decodes, so the fixture stays engine-neutral. `valid_vectors` check username/secret; `invalid_vectors` check the exact error string. IMPORTANT: a malformed-base64 vector is INTENTIONALLY EXCLUDED — its `decoding auth for <url>: <e>` message carries an impl-dependent SUFFIX (Go's `illegal base64 data at input byte N` vs the Rust base64 crate's text), so only the `invalid auth format for <url>` case (prefix-only, no runtime text) is goldenable; the decode-error PREFIX is unit-pinned instead, never live/golden-diffed. Read by BOTH the Go runner (cmd/shed-host-agent/golden_test.go:TestGoldenDockerInlineAuth) and the Rust runner (crates/shed-host-agent/src/docker_backend.rs tests::golden_docker_inline_auth).",
+  "protocol_version": 1,
+  "valid_vectors": [
+    {"name": "basic user:pass", "server_url": "registry.example.com", "plain": "myuser:mypass", "username": "myuser", "secret": "mypass"},
+    {"name": "colon in password preserved (SplitN-2)", "server_url": "registry.example.com", "plain": "user:pass:word:extra", "username": "user", "secret": "pass:word:extra"},
+    {"name": "empty password", "server_url": "reg.io", "plain": "onlyuser:", "username": "onlyuser", "secret": ""}
+  ],
+  "invalid_vectors": [
+    {"name": "no colon -> invalid auth format", "server_url": "registry.example.com", "plain": "nocolon", "expected_error": "invalid auth format for registry.example.com"}
+  ]
+}

--- a/tests/host-agent-diff/fixtures/docker_normalize.json
+++ b/tests/host-agent-diff/fixtures/docker_normalize.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "Golden fixture for the Docker registry-key canonicalization + config-map lookup. `normalize_vectors` pin normalizeRegistry (docker_backend.go:375 / docker_backend.rs:normalize_registry): strip https://|http:// prefix then trailing `/`, `/v1`, `/v2` — in THAT order, each a SINGLE occurrence (strip_prefix/strip_suffix, not trim_*_matches). `ghcr.io//` -> `ghcr.io/` pins one-occurrence; `.../v1/` -> `...` and `reg.io/v2/` -> `reg.io` pin the strip ORDER (trailing `/` before `/v1`|`/v2`). `lookup_vectors` pin lookupConfigMap's 3-way search (raw key -> normalized key -> normalize-every-key scan): each runner computes normalized = normalizeRegistry(raw) then looks it up, so a config key stored as `https://index.docker.io/v1/` matches a guest `index.docker.io` and vice versa; `expected` null = miss. Read by BOTH the Go runner (cmd/shed-host-agent/golden_test.go:TestGoldenDockerNormalize) and the Rust runner (crates/shed-host-agent/src/docker_backend.rs tests::golden_docker_normalize).",
+  "protocol_version": 1,
+  "normalize_vectors": [
+    {"input": "us-docker.pkg.dev", "expected": "us-docker.pkg.dev"},
+    {"input": "https://us-docker.pkg.dev", "expected": "us-docker.pkg.dev"},
+    {"input": "https://index.docker.io/v1/", "expected": "index.docker.io"},
+    {"input": "https://index.docker.io/v1", "expected": "index.docker.io"},
+    {"input": "http://localhost:5000", "expected": "localhost:5000"},
+    {"input": "ghcr.io", "expected": "ghcr.io"},
+    {"input": "ghcr.io/", "expected": "ghcr.io"},
+    {"input": "ghcr.io//", "expected": "ghcr.io/"},
+    {"input": "https://reg.io/v2", "expected": "reg.io"},
+    {"input": "reg.io/v2/", "expected": "reg.io"}
+  ],
+  "lookup_vectors": [
+    {"name": "exact raw key", "map": {"ghcr.io": "helperB", "https://index.docker.io/v1/": "helperA"}, "raw": "ghcr.io", "expected": "helperB"},
+    {"name": "scan-all-keys: guest sends normalized host, key is full docker form", "map": {"https://index.docker.io/v1/": "helperA"}, "raw": "index.docker.io", "expected": "helperA"},
+    {"name": "normalized-key path: guest sends full docker form, key is normalized", "map": {"index.docker.io": "helperC"}, "raw": "https://index.docker.io/v1/", "expected": "helperC"},
+    {"name": "miss", "map": {"a.io": "h"}, "raw": "b.io", "expected": null}
+  ]
+}

--- a/tests/host-agent-diff/fixtures/docker_path_augment.json
+++ b/tests/host-agent-diff/fixtures/docker_path_augment.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Golden fixture for augmentPATH (docker_backend.go:323 / docker_backend.rs:augment_path): the credential-helper install dirs (/usr/local/bin, /opt/homebrew/bin) are APPENDED to the child's PATH (skipping any already present), NOT prepended. Non-go_only vectors carry a single `path` string + `extra_dirs` -> `expected_path`; both runners produce the resulting PATH value and compare. An empty `path` yields ONLY the extras (no leading separator). go_only vectors carry an `env` array (multiple PATH= entries, or no PATH= entry) that only Go's []string-env augmentPATH can represent — the Rust Command env is a MAP keyed by name (no duplicate-PATH, no missing-PATH branch), so the Rust runner SKIPS them (see augment_path_go_only_note). The Go runner feeds `env` (if present) else [`PATH=`+path] to augmentPATH and extracts the effective (last-wins) PATH value. Read by BOTH the Go runner (cmd/shed-host-agent/golden_test.go:TestGoldenDockerPathAugment) and the Rust runner (crates/shed-host-agent/src/docker_backend.rs tests::golden_docker_path_augment).",
+  "protocol_version": 1,
+  "vectors": [
+    {"name": "append missing dirs", "path": "/usr/bin:/bin", "extra_dirs": ["/usr/local/bin", "/opt/homebrew/bin"], "expected_path": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"},
+    {"name": "no duplicate for a dir already present", "path": "/usr/local/bin:/usr/bin", "extra_dirs": ["/usr/local/bin"], "expected_path": "/usr/local/bin:/usr/bin"},
+    {"name": "empty PATH value yields only the extras (no leading separator)", "path": "", "extra_dirs": ["/opt/homebrew/bin"], "expected_path": "/opt/homebrew/bin"},
+    {"name": "extra already mid-PATH keeps single copy", "path": "/a:/opt/homebrew/bin:/b", "extra_dirs": ["/opt/homebrew/bin"], "expected_path": "/a:/opt/homebrew/bin:/b"},
+    {"name": "go_only: env has NO PATH entry -> a PATH is added (Go []string-env branch; Rust has no missing-PATH case)", "go_only": true, "env": ["HOME=/home/user"], "extra_dirs": ["/opt/homebrew/bin"], "expected_path": "/opt/homebrew/bin"},
+    {"name": "go_only: duplicate PATH= entries, the LAST is augmented (Go last-key-wins; Rust env is a map)", "go_only": true, "env": ["PATH=/early", "HOME=/home/user", "PATH=/usr/bin"], "extra_dirs": ["/opt/homebrew/bin"], "expected_path": "/usr/bin:/opt/homebrew/bin"}
+  ]
+}

--- a/tests/host-agent-diff/fixtures/docker_resolve.json
+++ b/tests/host-agent-diff/fixtures/docker_resolve.json
@@ -1,0 +1,54 @@
+{
+  "_comment": "Golden fixture for the Docker config slice — input host-agent config YAML (block-style maps + flow-list `[a, b]` registries, the yaml_lite subset) -> per-(server,shed) DockerConfig.Resolve() results: allow_all + registries + registry_count (== len(registries), the backend Status verdict). Read by BOTH the Go runner (cmd/shed-host-agent/golden_test.go:TestGoldenDockerResolve, via the production LoadConfig->Docker.Resolve path) and the Rust runner (crates/shed-host-agent/src/config.rs tests::golden_docker_resolve, via HostAgentConfig::parse().docker.resolve). Go has NO Resolve layering test, so this golden is Rust-STRONGER. It pins the load-bearing Option semantics: registries Option<Vec<String>> (absent -> inherit, `[]` -> REPLACE-with-empty / deny-all lockdown, `[a,b]` -> replace-not-merge across top/server/shed) and allow_all Option<bool> (absent -> inherit, false -> force-off, true -> force-on), plus the flow-list `[a, b]` parse the new yaml_lite Node::Sequence enables. Mirrors config_discovery_test.go:TestDockerResolve (extended).",
+  "protocol_version": 1,
+  "vectors": [
+    {
+      "name": "top-level defaults inherited when no server override; flow-list [a, b] parse",
+      "config_yaml": "docker:\n  registries: [ghcr.io, index.docker.io]\n  allow_all: false\n",
+      "queries": [
+        {"server": "mini3", "shed": "anything", "allow_all": false, "registries": ["ghcr.io", "index.docker.io"], "registry_count": 2}
+      ]
+    },
+    {
+      "name": "per-server allow_all pointer override inherits registries; per-shed replaces registries + forces allow_all false",
+      "config_yaml": "docker:\n  registries: [ghcr.io]\n  servers:\n    mini2:\n      allow_all: true\n      sheds:\n        web:\n          registries: [reg.example.com]\n          allow_all: false\n",
+      "queries": [
+        {"server": "mini3", "shed": "anything", "allow_all": false, "registries": ["ghcr.io"], "registry_count": 1},
+        {"server": "mini2", "shed": "api", "allow_all": true, "registries": ["ghcr.io"], "registry_count": 1},
+        {"server": "mini2", "shed": "web", "allow_all": false, "registries": ["reg.example.com"], "registry_count": 1}
+      ]
+    },
+    {
+      "name": "explicit empty registries [] at server -> replace-with-empty (deny-all lockdown); sibling server inherits",
+      "config_yaml": "docker:\n  registries: [ghcr.io, index.docker.io]\n  servers:\n    locked:\n      registries: []\n",
+      "queries": [
+        {"server": "locked", "shed": "x", "allow_all": false, "registries": [], "registry_count": 0},
+        {"server": "other", "shed": "x", "allow_all": false, "registries": ["ghcr.io", "index.docker.io"], "registry_count": 2}
+      ]
+    },
+    {
+      "name": "allow_all Option layering: None inherit / Some(false) force-off / Some(true) force-on; registries replace at server tier",
+      "config_yaml": "docker:\n  allow_all: true\n  registries: [ghcr.io]\n  servers:\n    off-server:\n      allow_all: false\n    inherit-server:\n      registries: [only.io]\n",
+      "queries": [
+        {"server": "off-server", "shed": "x", "allow_all": false, "registries": ["ghcr.io"], "registry_count": 1},
+        {"server": "inherit-server", "shed": "x", "allow_all": true, "registries": ["only.io"], "registry_count": 1},
+        {"server": "unknown", "shed": "x", "allow_all": true, "registries": ["ghcr.io"], "registry_count": 1}
+      ]
+    },
+    {
+      "name": "empty registries [] at shed under allow_all-true server -> per-shed deny-all lockdown; sibling shed inherits allow_all",
+      "config_yaml": "docker:\n  allow_all: true\n  servers:\n    mini2:\n      sheds:\n        locked:\n          registries: []\n          allow_all: false\n",
+      "queries": [
+        {"server": "mini2", "shed": "locked", "allow_all": false, "registries": [], "registry_count": 0},
+        {"server": "mini2", "shed": "other", "allow_all": true, "registries": [], "registry_count": 0}
+      ]
+    },
+    {
+      "name": "no docker block at all -> unconfigured deny-all (empty registries, allow_all false)",
+      "config_yaml": "server: http://localhost:8080\n",
+      "queries": [
+        {"server": "any", "shed": "any", "allow_all": false, "registries": [], "registry_count": 0}
+      ]
+    }
+  ]
+}

--- a/tests/host-agent-diff/test_docker_backend.py
+++ b/tests/host-agent-diff/test_docker_backend.py
@@ -1,0 +1,417 @@
+"""The Docker credential backend differential — surface-B `get`/`list`/`status`/`ping`/
+`unknown` over the docker-credentials namespace, asserted equal across the Go
+`cmd/shed-host-agent` and the Rust `crates/shed-host-agent`.
+
+**Hermetic by construction.** The `daemon` fixture writes the Docker `config.json`
+fixture into each impl's isolated `<HOME>/.docker/config.json` (`install_docker_config`
+kwarg), and `_clean_env` strips `DOCKER_CONFIG`, so both impls resolve the SAME config
+off `$HOME` with no real `~/.docker` read. The credential-helper exec seam is a fake
+`docker-credential-testhelper` (a python3 script, 0755 + shebang) installed into a
+PATH-prepended `helper-bin` dir (`docker_helper_bundle` kwarg); it appends a per-impl
+JSONL transcript of `{argv, stdin}` — argv+stdin ONLY, never PATH/env — and prints a
+fixed bundle, so the exec seam is deterministic and its transcript is diffable.
+
+**The unconfigured crux.** Unlike AWS (which gates itself off when unconfigured), the
+Docker backend is non-nil even absent — so BOTH impls subscribe `docker-credentials`
+for every server. Every cell `wait_for_subscribe("docker-credentials")` first (proving
+the subscription on both impls); the dedicated `test_docker_unconfigured` cell proves
+the crux directly (a minimal `docker:` block still subscribes + denies).
+
+**Error-string policy.** Only PREFIXES + codes are diffed live — the base64/JSON/
+exit-status runtime SUFFIXES are impl-dependent and excluded (helper-failure `reason` is
+unit-owned). The audit `reason`s asserted here (`registry "x" not in allowlist`,
+`no credentials found for "x"`, `denied: approval policy is deny-all`) carry NO runtime
+suffix, so they ARE diffed byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+import sys
+
+import pytest
+
+from normalize import canonical, mask_audit_entry, mask_bus_response
+from synthetic_bus import SyntheticBus
+
+NS = "docker-credentials"
+
+# The fixed helper bundle the fake `docker-credential-testhelper` prints (Capitalized
+# docker-credential-helper protocol tags → mapped to the snake_case guest wire).
+HELPER_BUNDLE = json.dumps(
+    {"ServerURL": "ghcr.io", "Username": "helper-user", "Secret": "helper-secret"}
+)
+
+
+def _b64(plain: str) -> str:
+    return base64.b64encode(plain.encode()).decode()
+
+
+# --- config helpers (block-style; `{server}` filled, `{audit_log}` survives) ----------
+
+_HEAD = "server: {server}\nssh:\n  approval:\n    policy: approve-all\n"
+_TAIL = "logging:\n  enabled: true\n  path: {audit_log}\n"
+
+
+def _config(bus_url: str, docker_block: str) -> str:
+    """Assemble a launch config: ssh approve-all + the given `docker:` block + logging.
+    `{server}` is filled now (str.replace), `{audit_log}` survives to the `daemon`
+    fixture's `.format()`."""
+    return (_HEAD + docker_block + _TAIL).replace("{server}", bus_url)
+
+
+# The `shed` block every request carries; echoed onto the response.
+SHED = {"name": "web", "backend": "vz", "server": "mini2"}
+EXPECTED_SHED = dict(SHED)
+
+
+def _req(req_id: str, operation: str, **extra) -> dict:
+    payload = {"operation": operation}
+    payload.update(extra)
+    return {
+        "id": req_id,
+        "namespace": NS,
+        "type": "request",
+        "final": True,
+        "timestamp": "2026-07-10T00:00:00Z",
+        "payload": payload,
+        "shed": SHED,
+    }
+
+
+# =====================================================================================
+# fake-seam self-test (proves the shim honors the contract before it's trusted)
+# =====================================================================================
+
+
+def test_docker_helper_shim_contract(tmp_path):
+    """Drive the generated fake helper directly (no daemon): it must capture argv+stdin
+    to the transcript and print the bundle verbatim — the contract the differential relies
+    on. Uses the conftest writer via a throwaway helper file."""
+    from conftest import _write_docker_helper
+
+    transcript = tmp_path / "t.jsonl"
+    helper = tmp_path / "docker-credential-testhelper"
+    _write_docker_helper(helper, transcript, HELPER_BUNDLE)
+    proc = subprocess.run(
+        [sys.executable, str(helper), "get"],
+        input="ghcr.io",
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert proc.returncode == 0
+    assert proc.stdout == HELPER_BUNDLE
+    lines = [ln for ln in transcript.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec == {"argv": ["get"], "stdin": "ghcr.io"}
+    # The transcript must NOT leak PATH/env.
+    assert "PATH" not in transcript.read_text()
+
+
+# =====================================================================================
+# cells
+# =====================================================================================
+
+
+@pytest.mark.differential
+def test_docker_get_inline_auth(daemon, differential):
+    """get via inline `auths` (base64 in config.json → fully deterministic, no helper):
+    payload + ok audit diffed."""
+    config_json = json.dumps({"auths": {"ghcr.io": {"auth": _b64("inline-user:inline-secret")}}})
+    docker_block = "docker:\n  allow_all: true\n  approval:\n    policy: approve-all\n"
+
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _config(bus.url, docker_block), install_docker_config=config_json) as d:
+                bus.wait_for_subscribe(NS, timeout=10.0)
+                bus.push_request(NS, _req("inl-1", "get", server_url="ghcr.io"))
+                resp = bus.await_response(NS, timeout=10.0)
+                audit = d.read_audit_jsonl(expect=1, timeout=10.0)[0]
+                return {
+                    "response": canonical(mask_bus_response(resp)),
+                    "audit": canonical(mask_audit_entry(audit)),
+                }
+
+    result = differential(scenario)
+    resp = result["response"]
+    assert resp["in_reply_to"] == "inl-1"
+    assert resp["shed"] == EXPECTED_SHED
+    assert resp["payload"] == {
+        "server_url": "ghcr.io",
+        "username": "inline-user",
+        "secret": "inline-secret",
+    }
+    # ok audit (LogEntry form): detail=server_url, NO code (asserted absent).
+    assert result["audit"] == {
+        "ts": "<ts>",
+        "shed": "web",
+        "ns": NS,
+        "op": "get",
+        "result": "ok",
+        "detail": "ghcr.io",
+        "approval": "approve-all",
+    }
+    assert "code" not in result["audit"], "ok get audit must carry NO code"
+
+
+@pytest.mark.differential
+def test_docker_get_helper(daemon, differential):
+    """get via a credHelper (the live exec seam): the helper transcript diffed Go-vs-Rust,
+    the response payload diffed, and the ok audit diffed."""
+    config_json = json.dumps({"credHelpers": {"ghcr.io": "testhelper"}})
+    docker_block = "docker:\n  allow_all: true\n  approval:\n    policy: approve-all\n"
+
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(
+                impl,
+                _config(bus.url, docker_block),
+                install_docker_config=config_json,
+                docker_helper_bundle=HELPER_BUNDLE,
+            ) as d:
+                bus.wait_for_subscribe(NS, timeout=10.0)
+                bus.push_request(NS, _req("hlp-1", "get", server_url="ghcr.io"))
+                resp = bus.await_response(NS, timeout=10.0)
+                audit = d.read_audit_jsonl(expect=1, timeout=10.0)[0]
+                transcript = d.read_docker_transcript(expect=1, timeout=10.0)
+                return {
+                    "response": canonical(mask_bus_response(resp)),
+                    "audit": canonical(mask_audit_entry(audit)),
+                    "transcript": transcript,
+                }
+
+    result = differential(scenario)
+    # The helper's bundle → the snake_case guest wire.
+    assert result["response"]["payload"] == {
+        "server_url": "ghcr.io",
+        "username": "helper-user",
+        "secret": "helper-secret",
+    }
+    # The exec seam: argv `["get"]`, stdin = the raw server_url, identical on both impls.
+    assert result["transcript"] == [{"argv": ["get"], "stdin": "ghcr.io"}]
+    assert result["audit"]["result"] == "ok"
+    assert result["audit"]["detail"] == "ghcr.io"
+
+
+@pytest.mark.differential
+def test_docker_not_allowed(daemon, differential):
+    """A registry outside the allowlist → guest `REGISTRY_NOT_ALLOWED` (a BACKEND deny,
+    distinct from the approval deny below) + audit result:error. The allowlist is checked
+    BEFORE config.json is read, so a blank config still denies."""
+    config_json = "{}"
+    docker_block = "docker:\n  registries: [allowed.io]\n  approval:\n    policy: approve-all\n"
+
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _config(bus.url, docker_block), install_docker_config=config_json) as d:
+                bus.wait_for_subscribe(NS, timeout=10.0)
+                bus.push_request(NS, _req("na-1", "get", server_url="blocked.io"))
+                resp = bus.await_response(NS, timeout=10.0)
+                audit = d.read_audit_jsonl(expect=1, timeout=10.0)[0]
+                return {
+                    "response": canonical(mask_bus_response(resp)),
+                    "audit": canonical(mask_audit_entry(audit)),
+                }
+
+    result = differential(scenario)
+    assert result["response"]["payload"] == {
+        "error": "credential request failed",
+        "code": "REGISTRY_NOT_ALLOWED",
+    }
+    audit = result["audit"]
+    assert audit["result"] == "error"
+    assert audit["code"] == "REGISTRY_NOT_ALLOWED"
+    assert audit["detail"] == "blocked.io"
+    # The backend reason carries no runtime suffix (Go `%q` == Rust `{:?}`), so it's diffed.
+    assert audit["reason"] == 'registry "blocked.io" not in allowlist'
+
+
+@pytest.mark.differential
+def test_docker_approval_deny(daemon, differential):
+    """The approval gate (docker.approval.policy: deny-all) rejects: the guest still gets
+    `REGISTRY_NOT_ALLOWED` (back-compat) while the audit carries `code:APPROVAL_DENIED,
+    result:denied` — the two-code disambiguation."""
+    config_json = json.dumps({"auths": {"ghcr.io": {"auth": _b64("u:s")}}})
+    docker_block = "docker:\n  allow_all: true\n  approval:\n    policy: deny-all\n"
+
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _config(bus.url, docker_block), install_docker_config=config_json) as d:
+                bus.wait_for_subscribe(NS, timeout=10.0)
+                bus.push_request(NS, _req("deny-1", "get", server_url="ghcr.io"))
+                resp = bus.await_response(NS, timeout=10.0)
+                audit = d.read_audit_jsonl(expect=1, timeout=10.0)[0]
+                return {
+                    "response": canonical(mask_bus_response(resp)),
+                    "audit": canonical(mask_audit_entry(audit)),
+                }
+
+    result = differential(scenario)
+    # Guest: REGISTRY_NOT_ALLOWED (unchanged) — NOT the audit's APPROVAL_DENIED.
+    assert result["response"]["payload"] == {
+        "error": "approval denied",
+        "code": "REGISTRY_NOT_ALLOWED",
+    }
+    audit = result["audit"]
+    assert audit["result"] == "denied"
+    assert audit["code"] == "APPROVAL_DENIED"
+    assert audit["detail"] == "ghcr.io"
+    assert audit["approval"] == "deny-all"
+    # The deny reason is the gate's error string (Go `err.Error()` == Rust outcome.reason).
+    assert audit["reason"] == "denied: approval policy is deny-all"
+
+
+@pytest.mark.differential
+def test_docker_not_found_anonymous(daemon, differential):
+    """An ALLOWED registry with no credential → guest `CREDENTIALS_NOT_FOUND` but audit
+    result:`anonymous` (the guest pulls anonymously). Assert BOTH the guest code AND the
+    anonymous audit — the load-bearing subtlety."""
+    config_json = "{}"  # allowed (allow_all) but empty → nothing to serve
+    docker_block = "docker:\n  allow_all: true\n  approval:\n    policy: approve-all\n"
+
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _config(bus.url, docker_block), install_docker_config=config_json) as d:
+                bus.wait_for_subscribe(NS, timeout=10.0)
+                bus.push_request(NS, _req("nf-1", "get", server_url="ghcr.io"))
+                resp = bus.await_response(NS, timeout=10.0)
+                audit = d.read_audit_jsonl(expect=1, timeout=10.0)[0]
+                return {
+                    "response": canonical(mask_bus_response(resp)),
+                    "audit": canonical(mask_audit_entry(audit)),
+                }
+
+    result = differential(scenario)
+    # Guest receives CREDENTIALS_NOT_FOUND (it turns this into an anonymous pull).
+    assert result["response"]["payload"] == {
+        "error": "credential request failed",
+        "code": "CREDENTIALS_NOT_FOUND",
+    }
+    audit = result["audit"]
+    assert audit["result"] == "anonymous", "an allowed-but-no-cred get audits as anonymous"
+    assert audit["code"] == "CREDENTIALS_NOT_FOUND"
+    assert audit["reason"] == 'no credentials found for "ghcr.io"'
+
+
+@pytest.mark.differential
+def test_docker_list(daemon, differential):
+    """list → the allowed registry→username map + a positional audit (`count:N`,
+    `approval:none`)."""
+    config_json = json.dumps(
+        {"credHelpers": {"gcr.io": "gcloud"}, "auths": {"ghcr.io": {"auth": _b64("user:token")}}}
+    )
+    docker_block = "docker:\n  allow_all: true\n  approval:\n    policy: approve-all\n"
+
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _config(bus.url, docker_block), install_docker_config=config_json) as d:
+                bus.wait_for_subscribe(NS, timeout=10.0)
+                bus.push_request(NS, _req("lst-1", "list"))
+                resp = bus.await_response(NS, timeout=10.0)
+                audit = d.read_audit_jsonl(expect=1, timeout=10.0)[0]
+                return {
+                    "response": canonical(mask_bus_response(resp)),
+                    "audit": canonical(mask_audit_entry(audit)),
+                }
+
+    result = differential(scenario)
+    assert result["response"]["payload"] == {
+        "registries": {"gcr.io": "(credential helper)", "ghcr.io": "user"}
+    }
+    # Positional audit: op=list, ok, detail=count:2, approval=none, NO outcome/code.
+    assert result["audit"] == {
+        "ts": "<ts>",
+        "shed": "web",
+        "ns": NS,
+        "op": "list",
+        "result": "ok",
+        "detail": "count:2",
+        "approval": "none",
+    }
+
+
+@pytest.mark.differential
+def test_docker_status(daemon, differential):
+    """status → `{connected:true, allow_all, registry_count}` for the resolved policy."""
+    docker_block = "docker:\n  registries: [a.io, b.io]\n  approval:\n    policy: approve-all\n"
+
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _config(bus.url, docker_block), install_docker_config="{}") as d:
+                bus.wait_for_subscribe(NS, timeout=10.0)
+                bus.push_request(NS, _req("st-1", "status"))
+                resp = bus.await_response(NS, timeout=10.0)
+                return canonical(mask_bus_response(resp))
+
+    result = differential(scenario)
+    assert result["in_reply_to"] == "st-1"
+    assert result["payload"] == {"connected": True, "allow_all": False, "registry_count": 2}
+
+
+@pytest.mark.differential
+def test_docker_ping(daemon, differential):
+    docker_block = "docker:\n  allow_all: true\n  approval:\n    policy: approve-all\n"
+
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _config(bus.url, docker_block), install_docker_config="{}") as d:
+                bus.wait_for_subscribe(NS, timeout=10.0)
+                bus.push_request(NS, _req("png-1", "ping"))
+                resp = bus.await_response(NS, timeout=10.0)
+                return canonical(mask_bus_response(resp))
+
+    result = differential(scenario)
+    assert result["in_reply_to"] == "png-1"
+    assert result["payload"] == {"status": "ok"}
+
+
+@pytest.mark.differential
+def test_docker_unknown_op(daemon, differential):
+    docker_block = "docker:\n  allow_all: true\n  approval:\n    policy: approve-all\n"
+
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            with daemon(impl, _config(bus.url, docker_block), install_docker_config="{}") as d:
+                bus.wait_for_subscribe(NS, timeout=10.0)
+                bus.push_request(NS, _req("unk-1", "delete"))
+                resp = bus.await_response(NS, timeout=10.0)
+                return canonical(mask_bus_response(resp))
+
+    result = differential(scenario)
+    assert result["in_reply_to"] == "unk-1"
+    assert result["payload"] == {"error": "unknown operation: delete", "code": "INTERNAL_ERROR"}
+
+
+@pytest.mark.differential
+def test_docker_unconfigured(daemon, differential):
+    """The unconfigured crux: a minimal `docker:` block (ONLY approval.policy, NO
+    registries/allow_all/config_path) and NO `~/.docker/config.json` under the isolated
+    `$HOME`. BOTH impls STILL subscribe `docker-credentials` (proven by
+    `wait_for_subscribe`) AND a `get` returns `REGISTRY_NOT_ALLOWED` (empty allowlist,
+    allow_all false) — the live proof of the non-nil-when-unconfigured constructor."""
+    docker_block = "docker:\n  approval:\n    policy: approve-all\n"
+
+    def scenario(impl):
+        with SyntheticBus() as bus:
+            # NO install_docker_config → default ~/.docker/config.json is absent.
+            with daemon(impl, _config(bus.url, docker_block)) as d:
+                bus.wait_for_subscribe(NS, timeout=10.0)  # subscription proven on both
+                bus.push_request(NS, _req("unc-1", "get", server_url="ghcr.io"))
+                resp = bus.await_response(NS, timeout=10.0)
+                audit = d.read_audit_jsonl(expect=1, timeout=10.0)[0]
+                return {
+                    "response": canonical(mask_bus_response(resp)),
+                    "audit": canonical(mask_audit_entry(audit)),
+                }
+
+    result = differential(scenario)
+    assert result["response"]["payload"] == {
+        "error": "credential request failed",
+        "code": "REGISTRY_NOT_ALLOWED",
+    }
+    assert result["audit"]["result"] == "error"
+    assert result["audit"]["code"] == "REGISTRY_NOT_ALLOWED"


### PR DESCRIPTION
Sub-plan 3 of the **3a.1 completion program** (stacked on #260 → #257 — retarget as parents merge): port the host-agent's **Docker credential backend** to Rust — `docker_backend.go` (429: allowlist, config.json resolution, credential-helper exec, inline auths) + `docker_handler.go` (the `docker-credentials` namespace) + the `DockerConfig` slice of `config.go`. After this slice the Go-vs-Rust bus subscription asymmetry is **egress only**.

Plan: `~/.claude/plans/monorepo-phase3-host-agent-docker-backend.md`, panel-reviewed by **Codex** (back online) + **Kimi K2.6** + **CodeRabbit** — the panel's unanimous critical finding reshaped the config slice: server/shed `registries` are `Option<Vec<String>>` (Go's nil-slice check: `None` = inherit, `Some([])` = **replace-with-empty lockdown** — security-relevant) and `yaml_lite` gained a `Node::Sequence` variant (flow-lists were previously unrepresentable).

## Commits

1. `7989164` — **config slice + yaml_lite sequences**: `DockerConfig` with the Option-typed override tiers, Go's exact `Resolve` nil-check semantics, NO `enabled()` / NO defaults (deliberate AWS asymmetries), `docker_resolve` golden (6 vectors incl. both lockdown tiers; Go runner via real `LoadConfig` — Go has no docker Resolve test, so this is Rust-stronger coverage).
2. `29c5722` — **backend**: constructor parity (error ONLY on an explicit unstat-able `config_path` — the unconditional-subscribe crux; absent config → live backend), the exact resolution order (normalize → **allowlist before any config read** → `credHelpers` errors **propagate** → `credsStore` errors **swallow and fall through** → inline auths → `CREDENTIALS_NOT_FOUND`), one-occurrence strip semantics in `normalizeRegistry` (panel catch: `trim_matches` would diverge on `ghcr.io//`), explicit `#[serde(rename = "ServerURL")]` helper protocol (panel catch: `rename_all` silently produces `ServerUrl`), `HelperExecutor` seam (PATH-then-extra-dirs abs-path resolve, PATH **append**, 5s timeout). 45 unit tests incl. the credsStore-vs-credHelpers failure asymmetry **Go itself never tests**; 3 goldens (normalize / inline-auth [malformed-base64 excluded — runtime error text diverges] / path-augment [`go_only` duplicate-PATH cases labeled]).
3. `ef1ee90` — **`respond_and_audit` extraction** (pure refactor, own commit for bisectability; panel-scoped rule-of-three; NamespaceHandler trait rejected as over-abstraction). Zero flips.
4. (this commit) — **handler + unconditional wiring + 11 harness cells** (50 → 61): the two-code deny disambiguation (guest `REGISTRY_NOT_ALLOWED` / audit `APPROVAL_DENIED` + gate reason) diffed live; `CREDENTIALS_NOT_FOUND` → `anonymous` audit; list ungated with no-audit-on-error; helper-exec transcript (argv+stdin) diffed Go-vs-Rust; the **unconfigured cell** proving both impls subscribe with no docker config. `ApprovalOutcome` gains Go's deny `reason` (wire-visible in docker audits; desktop-gate reason parity tracked for the config-port sub-plan).

## Evidence

- All 27 Go docker tests (20 backend + 7 handler) have named Rust mirrors, plus panel-added Rust-stronger rows.
- Introspected raw pairs: deny two-code split, anonymous audit with raw guest code, ok audit with no code/reason, helper transcript `argv=["get"], stdin="ghcr.io"` — byte-identical across impls.
- Full gate every commit: cargo workspace tests + clippy (default AND headless, now including a headless **test run**) + `make check` + 61-cell differential + all golden runners.

No server/guest changes; Go host-agent unchanged; nothing docker enters shed-core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED6csoQ3peM3GHc4c1CtqY
