### PR TITLE
feat(host-agent): egress SSE consumer — distinct backoff machine + endpoint-set convergence (Phase 3 leg 3a.1 sub-plan 4)

### DIFF
--- a/cmd/shed-host-agent/golden_test.go
+++ b/cmd/shed-host-agent/golden_test.go
@@ -428,6 +428,41 @@ func TestGoldenDockerResolve(t *testing.T) {
 	}
 }
 
+// TestGoldenEgressAuditEntry is the Go half of the egress_audit_entry golden. It
+// unmarshals each vector's `decision` into egressDecision (so the ts goes through the
+// PRODUCTION time.Time parse, incl. offset normalization and the zero-time case), routes
+// it through egressAuditEntry, and compares the resulting AuditEntry's wire JSON against
+// the shared fixture the Rust runner (egress.rs:tests::golden_egress_audit_entry) reads.
+// Pins the detail formatting, ns/op/result/reason mapping, ts UTC-render/blank, and the
+// always-present "approval":"" byte so the two impls cannot drift together.
+func TestGoldenEgressAuditEntry(t *testing.T) {
+	var fx struct {
+		ProtocolVersion int `json:"protocol_version"`
+		Vectors         []struct {
+			Name     string          `json:"name"`
+			Server   string          `json:"server"`
+			Decision json.RawMessage `json:"decision"`
+			Expected json.RawMessage `json:"expected"`
+		} `json:"vectors"`
+	}
+	readFixture(t, "egress_audit_entry.json", &fx)
+
+	if fx.ProtocolVersion != 1 {
+		t.Fatalf("egress_audit_entry.json protocol_version = %d, want 1 (version skew)", fx.ProtocolVersion)
+	}
+	if len(fx.Vectors) == 0 {
+		t.Fatal("egress_audit_entry.json has no vectors")
+	}
+	for _, v := range fx.Vectors {
+		var dec egressDecision
+		if err := json.Unmarshal(v.Decision, &dec); err != nil {
+			t.Errorf("%s: decode decision: %v", v.Name, err)
+			continue
+		}
+		assertJSONShapeEqual(t, "egress/"+v.Name, egressAuditEntry(v.Server, dec), v.Expected)
+	}
+}
+
 func TestGoldenGateNamespaces(t *testing.T) {
 	var fx struct {
 		ProtocolVersion int `json:"protocol_version"`

--- a/crates/shed-host-agent/src/audit.rs
+++ b/crates/shed-host-agent/src/audit.rs
@@ -89,8 +89,11 @@ fn is_empty_str(s: &&str) -> bool {
     s.is_empty()
 }
 
-/// Serialize one entry to its durable JSONL line (no trailing newline).
-fn to_jsonl(entry: &AuditEntry) -> String {
+/// Serialize one entry to its durable JSONL line (no trailing newline). `pub(crate)` so
+/// the egress golden runner (`egress::tests::golden_egress_audit_entry`) can pin the wire
+/// bytes — incl. the always-present `"approval":""` — against the shared fixture the Go
+/// runner compares via `json.Marshal(AuditEntry)`.
+pub(crate) fn to_jsonl(entry: &AuditEntry) -> String {
     let wire = WireEntry {
         ts: &entry.ts,
         server: &entry.server,

--- a/crates/shed-host-agent/src/bootstrap.rs
+++ b/crates/shed-host-agent/src/bootstrap.rs
@@ -334,95 +334,6 @@ fn find_on_path(name: &str, path: &std::ffi::OsStr) -> Option<PathBuf> {
     None
 }
 
-/// Parse an RFC3339 timestamp to unix seconds, matching what Go's `time.Time` collapses
-/// to for the mint bundle: `Ok(None)` for the zero time (`0001-01-01T00:00:00Z`),
-/// `Ok(Some(secs))` for a valid instant (offset applied, sub-second **truncated** as Go's
-/// `Format(time.RFC3339)` drops it), `Err(())` for a malformed non-empty value. The
-/// inverse of [`crate::status::rfc3339_utc`]; a round-trip against it is unit-pinned.
-fn parse_rfc3339_to_unix(s: &str) -> Result<Option<i64>, ()> {
-    // Layout: YYYY-MM-DDTHH:MM:SS[.frac](Z|±HH:MM). Split date/time on 'T'.
-    let (date, time_and_zone) = s.split_once('T').ok_or(())?;
-    let (y, mo, d) = {
-        let mut it = date.split('-');
-        let y: i64 = it.next().ok_or(())?.parse().map_err(|_| ())?;
-        let mo: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
-        let d: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
-        if it.next().is_some() {
-            return Err(());
-        }
-        (y, mo, d)
-    };
-    // Split the zone suffix off the time, then split off any fractional seconds.
-    let (time_part, offset_secs) = split_zone(time_and_zone)?;
-    let (hms, frac) = match time_part.split_once('.') {
-        Some((h, f)) => (h, Some(f)),
-        None => (time_part, None),
-    };
-    if let Some(f) = frac {
-        // Sub-second digits are validated (Go's RFC3339Nano parse would) then dropped.
-        if f.is_empty() || !f.bytes().all(|b| b.is_ascii_digit()) {
-            return Err(());
-        }
-    }
-    let (h, mi, se) = {
-        let mut it = hms.split(':');
-        let h: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
-        let mi: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
-        let se: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
-        if it.next().is_some() {
-            return Err(());
-        }
-        (h, mi, se)
-    };
-    if !(1..=12).contains(&mo) || !(1..=31).contains(&d) || h > 23 || mi > 59 || se > 60 {
-        return Err(());
-    }
-    // The Go zero time → None (Go's `IsZero()` → omitted `expires_at`).
-    if y == 1 && mo == 1 && d == 1 && h == 0 && mi == 0 && se == 0 && offset_secs == 0 {
-        return Ok(None);
-    }
-    let days = crate::status::days_from_civil(y, mo, d);
-    let secs = days * 86_400 + (h as i64) * 3_600 + (mi as i64) * 60 + (se as i64) - offset_secs;
-    Ok(Some(secs))
-}
-
-/// Split an RFC3339 zone suffix (`Z` or `±HH:MM`) off the end, returning the remaining
-/// time text and the offset in seconds to SUBTRACT to reach UTC.
-fn split_zone(time_and_zone: &str) -> Result<(&str, i64), ()> {
-    if let Some(rest) = time_and_zone.strip_suffix('Z') {
-        return Ok((rest, 0));
-    }
-    // Find the last '+' or '-' that starts the offset (after the time, so index >= 1).
-    let bytes = time_and_zone.as_bytes();
-    let mut idx = None;
-    for (i, &b) in bytes.iter().enumerate() {
-        if (b == b'+' || b == b'-') && i > 0 {
-            idx = Some(i);
-        }
-    }
-    let i = idx.ok_or(())?;
-    let (time_part, off) = time_and_zone.split_at(i);
-    // A `+05:00` zone is 5h AHEAD of UTC, so 5h is SUBTRACTED from the local time to
-    // reach UTC (positive value to subtract); `-05:00` adds (negative value).
-    let sign = if off.as_bytes()[0] == b'+' { 1 } else { -1 };
-    let off = &off[1..];
-    let (oh, om) = off.split_once(':').ok_or(())?;
-    let oh: i64 = parse_fixed::<u32>(oh, 2)? as i64;
-    let om: i64 = parse_fixed::<u32>(om, 2)? as i64;
-    if oh > 23 || om > 59 {
-        return Err(());
-    }
-    Ok((time_part, sign * (oh * 3_600 + om * 60)))
-}
-
-/// Parse an exactly-`width`-digit unsigned field (RFC3339 fields are fixed-width).
-fn parse_fixed<T: std::str::FromStr>(s: &str, width: usize) -> Result<T, ()> {
-    if s.len() != width || !s.bytes().all(|b| b.is_ascii_digit()) {
-        return Err(());
-    }
-    s.parse().map_err(|_| ())
-}
-
 /// serde field deserializer for `Bundle.expires_at`: `None` for absent/null/empty/zero;
 /// `Some(secs)` for a valid instant; a serde error for a malformed non-empty value (so
 /// the whole `Bundle::deserialize` fails, matching Go's `json.Unmarshal` into
@@ -437,7 +348,7 @@ where
     if s.is_empty() {
         return Ok(None);
     }
-    match parse_rfc3339_to_unix(s) {
+    match crate::status::parse_rfc3339_to_unix(s) {
         Ok(v) => Ok(v),
         Err(()) => Err(D::Error::custom("invalid RFC3339 expires_at")),
     }
@@ -647,7 +558,6 @@ fn clip(s: &str, n: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::status::rfc3339_utc;
 
     fn params() -> Params {
         Params {
@@ -853,30 +763,6 @@ mod tests {
             "control"
         )
         .is_err());
-    }
-
-    #[test]
-    fn rfc3339_round_trip_against_renderer() {
-        // parse_rfc3339_to_unix is the inverse of status::rfc3339_utc.
-        for unix in [0i64, 1_893_456_000, 1_700_000_000, 253_402_300_799] {
-            let s = rfc3339_utc(unix);
-            assert_eq!(parse_rfc3339_to_unix(&s), Ok(Some(unix)), "round-trip {s}");
-        }
-    }
-
-    #[test]
-    fn rfc3339_offset_and_fraction() {
-        // +05:00 offset normalizes to UTC; fractional seconds are truncated.
-        assert_eq!(
-            parse_rfc3339_to_unix("2030-01-01T05:00:00+05:00"),
-            Ok(Some(1_893_456_000))
-        );
-        assert_eq!(
-            parse_rfc3339_to_unix("2030-01-01T00:00:00.500Z"),
-            Ok(Some(1_893_456_000))
-        );
-        assert_eq!(parse_rfc3339_to_unix("garbage"), Err(()));
-        assert_eq!(parse_rfc3339_to_unix("2030-13-01T00:00:00Z"), Err(())); // bad month
     }
 
     #[test]

--- a/crates/shed-host-agent/src/bus.rs
+++ b/crates/shed-host-agent/src/bus.rs
@@ -30,8 +30,9 @@
 //! operation gets Go's exact `unknown operation: <op>` `INTERNAL_ERROR` envelope, and
 //! a payload that isn't a JSON object gets `{invalid payload, INTERNAL_ERROR}` — so the
 //! shed's request never hangs. The `aws-credentials` and `docker-credentials` namespaces
-//! are wired alongside (each its own per-namespace gate); only egress remains a later
-//! slice.
+//! are wired alongside (each its own per-namespace gate), and the always-on egress-audit
+//! SSE consumer ([`crate::egress`]) runs as a side task per server — so the Go and Rust
+//! daemons now touch the same endpoint set (the endpoint asymmetry closed with this slice).
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -871,10 +872,14 @@ pub struct DockerHandlers {
 /// per-handler `.Run`). `server_name` is the audit/approval `server` field — empty in
 /// single-server mode (matches Go).
 ///
-/// KNOWN GAP (for the harness): Go's watcher group also GETs the egress-audit stream
-/// (`/api/egress/stream`). That needs the egress route, so it is deliberately NOT wired
-/// here — after this slice the Rust daemon wires ssh-agent + (configured) aws-credentials
-/// + docker-credentials, and ONLY egress remains asymmetric.
+/// The always-on egress-audit SSE consumer (`GET /api/egress/stream`,
+/// [`crate::egress::EgressSubscriber`]) also runs — as a read-only SIDE TASK on the same
+/// `tasks` vec, racing the shared `shutdown` (mirroring Go's watcher group, which GETs
+/// the egress stream for every server). It is NOT a bus namespace, so it is not in
+/// `BUS_NAMESPACES`/`subscribed`. This slice wires the OPEN path (`tokens = None`, static
+/// token — `run_single_server_bus` is hardcoded open); the secure-control token source is
+/// a later (discovery/supervisor) slice. With egress wired the Go and Rust endpoint sets
+/// fully converge.
 pub async fn run_single_server_bus(
     server_url: String,
     shutdown: watch::Receiver<bool>,
@@ -907,8 +912,9 @@ pub async fn run_single_server_bus(
     // configured (Go: a nil AWS backend means no aws handler); docker-credentials when
     // the docker backend constructed — effectively unconditional, since the constructor
     // near-always yields `Some` (Go's `NewDockerBackend` is non-nil even unconfigured).
-    // Only the egress stream remains a later slice. Compute the set once, then log + spawn
-    // from it so a new namespace is a single push (no parallel branches to keep in sync).
+    // The always-on egress-audit SSE consumer runs alongside as a side task (below); it is
+    // NOT a bus namespace, so it is absent from this set. Compute the set once, then log +
+    // spawn from it so a new namespace is a single push (no parallel branches to sync).
     let mut subscribed: Vec<&'static str> = vec![NS_SSH_AGENT];
     if handlers.aws.is_some() {
         subscribed.push(NS_AWS_CREDENTIALS);
@@ -922,7 +928,8 @@ pub async fn run_single_server_bus(
         .filter(|ns| !subscribed.contains(ns))
         .collect();
     log.info(&format!(
-        "message bus subscribing namespaces={subscribed:?}; deferred (later slices): {deferred:?}"
+        "message bus subscribing namespaces={subscribed:?}; deferred (later slices): \
+         {deferred:?}; egress side task: always-on"
     ));
 
     // Share the seams across the per-namespace loops. Each namespace subscribes +
@@ -939,6 +946,27 @@ pub async fn run_single_server_bus(
             log.clone(),
         )));
     }
+
+    // The always-on egress-audit SSE consumer — Go's watcher group GETs
+    // `/api/egress/stream` for every server. NOT a bus namespace: a read-only SIDE TASK on
+    // the same `tasks` vec, racing the shared `shutdown`. This slice wires the OPEN path
+    // (`run_single_server_bus` is hardcoded open): no token source (`None`), an empty
+    // static token, no TLS pin. The secure-control `CredentialSource` spawn is deferred to
+    // the discovery/supervisor slice (this path has no `ServerTarget`/minter yet).
+    let egress = crate::egress::EgressSubscriber::new(
+        handlers.server_name.clone(),
+        server_url,
+        String::new(),
+        "",
+        None,
+        handlers.audit.clone(),
+        log.clone(),
+    );
+    let egress_shutdown = shutdown.clone();
+    tasks.push(tokio::spawn(async move {
+        egress.run(egress_shutdown).await;
+    }));
+
     for t in tasks {
         let _ = t.await;
     }

--- a/crates/shed-host-agent/src/config.rs
+++ b/crates/shed-host-agent/src/config.rs
@@ -20,8 +20,9 @@ pub const NS_DOCKER_CREDENTIALS: &str = "docker-credentials";
 /// The audit namespace stamped on every egress-control decision (mirror Go's
 /// `namespaceEgress`). Unlike the three above it is NOT a plugin-bus namespace — the
 /// egress consumer reads the read-only `GET /api/egress/stream` SSE route — so it is
-/// deliberately absent from `BUS_NAMESPACES`. `#[allow(dead_code)]` until commit 2 wires
-/// the egress side task (its only consumer today is `egress_audit_entry`, itself unwired).
+/// deliberately absent from `BUS_NAMESPACES`. Consumed by `egress_audit_entry`
+/// (`egress.rs`), NOT within `config.rs` itself, so the golden test's isolated
+/// `#[path]`-included `config` module (which pulls neither) would otherwise flag it dead.
 #[allow(dead_code)]
 pub const NS_EGRESS: &str = "egress";
 

--- a/crates/shed-host-agent/src/config.rs
+++ b/crates/shed-host-agent/src/config.rs
@@ -17,6 +17,13 @@ use std::time::Duration;
 pub const NS_SSH_AGENT: &str = "ssh-agent";
 pub const NS_AWS_CREDENTIALS: &str = "aws-credentials";
 pub const NS_DOCKER_CREDENTIALS: &str = "docker-credentials";
+/// The audit namespace stamped on every egress-control decision (mirror Go's
+/// `namespaceEgress`). Unlike the three above it is NOT a plugin-bus namespace — the
+/// egress consumer reads the read-only `GET /api/egress/stream` SSE route — so it is
+/// deliberately absent from `BUS_NAMESPACES`. `#[allow(dead_code)]` until commit 2 wires
+/// the egress side task (its only consumer today is `egress_audit_entry`, itself unwired).
+#[allow(dead_code)]
+pub const NS_EGRESS: &str = "egress";
 
 /// Approval-policy value that fails closed — the effective policy for an empty or
 /// omitted `approval.policy` (matches the Go `EffectivePolicy`).

--- a/crates/shed-host-agent/src/egress.rs
+++ b/crates/shed-host-agent/src/egress.rs
@@ -1,0 +1,893 @@
+//! The always-on egress-audit SSE consumer — a Rust port of the Go daemon's
+//! `cmd/shed-host-agent/egress_handler.go`.
+//!
+//! Unlike the plugin-bus namespaces this is NOT a bus subscription: it is a plain
+//! read-only `GET {server}/api/egress/stream` (`Accept: text/event-stream`) whose
+//! `data:` frames decode to [`EgressDecision`] (NOT `Envelope`). It reuses the SSE
+//! FRAMER ([`shed_core::sse::SseParser`]) but none of the bus request/response/gate
+//! machinery — every decision is mapped by [`egress_audit_entry`] into an
+//! [`AuditEntry`] (namespace `egress`) and recorded via the shared [`AuditSink`] (which
+//! fans it out to shed-desktop). Read-only: no `respond`, no approval, no new audit shape.
+//!
+//! It carries its OWN reconnect/backoff state machine ([`EgressSubscriber::run`]),
+//! DISTINCT from — and simpler than — the bus's: `base=1s`, `max=30s`, `unavailable=5m`;
+//! a 501/404 (egress disabled on the server) backs off the hard 5m and RESETS to base,
+//! any other error (or a clean stream-end) exponentially doubles to the 30s cap with NO
+//! 60s-held-reset. On a secure server the bearer is a CONTROL-scoped token (the egress
+//! route is control-scoped, unlike the credentials-scoped bus); a 401 invalidates the
+//! source so the next reconnect re-mints. An open server sends the static config token.
+//!
+//! NOTE (commit 1 of the egress slice): this module is LANDED but not yet SPAWNED — the
+//! always-on per-server task is wired in commit 2. Hence the module-level
+//! `#![allow(dead_code)]`; commit 2 removes it once `run_single_server_bus` spawns the
+//! side task.
+#![allow(dead_code)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use serde::Deserialize;
+use tokio::sync::watch;
+
+use shed_core::sse::SseParser;
+use shed_core::tls::pinned_client_config;
+
+use crate::audit::{AuditEntry, AuditSink};
+use crate::bus::BusLog;
+use crate::config::NS_EGRESS;
+use crate::status::{parse_rfc3339_to_unix, rfc3339_utc};
+
+/// shed-server's egress SSE endpoint (one `data:` frame per decision).
+const EGRESS_STREAM_PATH: &str = "/api/egress/stream";
+
+/// The backoff constants (mirror `egress_handler.go:104`). DISTINCT from the bus's:
+/// there is NO 60s-held-reset — a flapping-but-reachable server just ramps to `MAX`.
+const BASE_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+const UNAVAILABLE_BACKOFF: Duration = Duration::from_secs(5 * 60);
+
+/// Cap a single SSE event at 1 MiB (Go's `bufio.Scanner` cap): an oversized /
+/// never-terminating event surfaces as a read error → disconnect + reconnect.
+const MAX_SSE_EVENT_BYTES: usize = 1 << 20;
+
+/// One streamed egress decision — mirrors shed-server's `egress.AuditRecord` JSON
+/// (`egress_handler.go:egressDecision`). shed-extensions cannot import shed's
+/// `internal/egress`, so the (small, stable) wire shape is duplicated. Absent fields
+/// default to their zero value (`#[serde(default)]`); unknown fields are ignored.
+///
+/// `ts` is modeled **parse-on-deserialize-to-skip** (the plan's finding 12): Go's field
+/// is a `time.Time`, so `json.Unmarshal` of a present-but-not-RFC3339 `ts` ERRORS and the
+/// whole frame is skipped — while an ABSENT `ts` is the zero time (→ rendered `""`). A
+/// naive `ts: String` would NOT skip a malformed value, so the custom deserializer
+/// reproduces both halves exactly (`Ok(None)` = absent/zero, a serde error = malformed).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct EgressDecision {
+    /// Parsed unix seconds; `None` when absent/zero (→ rendered `""`). A present but
+    /// malformed value fails deserialization → the frame is skipped (Go parity).
+    #[serde(rename = "ts", deserialize_with = "de_egress_ts")]
+    pub ts: Option<i64>,
+    pub shed: String,
+    pub host: String,
+    pub port: i64,
+    pub resolved_ip: String,
+    pub protocol: String,
+    pub verdict: String,
+    pub reason: String,
+}
+
+/// Deserialize the egress `ts` to `Option<i64>` unix seconds, matching Go's `time.Time`
+/// json semantics: `null` / a present zero-time → `None`; a valid instant → `Some(secs)`
+/// (offset-normalized to UTC, sub-second truncated); an empty or otherwise malformed
+/// non-null string → a serde error so the enclosing frame is skipped. (An ABSENT key
+/// never reaches here — `#[serde(default)]` yields `None` directly.)
+fn de_egress_ts<'de, D>(d: D) -> Result<Option<i64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error as _;
+    let raw: Option<String> = Option::deserialize(d)?;
+    // `null` → Go's zero time (no-op unmarshal) → rendered "".
+    let Some(s) = raw else { return Ok(None) };
+    // A PRESENT string (incl. "") goes through the RFC3339 parser: Go unmarshals into a
+    // `time.Time`, so an empty/blank/malformed value is a parse error → skip the frame.
+    match parse_rfc3339_to_unix(&s) {
+        Ok(v) => Ok(v),
+        Err(()) => Err(D::Error::custom("invalid RFC3339 ts")),
+    }
+}
+
+/// Map one streamed decision into an [`AuditEntry`] (namespace `egress`) for the durable
+/// log + desktop feed — the pure `egress_handler.go:egressAuditEntry` port. `ts` renders
+/// via [`rfc3339_utc`] when present, else `""` (the shared [`AuditSink::log`] stamps a
+/// wall-clock ts when empty, as Go's `LogEntry` does). `code`/`approval`/`decided_by`/
+/// `scope`/`ttl` are left empty; the wire nonetheless carries `"approval":""` (present but
+/// empty) because `WireEntry.approval` is unconditional — a golden-pinned byte.
+pub fn egress_audit_entry(server: &str, d: &EgressDecision) -> AuditEntry {
+    let ts = match d.ts {
+        Some(secs) => rfc3339_utc(secs),
+        None => String::new(),
+    };
+    let detail = if d.resolved_ip.is_empty() {
+        format!("{}:{}", d.host, d.port)
+    } else {
+        format!("{}:{} ({})", d.host, d.port, d.resolved_ip)
+    };
+    AuditEntry {
+        ts,
+        server: server.to_string(),
+        shed: d.shed.clone(),
+        ns: NS_EGRESS.to_string(),
+        op: d.protocol.clone(),
+        result: d.verdict.clone(),
+        detail,
+        reason: d.reason.clone(),
+        ..Default::default()
+    }
+}
+
+/// The reason a single `stream` connection ended. Only [`EgressStreamError::Unavailable`]
+/// (501/404 — egress disabled on the server) is special-cased by the backoff machine; a
+/// clean stream-end (`Ok(())`) and every [`EgressStreamError::Other`] take the normal
+/// exponential backoff (mirror Go's `errors.Is(err, errEgressUnavailable)` branch).
+#[derive(Debug)]
+pub enum EgressStreamError {
+    /// 501 or 404: egress control is disabled on the server → hard 5m backoff.
+    Unavailable,
+    /// Any other transport / status error → normal exponential backoff.
+    Other(String),
+}
+
+impl std::fmt::Display for EgressStreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EgressStreamError::Unavailable => {
+                f.write_str("egress stream: unavailable (disabled on server)")
+            }
+            EgressStreamError::Other(m) => f.write_str(m),
+        }
+    }
+}
+
+/// Provides — and on a 401 invalidates — the CONTROL-scoped bearer token for the egress
+/// stream on a secure server (mirror Go's `tokenSource`). `Arc<CredentialSource>`
+/// satisfies it (the bridge below, behind `desktop-forwarding`); an OPEN server passes
+/// `None` and sends the static config token.
+///
+/// **Async** because `CredentialSource::token` is `async` with `self: &Arc<Self>` — a
+/// direct impl on `CredentialSource` is impossible, so the bridge is impl'd for
+/// `Arc<CredentialSource>`. Never `block_on`.
+#[async_trait::async_trait]
+pub trait EgressTokenSource: Send + Sync {
+    async fn token(&self) -> Result<String, String>;
+    fn invalidate(&self);
+}
+
+/// Bridge the caching, invalidatable control-token source onto [`EgressTokenSource`].
+/// Behind `desktop-forwarding` because the minter itself is feature-gated (so
+/// `--no-default-features` stays green). Ported now; spawned live by the discovery/
+/// supervisor slice (the single-server open path this slice wires uses `None`/static).
+#[cfg(feature = "desktop-forwarding")]
+#[async_trait::async_trait]
+impl EgressTokenSource for Arc<crate::minter::CredentialSource> {
+    async fn token(&self) -> Result<String, String> {
+        // UFCS selects the inherent `CredentialSource::token(self: &Arc<Self>)` — a bare
+        // `self.token()` would recurse into THIS trait method.
+        crate::minter::CredentialSource::token(self).await
+    }
+    fn invalidate(&self) {
+        // Deref past the Arc to the inherent method (the trait is impl'd on `Arc<_>`, so a
+        // bare `self.invalidate()` would recurse into THIS method).
+        (**self).invalidate()
+    }
+}
+
+/// An injectable sleep seam so the backoff machine ([`EgressSubscriber::run`]) is
+/// unit-testable without real time (the test sleeper records the requested waits and
+/// trips shutdown). Production uses [`TokioSleeper`].
+#[async_trait::async_trait]
+trait Sleeper: Send + Sync {
+    async fn sleep(&self, d: Duration);
+}
+
+struct TokioSleeper;
+
+#[async_trait::async_trait]
+impl Sleeper for TokioSleeper {
+    async fn sleep(&self, d: Duration) {
+        tokio::time::sleep(d).await;
+    }
+}
+
+/// The pure per-iteration backoff transition (mirror `egress_handler.go:Run`'s body):
+/// given the previous backoff and this connection's outcome, return `(wait, next_backoff)`.
+///
+///   * `Err(Unavailable)` (501/404): wait the hard `UNAVAILABLE_BACKOFF` (5m) and RESET
+///     the backoff to `BASE_BACKOFF` — NO doubling (re-checks whether egress is re-enabled
+///     later without hammering a disabled server every 30s).
+///   * `Ok(())` (clean stream-end) OR `Err(Other)`: wait the CURRENT backoff, then double
+///     it up to `MAX_BACKOFF`. A clean `Ok(())` is `!errEgressUnavailable` in Go, so it
+///     ALSO backs off + doubles — Rust must NOT special-case it (the plan's finding 10).
+fn backoff_step(prev: Duration, outcome: &Result<(), EgressStreamError>) -> (Duration, Duration) {
+    if matches!(outcome, Err(EgressStreamError::Unavailable)) {
+        (UNAVAILABLE_BACKOFF, BASE_BACKOFF)
+    } else {
+        let next = (prev * 2).min(MAX_BACKOFF);
+        (prev, next)
+    }
+}
+
+/// Build the egress stream's HTTP client (mirror `egress_handler.go:egressHTTPClient`):
+/// a fingerprint-pinned transport for an https URL + pin, else a plain client. SSE is
+/// long-lived, so there is NO overall request timeout.
+///
+/// **Fail-closed** when a pin is set on a non-`https://` URL: `Err(_)`, latched by the
+/// subscriber so EVERY request errors (refusing unpinned plaintext). shed-core's
+/// `build_http_client` does NOT itself fail-closed on pin+non-https — that scheme check
+/// lives in `Client::new` — so the check is REPLICATED here (the plan's finding 7).
+///
+/// DIVERGENCE from Go (deliberate, finding 6): Go's `egressHTTPClient` follows redirects
+/// with no https-only guard (an `http://` redirect would be followed UNPINNED); the Rust
+/// client REFUSES non-https redirects (matching shed-core's pinned session) — a Rust-side
+/// improvement kept on purpose, not parity.
+pub fn egress_http_client(server_url: &str, fingerprint: &str) -> Result<reqwest::Client, String> {
+    let builder = reqwest::Client::builder().redirect(reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.url().scheme() == "https" {
+            attempt.follow()
+        } else {
+            attempt.stop()
+        }
+    }));
+    if fingerprint.is_empty() {
+        return builder.build().map_err(|e| e.to_string());
+    }
+    // Replicated scheme check — refuse to send unpinned plaintext under a pin.
+    if !server_url.to_lowercase().starts_with("https://") {
+        return Err(format!(
+            "egress stream: TLS pin set but server URL {server_url:?} is not https; refusing unpinned plaintext"
+        ));
+    }
+    let cfg = pinned_client_config(fingerprint).map_err(|e| e.to_string())?;
+    builder
+        .use_preconfigured_tls(cfg)
+        .build()
+        .map_err(|e| e.to_string())
+}
+
+/// Consumes a shed-server's egress-audit SSE stream and records each decision into the
+/// shared [`AuditSink`] (namespace `egress`). Read-only. Mirror `EgressSubscriber`.
+pub struct EgressSubscriber {
+    server: String,
+    /// Base URL, trailing `/` trimmed (Go's `strings.TrimRight`).
+    url: String,
+    /// The static open-server config token (usually empty); sent when there's no source.
+    token: String,
+    /// The control-token source for a secure server; `None` = open (static token).
+    tokens: Option<Arc<dyn EgressTokenSource>>,
+    /// The authenticated client, or the fail-closed error (pin on a non-https URL) latched
+    /// so every request errors.
+    http: Result<reqwest::Client, String>,
+    audit: Arc<dyn AuditSink>,
+    log: Arc<dyn BusLog>,
+}
+
+impl EgressSubscriber {
+    /// Build a subscriber for one server target (mirror `NewEgressSubscriber`). `tokens`
+    /// supplies the control-scoped token for a secure server; pass `None` for an open
+    /// server (which sends the static `token`, usually empty).
+    pub fn new(
+        server: String,
+        mut url: String,
+        token: String,
+        tls_fingerprint: &str,
+        tokens: Option<Arc<dyn EgressTokenSource>>,
+        audit: Arc<dyn AuditSink>,
+        log: Arc<dyn BusLog>,
+    ) -> Self {
+        let http = egress_http_client(&url, tls_fingerprint);
+        // Trim trailing '/' in place (Go's `strings.TrimRight(t.URL, "/")`), consuming the
+        // owned `url` rather than re-allocating.
+        url.truncate(url.trim_end_matches('/').len());
+        EgressSubscriber {
+            server,
+            url,
+            token,
+            tokens,
+            http,
+            audit,
+            log,
+        }
+    }
+
+    /// The token to send, or `None` (send no `Authorization` header). A control token for
+    /// a secure server, else the static config token (`None` when empty). A mint error →
+    /// `None` (the request then 401s and `run` retries after `invalidate`). Mirror
+    /// `bearer()` + the `if tok != ""` header guard.
+    async fn bearer(&self) -> Option<String> {
+        let tok = match &self.tokens {
+            None => self.token.clone(),
+            Some(src) => match src.token().await {
+                Ok(t) => t,
+                Err(e) => {
+                    self.log.debug(&format!(
+                        "egress: control-token mint failed server={} error={e}",
+                        self.server
+                    ));
+                    String::new()
+                }
+            },
+        };
+        if tok.is_empty() {
+            None
+        } else {
+            Some(tok)
+        }
+    }
+
+    /// Make one connection and forward decisions until it errors, the stream ends, or
+    /// `shutdown` flips (mirror `stream()`). `shutdown` is threaded through the connect +
+    /// every read so a SIGTERM tears the loop down promptly (Go's `ctx`).
+    async fn stream(
+        &self,
+        shutdown: &watch::Receiver<bool>,
+    ) -> Result<(), EgressStreamError> {
+        // Fail-closed latch: a pin on a non-https URL errors every request.
+        let http = match &self.http {
+            Ok(c) => c,
+            Err(e) => return Err(EgressStreamError::Other(e.clone())),
+        };
+        let url = format!("{}{}", self.url, EGRESS_STREAM_PATH);
+        let mut req = http
+            .get(&url)
+            .header(reqwest::header::ACCEPT, "text/event-stream");
+        if let Some(tok) = self.bearer().await {
+            req = req.bearer_auth(tok);
+        }
+
+        // Race the connect against shutdown so a hung dial can't block teardown.
+        let resp = tokio::select! {
+            _ = wait_shutdown(shutdown.clone()) => return Ok(()),
+            r = req.send() => match r {
+                Ok(r) => r,
+                Err(e) => return Err(EgressStreamError::Other(format!("connecting: {e}"))),
+            }
+        };
+
+        let st = resp.status().as_u16();
+        if st != 200 {
+            // 401 → invalidate the source so the NEXT reconnect re-mints (Go :147-149).
+            if st == 401 {
+                if let Some(src) = &self.tokens {
+                    src.invalidate();
+                }
+            }
+            // 501/404 → egress disabled → hard 5m backoff; any other non-200 → normal.
+            if st == 501 || st == 404 {
+                return Err(EgressStreamError::Unavailable);
+            }
+            return Err(EgressStreamError::Other(format!(
+                "egress stream: unexpected status {st}"
+            )));
+        }
+
+        let mut stream = resp.bytes_stream();
+        let mut parser = SseParser::new().with_max_event_bytes(MAX_SSE_EVENT_BYTES);
+        loop {
+            let chunk = tokio::select! {
+                _ = wait_shutdown(shutdown.clone()) => return Ok(()),
+                c = stream.next() => c,
+            };
+            match chunk {
+                // Clean EOF (Go's `sc.Err() == nil`): flush any final unterminated record,
+                // then return Ok — the machine STILL backs off (finding 10).
+                None => {
+                    for ev in parser.finish() {
+                        self.forward(&ev.data);
+                    }
+                    return Ok(());
+                }
+                Some(Err(e)) => {
+                    return Err(EgressStreamError::Other(format!("reading stream: {e}")))
+                }
+                Some(Ok(bytes)) => {
+                    let events = match parser.try_feed(&bytes) {
+                        Ok(events) => events,
+                        // Over the 1 MiB cap → treat as a read error and reconnect.
+                        Err(e) => {
+                            return Err(EgressStreamError::Other(format!("reading stream: {e}")))
+                        }
+                    };
+                    for ev in events {
+                        self.forward(&ev.data);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Decode one `data:` payload as an [`EgressDecision`] and record it; a malformed
+    /// frame is skipped, keeping the stream alive (Go's `continue`). The framer already
+    /// stripped the `data:` prefix — so unlike the bus (which decodes `Envelope`) we
+    /// decode `EgressDecision` from `ev.data`.
+    fn forward(&self, data: &str) {
+        // A malformed frame is skipped, keeping the stream alive (Go's `continue`).
+        if let Ok(dec) = serde_json::from_str::<EgressDecision>(data) {
+            self.audit.log(egress_audit_entry(&self.server, &dec));
+        }
+    }
+
+    /// Stream decisions until `shutdown` flips, reconnecting with the DISTINCT egress
+    /// backoff machine (mirror `Run`). Production entry — uses the real [`TokioSleeper`].
+    pub async fn run(&self, shutdown: watch::Receiver<bool>) {
+        self.run_with_sleeper(shutdown, &TokioSleeper).await;
+    }
+
+    /// The backoff loop with an injectable [`Sleeper`] (deterministic in tests).
+    async fn run_with_sleeper(&self, shutdown: watch::Receiver<bool>, sleeper: &dyn Sleeper) {
+        let mut backoff = BASE_BACKOFF;
+        while !*shutdown.borrow() {
+            let outcome = self.stream(&shutdown).await;
+            if *shutdown.borrow() {
+                return;
+            }
+            let (wait, next) = backoff_step(backoff, &outcome);
+            match &outcome {
+                Err(EgressStreamError::Unavailable) => self.log.debug(&format!(
+                    "egress disabled on server; backing off server={} backoff={wait:?}",
+                    self.server
+                )),
+                Err(e) => self.log.debug(&format!(
+                    "egress stream ended; retrying error={e} backoff={backoff:?}"
+                )),
+                Ok(()) => {} // Go logs nothing for err == nil (the `else if err != nil`)
+            }
+            tokio::select! {
+                _ = wait_shutdown(shutdown.clone()) => return,
+                _ = sleeper.sleep(wait) => {}
+            }
+            backoff = next;
+        }
+    }
+}
+
+/// Resolve when `shutdown` is (or becomes) true; returns immediately if already flagged.
+/// Idempotent + cancel-safe (reusable across select arms), mirroring the bus helper.
+async fn wait_shutdown(mut shutdown: watch::Receiver<bool>) {
+    let _ = shutdown.wait_for(|flagged| *flagged).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    use httpmock::prelude::*;
+
+    // ---- test doubles ---------------------------------------------------------------
+
+    /// Collects fanned-out audit entries.
+    struct CollectingAudit(Mutex<Vec<AuditEntry>>);
+    impl CollectingAudit {
+        fn new() -> Arc<Self> {
+            Arc::new(Self(Mutex::new(Vec::new())))
+        }
+        fn entries(&self) -> Vec<AuditEntry> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+    impl AuditSink for CollectingAudit {
+        fn log(&self, entry: AuditEntry) {
+            self.0.lock().unwrap().push(entry);
+        }
+    }
+
+    struct SilentLog;
+    impl BusLog for SilentLog {
+        fn info(&self, _: &str) {}
+        fn warn(&self, _: &str) {}
+        fn debug(&self, _: &str) {}
+        fn error(&self, _: &str) {}
+    }
+    fn silent_log() -> Arc<dyn BusLog> {
+        Arc::new(SilentLog)
+    }
+
+    /// A fixed-token [`EgressTokenSource`] counting `invalidate` (mirror Go's
+    /// `fakeTokenSource`). Feature-independent.
+    struct FakeTokenSource {
+        token: String,
+        err: Option<String>,
+        invalidated: AtomicUsize,
+    }
+    impl FakeTokenSource {
+        fn ok(token: &str) -> Arc<Self> {
+            Arc::new(Self {
+                token: token.to_string(),
+                err: None,
+                invalidated: AtomicUsize::new(0),
+            })
+        }
+        fn erroring() -> Arc<Self> {
+            Arc::new(Self {
+                token: String::new(),
+                err: Some("mint failed".into()),
+                invalidated: AtomicUsize::new(0),
+            })
+        }
+        fn invalidated(&self) -> usize {
+            self.invalidated.load(Ordering::SeqCst)
+        }
+    }
+    #[async_trait::async_trait]
+    impl EgressTokenSource for FakeTokenSource {
+        async fn token(&self) -> Result<String, String> {
+            match &self.err {
+                Some(e) => Err(e.clone()),
+                None => Ok(self.token.clone()),
+            }
+        }
+        fn invalidate(&self) {
+            self.invalidated.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn subscriber(
+        url: &str,
+        token: &str,
+        tokens: Option<Arc<dyn EgressTokenSource>>,
+        audit: Arc<dyn AuditSink>,
+    ) -> EgressSubscriber {
+        EgressSubscriber::new(
+            "srv".into(),
+            url.into(),
+            token.into(),
+            "",
+            tokens,
+            audit,
+            silent_log(),
+        )
+    }
+
+    /// A shutdown receiver that never fires. The sender is intentionally leaked so
+    /// `wait_shutdown` blocks forever (a dropped sender would resolve it immediately,
+    /// aborting the network await as if shutdown had fired) — for tests whose stream
+    /// path must actually reach the mock server. Mirrors bus.rs's `never_shutdown`.
+    fn never_shutdown() -> watch::Receiver<bool> {
+        let (tx, rx) = watch::channel(false);
+        let _ = Box::leak(Box::new(tx));
+        rx
+    }
+
+    // ---- egress_audit_entry (mirror TestEgressAuditEntry[_NoResolvedIP] + goldens) ---
+
+    #[test]
+    fn egress_audit_entry_full() {
+        let d = EgressDecision {
+            ts: parse_rfc3339_to_unix("2020-01-01T00:00:00Z").unwrap(),
+            shed: "web".into(),
+            host: "evil.com".into(),
+            port: 443,
+            resolved_ip: "1.2.3.4".into(),
+            protocol: "https".into(),
+            verdict: "deny".into(),
+            reason: "default-deny".into(),
+        };
+        let e = egress_audit_entry("srv", &d);
+        assert_eq!(e.server, "srv");
+        assert_eq!(e.shed, "web");
+        assert_eq!(e.ns, "egress");
+        assert_eq!(e.op, "https");
+        assert_eq!(e.result, "deny");
+        assert_eq!(e.reason, "default-deny");
+        assert_eq!(e.detail, "evil.com:443 (1.2.3.4)");
+        assert_eq!(e.ts, "2020-01-01T00:00:00Z");
+        // code/approval/decided_by/scope/ttl all empty.
+        assert_eq!(e.approval, "");
+        assert_eq!(e.code, "");
+    }
+
+    #[test]
+    fn egress_audit_entry_no_resolved_ip() {
+        let d = EgressDecision {
+            shed: "web".into(),
+            host: "x.com".into(),
+            port: 80,
+            protocol: "http".into(),
+            verdict: "allow".into(),
+            ..Default::default()
+        };
+        let e = egress_audit_entry("srv", &d);
+        assert_eq!(e.detail, "x.com:80"); // no " (ip)" suffix
+    }
+
+    #[test]
+    fn egress_audit_entry_empty_ts_blank() {
+        // Absent ts → ts:"" (the sink stamps now downstream).
+        let d = EgressDecision {
+            host: "a.com".into(),
+            port: 1,
+            ..Default::default()
+        };
+        assert_eq!(egress_audit_entry("srv", &d).ts, "");
+    }
+
+    #[test]
+    fn egress_audit_entry_offset_ts_normalized_utc() {
+        // Rust-stronger: a non-UTC offset ts renders as its UTC numbers + Z (an
+        // offset-ignoring formatter would pass Go's UTC-only vector).
+        let d = EgressDecision {
+            ts: parse_rfc3339_to_unix("2020-01-01T02:00:00+02:00").unwrap(),
+            host: "evil.com".into(),
+            port: 443,
+            protocol: "https".into(),
+            verdict: "deny".into(),
+            ..Default::default()
+        };
+        assert_eq!(egress_audit_entry("srv", &d).ts, "2020-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn egress_decision_malformed_ts_skips_frame() {
+        // A present-but-bad ts fails deserialization (mirrors Go's time.Time unmarshal
+        // error → the whole frame is skipped), NOT a blank-ts entry.
+        assert!(serde_json::from_str::<EgressDecision>(
+            r#"{"ts":"not-a-time","host":"x","port":1}"#
+        )
+        .is_err());
+        // An empty-string ts is likewise a parse error (Go time.Time can't parse "").
+        assert!(serde_json::from_str::<EgressDecision>(r#"{"ts":"","host":"x","port":1}"#).is_err());
+        // An ABSENT ts is fine → None.
+        let d: EgressDecision =
+            serde_json::from_str(r#"{"host":"x","port":1}"#).expect("absent ts is valid");
+        assert_eq!(d.ts, None);
+    }
+
+    // ---- golden runner (Rust half of egress_audit_entry.json) -----------------------
+
+    #[test]
+    fn golden_egress_audit_entry() {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/host-agent-diff/fixtures/egress_audit_entry.json");
+        let raw = std::fs::read_to_string(&path).expect("read golden fixture");
+        let fx: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(fx["protocol_version"], 1, "version skew");
+        let vectors = fx["vectors"].as_array().unwrap();
+        assert!(!vectors.is_empty(), "no egress golden vectors");
+        for v in vectors {
+            let name = v["name"].as_str().unwrap();
+            let server = v["server"].as_str().unwrap();
+            let dec: EgressDecision =
+                serde_json::from_value(v["decision"].clone()).expect("decode decision");
+            let entry = egress_audit_entry(server, &dec);
+            // Compare the durable JSONL wire object (incl. the "approval":"" byte),
+            // parsed so key order is irrelevant — the same shape the Go runner marshals.
+            let got: serde_json::Value =
+                serde_json::from_str(&crate::audit::to_jsonl(&entry)).unwrap();
+            assert_eq!(got, v["expected"], "egress golden vector {name:?}");
+        }
+    }
+
+    // ---- backoff machine (Go code path, no direct Go test) --------------------------
+
+    #[test]
+    fn backoff_unavailable_hard_5m_and_resets() {
+        // 501/404 → hard 5m wait, reset to base, NO doubling — from base AND mid-ramp.
+        assert_eq!(
+            backoff_step(BASE_BACKOFF, &Err(EgressStreamError::Unavailable)),
+            (UNAVAILABLE_BACKOFF, BASE_BACKOFF)
+        );
+        assert_eq!(
+            backoff_step(
+                Duration::from_secs(8),
+                &Err(EgressStreamError::Unavailable)
+            ),
+            (UNAVAILABLE_BACKOFF, BASE_BACKOFF)
+        );
+    }
+
+    #[test]
+    fn backoff_normal_error_exponential_no_held_reset() {
+        // Other error → wait current, double to the 30s cap; NO 60s-held-reset. A clean
+        // Ok(()) ALSO backs off + doubles (finding 10).
+        let err = || Err(EgressStreamError::Other("boom".into()));
+        assert_eq!(backoff_step(BASE_BACKOFF, &err()), (Duration::from_secs(1), Duration::from_secs(2)));
+        assert_eq!(backoff_step(Duration::from_secs(2), &err()), (Duration::from_secs(2), Duration::from_secs(4)));
+        assert_eq!(backoff_step(Duration::from_secs(16), &err()), (Duration::from_secs(16), MAX_BACKOFF));
+        assert_eq!(backoff_step(MAX_BACKOFF, &err()), (MAX_BACKOFF, MAX_BACKOFF));
+        // A clean stream-end is !unavailable → still exp-backs-off (no no-backoff branch).
+        assert_eq!(backoff_step(BASE_BACKOFF, &Ok(())), (Duration::from_secs(1), Duration::from_secs(2)));
+    }
+
+    /// Records requested waits + trips shutdown after `stop_after` sleeps so `run`
+    /// terminates deterministically without real time.
+    struct RecordingSleeper {
+        waits: Mutex<Vec<Duration>>,
+        stop_after: usize,
+        shutdown: watch::Sender<bool>,
+    }
+    #[async_trait::async_trait]
+    impl Sleeper for RecordingSleeper {
+        async fn sleep(&self, d: Duration) {
+            let mut w = self.waits.lock().unwrap();
+            w.push(d);
+            if w.len() >= self.stop_after {
+                let _ = self.shutdown.send(true);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn run_drives_exponential_backoff_then_stops_on_shutdown() {
+        // A fail-closed subscriber (pin on a non-https URL) errors every stream() with a
+        // non-unavailable Other, so `run` exercises the exp-backoff sequence with no
+        // network. The recording sleeper trips shutdown after 2 sleeps.
+        let audit = CollectingAudit::new();
+        let sub = EgressSubscriber::new(
+            "srv".into(),
+            "http://127.0.0.1:1".into(),
+            String::new(),
+            "sha256:deadbeef", // pin + non-https → fail-closed → Other error each iter
+            None,
+            audit,
+            silent_log(),
+        );
+        assert!(sub.http.is_err(), "pin on non-https must latch fail-closed");
+        let (tx, rx) = watch::channel(false);
+        let sleeper = RecordingSleeper {
+            waits: Mutex::new(Vec::new()),
+            stop_after: 2,
+            shutdown: tx,
+        };
+        sub.run_with_sleeper(rx, &sleeper).await;
+        // 1s then 2s — exponential doubling, no held-reset.
+        assert_eq!(
+            *sleeper.waits.lock().unwrap(),
+            vec![Duration::from_secs(1), Duration::from_secs(2)]
+        );
+    }
+
+    // ---- stream over a loopback mock (mirror TestEgressSubscriber_*) -----------------
+
+    const DECISION_FRAME: &str = "data: {\"ts\":\"2020-01-01T00:00:00Z\",\"shed\":\"web\",\"host\":\"evil.com\",\"port\":443,\"protocol\":\"https\",\"verdict\":\"deny\",\"reason\":\"default-deny\"}\n\n";
+
+    #[tokio::test]
+    async fn stream_forwards_decisions_over_sse() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(GET)
+                    .path(EGRESS_STREAM_PATH)
+                    .header("authorization", "Bearer tok");
+                t.status(200)
+                    .header("content-type", "text/event-stream")
+                    .body(DECISION_FRAME);
+            })
+            .await;
+        let audit = CollectingAudit::new();
+        let sub = subscriber(&server.base_url(), "tok", None, audit.clone());
+        sub.stream(&never_shutdown()).await.expect("clean stream end");
+        let entries = audit.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].ns, "egress");
+        assert_eq!(entries[0].shed, "web");
+        assert_eq!(entries[0].result, "deny");
+    }
+
+    #[tokio::test]
+    async fn malformed_frame_skipped_stream_continues() {
+        let body = format!("data: not-json\n\n{DECISION_FRAME}");
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(GET).path(EGRESS_STREAM_PATH);
+                t.status(200).body(body);
+            })
+            .await;
+        let audit = CollectingAudit::new();
+        let sub = subscriber(&server.base_url(), "", None, audit.clone());
+        sub.stream(&never_shutdown()).await.expect("clean stream end");
+        // Only the good frame fanned out.
+        let entries = audit.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].shed, "web");
+    }
+
+    #[tokio::test]
+    async fn sends_control_token_not_credentials() {
+        let server = MockServer::start_async().await;
+        // Matches only when the CONTROL token (not the static creds token) is sent.
+        let m = server
+            .mock_async(|w, t| {
+                w.method(GET)
+                    .path(EGRESS_STREAM_PATH)
+                    .header("authorization", "Bearer ctl-tok");
+                t.status(200); // empty body → stream returns promptly
+            })
+            .await;
+        let audit = CollectingAudit::new();
+        let sub = subscriber(
+            &server.base_url(),
+            "creds-tok",
+            Some(FakeTokenSource::ok("ctl-tok")),
+            audit,
+        );
+        sub.stream(&never_shutdown()).await.expect("clean stream end");
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn status_401_invalidates_source() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(GET).path(EGRESS_STREAM_PATH);
+                t.status(401);
+            })
+            .await;
+        let fake = FakeTokenSource::ok("ctl-tok");
+        let audit = CollectingAudit::new();
+        let sub = subscriber(&server.base_url(), "", Some(fake.clone()), audit);
+        let err = sub.stream(&never_shutdown()).await.unwrap_err();
+        // 401 → invalidate (so the next reconnect re-mints) + a NON-unavailable error.
+        assert!(matches!(err, EgressStreamError::Other(_)));
+        assert_eq!(fake.invalidated(), 1);
+    }
+
+    #[tokio::test]
+    async fn status_501_returns_unavailable() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(GET).path(EGRESS_STREAM_PATH);
+                t.status(501);
+            })
+            .await;
+        let sub = subscriber(&server.base_url(), "", None, CollectingAudit::new());
+        assert!(matches!(
+            sub.stream(&never_shutdown()).await,
+            Err(EgressStreamError::Unavailable)
+        ));
+    }
+
+    #[tokio::test]
+    async fn status_404_returns_unavailable() {
+        // Rust-stronger: Go's _DisabledReturnsUnavailable exercises only 501.
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(GET).path(EGRESS_STREAM_PATH);
+                t.status(404);
+            })
+            .await;
+        let sub = subscriber(&server.base_url(), "", None, CollectingAudit::new());
+        assert!(matches!(
+            sub.stream(&never_shutdown()).await,
+            Err(EgressStreamError::Unavailable)
+        ));
+    }
+
+    #[test]
+    fn pin_on_plain_url_fails_closed() {
+        // A pin set on an http:// URL → the client build fails closed (the scheme check
+        // replicated here, since build_http_client does not itself fail closed).
+        assert!(egress_http_client("http://localhost:8080", "sha256:deadbeef").is_err());
+        // Sanity: a pin on https builds, and no pin builds.
+        assert!(egress_http_client("http://localhost:8080", "").is_ok());
+    }
+
+    #[tokio::test]
+    async fn open_server_sends_static_token_or_none() {
+        let audit = CollectingAudit::new();
+        // tokens=None + non-empty static token → that token.
+        let sub = subscriber("http://x", "static-tok", None, audit.clone());
+        assert_eq!(sub.bearer().await, Some("static-tok".to_string()));
+        // tokens=None + empty static token → no header.
+        let sub = subscriber("http://x", "", None, audit.clone());
+        assert_eq!(sub.bearer().await, None);
+        // A source that errors on mint → no header (→ 401 → retry).
+        let sub = subscriber("http://x", "ignored", Some(FakeTokenSource::erroring()), audit);
+        assert_eq!(sub.bearer().await, None);
+    }
+}

--- a/crates/shed-host-agent/src/egress.rs
+++ b/crates/shed-host-agent/src/egress.rs
@@ -17,11 +17,11 @@
 //! route is control-scoped, unlike the credentials-scoped bus); a 401 invalidates the
 //! source so the next reconnect re-mints. An open server sends the static config token.
 //!
-//! NOTE (commit 1 of the egress slice): this module is LANDED but not yet SPAWNED — the
-//! always-on per-server task is wired in commit 2. Hence the module-level
-//! `#![allow(dead_code)]`; commit 2 removes it once `run_single_server_bus` spawns the
-//! side task.
-#![allow(dead_code)]
+//! The always-on per-server task is spawned as a SIDE TASK by
+//! [`crate::bus::run_single_server_bus`] (racing the shared shutdown) — mirroring the Go
+//! watcher group's `run(NewEgressSubscriber(...).Run)`. This slice wires the OPEN path
+//! (`tokens = None`, static token); the concrete secure-control `CredentialSource` spawn
+//! arrives with the discovery/supervisor slice.
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/shed-host-agent/src/main.rs
+++ b/crates/shed-host-agent/src/main.rs
@@ -29,6 +29,9 @@ mod config;
 #[cfg(feature = "desktop-forwarding")]
 mod controltoken;
 mod docker_backend;
+// The always-on egress-audit SSE consumer (bus-side, not gated — like `bus`/`aws_backend`/
+// `docker_backend`). Landed here; the per-server side task is spawned in commit 2.
+mod egress;
 #[cfg(feature = "desktop-forwarding")]
 mod desktop;
 #[cfg(feature = "desktop-forwarding")]

--- a/crates/shed-host-agent/src/minter.rs
+++ b/crates/shed-host-agent/src/minter.rs
@@ -279,9 +279,11 @@ impl CredentialSource {
     }
 
     /// The current token, minting or re-minting as needed (implements the token half of
-    /// `sdk.TokenProvider`). Test-only until the supervisor slice wires the credentials
-    /// bus provider; the control path uses [`Self::force_token_with_expiry`].
-    #[cfg(test)]
+    /// `sdk.TokenProvider`). The egress SSE consumer is its first production consumer
+    /// (via the `EgressTokenSource` bridge for `Arc<CredentialSource>` in `egress.rs`,
+    /// behind `desktop-forwarding`): the control-scoped egress token is cached and
+    /// re-minted, and cleared by [`Self::invalidate`] after a 401. The `token.get` control
+    /// path instead uses [`Self::force_token_with_expiry`] (never a cached copy).
     pub async fn token(self: &Arc<Self>) -> Result<String, String> {
         self.obtain(false).await.map(|(tok, _)| tok)
     }
@@ -296,8 +298,8 @@ impl CredentialSource {
         self.obtain(true).await
     }
 
-    /// Clear the cached token so the next obtain re-mints. Called after a 401.
-    #[cfg(test)]
+    /// Clear the cached token so the next obtain re-mints. Called after a 401 (the egress
+    /// consumer's `EgressTokenSource::invalidate`, mirror Go `credentialSource.Invalidate`).
     pub fn invalidate(&self) {
         let mut st = self.state.lock().unwrap();
         st.token.clear();
@@ -714,6 +716,28 @@ mod tests {
         assert_eq!(fm.calls.load(Ordering::SeqCst), 1);
         s.invalidate();
         assert_eq!(s.token().await.unwrap(), "tok2"); // re-mint
+        assert_eq!(fm.calls.load(Ordering::SeqCst), 2);
+    }
+
+    // The egress slice un-gated `token()`/`invalidate()` from `#[cfg(test)]` to `pub`
+    // (first production consumer). These two rows re-pin the cache + invalidate semantics
+    // unguarded — the plan's BLOCKER-1 mapping rows.
+    #[tokio::test]
+    async fn credential_source_token_caches() {
+        let fm = FakeMinter::new(vec![Ok(minted("tok1")), Ok(minted("tok2"))]);
+        let s = new_credential_source(fm.clone(), target("s", "", 0), SCOPE_CONTROL);
+        assert_eq!(s.token().await.unwrap(), "tok1");
+        assert_eq!(s.token().await.unwrap(), "tok1"); // 2nd call served from cache
+        assert_eq!(fm.calls.load(Ordering::SeqCst), 1, "cached → one mint");
+    }
+
+    #[tokio::test]
+    async fn credential_source_invalidate_forces_remint() {
+        let fm = FakeMinter::new(vec![Ok(minted("tok1")), Ok(minted("tok2"))]);
+        let s = new_credential_source(fm.clone(), target("s", "", 0), SCOPE_CONTROL);
+        assert_eq!(s.token().await.unwrap(), "tok1");
+        s.invalidate();
+        assert_eq!(s.token().await.unwrap(), "tok2"); // next token() re-mints
         assert_eq!(fm.calls.load(Ordering::SeqCst), 2);
     }
 

--- a/crates/shed-host-agent/src/status.rs
+++ b/crates/shed-host-agent/src/status.rs
@@ -174,6 +174,102 @@ pub(crate) fn days_from_civil(y: i64, m: u32, d: u32) -> i64 {
     era * 146_097 + doe - 719_468
 }
 
+/// Parse an RFC3339 timestamp to unix seconds, matching what Go's `time.Time` collapses
+/// to: `Ok(None)` for the zero time (`0001-01-01T00:00:00Z`), `Ok(Some(secs))` for a
+/// valid instant (offset applied, sub-second **truncated** as Go's `Format(time.RFC3339)`
+/// drops it), `Err(())` for a malformed non-empty value. The inverse of
+/// [`rfc3339_utc`]; a round-trip against it is unit-pinned.
+///
+/// `pub(crate)` and homed in this always-on module (not the `desktop-forwarding`-gated
+/// `bootstrap`) so both the mint-bundle deserializer (`bootstrap::de_expires_at`, gated)
+/// and the always-on, bus-side egress consumer (`egress::egress_audit_entry`) reuse one
+/// implementation without a cross-gate dependency — mirroring how `days_from_civil` is
+/// shared. Go's `d.Time.UTC().Format(RFC3339)` is reproduced exactly incl. the zero-time
+/// and offset-normalize cases.
+pub(crate) fn parse_rfc3339_to_unix(s: &str) -> Result<Option<i64>, ()> {
+    // Layout: YYYY-MM-DDTHH:MM:SS[.frac](Z|±HH:MM). Split date/time on 'T'.
+    let (date, time_and_zone) = s.split_once('T').ok_or(())?;
+    let (y, mo, d) = {
+        let mut it = date.split('-');
+        let y: i64 = it.next().ok_or(())?.parse().map_err(|_| ())?;
+        let mo: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
+        let d: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
+        if it.next().is_some() {
+            return Err(());
+        }
+        (y, mo, d)
+    };
+    // Split the zone suffix off the time, then split off any fractional seconds.
+    let (time_part, offset_secs) = split_zone(time_and_zone)?;
+    let (hms, frac) = match time_part.split_once('.') {
+        Some((h, f)) => (h, Some(f)),
+        None => (time_part, None),
+    };
+    if let Some(f) = frac {
+        // Sub-second digits are validated (Go's RFC3339Nano parse would) then dropped.
+        if f.is_empty() || !f.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(());
+        }
+    }
+    let (h, mi, se) = {
+        let mut it = hms.split(':');
+        let h: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
+        let mi: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
+        let se: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
+        if it.next().is_some() {
+            return Err(());
+        }
+        (h, mi, se)
+    };
+    if !(1..=12).contains(&mo) || !(1..=31).contains(&d) || h > 23 || mi > 59 || se > 60 {
+        return Err(());
+    }
+    // The Go zero time → None (Go's `IsZero()` → omitted `expires_at`).
+    if y == 1 && mo == 1 && d == 1 && h == 0 && mi == 0 && se == 0 && offset_secs == 0 {
+        return Ok(None);
+    }
+    let days = days_from_civil(y, mo, d);
+    let secs = days * 86_400 + (h as i64) * 3_600 + (mi as i64) * 60 + (se as i64) - offset_secs;
+    Ok(Some(secs))
+}
+
+/// Split an RFC3339 zone suffix (`Z` or `±HH:MM`) off the end, returning the remaining
+/// time text and the offset in seconds to SUBTRACT to reach UTC.
+fn split_zone(time_and_zone: &str) -> Result<(&str, i64), ()> {
+    if let Some(rest) = time_and_zone.strip_suffix('Z') {
+        return Ok((rest, 0));
+    }
+    // Find the last '+' or '-' that starts the offset (after the time, so index >= 1).
+    let bytes = time_and_zone.as_bytes();
+    let mut idx = None;
+    for (i, &b) in bytes.iter().enumerate() {
+        if (b == b'+' || b == b'-') && i > 0 {
+            idx = Some(i);
+        }
+    }
+    let i = idx.ok_or(())?;
+    let (time_part, off) = time_and_zone.split_at(i);
+    // A `+05:00` zone is 5h AHEAD of UTC, so 5h is SUBTRACTED from the local time to
+    // reach UTC (positive value to subtract); `-05:00` adds (negative value).
+    let sign = if off.as_bytes()[0] == b'+' { 1 } else { -1 };
+    let off = &off[1..];
+    let (oh, om) = off.split_once(':').ok_or(())?;
+    let oh: i64 = parse_fixed::<u32>(oh, 2)? as i64;
+    let om: i64 = parse_fixed::<u32>(om, 2)? as i64;
+    if oh > 23 || om > 59 {
+        return Err(());
+    }
+    Ok((time_part, sign * (oh * 3_600 + om * 60)))
+}
+
+/// Parse an exactly-`width`-digit unsigned field (RFC3339 fields are fixed-width).
+fn parse_fixed<T: std::str::FromStr>(s: &str, width: usize) -> Result<T, ()> {
+    if s.len() != width || !s.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(());
+    }
+    s.parse().map_err(|_| ())
+}
+
 // ---------------------------------------------------------------------------
 // Status socket server (channel 4)
 // ---------------------------------------------------------------------------
@@ -475,6 +571,32 @@ mod tests {
         // The Unix "billennium": 2001-09-09 01:46:40 UTC.
         assert_eq!(rfc3339_utc(1_000_000_000), "2001-09-09T01:46:40Z");
         assert_eq!(rfc3339_utc(1_700_000_000), "2023-11-14T22:13:20Z");
+    }
+
+    #[test]
+    fn rfc3339_round_trip_against_renderer() {
+        // parse_rfc3339_to_unix is the inverse of rfc3339_utc.
+        for unix in [0i64, 1_893_456_000, 1_700_000_000, 253_402_300_799] {
+            let s = rfc3339_utc(unix);
+            assert_eq!(parse_rfc3339_to_unix(&s), Ok(Some(unix)), "round-trip {s}");
+        }
+    }
+
+    #[test]
+    fn rfc3339_offset_and_fraction() {
+        // +05:00 offset normalizes to UTC; fractional seconds are truncated.
+        assert_eq!(
+            parse_rfc3339_to_unix("2030-01-01T05:00:00+05:00"),
+            Ok(Some(1_893_456_000))
+        );
+        assert_eq!(
+            parse_rfc3339_to_unix("2030-01-01T00:00:00.500Z"),
+            Ok(Some(1_893_456_000))
+        );
+        assert_eq!(parse_rfc3339_to_unix("garbage"), Err(()));
+        assert_eq!(parse_rfc3339_to_unix("2030-13-01T00:00:00Z"), Err(())); // bad month
+        // The Go zero time collapses to None (omitted expires_at / absent egress ts).
+        assert_eq!(parse_rfc3339_to_unix("0001-01-01T00:00:00Z"), Ok(None));
     }
 
     #[test]

--- a/tests/host-agent-diff/README.md
+++ b/tests/host-agent-diff/README.md
@@ -151,8 +151,7 @@ identities (real-signing ed25519, canned blobs for rsa/ecdsa).
   normal path resolves immediately either way; a pathological full-backlog peer could hang
   the Rust side longer. Low severity, tracked for the config/lifecycle slice.
 
-- **Bus subscription set: ssh-agent + (configured) aws-credentials + docker-credentials
-  on both; ONLY egress remains Go-only.** In single-server mode (no `discovery:` block)
+- **Bus subscription set — converged.** In single-server mode (no `discovery:` block)
   both daemons connect to `server:` and subscribe to `ssh-agent`; when `aws.*` is
   configured (mode passthrough, or a role) both ALSO subscribe `aws-credentials`; and
   both subscribe `docker-credentials` in the common case — the Docker backend is non-nil
@@ -160,14 +159,11 @@ identities (real-signing ed25519, canned blobs for rsa/ecdsa).
   `config_path`), so the namespace is subscribed for every server. Each cell
   `wait_for_subscribe`-es its namespace on both impls (`test_bus_ping_pong.py`,
   `test_aws_backend.py`, `test_docker_backend.py`), so they compare apples to apples.
-  The **one** residual asymmetry remaining by design: the Go daemon also GETs
-  `/api/egress/stream` (its always-on egress subscriber), whereas the Rust daemon does
-  not yet (egress is the last unwired namespace, its own slice). The synthetic bus
-  tolerates the extra Go subscribe (501s the egress GET — Go backs off 5m, DEBUG-quiet)
-  — so the asymmetry is absorbed by the harness, not diffed. The differential asserts
-  only the compared **response envelope** for the namespace under test, never which
-  routes each daemon hit. This flips to a full match when the egress slice wires the Rust
-  egress path.
+  As of the egress slice both daemons ALSO GET the always-on egress-audit stream
+  (`/api/egress/stream`), so the Go and Rust **endpoint sets fully converge** — there is
+  no residual endpoint asymmetry. The synthetic bus now asserts (not tolerates) that both
+  impls hit egress: `test_egress.py` proves the subscribe, the fixed-ts audit diff, and
+  the per-impl 501 hard-backoff (no reconnect in window).
 
 - **Event replay ring.** The surface-A handshake (`hello`→`hello_ack`), the non-hello
   drop, single-consumer supersede, event fan-out + approval correlation (via the gated
@@ -217,7 +213,12 @@ owned by a different mechanism (golden/unit) or later slice, not the live diff.
 | bus | aws-credentials subscription (when configured) | **enforced** | live surface B (`test_aws_backend.py`: both impls `wait_for_subscribe("aws-credentials")`) |
 | bus | docker-credentials subscription (even unconfigured) | **enforced** | live surface B (`test_docker_backend.py`: both impls `wait_for_subscribe("docker-credentials")`, incl. the unconfigured cell) |
 | status | single-server `LiveStatus.servers[]` per-namespace state (incl. 409-rejected) | **xfail** | supervisor slice — Go surfaces `HostClient.Status()` via supervisor health; the Rust bus records the state + logs it, but `servers[]` stays empty until the supervisor lands |
-| egress | events / 401 / 404-501, 5m vs 30s backoff | **xfail** | live ("no reconnect in window") + unit (consts) |
+| egress | subscription convergence (both impls GET `/api/egress/stream`) | **enforced** | live surface B (`test_egress.py`: both `wait_for_egress`) |
+| egress | events → durable audit line (fixed-ts, diffed UNMASKED incl. `"approval":""`) | **enforced** | live surface B (`test_egress.py`) |
+| egress | 501 → hard 5m backoff (per-impl `egress_hits()==1`, no reconnect in window) | **enforced** | live surface B (`test_egress.py`) |
+| egress | 401-invalidate + control-token scope | **out-of-scope** | unit (`egress.rs`: `status_401_invalidates_source`, `sends_control_token_not_credentials`) — harness runs open (no token to invalidate) |
+| egress | 404→unavailable + backoff constants (1s/30s/5m, no held-reset) | **out-of-scope** | unit (`egress.rs`: `status_404_returns_unavailable`, `backoff_*`) — control-flow, not pure in→out |
+| egress | `egressDecision`→`AuditEntry` mapping (detail/ts-UTC/empty-ts/offset/`approval:""`) | **enforced** | golden (Go + Rust runners, `egress_audit_entry.json`) |
 | ssh backend · local-keys | `list` (masked canonical-equal + durable non-gated audit line) | **enforced** | live (`test_ssh_backend.py`) |
 | ssh backend · local-keys | `sign` rsa flags 0/2/4/6 (→ `ssh-rsa`/`rsa-sha2-256`/`rsa-sha2-512`/`rsa-sha2-256`; format diffed, blob verified per-impl) | **enforced** | live (`test_ssh_backend.py`, verify-not-bytes) |
 | ssh backend · local-keys | `sign` ecdsa (format diffed, blob verified per-impl) | **enforced** | live (`test_ssh_backend.py`) |

--- a/tests/host-agent-diff/fixtures/egress_audit_entry.json
+++ b/tests/host-agent-diff/fixtures/egress_audit_entry.json
@@ -1,0 +1,30 @@
+{
+  "_comment": "Golden fixture for the egress decision->audit mapping (cmd/shed-host-agent/egress_handler.go:egressAuditEntry / crates/shed-host-agent/src/egress.rs:egress_audit_entry). Each vector's `decision` is the streamed egressDecision JSON; `expected` is the durable-JSONL AuditEntry wire object. Read by BOTH the Go runner (golden_test.go:TestGoldenEgressAuditEntry, via json.Unmarshal->egressAuditEntry->json.Marshal) and the Rust runner (egress.rs:tests::golden_egress_audit_entry, via serde_json->egress_audit_entry->audit::to_jsonl) so the two impls cannot drift together on the detail formatting, ns/op/result/reason mapping, ts UTC-normalization, empty-ts blanking, or the always-present \"approval\":\"\" byte. Mirrors TestEgressAuditEntry / TestEgressAuditEntry_NoResolvedIP plus the Rust-stronger offset-ts and empty-ts rows. Compared as parsed values (key order irrelevant).",
+  "protocol_version": 1,
+  "vectors": [
+    {
+      "name": "full fields incl resolved ip; UTC ts",
+      "server": "srv",
+      "decision": {"ts": "2020-01-01T00:00:00Z", "shed": "web", "host": "evil.com", "port": 443, "resolved_ip": "1.2.3.4", "protocol": "https", "verdict": "deny", "reason": "default-deny"},
+      "expected": {"ts": "2020-01-01T00:00:00Z", "server": "srv", "shed": "web", "ns": "egress", "op": "https", "result": "deny", "detail": "evil.com:443 (1.2.3.4)", "reason": "default-deny", "approval": ""}
+    },
+    {
+      "name": "no resolved ip -> bare host:port detail; no reason",
+      "server": "srv",
+      "decision": {"shed": "web", "host": "x.com", "port": 80, "protocol": "http", "verdict": "allow"},
+      "expected": {"ts": "", "server": "srv", "shed": "web", "ns": "egress", "op": "http", "result": "allow", "detail": "x.com:80", "approval": ""}
+    },
+    {
+      "name": "absent ts -> blank ts (the sink stamps now downstream)",
+      "server": "srv",
+      "decision": {"shed": "web", "host": "a.com", "port": 8080, "protocol": "tcp", "verdict": "deny", "reason": "policy"},
+      "expected": {"ts": "", "server": "srv", "shed": "web", "ns": "egress", "op": "tcp", "result": "deny", "detail": "a.com:8080", "reason": "policy", "approval": ""}
+    },
+    {
+      "name": "non-UTC offset ts normalizes to UTC (Rust-stronger; Go test only used UTC)",
+      "server": "srv",
+      "decision": {"ts": "2020-01-01T02:00:00+02:00", "shed": "web", "host": "evil.com", "port": 443, "protocol": "https", "verdict": "deny", "reason": "default-deny"},
+      "expected": {"ts": "2020-01-01T00:00:00Z", "server": "srv", "shed": "web", "ns": "egress", "op": "https", "result": "deny", "detail": "evil.com:443", "reason": "default-deny", "approval": ""}
+    }
+  ]
+}

--- a/tests/host-agent-diff/synthetic_bus.py
+++ b/tests/host-agent-diff/synthetic_bus.py
@@ -13,10 +13,16 @@ server. It exposes exactly the three routes a single-server daemon touches:
 * `POST /api/plugins/listeners/{ns}/respond` — reads the response Envelope body,
   records it keyed by namespace, and returns **204** (the status the client
   expects; a non-204 is a bus error on both sides).
-* `GET /api/egress/stream` — returns **501** so the Go daemon's always-on egress
-  subscriber backs off hard (5m, DEBUG-quiet) instead of erroring. The Rust
-  slice-1b daemon never hits this route (egress is a later slice); the bus
-  tolerates the asymmetry — the differential compares only the ssh-agent response.
+* `GET /api/egress/stream` — the always-on egress-audit consumer's route, hit by
+  BOTH daemons now (the endpoint sets converged). Two modes, chosen at construction
+  (`SyntheticBus(egress=...)`):
+    - `"unavailable"` (default) → **501**, so each daemon's egress subscriber backs
+      off hard (5m, DEBUG-quiet) — the harness asserts per-impl `egress_hits() == 1`
+      within a short window to prove that hard backoff (no reconnect).
+    - `"events"` → **200** + a held `text/event-stream` that pushes `data:` decision
+      frames (`push_egress`) with FIXED timestamps, so both daemons write the SAME
+      durable audit JSONL line (a deterministic differential — Go stamps `now()` only
+      for an ABSENT ts).
 * Any other path — **404**.
 
 Threading model mirrors the plain-`socket`/blocking style of `desktop_client.py`:
@@ -58,11 +64,13 @@ class SyntheticBus:
     to point a daemon's `server:` at.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, egress: str = "unavailable") -> None:
+        assert egress in ("unavailable", "events"), f"bad egress mode {egress!r}"
         self.url: str | None = None
         self._httpd: ThreadingHTTPServer | None = None
         self._thread: threading.Thread | None = None
         self._shutdown = threading.Event()
+        self._egress_mode = egress  # "unavailable" (501) | "events" (200 + decision stream)
 
         # One Condition guards all cross-thread state below (subscribe/respond
         # records + the per-namespace push queues + the SSE thread registry).
@@ -71,6 +79,7 @@ class SyntheticBus:
         self._responses: dict[str, list[dict]] = {}  # ns -> response Envelopes (arrival order)
         self._queues: dict[str, queue.Queue] = {}  # ns -> frames to push over its SSE stream
         self._egress_hits = 0  # count of GET /api/egress/stream
+        self._egress_queue: queue.Queue = queue.Queue()  # decision frames (events mode)
         self._sse_threads: set[threading.Thread] = set()  # live SSE handler threads
 
     # -- lifecycle -----------------------------------------------------------
@@ -99,6 +108,7 @@ class SyntheticBus:
         with self._cond:
             for q in self._queues.values():
                 q.put(None)
+            self._egress_queue.put(None)  # unblock a parked egress-events SSE loop
             threads = list(self._sse_threads)
         for t in threads:
             t.join(timeout=2.0)
@@ -168,10 +178,32 @@ class SyntheticBus:
             return sorted(self._subscribed)
 
     def egress_hits(self) -> int:
-        """How many times `GET /api/egress/stream` has been hit (Go always; Rust
-        never, this slice)."""
+        """How many times `GET /api/egress/stream` has been hit by this bus instance's
+        daemon (each impl gets its OWN `SyntheticBus`, so this is a per-impl counter).
+        Both impls hit it now (the always-on egress subscriber)."""
         with self._cond:
             return self._egress_hits
+
+    def wait_for_egress(self, timeout: float = 5.0) -> None:
+        """Block until the daemon has GET-ed `/api/egress/stream` at least once (or raise
+        on timeout). A deadline poll, not a sleep — closes the daemon-connect window.
+        Proves this impl's daemon reaches the egress route (endpoint-set convergence)."""
+        deadline = time.monotonic() + timeout
+        with self._cond:
+            while self._egress_hits < 1:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise AssertionError(
+                        f"no GET /api/egress/stream within {timeout}s"
+                    )
+                self._cond.wait(remaining)
+
+    def push_egress(self, decision: dict) -> None:
+        """Push one egress `decision` onto the (events-mode) egress SSE stream as a
+        `data:` frame. Call after `wait_for_egress()` so the drainer is attached; the
+        queue buffers, so an early push simply waits. No-op unless `egress="events"`."""
+        frame = json.dumps(decision, separators=(",", ":"))
+        self._egress_queue.put(frame)
 
     # -- internals (called from handler threads) -----------------------------
 
@@ -196,6 +228,7 @@ class SyntheticBus:
     def _record_egress(self) -> None:
         with self._cond:
             self._egress_hits += 1
+            self._cond.notify_all()  # wake wait_for_egress
 
     def _register_sse_thread(self) -> None:
         with self._cond:
@@ -220,9 +253,7 @@ class _BusHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         path = urlsplit(self.path).path
         if path == _EGRESS_PATH:
-            # Egress disabled → 501; the Go egress subscriber backs off hard.
-            self._bus._record_egress()
-            self._send_empty(501)
+            self._serve_egress()
             return
         m = _MESSAGES_RE.match(path)
         if m:
@@ -240,10 +271,29 @@ class _BusHandler(BaseHTTPRequestHandler):
 
     # -- route handlers ------------------------------------------------------
 
+    def _serve_egress(self) -> None:
+        """The `GET /api/egress/stream` route. Records the hit (both impls now GET it),
+        then either 501s (`"unavailable"` mode → the daemon backs off hard) or holds a
+        200 `text/event-stream` and pushes queued decision frames (`"events"` mode)."""
+        bus = self._bus
+        bus._record_egress()
+        if bus._egress_mode != "events":
+            # Egress disabled → 501; each impl's subscriber backs off the hard 5m.
+            self._send_empty(501)
+            return
+        self._stream_sse(bus._egress_queue)
+
     def _serve_sse(self, ns: str) -> None:
         """Open the SSE stream for `ns`, record the subscribe, then push queued
         request frames until shutdown / client disconnect."""
         self._bus._record_subscribe(ns, self.headers.get("Authorization"))
+        self._stream_sse(self._bus._queue_for(ns))
+
+    def _stream_sse(self, q: queue.Queue) -> None:
+        """Send the 200 SSE handshake, then hold the connection and drain `q`, pushing
+        each frame as a `data:` line, until shutdown / `None` sentinel / client
+        disconnect. The shared streaming body of `_serve_sse` (per-namespace queue) and
+        `_serve_egress` events mode (the egress decision queue)."""
         try:
             self.send_response(200)
             self.send_header("Content-Type", "text/event-stream")
@@ -255,7 +305,6 @@ class _BusHandler(BaseHTTPRequestHandler):
         except OSError:
             return  # client vanished mid-handshake
 
-        q = self._bus._queue_for(ns)
         bus = self._bus
         bus._register_sse_thread()
         try:

--- a/tests/host-agent-diff/test_egress.py
+++ b/tests/host-agent-diff/test_egress.py
@@ -1,0 +1,122 @@
+"""Surface-B egress: the always-on egress-audit SSE consumer, asserted equal across the
+Go `cmd/shed-host-agent` and the Rust `crates/shed-host-agent`.
+
+Both daemons run a per-server, read-only `GET /api/egress/stream` subscriber (Go's
+watcher group; Rust's `egress.rs` side task on `run_single_server_bus`). With egress
+wired on both sides the endpoint sets fully converge — the synthetic bus no longer
+merely tolerates a Go-only egress GET, it asserts BOTH impls hit the route.
+
+Three cells (open server — the harness runs single-server open mode, so the token path
+is `None`/static; the 401-invalidate + control-token scope are unit-owned in
+`egress.rs`, Go's `_SendsControlToken`/`_401Invalidates` are httptest+fake):
+
+1. **subscription convergence** — both impls GET `/api/egress/stream` when the bus
+   starts (`wait_for_egress`), the endpoint-set-converged proof.
+2. **events** — the bus serves a 200 stream and pushes ONE decision frame with a FIXED
+   timestamp; both impls write the SAME durable audit JSONL line. The frame ts is fixed
+   (`2020-01-01T00:00:00Z`), so Go's `LogEntry` keeps it verbatim (it stamps `now()`
+   ONLY for an empty ts) — the whole line is deterministic and is diffed UNMASKED,
+   including the always-present `"approval":""` byte.
+3. **501 hard-backoff** — the bus 501s egress; each impl backs off the hard 5m (DEBUG-
+   quiet), so within a short window its OWN `egress_hits()` stays at 1 (per-impl — each
+   impl gets its own `SyntheticBus`), proving no fast reconnect.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from normalize import canonical
+from synthetic_bus import SyntheticBus
+
+# A single streamed egress decision (shed-server's `egressDecision` wire shape:
+# ts/shed/host/port/resolved_ip/protocol/verdict/reason). The FIXED ts makes the
+# resulting audit line deterministic on both impls (see the events cell).
+DECISION = {
+    "ts": "2020-01-01T00:00:00Z",
+    "shed": "web",
+    "host": "evil.com",
+    "port": 443,
+    "resolved_ip": "1.2.3.4",
+    "protocol": "https",
+    "verdict": "deny",
+    "reason": "default-deny",
+}
+
+# The durable audit JSONL line `egressAuditEntry(server="", DECISION)` produces on BOTH
+# impls: ns=egress, op=protocol, result=verdict, detail=host:port (resolved_ip),
+# reason echoed, ts kept from the frame, `approval:""` present, and `server` omitted
+# (single-server mode leaves it empty → omitempty on both sides).
+EXPECTED_AUDIT = {
+    "ts": "2020-01-01T00:00:00Z",
+    "shed": "web",
+    "ns": "egress",
+    "op": "https",
+    "result": "deny",
+    "detail": "evil.com:443 (1.2.3.4)",
+    "reason": "default-deny",
+    "approval": "",
+}
+
+# The no-reconnect observation window. Comfortably longer than a WRONG (normal exp)
+# first backoff (~1s) would take to re-GET, and far shorter than the correct 5m hard
+# backoff — so a 501 taking the normal path instead of the hard 5m would trip this.
+_NO_RECONNECT_WINDOW_S = 2.0
+
+
+@pytest.mark.differential
+def test_egress_subscription_convergence(daemon, single_server_config, differential):
+    """Both impls GET `/api/egress/stream` — the endpoint sets converged (this replaces
+    the old harness code that absorbed a Go-only egress subscribe)."""
+
+    def scenario(impl):
+        with SyntheticBus() as bus:  # default "unavailable" (501)
+            with daemon(impl, single_server_config(bus.url)):
+                bus.wait_for_egress(timeout=10.0)
+                return True
+
+    assert differential(scenario) is True
+
+
+@pytest.mark.differential
+def test_egress_events_audit_diff(daemon, single_server_config, differential):
+    """A fixed-ts decision frame → the SAME durable audit JSONL line on both impls,
+    diffed UNMASKED (deterministic frame ts), including the `"approval":""` byte."""
+
+    def scenario(impl):
+        with SyntheticBus(egress="events") as bus:
+            with daemon(impl, single_server_config(bus.url)) as d:
+                bus.wait_for_egress(timeout=10.0)
+                bus.push_egress(DECISION)
+                audit = d.read_audit_jsonl(expect=1, timeout=10.0)[0]
+                return canonical(audit)
+
+    line = differential(scenario)
+    assert line == canonical(EXPECTED_AUDIT)
+    # The empty-but-PRESENT approval byte (egress leaves approval empty; the wire keeps
+    # the key). A dropped key would fail the whole-line compare above too, but pin it.
+    assert "approval" in line and line["approval"] == ""
+    # ts is DIFFED (not masked): both impls rendered the frame ts identically.
+    assert line["ts"] == "2020-01-01T00:00:00Z"
+
+
+@pytest.mark.differential
+def test_egress_501_hard_backoff_no_reconnect(daemon, single_server_config, differential):
+    """A 501 egress route → each impl backs off the hard 5m (not the normal exp backoff),
+    so within a short window its OWN `egress_hits()` stays at 1 (per-impl counter)."""
+
+    def scenario(impl):
+        with SyntheticBus() as bus:  # default "unavailable" (501)
+            with daemon(impl, single_server_config(bus.url)):
+                bus.wait_for_egress(timeout=10.0)
+                time.sleep(_NO_RECONNECT_WINDOW_S)
+                hits = bus.egress_hits()
+                assert hits == 1, (
+                    f"{impl}: egress_hits={hits} within {_NO_RECONNECT_WINDOW_S}s; "
+                    "expected 1 (501 → hard 5m backoff, no fast reconnect)"
+                )
+                return hits
+
+    assert differential(scenario) == 1


### PR DESCRIPTION
Sub-plan 4 of the **3a.1 completion program** (stacked on #261 → #260 → #257): port the host-agent's **egress SSE consumer** (`egress_handler.go`, 243 lines) to Rust and **converge the Go/Rust bus endpoint sets** — the harness's last subscription asymmetry is gone.

Plan: `~/.claude/plans/monorepo-phase3-host-agent-egress.md`, panel-reviewed by **CodeRabbit + Kimi K2.6** (Codex usage-limited this round). The panel caught a genuine execution blocker before any code: the plan's central reuse — `CredentialSource::{token, invalidate}` — was `#[cfg(test)]`-gated with no production adapter; commit 1 un-gates them (egress is their first production consumer) and bridges via an async `EgressTokenSource` impl on `Arc<CredentialSource>` behind `desktop-forwarding`.

## Commits

1. `7487ea6` — **the egress module**: the **distinct** backoff machine (1s→30s doubling, NO held-reset — reusing the bus loop would be a subtle bug; 501/404 → 5m hard backoff then reset-to-base; 401 → invalidate + NORMAL backoff; clean stream-end also backs off), a pure `backoff_step` + injectable `Sleeper` so it's unit-driven without real time; `EgressDecision` with parse-on-deserialize ts (malformed ts skips the frame like Go's `time.Time`; absent → now-stamp); the `"approval":""` present-but-empty audit byte; the pin+non-https fail-closed check replicated (with Go's default-redirect leniency documented as a deliberately-not-ported weakness); `egress_audit_entry` golden (incl. a non-UTC-offset vector — the same offset trap the AWS slice closed) in both runners. All 7 `egress_handler_test.go` tests mirrored.
2. (this commit) — **wiring + the harness flip**: the consumer spawns as an unconditional per-server side task (open path live; secure source deferred to the discovery/supervisor slice); 3 new differential cells (endpoint-set convergence, events audit line diffed byte-for-byte **unmasked**, 501 no-reconnect-in-window); the README's bus-asymmetry known-gap paragraph deleted.

## Evidence

Introspected raw pairs: Go and Rust durable egress audit lines **byte-identical** (`{"approval":"","detail":"evil.com:443 (1.2.3.4)","ns":"egress","op":"https","reason":"default-deny","result":"deny","shed":"web","ts":"2020-01-01T00:00:00Z"}`), per-impl `egress_hits==1` inside the backoff window, both impls issuing the same `GET /api/egress/stream`.

Harness: **61 → 64 cells**, zero regressions; full gate (workspace tests + clippy default/headless + headless test RUN + `make check` + goldens) green on both commits.

No server/guest changes; Go host-agent unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED6csoQ3peM3GHc4c1CtqY
