### PR TITLE
feat(desktop): Tauri mac auto-update — real Sparkle, signed DMG packaging, beta release track

### DIFF
--- a/.claude/skills/shedtest-linux/SKILL.md
+++ b/.claude/skills/shedtest-linux/SKILL.md
@@ -71,6 +71,12 @@ make -C desktop e2e-tauri       # shared suite + test_tauri at --target tauri (n
   `prefs.remove_shed_rule {server, shed}` (the per-shed override row's remove button). Note
   `ui.modal` now only ever reports `create` | `launch` | `null` — Preferences is never a
   modal value.
+- **Updater ops on Linux report `linux_apt`.** `updater.status` → `{os, enabled, reason,
+  instantiated}` and `updater.check` exist on both targets (the Sparkle updater is macOS-only;
+  Linux ships via apt). On the Linux render gate `updater.status` is
+  `{os:"linux", enabled:false, reason:"linux_apt", instantiated:false}` regardless of test
+  mode, and `updater.check` returns the deterministic `updater_disabled:linux_apt` error
+  without crashing. `test_tauri.py` branches on `platform.system()` and pins this cell.
 - **Simulating a down (unreachable) host.** The shared session redirects EVERY configured
   server to the one in-process mock, so a per-host error row can't appear there. To exercise
   it, use a DEDICATED fixture config with an extra server plus the

--- a/.claude/skills/shedtest-mac/SKILL.md
+++ b/.claude/skills/shedtest-mac/SKILL.md
@@ -97,6 +97,46 @@ make -C desktop smoke                # drive the app + capture labeled screensho
   Tauri client run the `shedtest-linux` render gate under Xvfb (`ui.set_appearance`
   makes the dark shot deterministic there).
 
+## Tauri mac packaging + Sparkle updater (rough edges)
+
+The Tauri client now ships a **macOS** DMG with an embedded real Sparkle updater
+(`make -C desktop tauri-dmg-mac`; the updater is the tray popover's "Check for Updates…"
+row, drivable over IPC). Mac-specific gotchas:
+
+- **Every mac Tauri build needs `Sparkle.framework` staged first.** The overlay
+  `tauri.macos.conf.json` embeds it and the `tauri-plugin-sparkle-updater` crate's
+  `build.rs` **panics at build time if it is absent**. `make -C desktop sparkle-framework`
+  stages it (`scripts/fetch-sparkle.sh`, pinned Sparkle 2.8.1, checksum-verified,
+  idempotent); on Darwin it is an **automatic prerequisite** of `tauri-build` /
+  `tauri-lint` / `tauri-test` / `tauri-run`. The framework + `.sparkle-dist/` bin tools
+  are **gitignored** and `--exclude`'d from the Docker tar legs.
+- **Unbundled binaries load Sparkle via a debug-only rpath** injected by `build.rs`, so
+  `cargo test` / `make tauri-run` / the raw harness binary can link the staged framework.
+  **Release DMGs stay clean** — they use the bundled `@executable_path/../Frameworks` copy.
+- **Verifying the Sparkle dialog on a dev Mac is TCC-bound** (no in-process WebKitGTK
+  capture, and `screencapture` needs a Screen-Recording grant). The reliable signal is the
+  log, not a screenshot: `log show --predicate 'subsystem == "org.sparkle-project.Sparkle"'`
+  (look for the `.sessionInProgress` line) confirms the check ran and fronted a session.
+- **`npm --prefix ui exec tauri` keeps the shell's cwd** (load-bearing — the Tauri CLI
+  walks up from cwd to find `src-tauri/tauri.conf.json`; `bundle-tauri-mac.sh` runs it from
+  `desktop/tauri`). A wrong cwd fails to locate the config.
+- **Sparkle ≥ 2.6's `Downloader.xpc` has EMPTY entitlements** (its sandbox was removed,
+  Sparkle #2511). Never assert `app-sandbox` on it; the re-sign preserves the dist's empty
+  entitlements and must not inject the app's.
+- **The updater is drivable over IPC:** `updater.status` → `{os, enabled, reason,
+  instantiated}` and `updater.check`. Under the harness the plugin is **never registered**
+  (Swift parity), so status is `enabled=false, instantiated=false`, `reason="test_mode"` on
+  mac (`"linux_apt"` on the Linux render gate); `updater.check` returns the deterministic
+  `updater_disabled:<reason>` error and never crashes. `test_tauri.py` pins both.
+- **The mac dev config dir moved** to `~/Library/Application Support/ai.stridelabs.ShedDesktop`
+  (identity alignment for the Swift→Tauri hop). The harness is unaffected — it runs under a
+  throwaway HOME — but a hand-run dev bundle reads/writes there now.
+- **`hdiutil detach` can report a different disk number than `attach` printed** — verify the
+  actual device with `hdiutil info` rather than trusting the attach output when scripting
+  DMG mount/unmount.
+- **`cp -R` preserves read-only directory bits** — after copying a signed/notarized `.app`
+  around, `chmod -R u+w` it before `rm -rf`, or the delete fails on the read-only dirs.
+
 ## When you hit a NEW rough edge
 
 Update this skill whenever you hit a new rough edge it doesn't cover.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,12 @@ jobs:
               # and the Linux legs run inside this Dockerfile's image
               - 'desktop/Resources/**'
               - 'desktop/Dockerfile.tauri-linux'
+              # the mac bundle-smoke path (Sparkle staging + bundle/sign) and the
+              # Makefile that wires its targets — a change to only these must still
+              # run the tauri-mac bundle smoke
+              - 'desktop/scripts/fetch-sparkle.sh'
+              - 'desktop/scripts/bundle-tauri-mac.sh'
+              - 'desktop/Makefile'
             packaging:
               - 'desktop/packaging/**'
               - 'desktop/linux/**'
@@ -443,6 +449,82 @@ jobs:
         # + tauri-linux legs do). WKWebView needs no Xvfb; the mac screenshot op is
         # TCC-gated so it's skipped here (the WebKitGTK leg is the screenshot gate).
         run: SHED_TAURI_TEST_TIMEOUT_SCALE=4 make -C desktop e2e-tauri
+      - name: Bundle smoke (Sparkle staging + ordered re-sign + plist/signing assertions)
+        # The ONLY PR-time guard on the mac packaging path (the release job can't
+        # run per-PR). Runs bundle-tauri-mac.sh end-to-end with the ad-hoc identity
+        # (--debug; the script fetches Sparkle itself) — the raw Tauri bundler
+        # output would fail strict verify without the ordered Sparkle re-sign, so
+        # this exercises the real ship path. node_modules is already installed
+        # ("Frontend deps" above); the tauri build's beforeBuildCommand rebuilds
+        # the dist. The second bundle shares the cargo target dir (incremental).
+        working-directory: desktop
+        run: |
+          set -euo pipefail
+          die() { echo "::error::$1"; exit 1; }
+          assert_bundle() {
+            local expect_ver="$1"
+            local app="build/ShedDesktop.app"
+            local plist="${app}/Contents/Info.plist"
+            [ -d "${app}" ] || die "${app} missing"
+            # ShedDesktop.app named + bundle id aligned to the Swift app (so the
+            # eventual Swift->Tauri hop is a same-identity in-place Sparkle update).
+            local bid; bid="$(plutil -extract CFBundleIdentifier raw "${plist}")"
+            [ "${bid}" = "ai.stridelabs.ShedDesktop" ] || die "CFBundleIdentifier ${bid} != ai.stridelabs.ShedDesktop"
+            # CFBundleExecutable must name a real Mach-O under Contents/MacOS/.
+            local exec; exec="$(plutil -extract CFBundleExecutable raw "${plist}")"
+            [ -f "${app}/Contents/MacOS/${exec}" ] || die "CFBundleExecutable ${exec} not a file under Contents/MacOS/"
+            file -b "${app}/Contents/MacOS/${exec}" | grep -q "Mach-O" || die "CFBundleExecutable ${exec} is not Mach-O"
+            # Version stamped VERBATIM (both plist keys) — the prerelease run proves
+            # a `-rc.N` suffix is NOT normalized away (else rc1->rc2 false-passes).
+            local cfv cfsv
+            cfv="$(plutil -extract CFBundleVersion raw "${plist}")"
+            cfsv="$(plutil -extract CFBundleShortVersionString raw "${plist}")"
+            [ "${cfv}" = "${expect_ver}" ] || die "CFBundleVersion ${cfv} != ${expect_ver}"
+            [ "${cfsv}" = "${expect_ver}" ] || die "CFBundleShortVersionString ${cfsv} != ${expect_ver}"
+            # Sparkle embedded; Downloader.xpc entitlements after the re-sign are
+            # IDENTICAL to the pristine dist copy's (an EMPTY dict — Sparkle >=2.6
+            # dropped the Downloader sandbox, sparkle-project/Sparkle#2511). The
+            # load-bearing property: --preserve-metadata=entitlements kept the
+            # dist's and never injected the app's. (Do NOT grep for app-sandbox.)
+            local fw="${app}/Contents/Frameworks/Sparkle.framework"
+            [ -d "${fw}" ] || die "Sparkle.framework missing"
+            local bundled_dl="${fw}/Versions/B/XPCServices/Downloader.xpc"
+            local dist_dl="tauri/src-tauri/Sparkle.framework/Versions/B/XPCServices/Downloader.xpc"
+            # Capture both extractions and require each to succeed with output —
+            # a diff of two failed/empty streams would false-green.
+            local ent_dir; ent_dir="$(mktemp -d)"
+            codesign -d --entitlements :- "${bundled_dl}" > "${ent_dir}/bundled" \
+              || die "codesign entitlements extraction failed: ${bundled_dl}"
+            codesign -d --entitlements :- "${dist_dl}" > "${ent_dir}/dist" \
+              || die "codesign entitlements extraction failed: ${dist_dl}"
+            [ -s "${ent_dir}/bundled" ] || die "empty entitlements output for ${bundled_dl}"
+            diff "${ent_dir}/bundled" "${ent_dir}/dist" >/dev/null \
+              || die "Downloader.xpc entitlements differ from the pristine dist copy"
+            rm -rf "${ent_dir}"
+            # The three Sparkle keys are present, and SUPublicEDKey matches the
+            # Swift app's Info.plist.template (a drift would break the EdDSA chain
+            # exactly at the Swift->Tauri hop).
+            local k
+            for k in SUFeedURL SUPublicEDKey SUEnableAutomaticChecks; do
+              plutil -extract "${k}" raw "${plist}" >/dev/null 2>&1 || die "Info.plist missing ${k}"
+            done
+            local app_edkey tmpl_edkey
+            app_edkey="$(plutil -extract SUPublicEDKey raw "${plist}")"
+            tmpl_edkey="$(plutil -extract SUPublicEDKey raw Resources/Info.plist.template)"
+            [ "${app_edkey}" = "${tmpl_edkey}" ] || die "SUPublicEDKey ${app_edkey} != template ${tmpl_edkey}"
+            # The ordered re-sign must produce a strictly-valid bundle.
+            codesign --verify --strict "${app}" || die "codesign --verify --strict failed"
+            echo "bundle smoke OK: id=${bid} exec=${exec} ver=${cfv}/${cfsv} edkey=${app_edkey}"
+          }
+          # 1) The configured version, stamped verbatim.
+          ./scripts/bundle-tauri-mac.sh --debug
+          EXPECT_VER="$(python3 -c "import json,sys; print(json.load(open('tauri/src-tauri/tauri.conf.json'))['version'])")"
+          assert_bundle "${EXPECT_VER}"
+          # 2) A prerelease override — proves the suffix survives Tauri's plist
+          #    stamping verbatim (guards the rc1->rc2 rehearsal from a silent
+          #    false "up to date"). Incremental: shares the cargo target dir.
+          SHED_TAURI_CONFIG_OVERRIDE='{"version":"0.0.0-rc.1"}' ./scripts/bundle-tauri-mac.sh --debug
+          assert_bundle "0.0.0-rc.1"
 
   docs-build:
     name: docs build

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -636,7 +636,11 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "release $TAG already exists — reusing it"
           else
-            gh release create "$TAG" --title "$TAG" \
+            # Prerelease tags (the Tauri beta track) must not become the
+            # repo's "latest" release.
+            PRERELEASE_FLAG=""
+            case "$TAG" in *-*) PRERELEASE_FLAG="--prerelease" ;; esac
+            gh release create "$TAG" --title "$TAG" $PRERELEASE_FLAG \
               --notes "Release $TAG — assets are uploading."
           fi
 

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -20,7 +20,16 @@ name: Publish Images and Release
 #   5. desktop-release-create                 gh release create — desktop-only
 #                                             tags only (goreleaser owns
 #                                             release creation when ship_go)
-#   6. desktop-macos                          DMG + notarize + Sparkle appcast
+#   6. desktop-macos                          Swift DMG + notarize + Sparkle
+#                                             appcast — STABLE tags only
+#   6b. desktop-macos-tauri                   Tauri DMG + notarize + Sparkle
+#                                             appcast — PRERELEASE (*-*) tags
+#                                             only (beta channel). Mutually
+#                                             exclusive with desktop-macos:
+#                                             exactly one mac desktop job runs
+#                                             per tag, both produce the same
+#                                             ShedDesktop-<ver>.dmg → identical
+#                                             appcast step.
 #   7. desktop-linux (matrix)                 shed-desktop .deb per arch
 #   8. desktop-apt-dispatch                   apt-charliek dispatch (skips
 #                                             prerelease *-* tags)
@@ -44,8 +53,22 @@ name: Publish Images and Release
 #   release                | run         | skip (needs+if)  | run
 #   desktop-release-create | skip (ship) | run              | skip (ship_go=true)
 #   desktop-macos          | skip (ship) | run, after       | run, after
-#   desktop-linux          |             |   create ok      |   goreleaser ok
+#   desktop-macos-tauri    | skip (ship) |   create ok      |   goreleaser ok
+#   desktop-linux          |             |   (see below)    |   (see below)
 #   desktop-apt-dispatch   | skip (needs)| run              | run
+#
+# The two mac desktop jobs are MUTUALLY EXCLUSIVE on the same prerelease/stable
+# axis, and it's cross-cutting to the go/desktop/combined columns above:
+# desktop-macos runs on a STABLE tag (builds the Swift DMG) and skips on a
+# prerelease; desktop-macos-tauri runs on a PRERELEASE (*-* tag, the rc-rehearsal
+# path — builds the Tauri DMG, beta channel) and skips on a stable tag. The gate
+# is `contains(github.event.inputs.version || github.ref_name, '-')` (negated on
+# the Swift job), inlined into each job's `if:` — a job-level `if:` cannot see the
+# job's own `env.TAG`. So in any "run, after" cell above, exactly ONE of the two
+# runs; both produce ShedDesktop-<ver>.dmg, so the appcast step is identical and
+# update-appcast.py is untouched (it emits the beta channel iff the tag has a `-`).
+# desktop-linux + desktop-apt-dispatch are unaffected by that axis (the .deb
+# builds on both; apt-dispatch's own *-* guard already skips prereleases).
 #
 #   Failure propagation: release-plan fails → everything skips (loud, by
 #   design — includes the no-manifest-matches tag). On a combined tag, a
@@ -617,11 +640,15 @@ jobs:
               --notes "Release $TAG — assets are uploading."
           fi
 
-  # macOS: bundle (Sparkle.framework embedded), drag-install DMG, notarize +
-  # staple when the six Apple secrets exist (CAN_NOTARIZE), EdDSA-sign for the
-  # Sparkle appcast, and bot-push docs/appcast.xml to main. Skip-safe gating:
-  # a skipped `release` (desktop-only tag) or skipped `desktop-release-create`
-  # (combined tag) must not block; a FAILED one must.
+  # macOS (Swift app, STABLE tags only): bundle (Sparkle.framework embedded),
+  # drag-install DMG, notarize + staple when the six Apple secrets exist
+  # (CAN_NOTARIZE), EdDSA-sign for the Sparkle appcast, and bot-push
+  # docs/appcast.xml to main. Skip-safe gating: a skipped `release` (desktop-only
+  # tag) or skipped `desktop-release-create` (combined tag) must not block; a
+  # FAILED one must. The trailing `&& !contains(… '-')` makes this the STABLE-tag
+  # job — prerelease (*-*) tags route to desktop-macos-tauri instead (mutually
+  # exclusive; see the header audit table). The `inputs.version ||` half keeps a
+  # workflow_dispatch republish routing on the dispatched version, not the branch.
   desktop-macos:
     name: Desktop macOS DMG + appcast
     needs: [release-plan, release, desktop-release-create]
@@ -632,7 +659,8 @@ jobs:
       needs.release.result != 'failure' &&
       needs.release.result != 'cancelled' &&
       needs.desktop-release-create.result != 'failure' &&
-      needs.desktop-release-create.result != 'cancelled'
+      needs.desktop-release-create.result != 'cancelled' &&
+      !contains(github.event.inputs.version || github.ref_name, '-')
     runs-on: macos-15
     permissions:
       contents: write
@@ -831,6 +859,230 @@ jobs:
           fi
           git commit -m "chore(appcast): publish ${TAG}"
           # Token embedded in the push URL (stays in argv, never written to disk).
+          TOKEN_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          for attempt in 1 2 3; do
+            if git push "${TOKEN_URL}" HEAD:main; then
+              echo "::notice::Appcast pushed — docs.yml redeploys Pages → feed live."
+              exit 0
+            fi
+            echo "::warning::push attempt ${attempt} failed; rebasing onto origin/main"
+            git fetch "${TOKEN_URL}" main
+            git rebase FETCH_HEAD || { echo "::error::rebase conflict on docs/appcast.xml"; exit 1; }
+          done
+          echo "::error::push failed after 3 attempts."; exit 1
+
+  # macOS (Tauri app, PRERELEASE *-* tags only): the rc-rehearsal path. Same
+  # release-asset pipeline as desktop-macos (bundle → notarize+staple → upload →
+  # EdDSA-sign → appcast bot-push), but builds the TAURI DMG (beta channel) with
+  # the ordered Sparkle re-sign, runs the Tauri unit tests, and takes sign_update
+  # from the fetch-sparkle dist (the Swift job's SwiftPM-artifacts path doesn't
+  # exist here). Mutually exclusive with desktop-macos: the trailing
+  # `&& contains(… '-')` is the ONLY delta in the `if:` — a prerelease tag lands
+  # here, a stable tag lands on the Swift job. Both emit ShedDesktop-<ver>.dmg, so
+  # update-appcast.py is byte-identical in behavior (it stamps the beta channel
+  # iff the tag has a `-`). The `inputs.version ||` half keeps a workflow_dispatch
+  # republish routing on the dispatched version, not the branch ref_name.
+  desktop-macos-tauri:
+    name: Desktop macOS Tauri DMG + appcast (prerelease)
+    needs: [release-plan, release, desktop-release-create]
+    if: >-
+      always() &&
+      needs.release-plan.result == 'success' &&
+      needs.release-plan.outputs.ship_desktop == 'true' &&
+      needs.release.result != 'failure' &&
+      needs.release.result != 'cancelled' &&
+      needs.desktop-release-create.result != 'failure' &&
+      needs.desktop-release-create.result != 'cancelled' &&
+      contains(github.event.inputs.version || github.ref_name, '-')
+    runs-on: macos-15
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ github.event.inputs.version || github.ref_name }}
+      # Same six-secret gate as desktop-macos: sign + notarize only when the FULL
+      # prerequisite set is present, else an ad-hoc (Gatekeeper-blocked) DMG. The
+      # identity reaches the build step only when this is true.
+      CAN_NOTARIZE: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 != '' && secrets.MACOS_CERTIFICATE_PASSWORD != '' && secrets.SHED_DESKTOP_DEVELOPER_ID_IDENTITY != '' && secrets.APPLE_ID != '' && secrets.APPLE_TEAM_ID != '' && secrets.APPLE_APP_SPECIFIC_PASSWORD != '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.version || github.ref_name }}
+          # Same rationale as desktop-macos: don't persist GITHUB_TOKEN creds, so
+          # the appcast bot push authenticates as the App token (and docs.yml runs).
+          persist-credentials: false
+
+      - name: Rust toolchain
+        # The Tauri workspace (the sparkle-updater crate's build.rs + the shed-core
+        # path-deps) compiles during the bundle step; install the toolchain first.
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustc --version && cargo --version
+
+      - name: Node (the Vite/React frontend bundle)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: desktop/tauri/ui/package-lock.json
+
+      - name: Frontend deps (tauri CLI + the beforeBuildCommand bundle)
+        # bundle-tauri-mac.sh runs the tauri CLI from ui/node_modules, and the
+        # tauri build's beforeBuildCommand rebuilds the frontend dist.
+        run: cd desktop/tauri/ui && npm ci
+
+      # Inert until all six Apple secrets exist; imports the Developer ID cert into
+      # a throwaway keychain so codesign (in bundle-tauri-mac.sh) + notarization use
+      # it. Identical to desktop-macos's step.
+      - name: Import Developer ID certificate
+        if: env.CAN_NOTARIZE == 'true'
+        env:
+          MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          trap 'rm -f "$RUNNER_TEMP/cert.p12"' EXIT
+          kc="$RUNNER_TEMP/shed-desktop-signing.keychain-db"
+          kp="$(openssl rand -base64 24)"
+          security create-keychain -p "$kp" "$kc"
+          security set-keychain-settings -lut 21600 "$kc"
+          security unlock-keychain -p "$kp" "$kc"
+          echo "$MACOS_CERTIFICATE_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$kc" -P "$MACOS_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$kp" "$kc"
+          # shellcheck disable=SC2046
+          security list-keychains -d user -s "$kc" $(security list-keychains -d user | sed 's/"//g')
+          rm -f "$RUNNER_TEMP/cert.p12"
+
+      # tauri-dmg-mac = fetch-sparkle (make prereq) + bundle-tauri-mac.sh (ordered
+      # Sparkle re-sign) + make-dmg.sh. Identity reaches the script only when
+      # CAN_NOTARIZE, else the ad-hoc path (and make-dmg keeps the FIRST-LAUNCH
+      # note). DMG name is ShedDesktop-<VERSION>.dmg where VERSION = desktop/VERSION
+      # (== TAG#v by the release-plan lockstep check), same as the Swift job.
+      - name: Build + bundle + DMG (Tauri)
+        env:
+          SHED_DESKTOP_DEVELOPER_ID_IDENTITY: ${{ env.CAN_NOTARIZE == 'true' && secrets.SHED_DESKTOP_DEVELOPER_ID_IDENTITY || '' }}
+        run: make -C desktop tauri-dmg-mac
+
+      - name: Unit tests (Tauri workspace)
+        # The unit tests for THIS artifact — the Tauri standalone workspace, NOT the
+        # Swift `make test` (no build-core.sh here).
+        run: make -C desktop tauri-test
+
+      # Notarize + staple BEFORE the upload + appcast signing (stapling rewrites the
+      # DMG bytes, so sign_update must run against the stapled file). Gated on
+      # CAN_NOTARIZE; notarize.sh also self-guards on the APPLE_* creds.
+      - name: Notarize + staple (skipped without credentials)
+        if: env.CAN_NOTARIZE == 'true'
+        working-directory: desktop
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: ./scripts/notarize.sh "build/ShedDesktop-${TAG#v}.dmg"
+
+      - name: Detect DMG notarization status
+        id: dmg_notarized
+        working-directory: desktop
+        run: |
+          if xcrun stapler validate "build/ShedDesktop-${TAG#v}.dmg" >/dev/null 2>&1; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload the DMG (+ notarization notes on desktop-only releases)
+        # Same notes handling as desktop-macos: when the Go side ships, goreleaser
+        # owns the notes; on a desktop-only release, APPEND the guidance.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NOTARIZED: ${{ steps.dmg_notarized.outputs.value }}
+          SHIP_GO: ${{ needs.release-plan.outputs.ship_go }}
+        run: |
+          set -euo pipefail
+          VER="${TAG#v}"
+          gh release upload "$TAG" "desktop/build/ShedDesktop-${VER}.dmg" --clobber
+          if [ "${SHIP_GO}" = "true" ]; then
+            echo "combined release — goreleaser owns the notes; skipping the notes edit."
+            exit 0
+          fi
+          if [ "${NOTARIZED}" = "true" ]; then
+            NOTES="Notarized Developer ID build (auto-updates via Sparkle). Drag to /Applications and open normally."
+          else
+            NOTES="Ad-hoc signed build (auto-updates via Sparkle). Not notarized yet — see FIRST-LAUNCH.txt in the DMG for the one-time Gatekeeper step."
+          fi
+          BODY="$(gh release view "$TAG" --json body --jq '.body')"
+          if printf '%s' "${BODY}" | grep -qF "${NOTES}"; then
+            echo "notes already carry the notarization line — leaving them as-is."
+          else
+            printf '%s\n\n%s\n' "${BODY}" "${NOTES}" | gh release edit "$TAG" --notes-file -
+          fi
+
+      # ---- Sparkle appcast: sign the DMG + publish the feed as the release bot ----
+      - name: Mint release-bot token (self-repo, appcast push)
+        id: bot-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id:    ${{ secrets.RELEASE_BOT_CLIENT_ID }}
+          private-key:  ${{ secrets.RELEASE_BOT_APP_KEY }}
+          owner:        charliek
+          repositories: shed
+          permission-contents: write
+
+      - name: Sign DMG + append appcast entry
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SPARKLE_ED_PRIVATE_KEY}" ]; then
+            echo "::error::SPARKLE_ED_PRIVATE_KEY is unset — can't sign the appcast entry."
+            exit 1
+          fi
+          VER="${TAG#v}"
+          DMG="desktop/build/ShedDesktop-${VER}.dmg"
+          test -s "${DMG}" || { echo "::error::${DMG} missing — the DMG step must run first."; exit 1; }
+          # The Tauri job's sign_update comes from fetch-sparkle's dist (staged into
+          # the Tauri src-tauri by the bundle step), NOT the SwiftPM artifacts path.
+          SIGN_UPDATE="desktop/tauri/src-tauri/.sparkle-dist/bin/sign_update"
+          [ -x "${SIGN_UPDATE}" ] || { echo "::error::${SIGN_UPDATE} not found (fetch-sparkle must run in the build step)."; exit 1; }
+          W="$(mktemp -d)"; chmod 700 "$W"; trap 'rm -rf "$W"' EXIT
+          printf '%s' "${SPARKLE_ED_PRIVATE_KEY}" | base64 --decode > "${W}/key"
+          "${SIGN_UPDATE}" --ed-key-file "${W}/key" "${DMG}" > "${W}/sign.txt"
+          rm -f "${W}/key"
+          cat "${W}/sign.txt"
+          # The appcast lives on main; the tag was cut from main, so the untracked
+          # desktop/build/ + gitignored desktop/tauri/src-tauri/.sparkle-dist/
+          # artifacts survive the checkout. update-appcast.py runs FROM THE REPO ROOT
+          # (its SHED_DESKTOP_APPCAST default is cwd-relative) and emits the beta
+          # channel for this prerelease tag (it has a `-`).
+          git fetch origin main
+          git checkout main
+          SHED_DESKTOP_VERSION="${VER}" SHED_DESKTOP_TAG="${TAG}" \
+            SHED_DESKTOP_SIGN_FILE="${W}/sign.txt" \
+            SHED_DESKTOP_APPCAST="docs/appcast.xml" \
+            SHED_DESKTOP_REPO="charliek/shed" \
+            python3 desktop/scripts/update-appcast.py
+          xmllint --noout docs/appcast.xml
+
+      - name: Push signed appcast to main as release-bot
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+          BOT_SLUG: ${{ steps.bot-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet docs/appcast.xml; then
+            echo "::notice::docs/appcast.xml unchanged for ${TAG} — nothing to push."
+            exit 0
+          fi
+          bot_id="$(gh api "/users/${BOT_SLUG}[bot]" --jq '.id')"
+          git config user.name  "${BOT_SLUG}[bot]"
+          git config user.email "${bot_id}+${BOT_SLUG}[bot]@users.noreply.github.com"
+          git add docs/appcast.xml
+          staged="$(git diff --cached --name-only)"
+          if [ "${staged}" != "docs/appcast.xml" ]; then
+            echo "::error::unexpected staged paths beyond docs/appcast.xml:"; echo "${staged}"; exit 1
+          fi
+          git commit -m "chore(appcast): publish ${TAG}"
           TOKEN_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           for attempt in 1 2 3; do
             if git push "${TOKEN_URL}" HEAD:main; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,6 @@ All notable changes to this project will be documented in this file.
   macOS, Tauri Linux) gain the new kinds and the generic permission mode, gate the create
   sheet's kind chips on each shed's capabilities, surface `needs-auth` per agent, and
   apply the unknown-kind neutral-rendering policy.
-<<<<<<< HEAD
 - **Live RC activity (the rc hub).** `shed-ext-rc serve` runs a resident, on-demand,
   self-exiting per-shed daemon (loopback `127.0.0.1:1029`) that tails codex rollout and
   claude transcript JSONL — with a spinner-normalizing pane-stability engine as the
@@ -98,7 +97,8 @@ All notable changes to this project will be documented in this file.
 - **Tauri mac DMG packaging + prerelease-tag release job.** New `make tauri-dmg-mac`
   packaging (Sparkle staged by `scripts/fetch-sparkle.sh`, signed in Sparkle's ordered
   inner→outer sequence) and a `desktop-macos-tauri` release job: **prerelease** desktop
-  tags (`vX.Y.Z-rc.N`) build/notarize the Tauri DMG and append a **beta-channel** appcast
+  tags (`vX.Y.Z-rc.N`) build and — when Apple signing credentials are configured —
+  notarize the Tauri DMG and append a **beta-channel** appcast
   entry, while stable tags keep shipping the Swift DMG (mutually exclusive gates). This is
   the beta rollout track — stable users are untouched until promotion.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to this project will be documented in this file.
   macOS, Tauri Linux) gain the new kinds and the generic permission mode, gate the create
   sheet's kind chips on each shed's capabilities, surface `needs-auth` per agent, and
   apply the unknown-kind neutral-rendering policy.
+<<<<<<< HEAD
 - **Live RC activity (the rc hub).** `shed-ext-rc serve` runs a resident, on-demand,
   self-exiting per-shed daemon (loopback `127.0.0.1:1029`) that tails codex rollout and
   claude transcript JSONL — with a spinner-normalizing pane-stability engine as the
@@ -84,6 +85,22 @@ All notable changes to this project will be documented in this file.
   this also means `connect/{port}` now reaches loopback-bound guest services — parity with
   VZ — instead of dialing the VM's bridge IP (the peer address a guest service sees
   becomes `127.0.0.1`).
+- **Tauri macOS app gains Sparkle auto-update.** The Tauri client now packages a macOS
+  DMG (`ShedDesktop-<version>.dmg`) containing a signed `ShedDesktop.app` with an
+  embedded `Sparkle.framework`, wired to
+  the **same feed and EdDSA keys as the Swift app**
+  (`https://charliek.github.io/shed/appcast.xml`). Updates are **user-invoked only** — the
+  tray popover's **Check for Updates…** row is now live (no automatic background checks;
+  Swift parity) — and the macOS bundle identity is aligned to `ai.stridelabs.ShedDesktop`
+  so the eventual Swift→Tauri hop is a same-key, in-place update. On Linux the row stays a
+  truthful "Updates arrive via apt" tooltip. Drivable over IPC via `updater.status` /
+  `updater.check`.
+- **Tauri mac DMG packaging + prerelease-tag release job.** New `make tauri-dmg-mac`
+  packaging (Sparkle staged by `scripts/fetch-sparkle.sh`, signed in Sparkle's ordered
+  inner→outer sequence) and a `desktop-macos-tauri` release job: **prerelease** desktop
+  tags (`vX.Y.Z-rc.N`) build/notarize the Tauri DMG and append a **beta-channel** appcast
+  entry, while stable tags keep shipping the Swift DMG (mutually exclusive gates). This is
+  the beta rollout track — stable users are untouched until promotion.
 
 ## v0.7.10 — 2026-07-08
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,7 +19,7 @@ equals the tag**:
 | Component | Ship selector (version manifest) | Artifacts |
 |---|---|---|
 | `go` | `.claude-plugin/plugin.json` `.version` | Go binaries, brew formulas, `shed-server`/`shed-machine-rc` debs, ghcr rootfs images |
-| `desktop` | `desktop/VERSION` (with `crates/Cargo.toml`, the Tauri `Cargo.toml`/`tauri.conf.json`, and both Cargo locks in verified lockstep) | ShedDesktop DMG + Sparkle appcast, `shed-desktop` debs |
+| `desktop` | `desktop/VERSION` (with `crates/Cargo.toml`, the Tauri `Cargo.toml`/`tauri.conf.json`, and both Cargo locks in verified lockstep) | ShedDesktop DMG + Sparkle appcast, `shed-desktop` debs — during the Swift→Tauri transition, **stable** tags ship the Swift DMG and **prerelease** (`-`) tags ship the Tauri DMG on the appcast beta channel (see [`desktop/RELEASING.md`](desktop/RELEASING.md)) |
 
 - **Bumping**: `scripts/release/update-version.sh X.Y.Z
   [--components go,desktop]`. The default is `go` (preserves the

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -45,6 +45,17 @@ Core/UI split (see `docs/desktop/architecture.md`):
 The dedicated GTK client that used to ship the `.deb` has been **retired** — Tauri replaced
 it. There is no `--target gtk` and no `shed-gtk` crate.
 
+The Tauri client also has a **macOS packaging path** (Swift→Tauri transition): `make
+tauri-bundle-mac` / `make tauri-dmg-mac` build a signed `ShedDesktop.app`/DMG with an
+embedded real Sparkle updater. On **Darwin** every Tauri build (`tauri-build`/`-lint`/`-test`/
+`-run`) needs `Sparkle.framework` staged first (`make sparkle-framework` runs
+`scripts/fetch-sparkle.sh`, pinned + gitignored) — the sparkle-updater crate's `build.rs`
+panics without it. The mac Tauri bundle aligns its identity to the Swift app
+(`ai.stridelabs.ShedDesktop`, mac-only overlay `tauri.macos.conf.json`), so the mac dev
+config dir is `~/Library/Application Support/ai.stridelabs.ShedDesktop`; the **Linux** identity
+`ai.stridelabs.shed-desktop` (polkit/D-Bus/nfpm) is unchanged. See `desktop/RELEASING.md` for
+the beta-rollout release flow.
+
 ## The change loop (macOS)
 
 ```bash

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -14,6 +14,15 @@ APP := build/ShedDesktop.app
 # the recreated /work layout exactly as they do in the repo.
 REPO_ROOT := $(abspath $(CURDIR)/..)
 
+# Paths excluded from every Docker-leg source tarball: build outputs + the
+# mac-only staged Sparkle framework/dist (a dev Mac's staging must never enter
+# the containers).
+TAR_EXCLUDES := --exclude=desktop/tauri/src-tauri/target \
+  --exclude=desktop/tauri/src-tauri/Sparkle.framework \
+  --exclude=desktop/tauri/src-tauri/.sparkle-dist \
+  --exclude=desktop/tauri/ui/node_modules \
+  --exclude=crates/target
+
 .PHONY: help
 help:  ## List available targets
 	@echo "shed-desktop dev tasks:"
@@ -84,7 +93,7 @@ deb: tauri-ui-build  ## Build the shed-desktop Tauri .deb in Docker (ubuntu:24.0
 	    echo "deb [trusted=yes] https://repo.goreleaser.com/apt/ /" > /etc/apt/sources.list.d/goreleaser.list && \
 	    apt-get update -qq && apt-get install -y -qq nfpm >/dev/null && \
 	    mkdir -p /work && \
-	    tar -C /repo --exclude=desktop/tauri/src-tauri/target --exclude=desktop/tauri/ui/node_modules --exclude=crates/target \
+	    tar -C /repo $(TAR_EXCLUDES) \
 	      -cf - crates desktop/tauri desktop/linux desktop/packaging desktop/Resources desktop/pyproject.toml desktop/uv.lock | tar -C /work -xf - && \
 	    cd /work/desktop && ./linux/scripts/build-deb.sh $(DEB_VERSION) && \
 	    cp /work/desktop/out/*.deb /out/'
@@ -94,7 +103,36 @@ deb-validate: deb  ## Build + install-validate the .deb in a clean ubuntu:24.04 
 
 # ---- tauri (Phase A: a real Linux client toward Mac parity) -----------
 
+UNAME_S := $(shell uname -s)
+
 .PHONY: tauri-build tauri-run tauri-lint tauri-test tauri-ui-build tauri-build-linux tauri-test-linux
+.PHONY: sparkle-framework tauri-bundle-mac tauri-dmg-mac
+
+sparkle-framework:  ## Stage Sparkle.framework + bin tools for the Tauri mac app (pinned; idempotent)
+	./scripts/fetch-sparkle.sh
+
+# On Darwin every Tauri mac build needs Sparkle.framework staged first:
+# tauri.macos.conf.json's bundle.macOS.frameworks references it (the bundler
+# copies it at bundle time), and the sparkle-updater crate's build.rs (C2)
+# links it and panics when it is absent. Linux never compiles that crate
+# (mac-only target dep), and the Docker legs --exclude the staged framework
+# so it never enters the containers.
+ifeq ($(UNAME_S),Darwin)
+tauri-build: sparkle-framework
+tauri-run: sparkle-framework
+tauri-lint: sparkle-framework
+tauri-test: sparkle-framework
+endif
+
+# NOTE: `dmg` (Swift) and `tauri-dmg-mac` (Tauri) write the SAME outputs —
+# build/ShedDesktop.app + build/ShedDesktop-<ver>.dmg — building one clobbers
+# the other's artifacts.
+tauri-bundle-mac: sparkle-framework  ## Build + sign the Tauri mac app -> build/ShedDesktop.app
+	./scripts/bundle-tauri-mac.sh
+
+tauri-dmg-mac: tauri-bundle-mac  ## Tauri mac bundle + drag-install DMG (reuses make-dmg.sh; clobbers the Swift `dmg` outputs)
+	./scripts/make-dmg.sh
+
 tauri-ui-build:  ## Build the Vite/React frontend bundle (tauri/ui/dist)
 	cd tauri/ui && npm run build
 
@@ -139,7 +177,7 @@ tauri-build-linux: tauri-ui-build  ## Render gate: Tauri e2e on ubuntu:24.04 + W
 	  -e SHED_TAURI_TEST_TIMEOUT_SCALE=6 \
 	  shed-tauri-linux:latest \
 	  bash -lc 'set -e; mkdir -p /work; \
-	    tar -C /repo --exclude=desktop/tauri/src-tauri/target --exclude=desktop/tauri/ui/node_modules --exclude=crates/target \
+	    tar -C /repo $(TAR_EXCLUDES) \
 	      -cf - crates desktop/tauri desktop/tools desktop/Resources desktop/pyproject.toml desktop/uv.lock | tar -C /work -xf -; \
 	    cd /work/desktop && (cd tauri/src-tauri && cargo build --locked) && \
 	    xvfb-run -a --server-args="-screen 0 1400x900x24" \
@@ -161,7 +199,7 @@ tauri-test-linux: tauri-ui-build  ## Tauri crate cargo test on ubuntu:24.04 (Lin
 	  -e CARGO_TARGET_DIR=/target \
 	  shed-tauri-linux:latest \
 	  bash -lc 'set -e; mkdir -p /work; \
-	    tar -C /repo --exclude=desktop/tauri/src-tauri/target --exclude=desktop/tauri/ui/node_modules --exclude=crates/target \
+	    tar -C /repo $(TAR_EXCLUDES) \
 	      -cf - crates desktop/tauri desktop/tools desktop/Resources desktop/pyproject.toml desktop/uv.lock | tar -C /work -xf -; \
 	    cd /work/desktop/tauri/src-tauri && cargo test --locked'
 

--- a/desktop/RELEASING.md
+++ b/desktop/RELEASING.md
@@ -97,6 +97,77 @@ That makes `vX.Y.Z-rc.1` (with the desktop manifests bumped to match)
 the recommended dress rehearsal for DMG + notarize + EdDSA + appcast +
 deb before a first-of-its-kind release.
 
+## Tauri macOS app — the beta rollout (transition)
+
+The macOS app is transitioning from the Swift menu-bar app to the Tauri
+client. During the transition **the tag's channel picks the mac
+artifact** — two mutually exclusive jobs, exactly one per desktop-shipping
+tag (both still require `ship_desktop`, i.e. `desktop/VERSION` == the tag):
+
+| Tag shape | Job | Mac artifact | Appcast channel |
+|---|---|---|---|
+| Stable (`vX.Y.Z`) | `desktop-macos` (Swift) | `ShedDesktop-<ver>.dmg` (Swift) | stable |
+| Prerelease (`vX.Y.Z-rc.N`, any `-`) | `desktop-macos-tauri` | `ShedDesktop-<ver>.dmg` (Tauri) | beta |
+
+The gate is `contains(github.event.inputs.version || github.ref_name,
+'-')` (the Swift job carries the negation) — the `inputs.version ||`
+half keeps the `workflow_dispatch` republish path routing correctly
+(`ref_name` is a branch on dispatch). Both jobs emit the identically
+named `ShedDesktop-<ver>.dmg`, so the appcast append step is unchanged;
+`update-appcast.py` stamps `<sparkle:channel>beta</sparkle:channel>`
+whenever the tag contains `-` (the same rc-tag guard above).
+
+The Tauri client subscribes to the **beta** channel iff its own version
+carries a prerelease suffix (`CARGO_PKG_VERSION` contains `-`) — so an rc
+build receives rc appcast entries and a stable build never does. That is
+what makes an rc1→rc2 pair a **real in-place Sparkle update**, not a
+same-version no-op.
+
+### `desktop-macos-tauri` specifics (delta from the Swift job)
+
+- Builds via `make -C desktop tauri-dmg-mac` (Sparkle staged first by
+  `scripts/fetch-sparkle.sh`, pinned Sparkle 2.8.1) and runs
+  `make -C desktop tauri-test` (the Tauri crate's unit tests — **not**
+  the Swift `make test`).
+- `sign_update` comes from
+  `desktop/tauri/src-tauri/.sparkle-dist/bin/sign_update` (staged by
+  `fetch-sparkle.sh`), **NOT** the SwiftPM `desktop/.build/artifacts`
+  path the Swift job uses.
+- Signing is **deliberately stricter** than the Swift `bundle.sh`. The
+  Tauri script (`scripts/bundle-tauri-mac.sh`) signs Sparkle's nested
+  helpers in the required inner→outer order (`Installer.xpc` →
+  `Downloader.xpc` with `--preserve-metadata=entitlements` → `Autoupdate`
+  → `Updater.app` → `Sparkle.framework` → app) and **never `--deep`**,
+  while the Swift `bundle.sh` still `--deep`-signs its framework. Do NOT
+  "align" the Tauri script down to `--deep` — wrong order / `--deep`
+  signs and notarizes clean but breaks at update time.
+
+### Mandatory post-merge rehearsal before any promotion
+
+PR-time CI cannot prove installability — a wrong signing order
+notarizes clean and only fails when Sparkle applies the update. The only
+real proof is a two-tag rehearsal, done **after merge, before promotion**:
+
+1. Cut `vX.Y.Z-rc.1` (desktop-only prerelease bump via
+   `scripts/release/update-version.sh X.Y.Z-rc.1 --components desktop`)
+   → `desktop-macos-tauri` builds/notarizes the beta DMG.
+2. **Install rc1's DMG by hand** (first install — nothing to update from
+   yet).
+3. Cut `vX.Y.Z-rc.2` (repeat the desktop version bump —
+   `update-version.sh X.Y.Z-rc.2 --components desktop` — commit, tag; a
+   tag without the bump fails `release-plan.sh`) and verify a **real
+   in-place Sparkle update rc1→rc2** in the installed app (the rc build
+   is on the beta channel, so it sees the rc2 entry). This is the
+   signing-order proof.
+
+### Promotion (a later decision — NOT this PR)
+
+Promotion flips the two job gates so **stable** tags build the Tauri DMG
+(and the Swift job retires). Because the Tauri mac bundle carries the
+Swift app's identity (`ai.stridelabs.ShedDesktop`) and the same EdDSA
+key, the first stable Tauri release rides the same-key appcast chain
+straight into existing Swift installs as an in-place update.
+
 ## Local commands
 
 ```bash
@@ -104,6 +175,8 @@ make -C desktop bundle        # build + assemble ShedDesktop.app (debug)
 make -C desktop dmg           # release bundle + drag-install DMG (ad-hoc unless
                               # SHED_DESKTOP_DEVELOPER_ID_IDENTITY is set)
 make -C desktop test          # swift unit tests (builds the Rust core first)
+make -C desktop tauri-dmg-mac # Tauri mac bundle + drag-install DMG (Sparkle staged + signed;
+                              # clobbers the Swift `dmg` outputs under desktop/build/)
 make -C desktop deb           # the Tauri .deb via Docker
 make -C desktop deb-validate  # install-validate it in a clean container
 scripts/release/release-scripts-test.sh   # self-test the release scripts (repo root)
@@ -118,6 +191,11 @@ all of them: `scripts/release/update-version.sh X.Y.Z --components
 desktop`. `release-plan.sh` exits 1 naming the offender if they drift.
 (`desktop/tauri/ui/package.json` is deliberately NOT a version surface —
 the Tauri bundle version comes from `tauri.conf.json`.)
+
+The mac-only Tauri overlay `desktop/tauri/src-tauri/tauri.macos.conf.json`
+(productName/identifier/embedded `Sparkle.framework`) carries **no**
+`version` key — the base `tauri.conf.json` remains the single lockstep
+surface, so the Tauri mac DMG and the Linux `.deb` share one version.
 
 ## History
 

--- a/desktop/scripts/bundle-tauri-mac.sh
+++ b/desktop/scripts/bundle-tauri-mac.sh
@@ -16,6 +16,10 @@
 # Env (same conventions as bundle.sh):
 #   SHED_DESKTOP_DEVELOPER_ID_IDENTITY  codesign identity (default: ad-hoc "-")
 #   SHED_DESKTOP_ALLOW_UNSIGNED=1       continue past codesign failures
+#   SHED_TAURI_CONFIG_OVERRIDE          inline `tauri build --config <json>` merge
+#                                       (CI smoke only — e.g. a prerelease version
+#                                       override to prove the suffix survives plist
+#                                       stamping verbatim; NOT used by releases)
 #
 # Usage:
 #   ./scripts/bundle-tauri-mac.sh            # release (default)
@@ -75,6 +79,11 @@ TAURI_FLAGS=(--bundles app)
 if [ "${CONFIG}" = "debug" ]; then
   TAURI_FLAGS+=(--debug)
 fi
+# An inline config merge (CI smoke uses it to override the version) — passed to
+# the tauri CLI, before the standalone `--` that forwards the rest to cargo.
+if [ -n "${SHED_TAURI_CONFIG_OVERRIDE:-}" ]; then
+  TAURI_FLAGS+=(--config "${SHED_TAURI_CONFIG_OVERRIDE}")
+fi
 pushd "${REPO_ROOT}/tauri" >/dev/null
 npm --prefix ui exec tauri -- build "${TAURI_FLAGS[@]}" -- --locked
 popd >/dev/null
@@ -86,6 +95,11 @@ if [ ! -d "${BUNDLED_APP}" ]; then
 fi
 
 echo "==> Copying to ${APP_DIR}"
+# cp -R preserves read-only directory bits (Sparkle's dist has some), which can
+# make a bare rm -rf of a previous copy fail with "Directory not empty".
+if [ -d "${APP_DIR}" ]; then
+  chmod -R u+w "${APP_DIR}"
+fi
 rm -rf "${APP_DIR}"
 mkdir -p "${OUT_DIR}"
 cp -R "${BUNDLED_APP}" "${APP_DIR}"

--- a/desktop/scripts/bundle-tauri-mac.sh
+++ b/desktop/scripts/bundle-tauri-mac.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Tauri ShedDesktop.app bundling (macOS).
+#
+# The Tauri sibling of scripts/bundle.sh: builds the Tauri client with the
+# tauri CLI (which applies the tauri.macos.conf.json overlay — productName
+# ShedDesktop, identifier ai.stridelabs.ShedDesktop, embedded
+# Sparkle.framework), copies the .app to build/ShedDesktop.app, and re-signs
+# it in Sparkle's required order. scripts/make-dmg.sh packages the result
+# unchanged (same output paths as the Swift bundle — they clobber each other).
+#
+# Signing is deliberately STRICTER than bundle.sh (which --deep-signs the
+# framework): Sparkle 2 documents an ordered inner->outer sign of its nested
+# helpers, and a wrong order (or --deep on the outer app) signs + notarizes
+# clean but BREAKS AT UPDATE TIME. Do not "align" this down to bundle.sh.
+#
+# Env (same conventions as bundle.sh):
+#   SHED_DESKTOP_DEVELOPER_ID_IDENTITY  codesign identity (default: ad-hoc "-")
+#   SHED_DESKTOP_ALLOW_UNSIGNED=1       continue past codesign failures
+#
+# Usage:
+#   ./scripts/bundle-tauri-mac.sh            # release (default)
+#   ./scripts/bundle-tauri-mac.sh --debug    # debug bundle (CI smoke)
+
+set -euo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "error: bundle-tauri-mac.sh is macOS-only" >&2
+  exit 1
+fi
+
+CONFIG="release"
+if [ "${1:-}" = "--debug" ]; then
+  CONFIG="debug"
+elif [ -n "${1:-}" ]; then
+  echo "error: unknown argument '${1}' (only --debug is supported)" >&2
+  exit 1
+fi
+
+# Tauri's bundler auto-signs when it sees Apple signing env vars — with a real
+# cert it would sign the nested Sparkle helpers in the wrong order (and not
+# re-signable cleanly). This script owns signing; the bundler must only ever
+# apply its overwritable ad-hoc pass.
+for v in APPLE_SIGNING_IDENTITY APPLE_CERTIFICATE; do
+  if [ -n "${!v:-}" ]; then
+    echo "error: ${v} is set — unset it; the Tauri bundler must not sign." >&2
+    echo "       This script signs (identity from SHED_DESKTOP_DEVELOPER_ID_IDENTITY)." >&2
+    exit 1
+  fi
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+APP_NAME="ShedDesktop"
+BUNDLE_ID="ai.stridelabs.ShedDesktop"
+ENT_FILE="${REPO_ROOT}/tauri/src-tauri/${APP_NAME}.entitlements"
+OUT_DIR="${REPO_ROOT}/build"
+APP_DIR="${OUT_DIR}/${APP_NAME}.app"
+
+echo "==> Staging Sparkle.framework"
+"${SCRIPT_DIR}/fetch-sparkle.sh"
+
+if [ ! -d "${REPO_ROOT}/tauri/ui/node_modules" ]; then
+  echo "error: tauri/ui/node_modules missing — run 'npm --prefix tauri/ui ci' first" >&2
+  exit 1
+fi
+
+# The tauri CLI walks up from cwd to find src-tauri/tauri.conf.json, so run it
+# from tauri/ (npm exec resolves the binary from ui/node_modules but keeps the
+# cwd). Trailing args after the standalone `--` go to cargo: --locked so the
+# build cannot drift from (or dirty) the committed Cargo.lock the Linux .deb
+# and the release lockstep guard pin.
+echo "==> tauri build (${CONFIG})"
+TAURI_FLAGS=(--bundles app)
+if [ "${CONFIG}" = "debug" ]; then
+  TAURI_FLAGS+=(--debug)
+fi
+pushd "${REPO_ROOT}/tauri" >/dev/null
+npm --prefix ui exec tauri -- build "${TAURI_FLAGS[@]}" -- --locked
+popd >/dev/null
+
+BUNDLED_APP="${REPO_ROOT}/tauri/src-tauri/target/${CONFIG}/bundle/macos/${APP_NAME}.app"
+if [ ! -d "${BUNDLED_APP}" ]; then
+  echo "error: tauri build did not produce ${BUNDLED_APP}" >&2
+  exit 1
+fi
+
+echo "==> Copying to ${APP_DIR}"
+rm -rf "${APP_DIR}"
+mkdir -p "${OUT_DIR}"
+cp -R "${BUNDLED_APP}" "${APP_DIR}"
+
+# Tauri renames the binary to productName (ShedDesktop); verify the plist and
+# the file agree before signing seals them.
+EXEC_NAME="$(plutil -extract CFBundleExecutable raw "${APP_DIR}/Contents/Info.plist")"
+if [ ! -f "${APP_DIR}/Contents/MacOS/${EXEC_NAME}" ]; then
+  echo "error: CFBundleExecutable '${EXEC_NAME}' missing under Contents/MacOS/" >&2
+  ls "${APP_DIR}/Contents/MacOS/" >&2
+  exit 1
+fi
+
+FRAMEWORK="${APP_DIR}/Contents/Frameworks/Sparkle.framework"
+if [ ! -d "${FRAMEWORK}" ]; then
+  echo "error: ${FRAMEWORK} missing — tauri.macos.conf.json frameworks not applied?" >&2
+  exit 1
+fi
+
+# Sign in Sparkle's REQUIRED order, innermost first, never --deep. The
+# scripts under Contents/Resources/bin/ are NOT signed individually — they
+# are shell/Python text, not Mach-O; the outer app signature seals them
+# (same convention as bundle.sh).
+SIGN_IDENTITY="${SHED_DESKTOP_DEVELOPER_ID_IDENTITY:--}"
+TS_FLAG=""
+if [ "${SIGN_IDENTITY}" != "-" ]; then
+  TS_FLAG="--timestamp"
+fi
+if ! command -v codesign >/dev/null 2>&1; then
+  if [ "${SHED_DESKTOP_ALLOW_UNSIGNED:-0}" = "1" ]; then
+    echo "==> warn: codesign not found; SHED_DESKTOP_ALLOW_UNSIGNED=1, shipping unsigned"
+  else
+    echo "error: codesign not found (set SHED_DESKTOP_ALLOW_UNSIGNED=1 to bypass)" >&2
+    exit 1
+  fi
+else
+  if [ "${SIGN_IDENTITY}" = "-" ]; then
+    echo "==> Ad-hoc codesign (set SHED_DESKTOP_DEVELOPER_ID_IDENTITY for a notarizable build)"
+  else
+    echo "==> Developer ID codesign (identity: ${SIGN_IDENTITY})"
+  fi
+  codesign_or_die() {
+    local target="$1"
+    shift
+    # shellcheck disable=SC2086  # TS_FLAG must word-split (empty => no flag)
+    if codesign --force --sign "${SIGN_IDENTITY}" \
+         --options runtime \
+         ${TS_FLAG} \
+         "$@" \
+         "${target}"
+    then
+      return 0
+    fi
+    if [ "${SHED_DESKTOP_ALLOW_UNSIGNED:-0}" = "1" ]; then
+      echo "    warn: codesign(${target}) failed; SHED_DESKTOP_ALLOW_UNSIGNED=1, continuing"
+      return 0
+    fi
+    echo "    error: codesign(${target}) failed (set SHED_DESKTOP_ALLOW_UNSIGNED=1 to bypass)" >&2
+    exit 1
+  }
+  # Downloader.xpc: preserve the dist's entitlements verbatim (an EMPTY dict —
+  # Sparkle >= 2.6 removed its sandbox, sparkle-project/Sparkle#2511) rather
+  # than injecting the app's.
+  codesign_or_die "${FRAMEWORK}/Versions/B/XPCServices/Installer.xpc"
+  codesign_or_die "${FRAMEWORK}/Versions/B/XPCServices/Downloader.xpc" \
+    --preserve-metadata=entitlements
+  codesign_or_die "${FRAMEWORK}/Versions/B/Autoupdate"
+  codesign_or_die "${FRAMEWORK}/Versions/B/Updater.app"
+  codesign_or_die "${FRAMEWORK}"
+  codesign_or_die "${APP_DIR}" --entitlements "${ENT_FILE}"
+
+  echo "==> codesign --verify --strict"
+  if ! codesign --verify --strict "${APP_DIR}"; then
+    if [ "${SHED_DESKTOP_ALLOW_UNSIGNED:-0}" = "1" ]; then
+      echo "    warn: strict verify failed; SHED_DESKTOP_ALLOW_UNSIGNED=1, continuing"
+    else
+      echo "    error: strict verify failed" >&2
+      exit 1
+    fi
+  fi
+fi
+
+VERSION="$(plutil -extract CFBundleVersion raw "${APP_DIR}/Contents/Info.plist")"
+echo "==> Bundled: ${APP_DIR}"
+echo "    Bundle ID:  ${BUNDLE_ID}"
+echo "    Version:    ${VERSION}"
+echo "    Executable: ${APP_DIR}/Contents/MacOS/${EXEC_NAME}"
+echo "    Framework:  ${FRAMEWORK}"
+echo
+echo "Launch with: open '${APP_DIR}'"

--- a/desktop/scripts/fetch-sparkle.sh
+++ b/desktop/scripts/fetch-sparkle.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Stage Sparkle.framework + its bin/ tools for the Tauri mac app.
+#
+# Downloads the official Sparkle release tarball (pinned version + SHA256 —
+# same pinning discipline as tauri-plugin-sparkle-updater's own
+# scripts/download-sparkle.sh, whose 2.8.1 SHA this matches) and stages:
+#
+#   Sparkle.framework  -> tauri/src-tauri/Sparkle.framework   (gitignored)
+#   bin/ (sign_update, generate_keys, BinaryDelta, ...)
+#                      -> tauri/src-tauri/.sparkle-dist/bin/  (gitignored)
+#
+# The framework location is where the updater crate's build.rs looks (the dir
+# containing tauri.conf.json) and what tauri.macos.conf.json's
+# bundle.macOS.frameworks references. The .sparkle-dist tools are what the
+# release workflow uses to EdDSA-sign the DMG (the Swift job takes sign_update
+# from SwiftPM artifacts; the Tauri job has none, so it comes from here).
+#
+# Idempotent: skips the download when the framework is present and the stamp
+# file matches the pinned version + checksum.
+#
+# Usage:
+#   ./scripts/fetch-sparkle.sh          # or: make sparkle-framework
+
+set -euo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "==> non-macOS: skipping Sparkle staging (mac-only artifact)"
+  exit 0
+fi
+
+SPARKLE_VERSION="2.8.1"
+SPARKLE_SHA256="5cddb7695674ef7704268f38eccaee80e3accbf19e61c1689efff5b6116d85be"
+SPARKLE_URL="https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+DEST_DIR="${REPO_ROOT}/tauri/src-tauri"
+FRAMEWORK_DIR="${DEST_DIR}/Sparkle.framework"
+DIST_DIR="${DEST_DIR}/.sparkle-dist"
+STAMP_FILE="${DIST_DIR}/.staged"
+STAMP="${SPARKLE_VERSION} ${SPARKLE_SHA256}"
+
+if [ -d "${FRAMEWORK_DIR}" ] && [ -x "${DIST_DIR}/bin/sign_update" ] \
+  && [ -f "${STAMP_FILE}" ] \
+  && [ "$(cat "${STAMP_FILE}")" = "${STAMP}" ]; then
+  echo "==> Sparkle ${SPARKLE_VERSION} already staged: ${FRAMEWORK_DIR}"
+  exit 0
+fi
+
+TMP_DIR="$(mktemp -d -t shed-sparkle)"
+# Staged next to the destination so the final install is two same-volume mv's
+# (near-atomic), not a slow cp into a half-deleted target a concurrent build
+# could observe.
+STAGE_DIR="$(mktemp -d "${DEST_DIR}/.sparkle-stage.XXXXXX")"
+trap 'rm -rf "${TMP_DIR}" "${STAGE_DIR}"' EXIT
+
+echo "==> Downloading Sparkle ${SPARKLE_VERSION}"
+curl -fsSL -o "${TMP_DIR}/sparkle.tar.xz" "${SPARKLE_URL}"
+
+echo "==> Verifying checksum"
+echo "${SPARKLE_SHA256}  ${TMP_DIR}/sparkle.tar.xz" | shasum -a 256 -c - >/dev/null
+
+echo "==> Extracting"
+mkdir -p "${TMP_DIR}/extract"
+tar -xf "${TMP_DIR}/sparkle.tar.xz" -C "${TMP_DIR}/extract"
+
+for expected in "${TMP_DIR}/extract/Sparkle.framework" "${TMP_DIR}/extract/bin"; do
+  if [ ! -e "${expected}" ]; then
+    echo "error: Sparkle distribution is missing ${expected##*/} — layout changed?" >&2
+    exit 1
+  fi
+done
+
+# cp -R preserves the Versions/Current symlink farm codesign requires.
+cp -R "${TMP_DIR}/extract/Sparkle.framework" "${STAGE_DIR}/Sparkle.framework"
+mkdir -p "${STAGE_DIR}/.sparkle-dist"
+cp -R "${TMP_DIR}/extract/bin" "${STAGE_DIR}/.sparkle-dist/bin"
+printf '%s' "${STAMP}" > "${STAGE_DIR}/.sparkle-dist/.staged"
+
+rm -rf "${FRAMEWORK_DIR}" "${DIST_DIR}"
+mv "${STAGE_DIR}/Sparkle.framework" "${FRAMEWORK_DIR}"
+mv "${STAGE_DIR}/.sparkle-dist" "${DIST_DIR}"
+
+echo "==> Staged: ${FRAMEWORK_DIR}"
+echo "==> Staged: ${DIST_DIR}/bin"

--- a/desktop/tauri/.gitignore
+++ b/desktop/tauri/.gitignore
@@ -2,6 +2,11 @@
 src-tauri/target/
 src-tauri/gen/
 
+# Sparkle staging (scripts/fetch-sparkle.sh — pinned download, never committed).
+src-tauri/Sparkle.framework/
+src-tauri/.sparkle-dist/
+src-tauri/.sparkle-stage.*/
+
 # Frontend build output + deps (A0b: Vite). The committed Cargo.lock stays.
 ui/dist/
 ui/node_modules/

--- a/desktop/tauri/src-tauri/Cargo.lock
+++ b/desktop/tauri/src-tauri/Cargo.lock
@@ -656,6 +656,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,9 +2072,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2088,6 +2102,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.13.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -2146,6 +2161,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -3233,6 +3261,7 @@ dependencies = [
  "fs2",
  "libc",
  "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
  "objc2-local-authentication",
  "serde",
@@ -3243,6 +3272,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-autostart",
  "tauri-plugin-positioner",
+ "tauri-plugin-sparkle-updater",
  "tempfile",
  "tokio",
  "zbus",
@@ -3667,6 +3697,25 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-sparkle-updater"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5402e89cb4f120fb874951c46d9ff1c5f18fe34457025e01eb2325e1b83eab84"
+dependencies = [
+ "dispatch",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
 ]
 
 [[package]]

--- a/desktop/tauri/src-tauri/Cargo.toml
+++ b/desktop/tauri/src-tauri/Cargo.toml
@@ -67,6 +67,16 @@ objc2 = "0.6"
 block2 = "0.6"
 objc2-foundation = { version = "0.3", features = ["NSString", "NSError"] }
 objc2-local-authentication = { version = "0.3", features = ["LAContext", "LAError", "block2"] }
+# NSApp.activate before a Sparkle check (updater.rs) — the crate's own Gap 1: on a
+# tray/accessory app the Sparkle window can appear behind/unfocused. objc2-app-kit
+# 0.3 is already transitively in the lock (the sparkle-updater crate pulls it); we
+# depend on it directly for the `NSApplication` activation glue.
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSResponder"] }
+# Real Sparkle updater (macOS only, Swift-parity). Exact pin — young third-party
+# crate, deliberate bumps only. Registered ONLY outside test mode (lib.rs), so the
+# harness never instantiates an updater. build.rs links the staged Sparkle.framework
+# (make sparkle-framework prereq); Linux never compiles it (mac-only target dep).
+tauri-plugin-sparkle-updater = "=0.2.4"
 # macOS-only tauri features, unioned into the base `tauri` features:
 #  - image-png: `Image::from_bytes` for the menu-bar template tray icon (tray.rs).
 #  - macos-private-api: a TRANSPARENT popover window — needed for both its rounded

--- a/desktop/tauri/src-tauri/Info.plist
+++ b/desktop/tauri/src-tauri/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Extra Info.plist keys for the Tauri mac app — Tauri merges this file into
+  the plist it generates for ShedDesktop.app (mac-only by nature).
+
+  These MUST stay identical to the Swift app's Resources/Info.plist.template:
+  same SUFeedURL + SUPublicEDKey means the eventual Swift-to-Tauri hop is a
+  same-feed, same-key, in-place Sparkle update. The matching private key is
+  the SPARKLE_ED_PRIVATE_KEY repo secret. SUEnableAutomaticChecks=false so a
+  background check never pops a panel (updates are user-invoked, Swift
+  parity). LSUIElement=true: menu-bar/accessory app, no Dock icon (runtime
+  activation-policy switching promotes to Regular when a window opens).
+-->
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>shed desktop</string>
+  <key>LSUIElement</key>
+  <true/>
+  <key>SUFeedURL</key>
+  <string>https://charliek.github.io/shed/appcast.xml</string>
+  <key>SUPublicEDKey</key>
+  <string>ROs7kN5cyTTVpMUriF1B/RZ/BaV/HJeOC8gMbBjDw+4=</string>
+  <key>SUEnableAutomaticChecks</key>
+  <false/>
+</dict>
+</plist>

--- a/desktop/tauri/src-tauri/ShedDesktop.entitlements
+++ b/desktop/tauri/src-tauri/ShedDesktop.entitlements
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Entitlements for the Tauri ShedDesktop.app (mirrors
+  Resources/ShedDesktop.entitlements for the Swift app).
+
+  The app is NOT sandboxed (so outbound networking needs no entitlement),
+  and the Unix-domain IPC socket works under ad-hoc signing with no special
+  grant.
+
+  cs.disable-library-validation: required by the embedded ad-hoc
+  Sparkle.framework. Library validation insists every linked library share
+  the main executable's Team ID; ad-hoc has none, so the hardened runtime
+  would refuse to load Sparkle and the app would abort at launch. This
+  lifts the same-team requirement. REMOVE once a Developer ID + notarized
+  build ships (both signed by the same team satisfies validation).
+-->
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/desktop/tauri/src-tauri/build.rs
+++ b/desktop/tauri/src-tauri/build.rs
@@ -1,3 +1,19 @@
 fn main() {
     tauri_build::build();
+
+    // The macOS sparkle-updater crate (C2) links Sparkle.framework, whose install
+    // name is `@rpath/Sparkle.framework/...`, as a LOAD-TIME dependency. The bundled
+    // `.app` resolves it via Tauri's `@executable_path/../Frameworks` rpath (the
+    // bundler copies the framework there). But `cargo test` / `cargo run` and the
+    // raw harness binary (`target/debug/shed-desktop-tauri`) are UNbundled, so dyld
+    // would abort at startup unable to find the framework. Add an rpath to the
+    // framework staged beside this manifest (`make sparkle-framework`) for DEBUG
+    // builds only — the release DMG stays free of this dev-machine path and relies
+    // solely on its bundled `@executable_path/../Frameworks` copy.
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let profile = std::env::var("PROFILE").unwrap_or_default();
+    if target_os == "macos" && profile == "debug" {
+        let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{manifest}");
+    }
 }

--- a/desktop/tauri/src-tauri/src/ipc.rs
+++ b/desktop/tauri/src-tauri/src/ipc.rs
@@ -372,6 +372,11 @@ impl Handler {
                 Ok(json!({}))
             }
             "tray.dump" => Ok(self.tray_dump()),
+            // The Sparkle updater's drivable surface — proves the wiring + the
+            // test-mode disablement (the plugin is never registered under the
+            // harness, so `updater.status` reports `test_mode`/disabled here).
+            "updater.status" => Ok(crate::updater::status(&self.app, self.env.test_mode)),
+            "updater.check" => self.updater_check(),
             other => Err(err("unknown_op", format!("unknown op: {other}"))),
         }
     }
@@ -404,6 +409,22 @@ impl Handler {
             "popover_visible": popover_visible,
             "popover_height": popover_height,
         })
+    }
+
+    /// `updater.check` → on the enabled path front the app + present Sparkle (`{}`);
+    /// otherwise split by failure kind: a policy-disabled check is the deterministic
+    /// `updater_disabled` error whose message carries the reason
+    /// (`updater_disabled:<reason>`, so the harness can assert disablement without a
+    /// crash — never registered under the harness ⇒ test mode reports
+    /// `updater_disabled:test_mode`), while a runtime failure on the enabled path
+    /// surfaces via this file's `action_failed` convention.
+    fn updater_check(&self) -> Result<Value, (String, String)> {
+        use crate::updater::CheckError;
+        match crate::updater::check(&self.app, self.env.test_mode) {
+            Ok(()) => Ok(json!({})),
+            Err(e @ CheckError::Disabled(_)) => Err(err("updater_disabled", e.to_string())),
+            Err(CheckError::Operational(msg)) => Err(err("action_failed", msg)),
+        }
     }
 
     /// `prefs.dump` → the Preferences window's drivable state: the React-reported

--- a/desktop/tauri/src-tauri/src/lib.rs
+++ b/desktop/tauri/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod single_instance;
 mod state;
 mod termctl;
 mod tray;
+mod updater;
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -695,6 +696,27 @@ fn resize_popover(app: tauri::AppHandle, height: f64) {
 #[tauri::command]
 fn resize_popover(_app: tauri::AppHandle, _height: f64) {}
 
+// -- Sparkle updater (the popover "Check for Updates…" row + the drivable ops) --
+
+/// The updater's status — `{ os: "macos"|"linux", enabled, reason }` (enabled ==
+/// reason=="ok"). Drives the popover row (enabled vs a truthful disabled tooltip).
+/// Platform-truthful everywhere: Linux ⇒ `linux_apt`, mac test mode ⇒ `test_mode`,
+/// mac unbundled ⇒ `no_bundle`, else `ok`. Mirrors the `updater.status` IPC op.
+#[tauri::command]
+fn updater_status(app: tauri::AppHandle, env: tauri::State<'_, Env>) -> serde_json::Value {
+    updater::status(&app, env.test_mode)
+}
+
+/// A user-invoked update check (the popover row's click). On the enabled path fronts
+/// the app + presents Sparkle; otherwise returns an error string that distinguishes a
+/// policy-disabled check (`updater_disabled:<reason>`, unchanged) from an operational
+/// failure on the enabled path (`updater_failed:<msg>`). Mirrors the `updater.check`
+/// IPC op (which maps the same split onto the `updater_disabled`/`action_failed` codes).
+#[tauri::command]
+fn updater_check(app: tauri::AppHandle, env: tauri::State<'_, Env>) -> Result<(), String> {
+    updater::check(&app, env.test_mode).map_err(|e| e.to_string())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let env = Env::from_process();
@@ -754,7 +776,8 @@ pub fn run() {
     // the real path shells out `shed-ext-rc` over SSH.
     let rc_service = Arc::new(RcService::new_default(env.test_mode, env!("CARGO_PKG_VERSION")));
 
-    tauri::Builder::default()
+    #[allow(unused_mut)] // only the macOS+non-test arm re-binds it (the sparkle plugin)
+    let mut builder = tauri::Builder::default()
         // Launch-at-login (B4): register the plugin so `app.autolaunch()` resolves;
         // it does NOT enable autostart on its own (no startup side effect). The
         // React toggle drives our guarded `loginitem_*` commands, not the plugin's
@@ -774,7 +797,20 @@ pub fn run() {
         .manage(LoginItemCell(Mutex::new(false)))
         // The app-wide light/dark appearance, shared across webviews (unset at
         // launch → the OS `prefers-color-scheme` is the fallback).
-        .manage(AppearanceState(Mutex::new(None)))
+        .manage(AppearanceState(Mutex::new(None)));
+
+    // Real Sparkle updater — registered ONLY on macOS AND outside test mode, so the
+    // updater is never instantiated under the harness (Swift-parity, enforced at
+    // registration, not inside the crate). The plugin's setup manages a
+    // `SparkleUpdater` state iff it's a valid bundle (inert under `cargo run` / the
+    // raw harness binary). Its post-init config (auto-checks off + the channel set)
+    // is applied in `.setup` below via `updater::configure`.
+    #[cfg(target_os = "macos")]
+    if !env.test_mode {
+        builder = builder.plugin(tauri_plugin_sparkle_updater::init());
+    }
+
+    builder
         .invoke_handler(tauri::generate_handler![
             ui_report,
             list_sheds,
@@ -809,7 +845,9 @@ pub fn run() {
             open_dashboard,
             open_preferences,
             app_exit,
-            resize_popover
+            resize_popover,
+            updater_status,
+            updater_check
         ])
         .setup(move |app| {
             // The bundled terminal openers live in <resources>/bin; None in an
@@ -982,6 +1020,11 @@ pub fn run() {
                         let _ = main.hide();
                     }
                     ipc::set_activation_policy_prod(app.handle(), false);
+                    // Post-init updater config (the plugin's setup already ran +
+                    // managed the SparkleUpdater state if this is a valid bundle):
+                    // automatic checks off + the beta-iff-prerelease channel set,
+                    // applied before any user-invoked check_for_updates().
+                    updater::configure(app.handle(), env!("CARGO_PKG_VERSION"));
                 }
             }
             Ok(())

--- a/desktop/tauri/src-tauri/src/updater.rs
+++ b/desktop/tauri/src-tauri/src/updater.rs
@@ -1,0 +1,276 @@
+//! The Sparkle auto-updater integration — Swift-parity, user-invoked checks only.
+//!
+//! Real Sparkle is embedded via `tauri-plugin-sparkle-updater` (macOS only). The
+//! plugin is registered ONLY outside test mode (see `lib.rs`), so the harness never
+//! instantiates an updater (the Swift-parity guarantee, enforced at registration).
+//! The crate itself is inert outside a real bundle (`is_valid_bundle()` → the
+//! managed `SparkleUpdater` state is absent under `cargo run`/the raw harness binary).
+//!
+//! This module keeps the observable surface (`updater_status`/`updater_check` — both
+//! the WebView commands and the IPC ops) platform-truthful and drivable, and factors
+//! the two decisions the tests pin — the disabled/enabled REASON and the beta-channel
+//! rule — into pure functions with unit tests (the only pre-rehearsal coverage).
+
+use serde_json::{json, Value};
+use tauri::{AppHandle, Runtime};
+
+/// `enabled == true` — the updater is live and a check presents Sparkle.
+pub const REASON_OK: &str = "ok";
+/// Registered off under the harness — the plugin is never instantiated in test mode.
+pub const REASON_TEST_MODE: &str = "test_mode";
+/// macOS, not test mode, but no valid bundle (the `SparkleUpdater` state is absent —
+/// a `cargo run`/unbundled dev/raw-harness binary). Updates need the installed .app.
+pub const REASON_NO_BUNDLE: &str = "no_bundle";
+/// Linux ships via apt — there is no in-app updater (the row is truthful, not present).
+pub const REASON_LINUX_APT: &str = "linux_apt";
+
+/// The platform dimension of the reason precedence — Linux is a distinct rollout
+/// channel (apt), so it wins even in test mode (keeps the Linux render-gate cell
+/// deterministic regardless of the harness's test-mode flag).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UpdaterOs {
+    Macos,
+    Linux,
+}
+
+impl UpdaterOs {
+    /// The compile target's OS (only macOS + Linux are shed-desktop targets).
+    pub fn current() -> Self {
+        if cfg!(target_os = "macos") {
+            UpdaterOs::Macos
+        } else {
+            UpdaterOs::Linux
+        }
+    }
+
+    /// The wire string for the `os` field (NOT `platform` — that already means the
+    /// client kind `"tauri"` in `identify`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UpdaterOs::Macos => "macos",
+            UpdaterOs::Linux => "linux",
+        }
+    }
+}
+
+/// The reason the updater is in its current state, by strict precedence: platform
+/// first (Linux ⇒ `linux_apt` ALWAYS, even in test mode), then on macOS test mode ⇒
+/// `test_mode`, then a missing updater handle ⇒ `no_bundle`, else `ok`. Pure +
+/// unit-tested — it's the disabled/enabled decision every surface reads.
+pub fn updater_reason(os: UpdaterOs, test_mode: bool, have_updater: bool) -> &'static str {
+    match os {
+        UpdaterOs::Linux => REASON_LINUX_APT,
+        UpdaterOs::Macos => {
+            if test_mode {
+                REASON_TEST_MODE
+            } else if !have_updater {
+                REASON_NO_BUNDLE
+            } else {
+                REASON_OK
+            }
+        }
+    }
+}
+
+/// The Sparkle channels this build subscribes to: `Some(["beta"])` iff the build is a
+/// prerelease (`CARGO_PKG_VERSION` contains `-`, e.g. `0.7.11-rc.1`) — so an rc build
+/// receives beta appcast entries (making rc1→rc2 a REAL in-place Sparkle update test)
+/// while a stable build stays stable-only (a promoted user never sees rc entries).
+/// `Some(empty)` = stable-only (Sparkle always includes the default/no-channel items).
+/// Returns the EXACT value handed to `set_allowed_channels` (an `Option<Vec<String>>`):
+/// always `Some` today — the `Some`-vs-`None` distinction is load-bearing (a future
+/// change to `None` means "unrestricted" and MUST break a test), so the call site
+/// passes this through unmodified.
+// Only called from the macOS-only `configure`; kept uncfg'd so its unit tests
+// run everywhere (incl. the Linux Docker test leg).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn allowed_channels(version: &str) -> Option<Vec<String>> {
+    if version.contains('-') {
+        Some(vec!["beta".to_string()])
+    } else {
+        Some(Vec::new())
+    }
+}
+
+/// Whether a real, instantiated `SparkleUpdater` is managed (a valid bundle on
+/// macOS). Always false off macOS (no such plugin) — the reason precedence
+/// short-circuits Linux before this is consulted.
+#[cfg(target_os = "macos")]
+fn have_updater<R: Runtime>(app: &AppHandle<R>) -> bool {
+    use tauri_plugin_sparkle_updater::SparkleUpdaterExt;
+    app.sparkle_updater().is_some()
+}
+#[cfg(not(target_os = "macos"))]
+fn have_updater<R: Runtime>(_app: &AppHandle<R>) -> bool {
+    false
+}
+
+/// `updater_status`/`updater.status` payload: `{ os, enabled, reason, instantiated }`
+/// where `enabled == (reason == "ok")`. `instantiated` is whether a real Sparkle
+/// updater was instantiated — the `have_updater` probe (macOS: `sparkle_updater()`
+/// resolves to a managed instance; always `false` off macOS). It's independent of
+/// `reason` (which short-circuits on platform/test-mode BEFORE consulting the handle),
+/// so the harness can PROVE test mode never instantiated Sparkle (`instantiated ==
+/// false` while `reason == "test_mode"`).
+pub fn status<R: Runtime>(app: &AppHandle<R>, test_mode: bool) -> Value {
+    let os = UpdaterOs::current();
+    let instantiated = have_updater(app);
+    let reason = updater_reason(os, test_mode, instantiated);
+    json!({
+        "os": os.as_str(),
+        "enabled": reason == REASON_OK,
+        "reason": reason,
+        "instantiated": instantiated,
+    })
+}
+
+/// Why `check` did not present Sparkle: `Disabled(reason)` is the deterministic
+/// policy path (test mode / no bundle / apt — the row is off by design), whereas
+/// `Operational(msg)` is a runtime failure on the enabled path (e.g. main-thread
+/// scheduling). The two map to different IPC error codes (`updater_disabled` vs the
+/// `action_failed` convention), so callers must not collapse them into one string.
+#[derive(Debug)]
+pub enum CheckError {
+    /// The updater is off by policy — `reason` is one of the `REASON_*` constants.
+    Disabled(&'static str),
+    /// The enabled path failed operationally (main-thread scheduling, etc.).
+    Operational(String),
+}
+
+impl std::fmt::Display for CheckError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            // Unchanged wire string — the harness asserts `updater_disabled:<reason>`.
+            CheckError::Disabled(reason) => write!(f, "updater_disabled:{reason}"),
+            CheckError::Operational(msg) => write!(f, "updater_failed:{msg}"),
+        }
+    }
+}
+
+/// `updater_check`/`updater.check`: on the enabled path front the app + present
+/// Sparkle; otherwise a `CheckError::Disabled(reason)` (so a caller — and the harness
+/// — can assert disablement without a crash). A runtime failure on the enabled path is
+/// `CheckError::Operational`.
+pub fn check<R: Runtime>(app: &AppHandle<R>, test_mode: bool) -> Result<(), CheckError> {
+    let os = UpdaterOs::current();
+    let reason = updater_reason(os, test_mode, have_updater(app));
+    if reason != REASON_OK {
+        return Err(CheckError::Disabled(reason));
+    }
+    present_check(app).map_err(CheckError::Operational)
+}
+
+/// Configure the freshly-instantiated updater (macOS, non-test only — called from
+/// `setup` after the plugin registered): disable automatic checks (belt-and-braces
+/// with the plist `SUEnableAutomaticChecks=false` — the crate calls `startUpdater`
+/// unconditionally) and restrict the allowed channels to this build's set. Both
+/// setters route through the delegate/updater; `set_allowed_channels` is stored on
+/// the delegate and read by `allowedChannelsForUpdater:` at check time, so applying
+/// it here takes effect before any `check_for_updates()`. A no-op if the bundle is
+/// invalid (the managed state is absent).
+#[cfg(target_os = "macos")]
+pub fn configure<R: Runtime>(app: &AppHandle<R>, version: &str) {
+    use tauri_plugin_sparkle_updater::SparkleUpdaterExt;
+    if let Some(updater) = app.sparkle_updater() {
+        if let Err(e) = updater.set_automatically_checks_for_updates(false) {
+            eprintln!("shed-desktop-tauri: sparkle set_automatically_checks_for_updates failed: {e}");
+        }
+        if let Err(e) = updater.set_allowed_channels(allowed_channels(version)) {
+            eprintln!("shed-desktop-tauri: sparkle set_allowed_channels failed: {e}");
+        }
+    }
+}
+
+/// Front the app (Sparkle's Gap 1 — on a tray/accessory app the update window can
+/// appear behind/unfocused) then present the check. Marshalled onto the main thread:
+/// the IPC handler runs on a tokio worker, and both `NSApplication` and Sparkle must
+/// be touched on the main thread. Fire-and-forget (Sparkle drives its own UI async);
+/// the closure re-fetches the updater handle (a `State` can't cross the thread).
+#[cfg(target_os = "macos")]
+fn present_check<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    use tauri_plugin_sparkle_updater::SparkleUpdaterExt;
+    let handle = app.clone();
+    app.run_on_main_thread(move || {
+        activate_frontmost();
+        if let Some(updater) = handle.sparkle_updater() {
+            if let Err(e) = updater.check_for_updates() {
+                eprintln!("shed-desktop-tauri: sparkle check_for_updates failed: {e}");
+            }
+        }
+    })
+    .map_err(|e| e.to_string())
+}
+#[cfg(not(target_os = "macos"))]
+fn present_check<R: Runtime>(_app: &AppHandle<R>) -> Result<(), String> {
+    // Unreachable on the enabled path (Linux short-circuits to `linux_apt` above);
+    // kept so both surfaces compile + return the deterministic disabled string.
+    Err(format!("updater_disabled:{REASON_LINUX_APT}"))
+}
+
+/// Bring the app to the foreground so the Sparkle window is focused (mirrors how the
+/// rest of the app does main-thread AppKit work). Must run on the main thread.
+#[cfg(target_os = "macos")]
+fn activate_frontmost() {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::NSApplication;
+    if let Some(mtm) = MainThreadMarker::new() {
+        let ns_app = NSApplication::sharedApplication(mtm);
+        // Deprecated since macOS 14 in favor of `activate`, but it's the documented
+        // ignoring-other-apps behavior and works across our minimumSystemVersion.
+        #[allow(deprecated)]
+        ns_app.activateIgnoringOtherApps(true);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reason_precedence_linux_wins_even_in_test_mode() {
+        // Linux is the apt channel — deterministic regardless of test mode / handle.
+        assert_eq!(updater_reason(UpdaterOs::Linux, false, false), REASON_LINUX_APT);
+        assert_eq!(updater_reason(UpdaterOs::Linux, true, false), REASON_LINUX_APT);
+        assert_eq!(updater_reason(UpdaterOs::Linux, true, true), REASON_LINUX_APT);
+    }
+
+    #[test]
+    fn reason_precedence_macos() {
+        // test mode wins over a missing handle; then no handle ⇒ no_bundle; else ok.
+        assert_eq!(updater_reason(UpdaterOs::Macos, true, false), REASON_TEST_MODE);
+        assert_eq!(updater_reason(UpdaterOs::Macos, true, true), REASON_TEST_MODE);
+        assert_eq!(updater_reason(UpdaterOs::Macos, false, false), REASON_NO_BUNDLE);
+        assert_eq!(updater_reason(UpdaterOs::Macos, false, true), REASON_OK);
+    }
+
+    #[test]
+    fn all_four_reasons_are_reachable() {
+        // Guards the enabled/tooltip contract: exactly one reason maps to enabled.
+        let reasons = [
+            updater_reason(UpdaterOs::Macos, false, true),
+            updater_reason(UpdaterOs::Macos, true, true),
+            updater_reason(UpdaterOs::Macos, false, false),
+            updater_reason(UpdaterOs::Linux, false, true),
+        ];
+        assert_eq!(reasons, [REASON_OK, REASON_TEST_MODE, REASON_NO_BUNDLE, REASON_LINUX_APT]);
+        assert_eq!(reasons.iter().filter(|r| **r == REASON_OK).count(), 1);
+    }
+
+    #[test]
+    fn allowed_channels_beta_iff_prerelease() {
+        // Assert the FULL Option value (not just the inner Vec) — the `Some`-vs-`None`
+        // distinction is the load-bearing contract handed to `set_allowed_channels`
+        // (`Some(empty)` = stable-only; a future `None` = unrestricted MUST fail here).
+        assert_eq!(allowed_channels("0.7.10"), Some(Vec::<String>::new()));
+        assert_eq!(allowed_channels("0.7.11-rc.1"), Some(vec!["beta".to_string()]));
+        assert_eq!(allowed_channels("1.0.0-beta.2"), Some(vec!["beta".to_string()]));
+        // A plain stable version never subscribes to beta — but is still `Some(empty)`.
+        assert_eq!(allowed_channels("2.3.4"), Some(Vec::<String>::new()));
+    }
+
+    #[test]
+    fn os_wire_strings() {
+        assert_eq!(UpdaterOs::Macos.as_str(), "macos");
+        assert_eq!(UpdaterOs::Linux.as_str(), "linux");
+    }
+}

--- a/desktop/tauri/src-tauri/tauri.macos.conf.json
+++ b/desktop/tauri/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "ShedDesktop",
+  "mainBinaryName": "ShedDesktop",
+  "identifier": "ai.stridelabs.ShedDesktop",
+  "bundle": {
+    "macOS": {
+      "frameworks": ["Sparkle.framework"],
+      "minimumSystemVersion": "14.0",
+      "entitlements": "./ShedDesktop.entitlements"
+    }
+  }
+}

--- a/desktop/tauri/ui/package-lock.json
+++ b/desktop/tauri/ui/package-lock.json
@@ -16,6 +16,7 @@
         "tailwind-merge": "^2.5.4"
       },
       "devDependencies": {
+        "@tauri-apps/cli": "^2.11.4",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
@@ -1165,6 +1166,223 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/tauri"
+      }
+    },
+    "node_modules/@tauri-apps/cli": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.4.tgz",
+      "integrity": "sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==",
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "bin": {
+        "tauri": "tauri.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      },
+      "optionalDependencies": {
+        "@tauri-apps/cli-darwin-arm64": "2.11.4",
+        "@tauri-apps/cli-darwin-x64": "2.11.4",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.4",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.4",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.4",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.4",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.4",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.4"
+      }
+    },
+    "node_modules/@tauri-apps/cli-darwin-arm64": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.4.tgz",
+      "integrity": "sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-darwin-x64": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.4.tgz",
+      "integrity": "sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.4.tgz",
+      "integrity": "sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.4.tgz",
+      "integrity": "sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-musl": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.4.tgz",
+      "integrity": "sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.4.tgz",
+      "integrity": "sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-gnu": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.4.tgz",
+      "integrity": "sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-musl": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.4.tgz",
+      "integrity": "sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.4.tgz",
+      "integrity": "sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.4.tgz",
+      "integrity": "sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-x64-msvc": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.4.tgz",
+      "integrity": "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@types/babel__core": {

--- a/desktop/tauri/ui/package.json
+++ b/desktop/tauri/ui/package.json
@@ -17,6 +17,7 @@
     "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {
+    "@tauri-apps/cli": "^2.11.4",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",

--- a/desktop/tauri/ui/src/TrayPopover.tsx
+++ b/desktop/tauri/ui/src/TrayPopover.tsx
@@ -9,14 +9,34 @@ import { Fingerprint, Check, X, Shield, AppWindow, Settings, ArrowDownCircle, Po
 import {
   inTauri, fetchSheds, fetchApprovals, fetchGateNamespaces, decideApproval,
   openDashboard, openPreferences, quitApp, reportTray, resizePopover,
-  type Shed, type Approval,
+  updaterStatus, updaterCheck,
+  type Shed, type Approval, type UpdaterStatus,
 } from "@/lib/bridge";
+
+/** The row tooltip for each updater reason — `ok` is the enabled prompt; the rest are
+ *  truthful about WHY the check is unavailable (test mode / installed app / apt). */
+const UPDATER_TOOLTIP: Record<UpdaterStatus["reason"], string> = {
+  ok: "Check for updates",
+  test_mode: "Updates are disabled in test mode",
+  no_bundle: "Updates require the installed app",
+  linux_apt: "Updates arrive via apt",
+};
 
 export default function TrayPopover() {
   const [sheds, setSheds] = useState<Shed[]>([]);
   const [approvals, setApprovals] = useState<Approval[]>([]);
   const [connected, setConnected] = useState(false);
+  // The updater row's status (fetched once on mount — it's fixed for the process
+  // lifetime). Null until fetched → the row renders disabled (the safe default).
+  const [updater, setUpdater] = useState<UpdaterStatus | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!inTauri()) return;
+    let cancelled = false;
+    void updaterStatus().then((s) => { if (!cancelled && s) setUpdater(s); });
+    return () => { cancelled = true; };
+  }, []);
 
   useEffect(() => {
     if (!inTauri()) return;
@@ -178,7 +198,16 @@ export default function TrayPopover() {
       <div className="flex flex-col p-1.5">
         <FooterRow icon={AppWindow} label="Open dashboard" onClick={() => void openDashboard()} />
         <FooterRow icon={Settings} label="Preferences…" onClick={() => void openPreferences()} />
-        <FooterRow icon={ArrowDownCircle} label="Check for Updates…" disabled title="Updates arrive with the Tauri updater" />
+        <FooterRow
+          icon={ArrowDownCircle}
+          label="Check for Updates…"
+          disabled={!updater?.enabled}
+          // While the status fetch is unresolved OR after a failed fetch (updater ===
+          // null in both cases), show a neutral tooltip — never the no_bundle reason,
+          // which would misattribute the state. The row stays disabled meanwhile.
+          title={updater ? UPDATER_TOOLTIP[updater.reason] : "Checking updater status…"}
+          onClick={updater?.enabled ? () => void updaterCheck() : undefined}
+        />
         <FooterRow icon={Power} label="Quit" onClick={() => void quitApp()} />
       </div>
     </div>

--- a/desktop/tauri/ui/src/lib/bridge.ts
+++ b/desktop/tauri/ui/src/lib/bridge.ts
@@ -723,6 +723,29 @@ export async function openPreferences(): Promise<void> {
 export async function quitApp(): Promise<void> {
   await invoke("app_exit");
 }
+
+/** The Sparkle updater's status the popover "Check for Updates…" row reads on
+ *  render: `{ os, enabled, reason }` (enabled == reason=="ok"). Disabled reasons
+ *  drive a truthful tooltip (test_mode / no_bundle / linux_apt). Swallows errors to
+ *  undefined (the row then degrades to disabled). */
+export type UpdaterStatus = {
+  os: "macos" | "linux";
+  enabled: boolean;
+  reason: "ok" | "test_mode" | "no_bundle" | "linux_apt";
+  /** Whether a real Sparkle updater was instantiated (macOS bundle only; always false
+   *  off macOS AND under the harness — the drivable proof test mode never made one). */
+  instantiated: boolean;
+};
+export async function updaterStatus(): Promise<UpdaterStatus | undefined> {
+  return invoke<UpdaterStatus>("updater_status");
+}
+/** A user-invoked update check (the enabled row's click). Fire-and-forget — on the
+ *  enabled path Sparkle presents its own dialog; a disabled/failed call is logged,
+ *  not surfaced (the row is only clickable when status.enabled). */
+export async function updaterCheck(): Promise<void> {
+  const core = await import("@tauri-apps/api/core");
+  await core.invoke("updater_check").catch((e) => console.error("updater_check failed", e));
+}
 /** Ask Rust to content-size the popover window to the measured height (Swift NSPopover
  *  parity — no dead space). macOS-only in effect; a no-op on other targets. */
 export async function resizePopover(height: number): Promise<void> {

--- a/desktop/tools/shedtest/client.py
+++ b/desktop/tools/shedtest/client.py
@@ -536,3 +536,17 @@ class TauriClient(_ApprovalOps, _RcOps, _RustCoreClient):
     def tray_hide(self) -> None:
         """Hide the mac popover."""
         self.call("tray.hide")
+
+    # -- Sparkle updater (the popover "Check for Updates…" row) -----------
+    def updater_status(self) -> dict:
+        """The updater's status: `{os, enabled, reason}` (enabled == reason=='ok').
+        Platform-truthful: Linux ⇒ reason 'linux_apt'; mac under the harness ⇒
+        'test_mode' (the plugin is never registered in test mode); mac unbundled ⇒
+        'no_bundle'; a real bundle ⇒ 'ok'."""
+        return self.call("updater.status")
+
+    def updater_check(self) -> None:
+        """A user-invoked update check. On the enabled path presents Sparkle; when
+        disabled raises ShedError('updater_disabled') whose message carries the
+        reason ('updater_disabled:<reason>') — never crashes the app."""
+        self.call("updater.check")

--- a/desktop/tools/shedtest/test_tauri.py
+++ b/desktop/tools/shedtest/test_tauri.py
@@ -89,6 +89,34 @@ def test_tray_popover_drivable(tauri):
                      timeout=15, what="popover hidden after tray.hide")
 
 
+def test_updater_status_and_check_disabled(tauri):
+    # Sparkle updater (C2): the drivable status/check ops prove the gated wiring.
+    # The plugin is NEVER registered under the harness (test mode ⇒ Swift-parity: no
+    # updater instantiated), so on macOS the status is disabled with reason
+    # 'test_mode'. On Linux there's no in-app updater at all (apt channel), so the
+    # reason is 'linux_apt' regardless of test mode. Branch on the platform per the
+    # existing precedent in this file. `instantiated` is the independent proof that no
+    # Sparkle updater was ever made under the harness — false on BOTH platforms.
+    status = tauri.updater_status()
+    if platform.system() == "Darwin":
+        assert status == {"enabled": False, "reason": "test_mode", "os": "macos",
+                          "instantiated": False}
+    else:
+        assert status == {"enabled": False, "reason": "linux_apt", "os": "linux",
+                          "instantiated": False}
+
+    # updater.check on the disabled path returns the deterministic `updater_disabled`
+    # error (message carries the reason) — and NEVER crashes the app (a live op after
+    # confirms the process is still serving).
+    reason = "test_mode" if platform.system() == "Darwin" else "linux_apt"
+    with pytest.raises(ShedError) as exc:
+        tauri.updater_check()
+    assert exc.value.code == "updater_disabled"
+    assert exc.value.message == f"updater_disabled:{reason}"
+    # The app is still alive + serving after the (rejected) check.
+    assert tauri.identify()["platform"] == "tauri"
+
+
 def test_navigate_rejects_unknown_pane(tauri):
     # An unknown pane is a bad_request, not blindly emitted — a bogus pane would
     # otherwise blank the UI (PANES[pane] undefined).

--- a/docs/desktop/installation.md
+++ b/docs/desktop/installation.md
@@ -11,9 +11,29 @@ Grab the latest `ShedDesktop-<version>.dmg` from the
 [releases page](https://github.com/charliek/shed/releases), open it, and drag
 **ShedDesktop.app** to Applications.
 
-Release DMGs are **Developer-ID-signed and notarized**, so they launch without a Gatekeeper
-prompt. After the first launch the app **auto-updates** via Sparkle — menu → **Check for
-Updates…** — verified by an EdDSA signature independent of Apple notarization. See
+Official release DMGs are Developer-ID-signed and notarized when the release
+pipeline has signing credentials, and then launch without a Gatekeeper prompt.
+(An unsigned build ships a `FIRST-LAUNCH.txt` with the one-time bypass steps.)
+
+### Updates
+
+The app updates through **Sparkle**, served from the appcast at
+`https://charliek.github.io/shed/appcast.xml` and verified by an EdDSA signature independent
+of Apple notarization. Updates are **user-invoked only** — there are no automatic background
+checks. Trigger one from the menu-bar dropdown (or the tray popover) → **Check for Updates…**;
+if a newer build is published, Sparkle offers it and applies it in place.
+
+| Behavior | Value |
+|---|---|
+| Trigger | User-invoked (**Check for Updates…**); no automatic/scheduled checks |
+| Feed | `https://charliek.github.io/shed/appcast.xml` (stable channel) |
+| Verification | EdDSA signature (`SUPublicEDKey`), independent of Apple notarization |
+| Channels | Stable by default; prerelease (rc) builds subscribe to a **beta** channel |
+
+The Tauri macOS app is on a **beta rollout** — prerelease (`vX.Y.Z-rc.N`) tags publish a
+beta-channel Tauri DMG while stable users keep receiving the Swift app. Both share the same
+feed, EdDSA key, and bundle identity (`ai.stridelabs.ShedDesktop`), so the eventual promotion
+is a seamless in-place update. See
 [RELEASING.md](https://github.com/charliek/shed/blob/main/desktop/RELEASING.md).
 
 Locally built DMGs (`make -C desktop dmg`) are **ad-hoc signed**, so Gatekeeper blocks the

--- a/docs/desktop/installation.md
+++ b/docs/desktop/installation.md
@@ -13,7 +13,8 @@ Grab the latest `ShedDesktop-<version>.dmg` from the
 
 Official release DMGs are Developer-ID-signed and notarized when the release
 pipeline has signing credentials, and then launch without a Gatekeeper prompt.
-(An unsigned build ships a `FIRST-LAUNCH.txt` with the one-time bypass steps.)
+(An ad-hoc-signed, non-notarized build ships a `FIRST-LAUNCH.txt` with the
+one-time bypass steps.)
 
 ### Updates
 


### PR DESCRIPTION
## What

Adds auto-update to the Tauri mac app — the key remaining item before the Tauri desktop replaces the Swift UI as the released mac version. Embeds **real Sparkle 2.8.1** (via `tauri-plugin-sparkle-updater =0.2.4`, vetted from source) keeping the existing feed, `SUPublicEDKey`, `SPARKLE_ED_PRIVATE_KEY`, DMG enclosures, and `update-appcast.py` **unchanged**, and aligns the Tauri mac bundle identity to the Swift app (`ai.stridelabs.ShedDesktop`, `ShedDesktop.app`) so the eventual Swift→Tauri hop is a same-identity, same-key, in-place Sparkle update. The Linux `.deb` identity (`ai.stridelabs.shed-desktop` — polkit/D-Bus/nfpm) is untouched.

Four commits:

1. **mac packaging** — `tauri.macos.conf.json` overlay (identity, `mainBinaryName`, `bundle.macOS.frameworks`, minimumSystemVersion 14.0, entitlements), `src-tauri/Info.plist` (SU keys byte-identical to the Swift template, `SUEnableAutomaticChecks=false`, `LSUIElement`), `scripts/fetch-sparkle.sh` (pinned 2.8.1 + SHA256, idempotent, atomic staging), `scripts/bundle-tauri-mac.sh` (tauri CLI build `--locked` → Sparkle's ordered inner→outer re-sign, **never `--deep`**, `--preserve-metadata=entitlements` on Downloader.xpc → strict verify), `make tauri-bundle-mac` / `tauri-dmg-mac` (DMG via existing `make-dmg.sh`).
2. **updater integration** — plugin registered **only** outside `SHED_TAURI_TEST_MODE` (test mode never instantiates Sparkle; Swift parity), user-invoked checks only, beta-channel subscription **iff** the build version has a prerelease suffix, `NSApp.activate` glue for the tray app, `updater_status`/`updater_check` commands + `updater.status`/`updater.check` IPC ops (payload `{os, enabled, reason, instantiated}`; deterministic `updater_disabled:<reason>` errors), popover "Check for Updates…" row now live (Linux: truthful apt tooltip), Rust unit tests pin the channel rule + reason precedence, harness cells on both platforms.
3. **CI/release** — new `desktop-macos-tauri` job: **prerelease** desktop tags build/notarize the Tauri DMG and append **beta-channel** appcast entries; stable tags keep shipping the Swift DMG (mutually exclusive skip-safe gates incl. `workflow_dispatch` routing via `inputs.version`); `sign_update` from the staged Sparkle dist. PR-time bundle smoke in `tauri-mac` runs the real bundle+sign path twice and asserts identity, Mach-O executable, **verbatim** version stamping (incl. a `0.0.0-rc.1` override run guarding the rc rehearsal), Downloader.xpc entitlement preservation, `SUPublicEDKey` parity with the Swift template, and strict codesign.
4. **docs** — `desktop/RELEASING.md` beta-rollout flow + mandatory post-merge rc1→rc2 rehearsal, root RELEASING.md, `docs/desktop/installation.md` updates section, CHANGELOG (**Ships:** desktop), and the shedtest-mac/linux skills updated with the new rough edges.

## Rollout shape

Tauri release candidates ship as prerelease-tagged desktop-only releases (beta-channel-only appcast entries) while stable users keep receiving the Swift app. Promotion later = flip the two job gates (explicitly out of scope; no release tag is cut by this PR).

## Verification

- All suites green per commit: `tauri-lint` (clippy -D warnings), `tauri-test` (25 tests), `e2e-tauri` (76 passed), `tauri-build-linux` render gate (78 passed) — Linux identity/behavior unaffected.
- **Local DMG end-to-end**: built `ShedDesktop-0.7.10.dmg` ad-hoc, mounted, verified plist (identity/verbatim version/SU keys), launched the app (tray alive, clean quit).
- **Live updater**: packaged app in real mode reported `updater.status {enabled:true, reason:"ok"}`; `updater.check` ran a real Sparkle session against the production appcast (verified via Sparkle os_log; appcast latest == app version ⇒ benign no-op).
- CI smoke assertions all proven locally first, including the prerelease-suffix-survives run and the entitlements-extraction-must-succeed hardening.
- Plan was pressure-tested by a three-reviewer panel (CodeRabbit/Kimi/Cursor) and each commit passed a simplify pass + external review (Codex/Cursor), findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QReoPKEdMBFuYDmL51LUDx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sparkle-based “Check for Updates…” support to the macOS Tauri app.
  * Added beta-channel updates for prerelease macOS Tauri builds, while stable releases continue using the Swift app.
  * Added macOS Tauri DMG packaging and notarized release support.
* **Bug Fixes**
  * Updater checks now report clear, deterministic disabled states on Linux and in test environments without crashing.
* **Documentation**
  * Expanded installation, release, and development guidance for macOS updates, beta rollout, and packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->