### PR TITLE
feat(host-agent): config port — real YAML (saphyr-parser) + Validate parity (Phase 3 leg 3a.1 sub-plan 5)

### DIFF
--- a/cmd/shed-host-agent/golden_test.go
+++ b/cmd/shed-host-agent/golden_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -460,6 +461,53 @@ func TestGoldenEgressAuditEntry(t *testing.T) {
 			continue
 		}
 		assertJSONShapeEqual(t, "egress/"+v.Name, egressAuditEntry(v.Server, dec), v.Expected)
+	}
+}
+
+// TestGoldenConfigValidate is the Go half of the config_validate golden. It routes
+// each vector's config YAML through the PRODUCTION LoadConfig (yaml.Unmarshal then
+// Validate) on a temp file, and asserts the valid flag + (for the semantic errors)
+// the per-vector message substring against the shared fixture the Rust runner
+// (config.rs:golden_config_validate, via HostAgentConfig::try_parse+validate) also
+// reads. Malformed-YAML + duplicate-key vectors carry no substring — the message body
+// is yaml-lib specific (Go yaml.v3 vs saphyr), excluded per the docker suffix policy.
+func TestGoldenConfigValidate(t *testing.T) {
+	var fx struct {
+		ProtocolVersion int `json:"protocol_version"`
+		Vectors         []struct {
+			Name           string `json:"name"`
+			ConfigYAML     string `json:"config_yaml"`
+			Valid          bool   `json:"valid"`
+			ErrorSubstring string `json:"error_substring"`
+		} `json:"vectors"`
+	}
+	readFixture(t, "config_validate.json", &fx)
+
+	if fx.ProtocolVersion != 1 {
+		t.Fatalf("config_validate.json protocol_version = %d, want 1 (version skew)", fx.ProtocolVersion)
+	}
+	if len(fx.Vectors) == 0 {
+		t.Fatal("config_validate.json has no vectors")
+	}
+	for _, v := range fx.Vectors {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte(v.ConfigYAML), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := LoadConfig(path)
+		if v.Valid {
+			if err != nil {
+				t.Errorf("%s: expected valid, got error: %v", v.Name, err)
+			}
+			continue
+		}
+		if err == nil {
+			t.Errorf("%s: expected invalid config to error", v.Name)
+			continue
+		}
+		if v.ErrorSubstring != "" && !strings.Contains(err.Error(), v.ErrorSubstring) {
+			t.Errorf("%s: error %q lacks substring %q", v.Name, err.Error(), v.ErrorSubstring)
+		}
 	}
 }
 

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -34,6 +34,24 @@ compile everywhere (macOS, Linux, and eventually mobile) without dragging a desk
 The Tauri crate consumes `shed-core` + `shed-app` as cross-workspace **path-deps**; it is not a
 member here. Do not add it as one.
 
+### The no-YAML-dep posture — and its one carve-out
+
+Both clients hand-roll a tiny indentation reader (`shed-core`'s and `shed-host-agent`'s own
+`yaml_lite` mods) rather than take a YAML dependency. That aversion targets the **serde-based**
+crates (`serde_yaml` — archived/unmaintained — and `serde_norway`): serde-derive on the config
+structs is what's being avoided, not a parser per se.
+
+**The scoped exception:** `shed-host-agent` depends on **`saphyr-parser`** (pure-Rust, no-serde,
+no-C, no encoding_rs, `default-features = false`) to back ITS `yaml_lite::parse`. Justification:
+the shipped `configs/extensions.example.yaml` uses block-style `docker.registries:` sequences the
+line/colon reader silently dropped, and Go's `LoadConfig` rejects malformed YAML the hand-rolled
+reader could not detect — a real Go-vs-Rust divergence on the product's own default config.
+`saphyr-parser` sits behind the `Node` interface (swap-insulation for its pre-1.0 API) and is a
+**leaf-crate dep of the `shed-host-agent` binary only** — it does NOT reach `shed-core`/`shed-app`/
+`shed-core-ffi`/the Tauri client (proven by `cargo tree -i saphyr-parser`). **shed-core's own
+`yaml_lite` stays hand-rolled** (it carries a Swift byte-parity test); converging the two readers
+onto `saphyr-parser` would be a separate shed-core slice, not assumed here.
+
 ## Build / test
 
 ```bash

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2812,6 +2818,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "saphyr-parser"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebfd783fcf1b3f6bafd557be0e1427ec54f826f513c3cdd749f9844484df2a13"
+dependencies = [
+ "arraydeque",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3055,6 +3071,7 @@ dependencies = [
  "p521",
  "reqwest",
  "rsa",
+ "saphyr-parser",
  "serde",
  "serde_json",
  "sha1",

--- a/crates/shed-host-agent/Cargo.toml
+++ b/crates/shed-host-agent/Cargo.toml
@@ -38,6 +38,16 @@ libc = "0.2"
 shed-core = { path = "../shed-core" }
 async-trait = { workspace = true }
 uuid = { workspace = true }
+# The host-agent config reader's YAML parser (config.rs `yaml_lite` mod). The repo's
+# clients otherwise hand-roll a tiny indentation reader to avoid a YAML dep (see the
+# carve-out note in crates/CLAUDE.md); this crate is the scoped exception. saphyr-parser
+# is a pure-Rust, no-serde, no-C, YAML-1.2 event-stream parser (no encoding_rs in 0.0.x)
+# — used ONLY to feed the existing `Node` model, so the swap stays behind that interface.
+# It buys real structure (block sequences, flow maps, malformed-input detection) that the
+# line/colon reader cannot: the shipped configs/extensions.example.yaml uses block-style
+# `registries:` sequences the old reader silently dropped. Leaf-crate only — see the PR's
+# DEP_DELTA for the reverse-dep proof that it does NOT reach shed-app/Tauri.
+saphyr-parser = { version = "0.0.11", default-features = false }
 # The bus HTTP client: reqwest (rustls) for SSE subscribe + respond POST, and
 # futures-util for the bytes-stream adaptor. Match shed-core's stack so cargo
 # unifies one reqwest/rustls build across the workspace.

--- a/crates/shed-host-agent/src/config.rs
+++ b/crates/shed-host-agent/src/config.rs
@@ -4,9 +4,16 @@
 //! config schema (discovery, per-server overrides, AWS/Docker resolution,
 //! biometric scope/ttl, `Validate()`) is a later slice.
 //!
-//! Parser style follows shed-core's `config.rs`: a deliberately tiny
-//! indentation-aware nested-map/scalar reader (`yaml_lite`) rather than a YAML
-//! crate dependency — the repo intentionally avoids serde_yaml/serde_norway.
+//! Parsing: the `yaml_lite` mod exposes the same tiny `Node` model shed-core's
+//! reader uses, but its parser is backed by `saphyr-parser` (a pure-Rust,
+//! no-serde/no-C YAML-1.2 *event* stream). The repo's deliberate no-YAML-dep
+//! posture targets the serde-based crates (`serde_yaml`/`serde_norway`); the
+//! host-agent reader is the scoped exception — a real parser gains block
+//! sequences, flow maps, and malformed-input detection the line/colon reader
+//! could not, which the shipped `configs/extensions.example.yaml` (block-style
+//! `registries:`) actually needs. See `crates/CLAUDE.md` for the carve-out;
+//! shed-core's own `yaml_lite` (a separate crate, Swift byte-parity test) stays
+//! hand-rolled.
 
 use std::collections::BTreeMap;
 use std::io;
@@ -194,13 +201,33 @@ impl HostAgentConfig {
     pub fn load(path: &str) -> io::Result<HostAgentConfig> {
         let expanded = expand_tilde(path);
         let text = std::fs::read_to_string(&expanded)?;
-        Ok(Self::parse(&text))
+        // Malformed YAML is a hard error (mirrors Go's `yaml.Unmarshal` →
+        // `os.Exit(1)`); the daemon must not fail open with a half-read policy.
+        Self::try_parse(&text).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 
-    /// Parse config text. Missing keys take their defaults (policies default to
-    /// empty → deny-all effective; logging enabled true).
+    /// Parse config text, returning an error on malformed YAML. Missing keys take
+    /// their defaults (policies default to empty → deny-all effective; logging
+    /// enabled true). This is the fallible path `load` uses; the infallible
+    /// `HostAgentConfig::parse` convenience wraps it for known-good test literals.
+    pub fn try_parse(text: &str) -> Result<HostAgentConfig, String> {
+        let root = yaml_lite::parse(text)?;
+        Ok(Self::from_root(&root))
+    }
+
+    /// Parse known-good config text, panicking on malformed YAML. A convenience for
+    /// the in-crate tests + fixtures that pass literals known to parse; production
+    /// load goes through [`HostAgentConfig::try_parse`] (via `load`), so this is
+    /// only reached from test builds — so it is `#[cfg(test)]`-gated out of the
+    /// production binary entirely rather than kept as a dead-code-allowed symbol.
+    #[cfg(test)]
     pub fn parse(text: &str) -> HostAgentConfig {
-        let root = yaml_lite::parse(text);
+        Self::try_parse(text).expect("yaml fixture parses")
+    }
+
+    /// Build the config from an already-parsed `Node` tree (the `Node → config`
+    /// half of `try_parse`).
+    fn from_root(root: &yaml_lite::Node) -> HostAgentConfig {
         let policy = |ns_key: &str| -> String {
             root.get_path(&[ns_key, "approval", "policy"])
                 .unwrap_or_default()
@@ -239,8 +266,8 @@ impl HostAgentConfig {
             ),
             server,
             has_discovery: root.has_key("discovery"),
-            aws: AwsConfig::from_node(&root),
-            docker: DockerConfig::from_node(&root),
+            aws: AwsConfig::from_node(root),
+            docker: DockerConfig::from_node(root),
         }
     }
 
@@ -368,29 +395,41 @@ pub struct ResolvedAws {
 impl AwsConfig {
     /// Build the AWS slice from the parsed config tree, applying the same load
     /// defaults Go's `DefaultConfig`/`LoadConfig` do (`config.go:439-443`): an
-    /// empty/absent `source_profile` → `"default"`, `session_duration` → `"1h"`,
-    /// `cache_refresh_before` → `"5m"`. For an ABSENT key (or absent `aws:` block)
-    /// this matches Go exactly (the defaults sit on `DefaultConfig` and the YAML
-    /// merge only overwrites keys the document names). For an EXPLICITLY-EMPTY
-    /// scalar (`source_profile: ""`) Go keeps the empty string — it would call STS
-    /// with profile `""` — while this port re-applies the default; `yaml_lite`
-    /// cannot even represent the distinction (a bare `key:` parses as an empty
-    /// map). Known divergence, same class as the other `yaml_lite` permissiveness
-    /// gaps, closed by the config-port sub-plan (cursor review, 2026-07-11).
+    /// absent `source_profile` → `"default"`, `session_duration` → `"1h"`,
+    /// `cache_refresh_before` → `"5m"`.
+    ///
+    /// Null-vs-empty parity (matches Go's `yaml.Unmarshal`-over-`DefaultConfig`
+    /// merge, verified against `LoadConfig`): an ABSENT key OR a bare `key:` (YAML
+    /// null) leaves the `DefaultConfig` default in place, while an EXPLICIT empty
+    /// string `key: ""` overwrites it with `""` (Go would then call STS with
+    /// profile `""`). The saphyr swap makes this representable — a null value parses
+    /// to [`yaml_lite::Node::Null`] and a quoted empty to `Scalar("")` — so the
+    /// `scalar_or_default` helper branches on the node shape, not on emptiness.
+    /// (Pinned cross-language by the `source_profile` vectors in the `aws_resolve`
+    /// golden.)
     ///
     /// `aws.sheds` (Go's removed global per-shed map) is intentionally NOT read: it
     /// is parse-and-ignore for resolution. Go's `AWSConfig.validate` rejects it with
-    /// a migration message; that rejection is sub-plan 5.
+    /// a migration message; that rejection is sub-plan 5's `validate()` (commit 2).
     fn from_node(root: &yaml_lite::Node) -> AwsConfig {
         use yaml_lite::Node;
         let aws = root.as_map().and_then(|m| m.get("aws")).and_then(Node::as_map);
+        // A non-defaulted scalar: absent / null / non-scalar → "".
         let scalar = |key: &str| -> String {
             aws.and_then(|m| m.get(key))
                 .and_then(Node::as_scalar)
                 .unwrap_or("")
                 .to_string()
         };
-        let default_if_empty = |v: String, d: &str| if v.is_empty() { d.to_string() } else { v };
+        // A defaulted scalar with Go's null-vs-empty semantics: an explicit
+        // `Scalar` (including `""`) is kept verbatim; absent / null / non-scalar
+        // falls back to the DefaultConfig default.
+        let scalar_or_default = |key: &str, d: &str| -> String {
+            match aws.and_then(|m| m.get(key)) {
+                Some(Node::Scalar(s)) => s.clone(),
+                _ => d.to_string(),
+            }
+        };
 
         let mut servers = BTreeMap::new();
         if let Some(servers_map) = aws.and_then(|m| m.get("servers")).and_then(Node::as_map) {
@@ -431,11 +470,11 @@ impl AwsConfig {
         }
 
         AwsConfig {
-            source_profile: default_if_empty(scalar("source_profile"), "default"),
+            source_profile: scalar_or_default("source_profile", "default"),
             default_role: scalar("default_role"),
             mode: scalar("mode"),
-            session_duration: default_if_empty(scalar("session_duration"), "1h"),
-            cache_refresh_before: default_if_empty(scalar("cache_refresh_before"), "5m"),
+            session_duration: scalar_or_default("session_duration", "1h"),
+            cache_refresh_before: scalar_or_default("cache_refresh_before", "5m"),
             servers,
         }
     }
@@ -673,24 +712,36 @@ fn opt_bool(node: Option<&yaml_lite::Node>) -> Option<bool> {
         .map(|s| s == "true")
 }
 
-/// A deliberately tiny indentation-based reader. Handles exactly what the
-/// host-agent config's relevant subset contains: nested maps and scalar leaves.
-/// Inline `{}` is an empty map; comments (`#`) and blank lines are skipped. A port
-/// of shed-core's `yaml_lite` (with a `get_path` map-walk helper added).
+/// The host-agent config parser, exposing a tiny `Node` model (nested maps,
+/// scalars, sequences, and an explicit null) over a real YAML-1.2 parser.
+///
+/// The parser is driven off `saphyr-parser`'s low-level *event* stream (see the
+/// module-level carve-out note at the top of this file): [`parse`] pulls
+/// `StreamStart`/`DocumentStart`/`MappingStart`/`Scalar`/… events and folds them
+/// into `Node`. Only the FIRST document is consumed (mirrors Go's
+/// `yaml.Unmarshal`); duplicate map keys and malformed input return `Err`
+/// (matching yaml.v3). The old hand-rolled line/colon reader is gone — with it the
+/// silent block-sequence drop, the flow-map-as-opaque-scalar gap, and the
+/// can't-detect-malformed gap that `config.rs`/`README` tracked as divergences.
 pub(crate) mod yaml_lite {
+    use saphyr_parser::{Event, Parser, ScalarStyle};
+    use std::borrow::Cow;
     use std::collections::HashMap;
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub enum Node {
         Map(HashMap<String, Node>),
         Scalar(String),
-        /// A flow-style sequence (`[a, b, c]`) of scalar (or, in principle, nested)
-        /// nodes. Added for the Docker `registries` allowlist, which the shipped
-        /// config + `config_test.go` express as a flow list. Only flow-style `[..]`
-        /// is parsed — block-style `- item` lists are NOT supported by this minimal
-        /// reader (the line/colon model has no natural place for them; every fixture
-        /// that needs a list uses the flow form).
+        /// A YAML sequence (array), from either flow style (`[a, b, c]`) or block
+        /// style (`- a`\n`- b`). Both fold to the same node now that a real parser
+        /// backs the reader; the shipped `configs/extensions.example.yaml` uses the
+        /// block form for `docker.registries`.
         Sequence(Vec<Node>),
+        /// An explicit YAML null: a bare `key:`, `key: ~`, or `key: null`. Distinct
+        /// from an empty string `key: ""` (a `Scalar("")`) so the readers can port
+        /// Go's null-vs-empty merge semantics — a null leaves a `DefaultConfig`
+        /// default in place; an empty string overwrites it.
+        Null,
     }
 
     impl Node {
@@ -767,115 +818,117 @@ pub(crate) mod yaml_lite {
         }
     }
 
-    struct Line {
-        indent: usize,
-        key: String,
-        value: Option<Node>, // None → a nested block follows; Some → a leaf (scalar or sequence)
+    /// Parse config text into a [`Node`] tree, consuming ONLY the first YAML
+    /// document (mirrors Go's `yaml.Unmarshal`, which decodes the first document
+    /// and ignores the rest). Returns `Err(message)` on malformed input or a
+    /// duplicate map key — the cases yaml.v3 rejects and the old line/colon reader
+    /// silently swallowed. An empty input (no document) yields an empty map.
+    pub fn parse(text: &str) -> Result<Node, String> {
+        let mut builder = Builder {
+            parser: Parser::new_from_str(text),
+        };
+        loop {
+            match builder.next_event()? {
+                // Skip stream/framing events until the first document's root.
+                Event::StreamStart | Event::Nothing => continue,
+                Event::StreamEnd => return Ok(Node::Map(HashMap::new())),
+                Event::DocumentStart(_) => {
+                    let root_ev = builder.next_event()?;
+                    // A document with no content node (e.g. `---` alone) → null.
+                    return match root_ev {
+                        Event::DocumentEnd | Event::StreamEnd => Ok(Node::Null),
+                        other => builder.build_node(other),
+                    };
+                }
+                other => return Err(format!("unexpected top-level YAML event: {other:?}")),
+            }
+        }
     }
 
-    pub fn parse(text: &str) -> Node {
-        let lines: Vec<Line> = text
-            .split('\n')
-            .filter_map(|raw| {
-                let trimmed = raw.trim();
-                if trimmed.is_empty() || trimmed.starts_with('#') {
-                    return None;
+    /// Drives the saphyr event stream into the `Node` model.
+    struct Builder<'a> {
+        parser: Parser<'a, saphyr_parser::StrInput<'a>>,
+    }
+
+    impl<'a> Builder<'a> {
+        /// Pull the next event, flattening a scan error or a truncated stream into
+        /// an `Err` message. The returned `Event` borrows from the parser INPUT
+        /// (`'a`), not from `&mut self`, so a built child node can be assembled while
+        /// the next event is pulled.
+        fn next_event(&mut self) -> Result<Event<'a>, String> {
+            match self.parser.next_event() {
+                Some(Ok((ev, _span))) => Ok(ev),
+                Some(Err(e)) => Err(e.to_string()),
+                None => Err("unexpected end of YAML event stream".to_string()),
+            }
+        }
+
+        /// Build a node from `first_ev`, recursing into maps/sequences.
+        fn build_node(&mut self, first_ev: Event<'a>) -> Result<Node, String> {
+            match first_ev {
+                Event::Scalar(value, style, _anchor, _tag) => Ok(scalar_node(value, style)),
+                Event::SequenceStart(..) => self.build_sequence(),
+                Event::MappingStart(..) => self.build_mapping(),
+                Event::Alias(_) => {
+                    Err("YAML anchors/aliases are not supported in host-agent config".to_string())
                 }
-                let indent = raw.len() - raw.trim_start_matches(' ').len();
-                let colon = raw.find(':')?;
-                let key = raw[..colon].trim();
-                let mut rest = raw[colon + 1..].trim().to_string();
-                // Strip an inline comment after a scalar value.
-                if let Some(hash) = rest.find('#') {
-                    rest = rest[..hash].trim().to_string();
+                other => Err(format!("unexpected YAML node event: {other:?}")),
+            }
+        }
+
+        /// Fold a sequence's items until `SequenceEnd`.
+        fn build_sequence(&mut self) -> Result<Node, String> {
+            let mut items = Vec::new();
+            loop {
+                match self.next_event()? {
+                    Event::SequenceEnd => return Ok(Node::Sequence(items)),
+                    ev => items.push(self.build_node(ev)?),
                 }
-                let value = if rest.is_empty() || rest == "{}" {
-                    None
-                } else if rest.starts_with('[') && rest.ends_with(']') {
-                    // A flow-style sequence `[a, b, c]` (or empty `[]`).
-                    Some(parse_flow_seq(&rest[1..rest.len() - 1]))
-                } else {
-                    Some(Node::Scalar(unquote(&rest)))
+            }
+        }
+
+        /// Fold a mapping's key/value pairs until `MappingEnd`. A duplicate key is
+        /// an error (yaml.v3 rejects it; a silent last-wins insert would over- or
+        /// under-grant a policy). Non-scalar keys are rejected (documented-open).
+        fn build_mapping(&mut self) -> Result<Node, String> {
+            let mut map = HashMap::new();
+            loop {
+                let key = match self.next_event()? {
+                    Event::MappingEnd => return Ok(Node::Map(map)),
+                    Event::Scalar(value, _style, _anchor, _tag) => value.into_owned(),
+                    other => {
+                        return Err(format!("unsupported non-scalar map key: {other:?}"));
+                    }
                 };
-                Some(Line {
-                    indent,
-                    key: unquote(key),
-                    value,
-                })
-            })
-            .collect();
-        let mut index = 0;
-        build(&lines, &mut index, -1)
-    }
-
-    /// Parse the comma-separated inner content of a flow-style list (the text
-    /// between `[` and `]`) into a `Node::Sequence` of scalars. Items are trimmed
-    /// and unquoted; empty items are dropped by the filter, so an empty (or
-    /// whitespace-only) inner yields an empty sequence — the `[]` deny-all case —
-    /// as does a trailing empty element from a dangling comma (the shipped flow
-    /// lists never carry one).
-    ///
-    /// **Known divergence (CodeRabbit review, tracked for the config-port
-    /// sub-plan):** a MALFORMED flow list (`registries: [only-this` — unterminated
-    /// bracket) fails the `ends_with(']')` detector and degrades to a scalar,
-    /// which the Option-typed readers treat as an ABSENT key → inherit. Go's
-    /// yaml.Unmarshal hard-fails and the daemon refuses to start, so an operator
-    /// typo in a lockdown line is loud there and silently fail-open here. The
-    /// permissive-`yaml_lite`-vs-strict-Go class (incl. this case) is closed by
-    /// the config-port slice's validation parity (malformed YAML → exit 1).
-    /// Quoted items containing commas also split naively (documented flow-list
-    /// scope; registry hostnames cannot contain commas).
-    fn parse_flow_seq(inner: &str) -> Node {
-        let items = inner
-            .split(',')
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(|s| Node::Scalar(unquote(s)))
-            .collect();
-        Node::Sequence(items)
-    }
-
-    fn build(lines: &[Line], index: &mut usize, parent_indent: isize) -> Node {
-        let mut map = HashMap::new();
-        if *index >= lines.len() {
-            return Node::Map(map);
-        }
-        let child_indent = lines[*index].indent as isize;
-        while *index < lines.len() {
-            let indent = lines[*index].indent as isize;
-            if indent <= parent_indent {
-                break;
-            }
-            if indent != child_indent {
-                // A line deeper than expected without a parent (defensive skip).
-                *index += 1;
-                continue;
-            }
-            let key = lines[*index].key.clone();
-            match lines[*index].value.clone() {
-                Some(node) => {
-                    map.insert(key, node);
-                    *index += 1;
-                }
-                None => {
-                    *index += 1;
-                    let child = build(lines, index, child_indent);
-                    map.insert(key, child);
+                let value_ev = self.next_event()?;
+                let value = self.build_node(value_ev)?;
+                if map.insert(key.clone(), value).is_some() {
+                    return Err(format!("duplicate map key {key:?}"));
                 }
             }
         }
-        Node::Map(map)
     }
 
-    fn unquote(s: &str) -> String {
-        if s.len() >= 2
-            && ((s.starts_with('"') && s.ends_with('"'))
-                || (s.starts_with('\'') && s.ends_with('\'')))
-        {
-            s[1..s.len() - 1].to_string()
+    /// Map a scalar event to a node, resolving a plain YAML null (`` / `~` /
+    /// `null`) to [`Node::Null`]. A quoted empty (`""`, style `DoubleQuoted`/
+    /// `SingleQuoted`) stays `Scalar("")` — the null-vs-empty distinction the AWS
+    /// reader depends on. saphyr has already unquoted/unescaped the content.
+    fn scalar_node(value: Cow<'_, str>, style: ScalarStyle) -> Node {
+        if style == ScalarStyle::Plain && is_yaml_null(&value) {
+            Node::Null
         } else {
-            s.to_string()
+            // Move the String out of an owned Cow (escaped/quoted scalars) for
+            // free; allocate only for a borrowed one — mirrors the map-key path's
+            // `value.into_owned()` rather than an unconditional `to_string()`.
+            Node::Scalar(value.into_owned())
         }
+    }
+
+    /// The YAML-1.2 core-schema null tokens (only meaningful for a PLAIN scalar).
+    /// An empty plain node surfaces as `~` from saphyr, but `""` is included
+    /// defensively.
+    fn is_yaml_null(s: &str) -> bool {
+        matches!(s, "" | "~" | "null" | "Null" | "NULL")
     }
 }
 
@@ -1483,7 +1536,8 @@ f: scalar
 g:
   nested: [deep]
 ",
-        );
+        )
+        .expect("valid flow-list config parses");
         let m = root.as_map().unwrap();
         // Multi-item flow list.
         assert_eq!(
@@ -1517,6 +1571,169 @@ g:
         assert_eq!(m["a"].as_seq().unwrap().len(), 3);
         // An ABSENT key is None — the inherit signal (distinct from present `[]`).
         assert!(m.get("absent").is_none());
+    }
+
+    // ---- yaml_lite: the saphyr-backed parser (block seqs, flow maps, null-vs-empty,
+    //      malformed/duplicate-key detection, first-document-only) -------------------
+
+    /// Block-style sequences now parse — the load-bearing new deliverable. The
+    /// shipped `configs/extensions.example.yaml` writes `docker.registries` as a
+    /// `- item` block list; the old line/colon reader dropped the colonless items so
+    /// `docker.registries` parsed EMPTY. Cross-language pinned by the block-seq
+    /// vector in the `docker_resolve` golden.
+    #[test]
+    fn yaml_lite_block_sequence() {
+        let cfg = HostAgentConfig::parse(
+            "\
+docker:
+  registries:
+    - index.docker.io
+    - ghcr.io
+  approval:
+    policy: approve-all
+",
+        );
+        assert_eq!(
+            cfg.docker.registries,
+            vec!["index.docker.io".to_string(), "ghcr.io".to_string()]
+        );
+    }
+
+    /// The shipped example config's block-style `registries:` parses to the two
+    /// hostnames Go's `TestExampleConfigIsValid` asserts — the real uncaught
+    /// divergence on the product's own default config. (Full validate parity of the
+    /// example config is commit 2; this pins only the parse-level block-seq win.)
+    #[test]
+    fn example_config_registries_parse() {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../configs/extensions.example.yaml");
+        let text = std::fs::read_to_string(&path).expect("read example config");
+        let cfg = HostAgentConfig::try_parse(&text).expect("example config parses");
+        assert_eq!(
+            cfg.docker.registries,
+            vec!["index.docker.io".to_string(), "ghcr.io".to_string()]
+        );
+        assert_eq!(cfg.effective_policy(NS_DOCKER_CREDENTIALS), "approve-all");
+    }
+
+    /// A flow-style map (`ssh: { approval: { policy: X } }`) parses to the SAME
+    /// nested `Node::Map` structure as the block form — the old reader treated the
+    /// whole `{ ... }` as an opaque scalar (→ all deny-all).
+    #[test]
+    fn yaml_lite_inline_flow_map() {
+        let flow = HostAgentConfig::parse("ssh: { approval: { policy: shed-desktop } }\n");
+        let block = HostAgentConfig::parse("ssh:\n  approval:\n    policy: shed-desktop\n");
+        assert_eq!(flow.effective_policy(NS_SSH_AGENT), "shed-desktop");
+        assert_eq!(
+            flow.effective_policy(NS_SSH_AGENT),
+            block.effective_policy(NS_SSH_AGENT)
+        );
+    }
+
+    /// Flow sequences: empty `[]` is a present-but-empty `Sequence(vec![])` (NOT
+    /// absent) so the Docker `Option<Vec>` replace semantics see a deny-all
+    /// lockdown; a non-empty list carries its items.
+    #[test]
+    fn yaml_lite_flow_sequence_empty_and_nonempty() {
+        use yaml_lite::Node;
+        let root = yaml_lite::parse("a: []\nb: [x, y]\n").expect("parses");
+        let m = root.as_map().unwrap();
+        assert!(matches!(&m["a"], Node::Sequence(v) if v.is_empty()));
+        assert_eq!(m["a"].as_scalar_list().unwrap(), Vec::<String>::new());
+        assert_eq!(
+            m["b"].as_scalar_list().unwrap(),
+            vec!["x".to_string(), "y".to_string()]
+        );
+    }
+
+    /// Null-vs-empty scalar recovery (the M1 adapter contract + C1): a bare `key:`
+    /// (YAML null) is `Node::Null`; a quoted empty `key: ""` is `Scalar("")`. A
+    /// null-valued key is STILL inserted into the map (so `has_key` stays true for a
+    /// bare `discovery:`). The Go-golden `source_profile` cross-language vector
+    /// (`aws_resolve` golden) pins the resolved-config half.
+    #[test]
+    fn yaml_lite_null_vs_empty_scalar() {
+        use yaml_lite::Node;
+        let root = yaml_lite::parse(
+            "\
+bare:
+tilde: ~
+word: null
+empty: \"\"
+value: hi
+discovery:
+",
+        )
+        .expect("parses");
+        let m = root.as_map().unwrap();
+        assert_eq!(m["bare"], Node::Null);
+        assert_eq!(m["tilde"], Node::Null);
+        assert_eq!(m["word"], Node::Null);
+        assert_eq!(m["empty"], Node::Scalar(String::new()));
+        assert_eq!(m["value"], Node::Scalar("hi".to_string()));
+        // A null-valued key is inserted — presence detection still works.
+        assert!(root.has_key("discovery"));
+        assert!(root.has_key("bare"));
+        // as_scalar on Null is None → get_path yields None → the reader defaults.
+        assert_eq!(m["bare"].as_scalar(), None);
+
+        // The resolved-config half: bare `source_profile:` (null) keeps the
+        // DefaultConfig default; explicit `source_profile: ""` keeps the empty
+        // string. (Verified against Go's LoadConfig; goldened cross-language.)
+        let null_sp = HostAgentConfig::parse("aws:\n  source_profile:\n");
+        assert_eq!(null_sp.aws.source_profile, "default");
+        let empty_sp = HostAgentConfig::parse("aws:\n  source_profile: \"\"\n");
+        assert_eq!(empty_sp.aws.source_profile, "");
+    }
+
+    /// A duplicate map key is an error (yaml.v3 rejects it; a silent last-wins
+    /// insert would over/under-grant). Cross-language pinned `{valid:false}` in
+    /// commit 2's validate golden.
+    #[test]
+    fn yaml_lite_duplicate_key_errors() {
+        let err = yaml_lite::parse("server: http://a:8080\nserver: http://b:8080\n")
+            .expect_err("duplicate key rejected");
+        assert!(err.contains("duplicate map key"), "err = {err}");
+        // Nested duplicate keys are caught too.
+        assert!(
+            yaml_lite::parse("aws:\n  mode: passthrough\n  mode: assume-role\n").is_err(),
+            "nested duplicate key should error"
+        );
+    }
+
+    /// Malformed input returns `Err` (the saphyr win the line/colon reader could
+    /// not detect): top-level garbage and an unterminated flow bracket both fail,
+    /// so `load` exits 1 like Go's `yaml.Unmarshal`.
+    #[test]
+    fn yaml_lite_parse_errors_on_malformed() {
+        assert!(yaml_lite::parse("{{invalid yaml").is_err());
+        assert!(yaml_lite::parse("docker:\n  registries: [only-this\n").is_err());
+        assert!(yaml_lite::parse("a: b\n\tc: d\n").is_err()); // tab indentation
+        // And `load` surfaces it as an error (main.rs exits 1).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.yaml");
+        std::fs::write(&path, "{{invalid yaml").unwrap();
+        assert!(HostAgentConfig::load(path.to_str().unwrap()).is_err());
+    }
+
+    /// Only the FIRST document is consumed (mirrors Go's `yaml.Unmarshal`): a
+    /// multi-document stream resolves the first document's values and ignores the
+    /// rest.
+    #[test]
+    fn yaml_lite_multi_doc_takes_first() {
+        let cfg = HostAgentConfig::parse("server: http://a:8080\n---\nserver: http://b:8080\n");
+        assert_eq!(cfg.server, "http://a:8080");
+    }
+
+    /// Empty / comment-only input yields an empty map (all defaults), unchanged from
+    /// the old reader.
+    #[test]
+    fn yaml_lite_empty_and_comment_only() {
+        assert_eq!(yaml_lite::parse("").unwrap(), yaml_lite::Node::Map(Default::default()));
+        assert_eq!(
+            yaml_lite::parse("# just a comment\n").unwrap(),
+            yaml_lite::Node::Map(Default::default())
+        );
     }
 
     // ---- Docker config slice (mirror config_discovery_test.go / config_test.go) ---

--- a/crates/shed-host-agent/src/config.rs
+++ b/crates/shed-host-agent/src/config.rs
@@ -1,8 +1,11 @@
 //! Minimal host-agent config reader for slice 0 — deliberately scoped to exactly
 //! what the LiveStatus self-report needs: the three approval policies
-//! (`ssh/aws/docker .approval.policy`) plus `logging.{enabled,path}`. The full
-//! config schema (discovery, per-server overrides, AWS/Docker resolution,
-//! biometric scope/ttl, `Validate()`) is a later slice.
+//! (`ssh/aws/docker .approval.policy`) plus `logging.{enabled,path}`. `load` now
+//! also runs [`HostAgentConfig::validate`] — a faithful port of Go's
+//! `Config.Validate` (the three policy allow-sets, `aws.sheds`/`aws.mode`, and
+//! `approval_timeout`), so the Rust daemon rejects (exit 1) exactly the configs the
+//! Go daemon rejects. The remaining schema (discovery-block contents, per-server
+//! biometric scope/ttl) stays structurally out of this headless reader.
 //!
 //! Parsing: the `yaml_lite` mod exposes the same tiny `Node` model shed-core's
 //! reader uses, but its parser is backed by `saphyr-parser` (a pure-Rust,
@@ -45,6 +48,13 @@ pub const POLICY_DENY_ALL: &str = "deny-all";
 pub const POLICY_APPROVE_ALL: &str = "approve-all";
 /// Approval-policy value that delegates the decision to the shed-desktop app.
 pub const POLICY_SHED_DESKTOP: &str = "shed-desktop";
+/// Native Touch ID biometric policy (SSH only — `validate` rejects it for
+/// aws/docker). Matches Go's `PolicyBiometrics`. Referenced only by `validate`'s
+/// ssh allow-set.
+pub const POLICY_BIOMETRICS: &str = "biometrics";
+/// Native Touch ID + Apple Watch / password fallback (SSH only). Matches Go's
+/// `PolicyBiometricsOrPassword`.
+pub const POLICY_BIOMETRICS_OR_PASSWORD: &str = "biometrics-or-password";
 
 /// The single-server bus URL default — matches Go's `Config.Server` default
 /// (`config.go:428`). Used only in single-server mode (no `discovery:` block).
@@ -152,6 +162,144 @@ pub(crate) fn parse_go_duration_nanos(s: &str) -> Option<i128> {
     Some(if neg { -total } else { total })
 }
 
+/// Validate one extension's `approval.policy` against its allow-set, mirroring Go's
+/// `validatePolicy` (`config.go:544-554`). An empty policy is valid (means deny-all).
+/// A non-empty value not in `allowed` → the exact Go error
+/// `%s.approval.policy %q is not one of %s` (allow-set joined by `", "`, in the
+/// order Go passes it). The `%q` render is reproduced with literal double quotes so
+/// the bytes match for the ASCII policy tokens in play (never `{:?}`, which could
+/// diverge from Go's `%q` escaping on non-ASCII).
+fn validate_policy(provider: &str, policy: &str, allowed: &[&str]) -> Result<(), String> {
+    if policy.is_empty() || allowed.contains(&policy) {
+        return Ok(());
+    }
+    Err(format!(
+        "{provider}.approval.policy \"{policy}\" is not one of {}",
+        allowed.join(", ")
+    ))
+}
+
+/// Validate an AWS `mode` field, mirroring Go's `validateMode` (`config.go:580-588`).
+/// An empty value (means assume-role) or a known mode is valid; anything else → the
+/// exact Go error `%s %q is not one of %s, %s` (`assume-role, passthrough`). `field`
+/// is the located field name (`aws.mode`, `aws.servers.<s>.mode`,
+/// `aws.servers.<s>.sheds.<sh>.mode`).
+fn validate_mode(field: &str, mode: &str) -> Result<(), String> {
+    match mode {
+        "" | AWS_MODE_ASSUME_ROLE | AWS_MODE_PASSTHROUGH => Ok(()),
+        _ => Err(format!(
+            "{field} \"{mode}\" is not one of {AWS_MODE_ASSUME_ROLE}, {AWS_MODE_PASSTHROUGH}"
+        )),
+    }
+}
+
+/// Validate `approval_timeout` off its RAW string, mirroring Go's
+/// `ApprovalTimeoutDuration` (`config.go:511-524`) as invoked by `Validate`: an
+/// EMPTY raw defaults to `"25s"` (valid); a non-empty raw is parsed with the strict
+/// Go-`time.ParseDuration` semantics — a parse failure → `approval_timeout %q is not
+/// a valid duration: <inner>` (the `%q` shows the RAW, so it is `""` for the empty
+/// case, matching Go), and a non-positive value → `approval_timeout %q must be
+/// positive`. Both `%q` renders use the RAW (not the defaulted `"25s"`), matching
+/// Go's `c.ApprovalTimeout` in the format args.
+fn validate_approval_timeout(raw: &str) -> Result<(), String> {
+    let to_parse = if raw.is_empty() { "25s" } else { raw };
+    match parse_go_duration_strict(to_parse) {
+        Err(inner) => Err(format!(
+            "approval_timeout \"{raw}\" is not a valid duration: {inner}"
+        )),
+        Ok(nanos) if nanos <= 0 => Err(format!("approval_timeout \"{raw}\" must be positive")),
+        Ok(_) => Ok(()),
+    }
+}
+
+/// A STRICT Go-`time.ParseDuration` port for the validate path: unlike the fail-safe
+/// [`parse_go_duration_nanos`] (which the accessor keeps), this does NOT trim
+/// whitespace (Go rejects `" 5s "`), uses integer/checked arithmetic (no `f64`
+/// precision loss), and returns `Err` on overflow beyond `i64` nanoseconds (Go's
+/// duration is an `int64`). Result is signed nanoseconds so the caller can test
+/// positivity. The `Err` payload is Rust-internal (the golden pins only
+/// `is not a valid duration`, never the inner text — yaml/`fmt`-lib specific, per the
+/// docker suffix precedent).
+fn parse_go_duration_strict(s: &str) -> Result<i128, String> {
+    if s.is_empty() {
+        return Err("empty duration".to_string());
+    }
+    let (neg, rest0) = match s.strip_prefix('-') {
+        Some(r) => (true, r),
+        None => (false, s.strip_prefix('+').unwrap_or(s)),
+    };
+    // Go accepts a bare "0" (and "+0"/"-0") with no unit.
+    if rest0 == "0" {
+        return Ok(0);
+    }
+    if rest0.is_empty() {
+        return Err("no digits in duration".to_string());
+    }
+    let mut rest = rest0;
+    let mut total: i128 = 0;
+    while !rest.is_empty() {
+        // Each fragment is a number (integer part + optional `.frac`) then a unit.
+        // A leading char that is neither a digit nor '.' is malformed (this also
+        // rejects embedded whitespace, since we never trimmed).
+        if !rest.starts_with(|c: char| c.is_ascii_digit() || c == '.') {
+            return Err("expected digit or '.' in duration".to_string());
+        }
+        let int_len = rest
+            .find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(rest.len());
+        let int_str = &rest[..int_len];
+        rest = &rest[int_len..];
+        let mut frac_str = "";
+        if let Some(after_dot) = rest.strip_prefix('.') {
+            let frac_len = after_dot
+                .find(|c: char| !c.is_ascii_digit())
+                .unwrap_or(after_dot.len());
+            frac_str = &after_dot[..frac_len];
+            rest = &after_dot[frac_len..];
+        }
+        if int_str.is_empty() && frac_str.is_empty() {
+            return Err("number without digits in duration".to_string());
+        }
+        // Unit: the run of chars up to the next number/'.'.
+        let unit_len = rest
+            .find(|c: char| c.is_ascii_digit() || c == '.')
+            .unwrap_or(rest.len());
+        let unit_nanos: i128 = match &rest[..unit_len] {
+            "" => return Err("missing unit in duration".to_string()),
+            "ns" => 1,
+            "us" | "µs" | "μs" => 1_000,
+            "ms" => 1_000_000,
+            "s" => 1_000_000_000,
+            "m" => 60_000_000_000,
+            "h" => 3_600_000_000_000,
+            other => return Err(format!("unknown unit {other:?} in duration")),
+        };
+        rest = &rest[unit_len..];
+        // Integer contribution (checked, no f64).
+        let int_val: i128 = int_str
+            .parse()
+            .map_err(|_| "integer overflow in duration".to_string())?;
+        let mut frag = int_val.checked_mul(unit_nanos).ok_or("duration overflow")?;
+        // Fractional contribution: keep up to 18 digits (ns precision; guards the
+        // scale `pow` from overflowing) and scale down with integer division.
+        if !frac_str.is_empty() {
+            let flen = frac_str.len().min(18);
+            let frac_val: i128 = frac_str[..flen]
+                .parse()
+                .map_err(|_| "fraction overflow in duration".to_string())?;
+            let scale = 10i128.pow(flen as u32);
+            let frac_nanos = frac_val.checked_mul(unit_nanos).ok_or("duration overflow")? / scale;
+            frag = frag.checked_add(frac_nanos).ok_or("duration overflow")?;
+        }
+        total = total.checked_add(frag).ok_or("duration overflow")?;
+        // Bound to i64 nanoseconds like Go's int64 duration.
+        if total > i64::MAX as i128 {
+            return Err("duration overflow".to_string());
+        }
+    }
+    Ok(if neg { -total } else { total })
+}
+
 /// The slice-0/1 view of the host-agent config: the fields LiveStatus needs plus
 /// `approval_timeout` (the delegated-approval budget the desktop server enforces).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -168,6 +316,14 @@ pub struct HostAgentConfig {
     // Read only by `approval_timeout()`, which only the desktop server calls.
     #[cfg_attr(not(feature = "desktop-forwarding"), allow(dead_code))]
     approval_timeout: Duration,
+    /// The RAW `approval_timeout` string exactly as written in the config (`""`
+    /// when the key is absent/null). Retained so [`HostAgentConfig::validate`] can
+    /// re-check it the way Go's `Validate` re-parses `Config.ApprovalTimeout`: an
+    /// EMPTY raw is valid (→ 25s default); a non-empty raw that fails to parse or is
+    /// non-positive is rejected. The parsed `approval_timeout` above still fail-safes
+    /// the VALUE to 25s (the accessor never rejects), mirroring Go's second,
+    /// error-ignoring `ApprovalTimeoutDuration()` call in `main.go`.
+    approval_timeout_raw: String,
     /// The single-server bus URL (`server:`), defaulting to `DEFAULT_SERVER_URL`.
     /// The message-bus daemon connects here in single-server mode. In Go this is
     /// `Config.Server`, used only when `Discovery` is nil.
@@ -201,9 +357,43 @@ impl HostAgentConfig {
     pub fn load(path: &str) -> io::Result<HostAgentConfig> {
         let expanded = expand_tilde(path);
         let text = std::fs::read_to_string(&expanded)?;
-        // Malformed YAML is a hard error (mirrors Go's `yaml.Unmarshal` →
-        // `os.Exit(1)`); the daemon must not fail open with a half-read policy.
-        Self::try_parse(&text).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+        // load = parse → validate (mirrors Go's `LoadConfig`: `yaml.Unmarshal` then
+        // `Validate()`). Malformed YAML is a hard error (Go's `parsing config` path);
+        // a validate failure is a hard error too (Go's `invalid config` path). Either
+        // one → `Err` → `main.rs` exits 1; the daemon must not fail open with a
+        // half-read or invalid policy.
+        let cfg =
+            Self::try_parse(&text).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        cfg.validate()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(cfg)
+    }
+
+    /// Validate the loaded config, in Go's EXACT `Config.Validate` check order
+    /// (`config.go:487-505`): the three approval-policy allow-sets
+    /// (ssh → aws → docker), then `AWS.validate` (`aws.sheds` → `aws.mode` →
+    /// per-server → per-shed), then `approval_timeout`. Returns the FIRST failure's
+    /// message (Go returns the first error), with the same field prefixes and
+    /// message shapes so the language-neutral golden can pin per-vector substrings.
+    /// An empty policy is valid (→ deny-all); SSH alone accepts the native biometric
+    /// policies (aws/docker reject them). Called from [`HostAgentConfig::load`].
+    pub fn validate(&self) -> Result<(), String> {
+        // Go's `sshAllowed` / `credAllowed` (`config.go:488-489`), same order — the
+        // order is byte-visible in the `is not one of %s` join.
+        const SSH_ALLOWED: &[&str] = &[
+            POLICY_DENY_ALL,
+            POLICY_APPROVE_ALL,
+            POLICY_BIOMETRICS,
+            POLICY_BIOMETRICS_OR_PASSWORD,
+            POLICY_SHED_DESKTOP,
+        ];
+        const CRED_ALLOWED: &[&str] = &[POLICY_DENY_ALL, POLICY_APPROVE_ALL, POLICY_SHED_DESKTOP];
+        validate_policy("ssh", &self.ssh_policy, SSH_ALLOWED)?;
+        validate_policy("aws", &self.aws_policy, CRED_ALLOWED)?;
+        validate_policy("docker", &self.docker_policy, CRED_ALLOWED)?;
+        self.aws.validate()?;
+        validate_approval_timeout(&self.approval_timeout_raw)?;
+        Ok(())
     }
 
     /// Parse config text, returning an error on malformed YAML. Missing keys take
@@ -233,6 +423,12 @@ impl HostAgentConfig {
                 .unwrap_or_default()
                 .to_string()
         };
+        // The RAW `approval_timeout` string, read once and shared between the
+        // fail-safe parsed Duration (the accessor) and the string `validate` re-checks.
+        let approval_timeout_raw = root
+            .get_path(&["approval_timeout"])
+            .unwrap_or_default()
+            .to_string();
         let logging_enabled = match root.get_path(&["logging", "enabled"]) {
             Some(v) => v != "false",
             None => true,
@@ -261,11 +457,19 @@ impl HostAgentConfig {
                 .to_string(),
             logging_enabled,
             logging_path,
-            approval_timeout: parse_approval_timeout(
-                root.get_path(&["approval_timeout"]).unwrap_or_default(),
-            ),
+            approval_timeout: parse_approval_timeout(&approval_timeout_raw),
+            approval_timeout_raw,
             server,
-            has_discovery: root.has_key("discovery"),
+            // A `discovery:` key PRESENT and NON-NULL flips to multi-server mode.
+            // A bare `discovery:` (YAML null) must read as ABSENT: Go unmarshals a
+            // null into `*DiscoveryConfig` as nil, and every discovery path gates on
+            // `cfg.Discovery != nil` (`main.go:142/207/235`), so a null `discovery:`
+            // stays SINGLE-server. `discovery: {}` (empty map) is non-null → multi
+            // (Go gives a non-nil empty struct). (CodeRabbit review finding.)
+            has_discovery: !matches!(
+                root.as_map().and_then(|m| m.get("discovery")),
+                None | Some(yaml_lite::Node::Null)
+            ),
             aws: AwsConfig::from_node(root),
             docker: DockerConfig::from_node(root),
         }
@@ -282,9 +486,11 @@ impl HostAgentConfig {
     /// The delegated-approval budget the desktop server enforces per request, and
     /// which drives the `hello_ack.request_timeout_ms` it advertises. Mirrors Go's
     /// `ApprovalTimeoutDuration` + `NewDesktopServer`'s guard: an absent, invalid,
-    /// or non-positive `approval_timeout` falls back to 25s. (The full config's
-    /// `Validate()` hard-rejects an invalid value at startup; this minimal reader
-    /// does no validation, so it fails safe to the default instead — a later slice.)
+    /// or non-positive `approval_timeout` falls back to 25s. [`HostAgentConfig::load`]
+    /// now hard-rejects an invalid/non-positive value at startup (via `validate`), so
+    /// production never reaches this accessor with a bad value; the fail-safe remains
+    /// for the in-crate `parse` convenience (which skips validation), mirroring Go's
+    /// second, error-ignoring `ApprovalTimeoutDuration()` call in `main.go`.
     #[cfg_attr(not(feature = "desktop-forwarding"), allow(dead_code))]
     pub fn approval_timeout(&self) -> Duration {
         self.approval_timeout
@@ -356,6 +562,12 @@ pub struct AwsConfig {
     pub mode: String,
     pub session_duration: String,
     pub cache_refresh_before: String,
+    /// The REMOVED global per-shed override map (Go's `AWSConfig.Sheds`). Parsed
+    /// ONLY so [`HostAgentConfig::validate`] can reject a populated one with the
+    /// migration message (`config.go:561`, the `len > 0` reject); it does NOT affect
+    /// resolution. Bare `sheds:` / `sheds: {}` / `sheds: null` parse to an EMPTY map
+    /// (len 0 = valid); only a populated map rejects.
+    pub sheds: BTreeMap<String, AwsShedConfig>,
     pub servers: BTreeMap<String, AwsServerConfig>,
 }
 
@@ -389,6 +601,30 @@ pub struct ResolvedAws {
     pub session_duration: String,
 }
 
+/// Read a `sheds:` submap into `AwsShedConfig` entries (the per-shed `role`/`mode`/
+/// `session_duration` scalars). Shared by both the per-server `servers.<s>.sheds`
+/// walk (used for resolution) and the removed global `aws.sheds` walk (used only for
+/// the validate reject). A non-map entry is skipped, matching the lenient reader.
+fn read_aws_sheds(
+    map: &std::collections::HashMap<String, yaml_lite::Node>,
+) -> BTreeMap<String, AwsShedConfig> {
+    use yaml_lite::Node;
+    let mut out = BTreeMap::new();
+    for (name, entry) in map {
+        let Some(sf) = entry.as_map() else { continue };
+        let g = |k: &str| sf.get(k).and_then(Node::as_scalar).unwrap_or("").to_string();
+        out.insert(
+            name.clone(),
+            AwsShedConfig {
+                role: g("role"),
+                mode: g("mode"),
+                session_duration: g("session_duration"),
+            },
+        );
+    }
+    out
+}
+
 // `from_node` is live (called by `HostAgentConfig::parse`); `resolve`/`enabled` are
 // reached through the AWS backend + `main.rs`, wired into the bus (`new_sts_backend`
 // calls `enabled`; the backend's get_credentials/status call `resolve`).
@@ -408,9 +644,9 @@ impl AwsConfig {
     /// (Pinned cross-language by the `source_profile` vectors in the `aws_resolve`
     /// golden.)
     ///
-    /// `aws.sheds` (Go's removed global per-shed map) is intentionally NOT read: it
-    /// is parse-and-ignore for resolution. Go's `AWSConfig.validate` rejects it with
-    /// a migration message; that rejection is sub-plan 5's `validate()` (commit 2).
+    /// `aws.sheds` (Go's removed global per-shed map) IS parsed now — but only so
+    /// [`HostAgentConfig::validate`] can reject a populated one (the `len > 0`
+    /// migration reject, `config.go:561`). It stays parse-and-ignore for resolution.
     fn from_node(root: &yaml_lite::Node) -> AwsConfig {
         use yaml_lite::Node;
         let aws = root.as_map().and_then(|m| m.get("aws")).and_then(Node::as_map);
@@ -442,21 +678,11 @@ impl AwsConfig {
                         .unwrap_or("")
                         .to_string()
                 };
-                let mut sheds = BTreeMap::new();
-                if let Some(sheds_map) = fields.get("sheds").and_then(Node::as_map) {
-                    for (sname, sentry) in sheds_map {
-                        let Some(sf) = sentry.as_map() else { continue };
-                        let g = |k: &str| sf.get(k).and_then(Node::as_scalar).unwrap_or("").to_string();
-                        sheds.insert(
-                            sname.clone(),
-                            AwsShedConfig {
-                                role: g("role"),
-                                mode: g("mode"),
-                                session_duration: g("session_duration"),
-                            },
-                        );
-                    }
-                }
+                let sheds = fields
+                    .get("sheds")
+                    .and_then(Node::as_map)
+                    .map(read_aws_sheds)
+                    .unwrap_or_default();
                 servers.insert(
                     name.clone(),
                     AwsServerConfig {
@@ -475,8 +701,35 @@ impl AwsConfig {
             mode: scalar("mode"),
             session_duration: scalar_or_default("session_duration", "1h"),
             cache_refresh_before: scalar_or_default("cache_refresh_before", "5m"),
+            // The removed global `aws.sheds` map: parsed for the validate reject
+            // (`!is_empty()`), never used for resolution. Bare/`{}`/`null` → empty.
+            sheds: aws
+                .and_then(|m| m.get("sheds"))
+                .and_then(Node::as_map)
+                .map(read_aws_sheds)
+                .unwrap_or_default(),
             servers,
         }
+    }
+
+    /// Validate the AWS slice, mirroring Go's `AWSConfig.validate` (`config.go:560-578`)
+    /// in the same order: the removed `aws.sheds` map (`len > 0` → migration reject),
+    /// then `aws.mode`, then each server's mode, then each per-shed mode.
+    fn validate(&self) -> Result<(), String> {
+        if !self.sheds.is_empty() {
+            return Err(
+                "aws.sheds was removed; move entries under aws.servers.<server>.sheds.<shed>"
+                    .to_string(),
+            );
+        }
+        validate_mode("aws.mode", &self.mode)?;
+        for (name, sv) in &self.servers {
+            validate_mode(&format!("aws.servers.{name}.mode"), &sv.mode)?;
+            for (shed, sc) in &sv.sheds {
+                validate_mode(&format!("aws.servers.{name}.sheds.{shed}.mode"), &sc.mode)?;
+            }
+        }
+        Ok(())
     }
 
     /// Layer AWS overrides for a `(server, shed)` pair, most specific wins:
@@ -793,9 +1046,11 @@ pub(crate) mod yaml_lite {
             }
         }
 
-        /// Whether this node is a map containing `key` (as a scalar or a nested
-        /// block). Used to detect the presence of a top-level block like
-        /// `discovery:` whose contents this minimal reader doesn't yet parse.
+        /// Whether this node is a map containing `key` (present at any value,
+        /// including a null value). Production now distinguishes present-and-null
+        /// from present-and-non-null directly (`has_discovery`), so this stays as a
+        /// test-only presence accessor.
+        #[cfg(test)]
         pub fn has_key(&self, key: &str) -> bool {
             match self {
                 Node::Map(m) => m.contains_key(key),
@@ -1031,6 +1286,13 @@ discovery:
         assert!(!cfg.is_single_server());
         assert!(cfg.has_discovery);
         assert_eq!(cfg.server, DEFAULT_SERVER_URL);
+
+        // A bare `discovery:` (YAML null) reads as ABSENT → SINGLE-server, matching
+        // Go's nil `*DiscoveryConfig` (CodeRabbit review). An empty MAP `discovery: {}`
+        // is non-null → multi-server (Go non-nil empty struct).
+        assert!(HostAgentConfig::parse("discovery:\n").is_single_server());
+        assert!(!HostAgentConfig::parse("discovery: {}\n").is_single_server());
+        assert!(!HostAgentConfig::parse("discovery:\n  watch: off\n").is_single_server());
     }
 
     #[test]
@@ -1599,23 +1861,6 @@ docker:
         );
     }
 
-    /// The shipped example config's block-style `registries:` parses to the two
-    /// hostnames Go's `TestExampleConfigIsValid` asserts — the real uncaught
-    /// divergence on the product's own default config. (Full validate parity of the
-    /// example config is commit 2; this pins only the parse-level block-seq win.)
-    #[test]
-    fn example_config_registries_parse() {
-        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("../../configs/extensions.example.yaml");
-        let text = std::fs::read_to_string(&path).expect("read example config");
-        let cfg = HostAgentConfig::try_parse(&text).expect("example config parses");
-        assert_eq!(
-            cfg.docker.registries,
-            vec!["index.docker.io".to_string(), "ghcr.io".to_string()]
-        );
-        assert_eq!(cfg.effective_policy(NS_DOCKER_CREDENTIALS), "approve-all");
-    }
-
     /// A flow-style map (`ssh: { approval: { policy: X } }`) parses to the SAME
     /// nested `Node::Map` structure as the block form — the old reader treated the
     /// whole `{ ... }` as an opaque scalar (→ all deny-all).
@@ -1951,6 +2196,311 @@ docker:
                     q["registry_count"].as_u64().unwrap(),
                     "registry_count {name:?}"
                 );
+            }
+        }
+    }
+
+    // ---- validate() parity (mirror config_test.go's Validate tests) --------------
+
+    /// Parse `yaml` then `validate()` — the `load = parse → validate` chain without a
+    /// temp file. Returns the validate error (parse is known-good for these literals).
+    fn validate_yaml(yaml: &str) -> Result<(), String> {
+        HostAgentConfig::parse(yaml).validate()
+    }
+
+    /// Mirrors `config_test.go:TestLoadConfigRejectsBadPolicy`. An unknown ssh policy
+    /// is rejected with the EXACT Go message (allow-set joined in Go's order). (P: C2)
+    /// the substring the golden pins is `ssh.approval.policy`, NOT bare `is not one
+    /// of` (which also matches `aws.mode`).
+    #[test]
+    fn validate_rejects_unknown_ssh_policy() {
+        let err = validate_yaml("ssh:\n  approval:\n    policy: maybe\n")
+            .expect_err("unknown ssh policy rejected");
+        assert_eq!(
+            err,
+            "ssh.approval.policy \"maybe\" is not one of \
+             deny-all, approve-all, biometrics, biometrics-or-password, shed-desktop"
+        );
+    }
+
+    /// aws + docker unknown policies are rejected with the cred allow-set (no
+    /// biometrics). The prefixes prove the aws/docker path fired, not ssh.
+    #[test]
+    fn validate_rejects_unknown_aws_and_docker_policy() {
+        let aws = validate_yaml("aws:\n  approval:\n    policy: maybe\n")
+            .expect_err("unknown aws policy rejected");
+        assert_eq!(
+            aws,
+            "aws.approval.policy \"maybe\" is not one of deny-all, approve-all, shed-desktop"
+        );
+        let docker = validate_yaml("docker:\n  approval:\n    policy: maybe\n")
+            .expect_err("unknown docker policy rejected");
+        assert_eq!(
+            docker,
+            "docker.approval.policy \"maybe\" is not one of deny-all, approve-all, shed-desktop"
+        );
+    }
+
+    /// Mirrors `config_test.go:TestValidateRejectsBiometricForAWS` — the native
+    /// biometric policies are SSH-only; the cred allow-set excludes them for
+    /// aws/docker. The same policy is ACCEPTED for ssh.
+    #[test]
+    fn validate_rejects_biometrics_for_aws_and_docker() {
+        assert!(validate_yaml("aws:\n  approval:\n    policy: biometrics\n").is_err());
+        assert!(
+            validate_yaml("docker:\n  approval:\n    policy: biometrics-or-password\n").is_err()
+        );
+        // ...but ssh accepts both native biometric policies.
+        assert!(validate_yaml("ssh:\n  approval:\n    policy: biometrics\n").is_ok());
+        assert!(validate_yaml("ssh:\n  approval:\n    policy: biometrics-or-password\n").is_ok());
+    }
+
+    /// Mirrors `config_test.go:TestValidateAcceptsValidPolicies` — ssh
+    /// biometrics-or-password + aws shed-desktop + docker approve-all all validate.
+    #[test]
+    fn validate_accepts_valid_policies() {
+        assert!(validate_yaml(
+            "ssh:\n  approval:\n    policy: biometrics-or-password\n\
+             aws:\n  approval:\n    policy: shed-desktop\n\
+             docker:\n  approval:\n    policy: approve-all\n"
+        )
+        .is_ok());
+    }
+
+    /// Mirrors `config_test.go:TestValidateAWS` (removed-sheds subtest). A POPULATED
+    /// `aws.sheds` map is rejected with the migration message (P: H2 — the reject is
+    /// `len > 0`, `config.go:561`, built as a map then `!is_empty()`).
+    #[test]
+    fn validate_rejects_aws_sheds_removed() {
+        let err = validate_yaml("aws:\n  sheds:\n    web:\n      role: arn:aws:iam::123:role/web\n")
+            .expect_err("populated aws.sheds rejected");
+        assert_eq!(
+            err,
+            "aws.sheds was removed; move entries under aws.servers.<server>.sheds.<shed>"
+        );
+    }
+
+    /// (P: H2 — the four-case pin.) Bare `sheds:` (null), `sheds: {}` (empty map), and
+    /// `sheds: null` are ALL valid (len 0); only a populated map rejects. This proves
+    /// the check is `!is_empty()`, NOT `has_key`.
+    #[test]
+    fn validate_aws_sheds_empty_forms_ok() {
+        assert!(validate_yaml("aws:\n  sheds:\n").is_ok(), "bare sheds:");
+        assert!(validate_yaml("aws:\n  sheds: {}\n").is_ok(), "empty map");
+        assert!(validate_yaml("aws:\n  sheds: null\n").is_ok(), "explicit null");
+        // ...and an absent aws block entirely.
+        assert!(validate_yaml("").is_ok(), "no aws block");
+    }
+
+    /// Mirrors `config_test.go:TestValidateAWS` (mode subtests). An unknown mode at
+    /// the top level, a server, or a shed is rejected with the located field name and
+    /// the `assume-role, passthrough` allow-set.
+    #[test]
+    fn validate_rejects_bad_aws_mode() {
+        let top = validate_yaml("aws:\n  mode: bogus\n").expect_err("bad top mode");
+        assert_eq!(top, "aws.mode \"bogus\" is not one of assume-role, passthrough");
+        let server = validate_yaml("aws:\n  servers:\n    mini2:\n      mode: nope\n")
+            .expect_err("bad server mode");
+        assert_eq!(
+            server,
+            "aws.servers.mini2.mode \"nope\" is not one of assume-role, passthrough"
+        );
+        let shed = validate_yaml(
+            "aws:\n  servers:\n    mini2:\n      sheds:\n        web:\n          mode: nope\n",
+        )
+        .expect_err("bad shed mode");
+        assert_eq!(
+            shed,
+            "aws.servers.mini2.sheds.web.mode \"nope\" is not one of assume-role, passthrough"
+        );
+    }
+
+    /// Mirrors `config_test.go:TestValidateAWS` (accepts-valid-modes subtest). Valid
+    /// modes at every level (empty/assume-role/passthrough) validate.
+    #[test]
+    fn validate_accepts_valid_aws_modes() {
+        let ok = validate_yaml(
+            "\
+aws:
+  mode: passthrough
+  servers:
+    mini2:
+      mode: assume-role
+      sheds:
+        web:
+          mode: passthrough
+",
+        );
+        assert!(ok.is_ok(), "{ok:?}");
+    }
+
+    /// Mirrors `config_test.go:TestApprovalTimeout` + the H1 edge vectors. The
+    /// accessor still fail-safes the VALUE to 25s (unchanged); `validate` now REJECTS
+    /// a bad/non-positive raw with the RIGHT per-vector message (P: C2), and the
+    /// STRICT parser rejects what the fail-safe f64 parser tolerated (whitespace /
+    /// overflow).
+    #[test]
+    fn validate_rejects_bad_approval_timeout() {
+        // Empty raw is valid (→ 25s default) — Go's `v == "" → "25s"`.
+        assert!(validate_yaml("").is_ok(), "absent approval_timeout");
+        assert!(
+            validate_yaml("approval_timeout: 40s\n").is_ok(),
+            "valid approval_timeout"
+        );
+        // Unparseable → `is not a valid duration`.
+        for bad in ["nonsense", "10"] {
+            let err = validate_yaml(&format!("approval_timeout: {bad}\n"))
+                .expect_err("unparseable approval_timeout");
+            assert!(
+                err.contains("is not a valid duration"),
+                "approval_timeout {bad:?}: {err:?}"
+            );
+            assert!(err.contains("approval_timeout"), "{err:?}");
+        }
+        // Non-positive → `must be positive`.
+        for bad in ["0s", "-5s"] {
+            let err = validate_yaml(&format!("approval_timeout: {bad}\n"))
+                .expect_err("non-positive approval_timeout");
+            assert!(err.contains("must be positive"), "approval_timeout {bad:?}: {err:?}");
+        }
+        // STRICT-parser hardening (P: H1): quoted leading/trailing whitespace (Go
+        // errors, the fail-safe parser trimmed) and an i64-overflowing magnitude are
+        // BOTH rejected here even though the accessor would silently 25s them.
+        let ws = validate_yaml("approval_timeout: \" 5s \"\n").expect_err("whitespace rejected");
+        assert!(ws.contains("is not a valid duration"), "{ws:?}");
+        let overflow = validate_yaml("approval_timeout: 10000000000000000000h\n")
+            .expect_err("overflow rejected");
+        assert!(overflow.contains("is not a valid duration"), "{overflow:?}");
+    }
+
+    /// The strict duration parser (`parse_go_duration_strict`) is a faithful
+    /// `time.ParseDuration` subset: it ACCEPTS the same valid forms the fail-safe f64
+    /// parser does, but REJECTS whitespace + overflow (no trim, integer/checked math).
+    #[test]
+    fn go_duration_strict_edge_cases() {
+        assert_eq!(parse_go_duration_strict("25s"), Ok(25_000_000_000));
+        assert_eq!(parse_go_duration_strict("1.5h"), Ok(5_400_000_000_000));
+        assert_eq!(parse_go_duration_strict("1h30m"), Ok(5_400_000_000_000));
+        assert_eq!(parse_go_duration_strict("300ms"), Ok(300_000_000));
+        assert_eq!(parse_go_duration_strict("0"), Ok(0));
+        assert_eq!(parse_go_duration_strict("-5s"), Ok(-5_000_000_000));
+        // Rejected (Go rejects too): no unit, whitespace, empty, unknown unit, overflow.
+        assert!(parse_go_duration_strict("10").is_err(), "bare number, no unit");
+        assert!(parse_go_duration_strict(" 5s ").is_err(), "whitespace not trimmed");
+        assert!(parse_go_duration_strict("5 s").is_err(), "internal whitespace");
+        assert!(parse_go_duration_strict("").is_err(), "empty");
+        assert!(parse_go_duration_strict("5y").is_err(), "unknown unit");
+        assert!(
+            parse_go_duration_strict("10000000000000000000h").is_err(),
+            "overflow"
+        );
+    }
+
+    /// Mirrors `config_test.go:TestExampleConfigIsValid`. The shipped default config
+    /// loads + validates and carries the documented, CARRIED defaults (ssh
+    /// biometrics-or-password, aws off/deny-all, docker approve-all + the block-seq
+    /// `registries == [index.docker.io, ghcr.io]`). (P: HONEST SCOPE) it CANNOT assert
+    /// `session_ttl == "1h"` (native-biometric, not in `HostAgentConfig`).
+    #[test]
+    fn example_config_loads_and_validates() {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../configs/extensions.example.yaml");
+        let text = std::fs::read_to_string(&path).expect("read example config");
+        let cfg = HostAgentConfig::try_parse(&text).expect("example config parses");
+        cfg.validate().expect("example config validates");
+        assert_eq!(cfg.effective_policy(NS_SSH_AGENT), "biometrics-or-password");
+        assert_eq!(cfg.effective_policy(NS_AWS_CREDENTIALS), POLICY_DENY_ALL);
+        assert_eq!(cfg.effective_policy(NS_DOCKER_CREDENTIALS), "approve-all");
+        assert_eq!(
+            cfg.docker.registries,
+            vec!["index.docker.io".to_string(), "ghcr.io".to_string()]
+        );
+    }
+
+    /// Mirrors `config_test.go:TestLoadConfigDeprecatedDesktopKeysIgnored`. A config
+    /// that still sets the deprecated `desktop.*` keys with EXPLICIT ZERO/false values
+    /// LOADS OK (exit 0) — the Rust reader ignores the block entirely, and validate
+    /// touches only policies/aws/approval_timeout. (P: H3) this is unit-owned: "still
+    /// loads" has no live exit-code cell. (P: H4) warnings are op-log-only and not
+    /// ported. Driven through the real `load` (parse → validate) on a temp file.
+    #[test]
+    fn deprecated_desktop_keys_load_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            "server: http://localhost:8080\n\
+             desktop:\n  enabled: false\n  socket_path: ~/somewhere/else.sock\n  timeout_ms: 0\n",
+        )
+        .unwrap();
+        let cfg =
+            HostAgentConfig::load(path.to_str().unwrap()).expect("deprecated desktop keys load ok");
+        // The budget still comes from approval_timeout (defaulted 25s), not timeout_ms.
+        assert_eq!(cfg.approval_timeout(), Duration::from_secs(25));
+    }
+
+    /// Validate runs in Go's EXACT order (`config.go:487-505`): ssh → aws → docker
+    /// policy → aws.validate(sheds → mode → …) → approval_timeout. With multiple
+    /// errors present, the FIRST in that order surfaces.
+    #[test]
+    fn validate_check_order_is_go() {
+        // ssh policy is checked before aws.mode before approval_timeout: a config bad
+        // on all three surfaces the SSH error first.
+        let err = validate_yaml(
+            "ssh:\n  approval:\n    policy: maybe\naws:\n  mode: bogus\napproval_timeout: nonsense\n",
+        )
+        .expect_err("multi-error config");
+        assert!(err.starts_with("ssh.approval.policy"), "{err:?}");
+        // With ssh valid, aws.validate (mode) beats approval_timeout.
+        let err = validate_yaml("aws:\n  mode: bogus\napproval_timeout: nonsense\n")
+            .expect_err("aws + timeout bad");
+        assert!(err.starts_with("aws.mode"), "{err:?}");
+    }
+
+    /// Wiring proof: a validate-failing config FILE surfaces through `load` as an
+    /// `Err` (the same path `main.rs` maps to exit 1, mirroring `main.go:82-86`).
+    #[test]
+    fn load_rejects_invalid_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, "ssh:\n  approval:\n    policy: maybe\n").unwrap();
+        assert!(
+            HostAgentConfig::load(path.to_str().unwrap()).is_err(),
+            "invalid policy config must fail load (main.rs exit 1)"
+        );
+    }
+
+    /// The Rust half of the `config_validate` golden — reads the SAME shared fixture
+    /// the Go runner reads (`cmd/shed-host-agent/golden_test.go:TestGoldenConfigValidate`,
+    /// via the production `LoadConfig`), driving `try_parse` → `validate` (the
+    /// `load = parse → validate` chain minus the file I/O). Pins that both impls agree
+    /// on valid-vs-invalid and (for the semantic errors) share the PER-VECTOR message
+    /// substring. Malformed-YAML + duplicate-key vectors pin only `{valid:false}` (the
+    /// message body is yaml-lib specific — docker suffix precedent). In-crate (the
+    /// `aws_resolve`/`docker_resolve` precedent — binary crate, no lib).
+    #[test]
+    fn golden_config_validate() {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/host-agent-diff/fixtures/config_validate.json");
+        let raw = std::fs::read_to_string(&path).expect("read golden fixture");
+        let fx: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(fx["protocol_version"], 1, "version skew");
+        let vectors = fx["vectors"].as_array().unwrap();
+        assert!(!vectors.is_empty(), "fixture has no vectors");
+        for v in vectors {
+            let name = v["name"].as_str().unwrap();
+            let want_valid = v["valid"].as_bool().unwrap();
+            let yaml = v["config_yaml"].as_str().unwrap();
+            // load = parse → validate; a parse error (malformed / duplicate-key) OR a
+            // validate error both mean "not valid" (Go's LoadConfig fails at either).
+            let result: Result<(), String> = match HostAgentConfig::try_parse(yaml) {
+                Err(e) => Err(e),
+                Ok(cfg) => cfg.validate(),
+            };
+            assert_eq!(result.is_ok(), want_valid, "valid {name:?}: {result:?}");
+            if let Some(sub) = v["error_substring"].as_str() {
+                let err = result.expect_err("substring vector must produce an error");
+                assert!(err.contains(sub), "vector {name:?}: {err:?} lacks {sub:?}");
             }
         }
     }

--- a/crates/shed-host-agent/src/controltoken.rs
+++ b/crates/shed-host-agent/src/controltoken.rs
@@ -108,11 +108,13 @@ impl ControlTokenMinter for ControlTokenProvider {
 /// server missing `ssh_port` reject as "no ssh endpoint" rather than silently minting
 /// against port 22.
 ///
-/// NOTE (tracked gap, config-port slice): Go errors on malformed YAML; the permissive
-/// `yaml_lite` reader does not — so a malformed `~/.shed/config.yaml` diverges (likely
-/// `unknown server`). The harness writes a valid block-style config, so the differential
-/// doesn't exercise it. Same class as the `config-parse · inline-flow` / `config-validate`
-/// xfail cells.
+/// Malformed YAML is an error, matching Go's `LoadDiscoveredServers` — the
+/// `yaml_lite` reader is now backed by `saphyr-parser`, so a malformed
+/// `~/.shed/config.yaml` returns `Err` (was silently permissive before the config-port
+/// slice). Go uses `parsing shed config %s` for a YAML parse failure (`discovery.go:73`)
+/// and `reading shed config %s` for a file-read failure (`discovery.go:68`); this
+/// mirrors both. The error bubbles up through `resolve`'s outer `reading server config:`
+/// wrapper into the `token.get` response — the shared assertable prefix.
 pub fn load_discovered_servers(path: &str) -> Result<Vec<ServerTarget>, String> {
     use crate::config::yaml_lite::{self, Node};
 
@@ -122,7 +124,7 @@ pub fn load_discovered_servers(path: &str) -> Result<Vec<ServerTarget>, String> 
         Err(e) => return Err(format!("reading shed config {path}: {e}")),
     };
 
-    let root = yaml_lite::parse(&data);
+    let root = yaml_lite::parse(&data).map_err(|e| format!("parsing shed config {path}: {e}"))?;
     let mut targets = Vec::new();
     if let Some(servers) = root.as_map().and_then(|m| m.get("servers")).and_then(Node::as_map) {
         for (name, entry) in servers {
@@ -276,6 +278,18 @@ servers:
             load_discovered_servers("/nonexistent/config.yaml").unwrap(),
             Vec::new()
         );
+    }
+
+    /// A malformed `~/.shed/config.yaml` is now an error (mirrors Go's
+    /// `LoadDiscoveredServers`; the saphyr-backed reader detects it where the old
+    /// line/colon reader was silently permissive). The error carries Go's inner
+    /// `parsing shed config` prefix and bubbles through `resolve`'s outer
+    /// `reading server config:` wrapper into the `token.get` response.
+    #[test]
+    fn load_discovered_servers_errors_on_malformed() {
+        let (_d, cfg) = write_config("{{invalid yaml");
+        let err = load_discovered_servers(&cfg).expect_err("malformed config rejected");
+        assert!(err.contains("parsing shed config"), "err = {err}");
     }
 
     /// The Rust half of the `load_discovered_servers` golden — reads the SAME shared

--- a/tests/host-agent-diff/README.md
+++ b/tests/host-agent-diff/README.md
@@ -130,21 +130,39 @@ identities (real-signing ed25519, canned blobs for rsa/ecdsa).
 
 ## Known contract gaps (slice 0)
 
-- **Inline flow-style YAML config.** The Rust slice-0 `yaml_lite` config parser handles
-  **block-style** maps only; it treats an inline flow map like
-  `ssh: { approval: { policy: shed-desktop } }` as an opaque scalar and falls back to
-  all-`deny-all` with an empty gate list, whereas the Go daemon (real YAML) parses it.
-  The harness therefore writes its launch config in **block style** (both parsers agree),
-  and this divergence is tracked as an `xfail`/out-of-scope cell below (`config-parse ·
-  inline-flow`) — a later slice brings the Rust parser to parity.
+- **Config parsing & validation — STRUCTURAL sub-class retired; typed-decode residue
+  documented-open.** The Rust config reader (`config.rs` `yaml_lite`) is now backed by
+  `saphyr-parser` (a pure-Rust YAML-1.2 event parser, `default-features = false`), not the
+  old line/colon reader. That **retires the structural sub-class** of the Go-vs-Rust gap:
+  inline **flow maps** (`ssh: { approval: { policy: shed-desktop } }`) and **flow
+  sequences** parse like block style (`test_config_inline_flow.py`); **block-style
+  sequences** parse (the shipped `configs/extensions.example.yaml` `registries:` block list
+  parses to `[index.docker.io, ghcr.io]` instead of silently dropping to empty — golden
+  `config_validate` + the `example_config_loads_and_validates` unit); **malformed YAML is
+  detected** (returns `Err` → exit 1) instead of being swallowed; and a bare `key:` (YAML
+  null) is distinct from `key: ""` (empty string), so Go's null-vs-empty merge is
+  reproduced (`source_profile` cross-language golden). On top of the parser, the Rust
+  `HostAgentConfig::load` now runs a faithful `validate()` port and **rejects (exit 1) the
+  SAME configs Go `LoadConfig`/`Validate` rejects** — unknown/biometric policy strings, the
+  AWS/Docker biometric policies, `aws.mode`/`aws.sheds` errors, a non-positive/invalid
+  `approval_timeout`, malformed YAML, and duplicate map keys — enforced live by
+  `test_config_validate.py` (exit-1 parity on both impls) and pinned per-vector by the
+  `config_validate.json` golden (both runners).
 
-- **Config validation.** The Rust slice-0 config reader is `LiveStatus`-scoped: it does
-  **not** yet reject the things Go `LoadConfig`/`Validate` rejects (unknown policy strings,
-  the AWS/Docker biometric policies, `aws.mode`/`aws.sheds` errors, a non-positive
-  `approval_timeout`, malformed YAML). So e.g. `aws.approval.policy: biometrics` exits 1 in
-  Go but currently starts in Rust and echoes `biometrics`. The full config **port +
-  validation-parity differential** is its own later slice (config.go's `Validate` is ~120
-  lines); tracked as `config-validate` below.
+  **Documented-open (a real parser fixes STRUCTURE, not typed resolution):** the `Node`
+  model is stringly-typed and the readers coerce leniently, so a **typed-decode residue**
+  survives and is NOT closed here — **scalar-into-typed-field coercion** (`http_port:
+  not-a-number` → Go errors, Rust defaults; `approval_timeout: [a,b]` → Go errors, Rust
+  falls back to 25s; a scalar where a list is expected), and **bool alternate forms**
+  (`allow_all: yes` / `on` / `True` → Go `yaml.v3` resolves to a bool, but Rust `opt_bool`
+  treats only lowercase `"true"` as true — CodeRabbit-confirmed). **Closed** by the swap:
+  duplicate map keys (→ `Err`, matching yaml.v3) and multi-document input (first document
+  consumed, matching Go's `yaml.Unmarshal`). Also documented-open: anchors/aliases/
+  merge-keys, non-string keys, tagged scalars (low real-world risk), and the **cross-client
+  inconsistency on the shared `~/.shed/config.yaml`** — the host-agent (`saphyr-parser`) and
+  the desktop app (shed-core's own hand-rolled `yaml_lite`, a separate crate with a Swift
+  byte-parity test) may now diverge on the SAME file; converging the two readers is a
+  separate shed-core slice, not this one.
 
 - **Bounded connect timeout.** The Rust `status` client and the daemon's live-socket
   stale-probe use blocking Unix `connect()`; Go uses `net.DialTimeout` (2s / 500ms). The
@@ -173,11 +191,16 @@ identities (real-signing ed25519, canned blobs for rsa/ecdsa).
   flows (they connect a fresh consumer with `replay_events:0`) — a buffered-then-connect
   drive is a follow-up.
 
-- **Minter — malformed `~/.shed/config.yaml`.** The Rust `load_discovered_servers` reuses
-  the permissive `yaml_lite` reader, which never errors; Go `LoadDiscoveredServers` errors
-  on malformed YAML (→ `reading server config: …` in `token.response.error`). The harness
-  writes a valid block-style config, so the differential doesn't exercise it. Same class as
-  the inline-flow / config-validate gaps; brought to parity by the config-port slice.
+- **Minter — malformed `~/.shed/config.yaml` — CLOSED.** The Rust `load_discovered_servers`
+  is backed by the saphyr `yaml_lite` reader now, so a malformed `~/.shed/config.yaml`
+  returns `Err` (was silently permissive), matching Go `LoadDiscoveredServers`. Both impls
+  surface it as `reading server config: …` in the `token.response.error` when a `token.get`
+  triggers a resolve — enforced live by `test_token_get.py::test_token_get_malformed_shed_config`
+  (the outer `reading server config:` prefix, per-impl; the inner body is yaml-lib specific
+  — Go `parsing shed config` vs the saphyr message — and excluded per the docker suffix
+  precedent). This stays a SEPARATE cell from the `config-validate` matrix: it exercises a
+  DIFFERENT file (`~/.shed/config.yaml`, not the launch `-config`) and a DIFFERENT chain
+  (`token.get` → `resolve` → `load_discovered_servers`).
 
 ## Per-cell status table
 
@@ -196,10 +219,10 @@ owned by a different mechanism (golden/unit) or later slice, not the live diff.
 | lifecycle | SIGTERM → exit 0 + both sockets unlinked | **enforced** | live (`test_lifecycle.py`) |
 | socket | status socket bind + `0600` file perms | **enforced** | live (`conftest` daemon + `test_socket_perms.py`) |
 | socket | socket-dir `0700` + stale-vs-live rebinding | **xfail** | live (config/lifecycle slice) |
-| config-validate | reject unknown/biometric policy, bad mode/timeout, malformed YAML (parity) | **xfail** | live (config-port slice; see "Known contract gaps") |
+| config-validate | reject unknown/biometric policy, bad mode/timeout, malformed YAML, duplicate key (exit-1 parity) | **enforced** | live (`test_config_validate.py`) + golden (`config_validate.json`, Go + Rust runners) |
 | decision | `EffectivePolicy` (`""→deny-all`, echoes) | **enforced** | golden (Go + Rust runners) |
 | decision | `desktopGateNamespaces` ordered gate list | **enforced** | golden (Go + Rust runners) |
-| config-parse | inline-flow-style YAML (`{ ... }`) parity | **xfail** | live — Rust `yaml_lite` block-only (see "Known contract gaps") |
+| config-parse | inline-flow-style YAML (`{ ... }`) parity (masked `LiveStatus` policies canonical-equal) | **enforced** | live (`test_config_inline_flow.py`) |
 | desktop UDS server | hello/hello_ack handshake (masked canonical-equal) + non-hello first line dropped | **enforced** | live surface A (`test_desktop_handshake.py`, `test_desktop_first_non_hello_drops.py`) |
 | desktop UDS server | single-consumer last-writer-wins supersede (`accepted:false, reason:"superseded"`, old closed) | **enforced** | live surface A (`test_desktop_supersede.py`) |
 | desktop UDS server | `token.get` → `token.response` (masked; `token`+`expires_at` compared UNMASKED via the PATH-shim mint) | **enforced** | live surface A (`test_token_get.py`) |
@@ -239,7 +262,7 @@ owned by a different mechanism (golden/unit) or later slice, not the live diff.
 | minter | host-key-mismatch terminal; single-flight; refresh cadence | **enforced (unit)** | unit parity (`minter.rs` / `bootstrap.rs`, incl. real-runner shell-shim tests) |
 | minter | `load_discovered_servers` shape (ssh_port=0-vs-22, empty-host skip, sort) | **enforced (golden)** | Go + Rust golden runners on `fixtures/load_discovered_servers.json` |
 | minter | credentials-scope live bus drive | **xfail** | supervisor slice (no bus token provider wired yet) |
-| minter | malformed `~/.shed/config.yaml` error parity | **xfail** | config-port slice — Go `LoadDiscoveredServers` errors on bad YAML; the permissive `yaml_lite` reader does not (same class as `config-parse · inline-flow` / `config-validate`) |
+| minter | malformed `~/.shed/config.yaml` error parity (outer `reading server config:` prefix, per-impl) | **enforced** | live (`test_token_get.py::test_token_get_malformed_shed_config`) |
 | supervisor | reconcile / restart-on-cred-or-TLS-change | **xfail** | live; `shouldMint` matrix → golden |
 | discovery | off / poll / fsnotify | **xfail** | live (convergence w/ deadline); `LoadDiscoveredServers` shape → golden |
 | concurrency | single-flight mint, drop-on-full fan-out | **out-of-scope** | unit parity |

--- a/tests/host-agent-diff/fixtures/aws_resolve.json
+++ b/tests/host-agent-diff/fixtures/aws_resolve.json
@@ -79,6 +79,20 @@
       ],
       "enabled": false,
       "defaults": {"source_profile": "default", "session_duration": "1h", "cache_refresh_before": "5m"}
+    },
+    {
+      "name": "null-vs-empty: bare source_profile: (YAML null) keeps the DefaultConfig default (verified against Go LoadConfig)",
+      "config_yaml": "aws:\n  source_profile:\n",
+      "queries": [],
+      "enabled": false,
+      "defaults": {"source_profile": "default", "session_duration": "1h", "cache_refresh_before": "5m"}
+    },
+    {
+      "name": "null-vs-empty: explicit source_profile: \"\" (empty string) overwrites the default with empty (verified against Go LoadConfig)",
+      "config_yaml": "aws:\n  source_profile: \"\"\n",
+      "queries": [],
+      "enabled": false,
+      "defaults": {"source_profile": "", "session_duration": "1h", "cache_refresh_before": "5m"}
     }
   ]
 }

--- a/tests/host-agent-diff/fixtures/config_validate.json
+++ b/tests/host-agent-diff/fixtures/config_validate.json
@@ -1,0 +1,96 @@
+{
+  "_comment": "Golden fixture for the host-agent config validate() gate — input config YAML -> {valid, error_substring?}. Read by BOTH the Go runner (cmd/shed-host-agent/golden_test.go:TestGoldenConfigValidate, via the production LoadConfig, which runs yaml.Unmarshal then Validate) and the Rust runner (crates/shed-host-agent/src/config.rs tests::golden_config_validate, via HostAgentConfig::try_parse then validate) so the two impls cannot drift together on valid-vs-invalid or the per-vector semantic-error message substrings. Mirrors config_test.go TestLoadConfigRejectsBadPolicy / TestValidateRejectsBiometricForAWS / TestValidateAcceptsValidPolicies / TestValidateAWS / TestApprovalTimeout / TestLoadConfigInvalidYAML. PER-VECTOR substrings (P: C2): each carries the RIGHT substring so it proves the intended path fired (e.g. ssh.approval.policy, NOT bare 'is not one of' which also matches aws.mode). Malformed-YAML + duplicate-key pin only {valid:false} — the message body is yaml-lib specific (Go yaml.v3 vs saphyr), excluded per the docker suffix precedent.",
+  "protocol_version": 1,
+  "vectors": [
+    {
+      "name": "valid: empty config (all deny-all, default approval_timeout)",
+      "config_yaml": "",
+      "valid": true
+    },
+    {
+      "name": "valid: ssh biometrics-or-password + aws shed-desktop + docker approve-all",
+      "config_yaml": "ssh:\n  approval:\n    policy: biometrics-or-password\naws:\n  approval:\n    policy: shed-desktop\ndocker:\n  approval:\n    policy: approve-all\n",
+      "valid": true
+    },
+    {
+      "name": "valid: aws modes at every level (passthrough / assume-role / passthrough)",
+      "config_yaml": "aws:\n  mode: passthrough\n  servers:\n    mini2:\n      mode: assume-role\n      sheds:\n        web:\n          mode: passthrough\n",
+      "valid": true
+    },
+    {
+      "name": "valid: aws.sheds empty map is len 0 (not a reject)",
+      "config_yaml": "aws:\n  sheds: {}\n",
+      "valid": true
+    },
+    {
+      "name": "invalid: unknown ssh policy",
+      "config_yaml": "ssh:\n  approval:\n    policy: maybe\n",
+      "valid": false,
+      "error_substring": "ssh.approval.policy"
+    },
+    {
+      "name": "invalid: biometrics rejected for aws (cred allow-set excludes it)",
+      "config_yaml": "aws:\n  approval:\n    policy: biometrics\n",
+      "valid": false,
+      "error_substring": "aws.approval.policy"
+    },
+    {
+      "name": "invalid: biometrics-or-password rejected for docker",
+      "config_yaml": "docker:\n  approval:\n    policy: biometrics-or-password\n",
+      "valid": false,
+      "error_substring": "docker.approval.policy"
+    },
+    {
+      "name": "invalid: populated aws.sheds removed",
+      "config_yaml": "aws:\n  sheds:\n    web:\n      role: arn:aws:iam::123:role/web\n",
+      "valid": false,
+      "error_substring": "aws.sheds was removed"
+    },
+    {
+      "name": "invalid: unknown aws.mode",
+      "config_yaml": "aws:\n  mode: bogus\n",
+      "valid": false,
+      "error_substring": "aws.mode \"bogus\" is not one of"
+    },
+    {
+      "name": "invalid: unknown per-shed aws mode (located field name)",
+      "config_yaml": "aws:\n  servers:\n    mini2:\n      sheds:\n        web:\n          mode: nope\n",
+      "valid": false,
+      "error_substring": "aws.servers.mini2.sheds.web.mode"
+    },
+    {
+      "name": "invalid: approval_timeout nonsense",
+      "config_yaml": "approval_timeout: nonsense\n",
+      "valid": false,
+      "error_substring": "is not a valid duration"
+    },
+    {
+      "name": "invalid: approval_timeout bare number (missing unit)",
+      "config_yaml": "approval_timeout: 10\n",
+      "valid": false,
+      "error_substring": "is not a valid duration"
+    },
+    {
+      "name": "invalid: approval_timeout zero is not positive",
+      "config_yaml": "approval_timeout: 0s\n",
+      "valid": false,
+      "error_substring": "must be positive"
+    },
+    {
+      "name": "invalid: approval_timeout negative is not positive",
+      "config_yaml": "approval_timeout: -5s\n",
+      "valid": false,
+      "error_substring": "must be positive"
+    },
+    {
+      "name": "invalid: malformed YAML (top-level garbage)",
+      "config_yaml": "{{invalid yaml",
+      "valid": false
+    },
+    {
+      "name": "invalid: duplicate map key",
+      "config_yaml": "server: http://a:8080\nserver: http://b:8080\n",
+      "valid": false
+    }
+  ]
+}

--- a/tests/host-agent-diff/fixtures/docker_resolve.json
+++ b/tests/host-agent-diff/fixtures/docker_resolve.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Golden fixture for the Docker config slice — input host-agent config YAML (block-style maps + flow-list `[a, b]` registries, the yaml_lite subset) -> per-(server,shed) DockerConfig.Resolve() results: allow_all + registries + registry_count (== len(registries), the backend Status verdict). Read by BOTH the Go runner (cmd/shed-host-agent/golden_test.go:TestGoldenDockerResolve, via the production LoadConfig->Docker.Resolve path) and the Rust runner (crates/shed-host-agent/src/config.rs tests::golden_docker_resolve, via HostAgentConfig::parse().docker.resolve). Go has NO Resolve layering test, so this golden is Rust-STRONGER. It pins the load-bearing Option semantics: registries Option<Vec<String>> (absent -> inherit, `[]` -> REPLACE-with-empty / deny-all lockdown, `[a,b]` -> replace-not-merge across top/server/shed) and allow_all Option<bool> (absent -> inherit, false -> force-off, true -> force-on), plus the flow-list `[a, b]` parse the new yaml_lite Node::Sequence enables. Mirrors config_discovery_test.go:TestDockerResolve (extended).",
+  "_comment": "Golden fixture for the Docker config slice — input host-agent config YAML (block-style maps + flow-list `[a, b]` registries, the yaml_lite subset) -> per-(server,shed) DockerConfig.Resolve() results: allow_all + registries + registry_count (== len(registries), the backend Status verdict). Read by BOTH the Go runner (cmd/shed-host-agent/golden_test.go:TestGoldenDockerResolve, via the production LoadConfig->Docker.Resolve path) and the Rust runner (crates/shed-host-agent/src/config.rs tests::golden_docker_resolve, via HostAgentConfig::parse().docker.resolve). Go has NO Resolve layering test, so this golden is Rust-STRONGER. It pins the load-bearing Option semantics: registries Option<Vec<String>> (absent -> inherit, `[]` -> REPLACE-with-empty / deny-all lockdown, `[a,b]` -> replace-not-merge across top/server/shed) and allow_all Option<bool> (absent -> inherit, false -> force-off, true -> force-on), plus the flow-list `[a, b]` AND block-style `- item` (the shipped extensions.example.yaml form) parse the saphyr-backed yaml_lite Node::Sequence enables. Mirrors config_discovery_test.go:TestDockerResolve (extended).",
   "protocol_version": 1,
   "vectors": [
     {
@@ -48,6 +48,13 @@
       "config_yaml": "server: http://localhost:8080\n",
       "queries": [
         {"server": "any", "shed": "any", "allow_all": false, "registries": [], "registry_count": 0}
+      ]
+    },
+    {
+      "name": "BLOCK-STYLE registries sequence (the shipped extensions.example.yaml form) parses to [index.docker.io, ghcr.io], not empty",
+      "config_yaml": "docker:\n  registries:\n    - index.docker.io\n    - ghcr.io\n  allow_all: false\n",
+      "queries": [
+        {"server": "mini3", "shed": "anything", "allow_all": false, "registries": ["index.docker.io", "ghcr.io"], "registry_count": 2}
       ]
     }
   ]

--- a/tests/host-agent-diff/test_config_inline_flow.py
+++ b/tests/host-agent-diff/test_config_inline_flow.py
@@ -1,0 +1,67 @@
+"""Inline flow-style YAML config parses identically in BOTH impls (the config-parse ·
+inline-flow parity, closed by the saphyr parser swap).
+
+Before the config-port slice the Rust `yaml_lite` reader was a line/colon reader that
+treated an inline flow map like `ssh: { approval: { policy: shed-desktop } }` as an
+opaque scalar and fell back to all-`deny-all` with an empty gate list, while the Go
+daemon (real YAML) parsed it — a tracked `xfail`. The reader is now backed by
+`saphyr-parser`, which parses flow maps + flow sequences natively, so this cell drives a
+FULLY flow-style launch config through both daemons and asserts their masked
+`LiveStatus` is canonical-equal, with the three approval policies parsed out of the flow
+maps (not defaulted to deny-all).
+
+This is the wire-visible half the plan's M3 disposition endorses: `LiveStatus.policies`
+is the observable proof that inline-flow `approval.policy` values are parsed. (The Go
+daemon has always parsed flow style, so the differential is a real Rust-parity check, not
+a tautology — a Rust regression to the old opaque-scalar behavior would surface here as
+`policies: {all deny-all}` != Go.) It is the SAME watch-none scenario as
+`test_status_running.py`, only written in flow style — so the expected values match that
+cell exactly.
+
+The literal `{ }` braces are doubled (`{{ }}`) so the `daemon` fixture's
+`.format(audit_log=..., source=...)` leaves them as single braces in the emitted config
+while still filling the `{audit_log}` / `{source}` fields.
+"""
+
+import json
+
+import pytest
+
+from normalize import canonical, mask_live_status
+
+# A fully inline flow-style launch config (every mapping/sequence in flow form). Escaped
+# braces (`{{`/`}}`) survive the `daemon` fixture's `.format()` as single braces; the
+# `{audit_log}` / `{source}` fields are filled by the fixture. Equivalent to
+# conftest.WATCH_NONE_CONFIG but flow-style — chosen so the Rust parser must handle nested
+# flow maps + a flow sequence, and so BOTH impls report an empty `servers` list.
+INLINE_FLOW_CONFIG = (
+    "ssh: {{ approval: {{ policy: shed-desktop }} }}\n"
+    "aws: {{ approval: {{ policy: approve-all }} }}\n"
+    "docker: {{ approval: {{ policy: deny-all }} }}\n"
+    "logging: {{ enabled: true, path: {audit_log} }}\n"
+    "discovery: {{ servers: [], watch: off, source: {source} }}\n"
+)
+
+
+@pytest.mark.differential
+def test_inline_flow_config_parses_equal(daemon, differential):
+    def scenario(impl):
+        with daemon(impl, INLINE_FLOW_CONFIG) as d:
+            r = d.status(json=True)
+            assert r.returncode == 0, f"{impl}: status --json exit {r.returncode}\n{r.stderr}"
+            obj = json.loads(r.stdout)
+            return canonical(mask_live_status(obj, d.socket_dir, d.config_path))
+
+    masked = differential(scenario)
+
+    # The flow-map `approval.policy` values were parsed (not defaulted to deny-all) —
+    # exactly the block-style expectation from test_status_running.py, proving flow and
+    # block style parse identically on BOTH impls.
+    assert masked["policies"] == {
+        "ssh-agent": "shed-desktop",
+        "aws-credentials": "approve-all",
+        "docker-credentials": "deny-all",
+    }
+    assert masked["gate_namespaces"] == ["ssh-agent"]
+    # The empty flow sequence `servers: []` parsed as "watch none" on both impls.
+    assert masked["servers"] == []

--- a/tests/host-agent-diff/test_config_validate.py
+++ b/tests/host-agent-diff/test_config_validate.py
@@ -1,0 +1,77 @@
+"""A daemon started with a valid-YAML-but-INVALID (or malformed) `-config` exits 1 in
+BOTH impls — the live half of the config-validate parity. Each vector is a config Go's
+`LoadConfig`/`Validate` rejects (`cmd/shed-host-agent/config.go`): an unknown/biometric
+policy, an `aws.mode`/`aws.sheds` error, a non-positive/invalid `approval_timeout`, a
+duplicate map key, or malformed YAML. The Rust `HostAgentConfig::load` now rejects the
+SAME set (saphyr parser + `validate()` port), so both daemons exit 1 before binding any
+socket.
+
+Direct-launch-await-exit-1 pattern (like `test_ssh_mode_error.py` / `test_config_error.py`),
+NOT the `daemon` fixture — a rejected config never binds a socket, so there is nothing to
+query; only the exit code is compared. The operational log (Go `slog` vs Rust `tracing`)
+is the message channel and is excluded from the differential; per-vector message
+substrings are pinned language-neutrally by the `config_validate.json` golden (both
+runners), not here.
+
+There is deliberately NO exit-0 positive control: a VALID config boots the daemon and
+runs forever (it never exits), so this exit-code pattern cannot assert exit 0. The
+"a valid / deprecated-key config loads OK" case is unit-owned (`config.rs`
+`deprecated_desktop_keys_load_ok`) and golden-owned (`config_validate.json` `valid:true`
+vectors), per the plan's H3 disposition.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+from conftest import _clean_env
+
+# (id, config_yaml) — each valid YAML but an invalid config, OR malformed YAML. Mirrors
+# the config_validate.json golden's invalid vectors; the golden pins the per-vector
+# message substring, this cell pins the live exit-1 parity on both impls.
+BAD_CONFIGS = [
+    ("unknown-ssh-policy", "ssh:\n  approval:\n    policy: maybe\n"),
+    ("biometrics-for-aws", "aws:\n  approval:\n    policy: biometrics\n"),
+    ("biometrics-or-password-for-docker", "docker:\n  approval:\n    policy: biometrics-or-password\n"),
+    ("aws-mode-bogus", "aws:\n  mode: bogus\n"),
+    ("per-shed-bad-mode", "aws:\n  servers:\n    mini2:\n      sheds:\n        web:\n          mode: nope\n"),
+    ("populated-aws-sheds", "aws:\n  sheds:\n    web:\n      role: arn:aws:iam::123:role/web\n"),
+    ("approval-timeout-nonsense", "approval_timeout: nonsense\n"),
+    ("approval-timeout-zero", "approval_timeout: 0s\n"),
+    ("approval-timeout-negative", "approval_timeout: -5s\n"),
+    ("approval-timeout-bare-10", "approval_timeout: 10\n"),
+    ("duplicate-key", "server: http://a:8080\nserver: http://b:8080\n"),
+    ("malformed-top-level-garbage", "{{invalid yaml"),
+    ("malformed-unterminated-flow", "ssh:\n  approval:\n    policy: [unterminated\n"),
+]
+
+
+@pytest.mark.parametrize("cfg_id,config_yaml", BAD_CONFIGS, ids=[c[0] for c in BAD_CONFIGS])
+@pytest.mark.parametrize("impl", ["go", "rust"])
+def test_invalid_config_exits_1(binaries, tmp_path_factory, impl, cfg_id, config_yaml):
+    root = tmp_path_factory.mktemp(f"cfgvalidate-{impl}")
+    home = root / "home"
+    home.mkdir()
+    cfg = root / "cfg.yaml"
+    cfg.write_text(config_yaml)
+
+    # The daemon exits before binding any socket, so the dir length doesn't matter; a
+    # short mkdtemp keeps it consistent with the rest of the harness anyway.
+    socket_dir = tempfile.mkdtemp(prefix="hadiff-")
+    try:
+        proc = subprocess.run(
+            [binaries[impl], "-config", str(cfg), "-log-file", str(root / "op.log")],
+            env=_clean_env(socket_dir, home),
+            capture_output=True,
+            timeout=30,
+        )
+        assert proc.returncode == 1, (
+            f"{impl}/{cfg_id}: exit {proc.returncode} (want 1)\n"
+            f"stderr={proc.stderr.decode('utf-8', 'replace')}"
+        )
+    finally:
+        shutil.rmtree(socket_dir, ignore_errors=True)

--- a/tests/host-agent-diff/test_token_get.py
+++ b/tests/host-agent-diff/test_token_get.py
@@ -191,3 +191,47 @@ def test_token_get(daemon, single_server_config, differential):
     # The control-scope live check: the remote command's <scope> is `control`.
     scope = argv[argv.index("_bootstrap") + 1 + 1]  # ..._bootstrap <host> <scope>
     assert scope == "control", f"minted with scope {scope!r}, want control"
+
+
+# A MALFORMED `~/.shed/config.yaml` the control-token provider reads when resolving a
+# server for `token.get`. Before the config-port slice the Rust `load_discovered_servers`
+# reused the permissive line/colon `yaml_lite` reader, which never errored; Go
+# `LoadDiscoveredServers` errored on malformed YAML. The reader is now backed by
+# `saphyr-parser`, so BOTH impls surface an error — wrapped as `reading server config:`
+# in the `token.response.error`.
+MALFORMED_SHED_CONFIG = "{{invalid yaml"
+
+
+@pytest.mark.parametrize("impl", ["go", "rust"])
+def test_token_get_malformed_shed_config(daemon, single_server_config, impl):
+    """A `token.get` against a daemon whose `~/.shed/config.yaml` is MALFORMED fails
+    closed: the control-token provider's resolve reads the config, the parse errors, and
+    the daemon replies `token.response{error}` (never a partial token).
+
+    The OUTER wrapper prefix `reading server config:` is the only shared, assertable
+    surface (P: C3): Go's inner text is `parsing shed config <path>` (`discovery.go:73`
+    for malformed) while Rust's is `parsing shed config <path>: <saphyr msg>` — the inner
+    body is yaml-lib specific and excluded (docker suffix precedent), so this asserts the
+    outer prefix per-impl (NOT a full-string differential). The launch config itself is a
+    VALID single-server block config, so the daemon boots normally; only the SEPARATE
+    `~/.shed/config.yaml` the minter reads is malformed (the M2 "different file, different
+    chain" reason this stays a distinct cell from the config-validate matrix)."""
+    with SyntheticBus() as bus:
+        with daemon(
+            impl,
+            single_server_config(bus.url),
+            shed_config=MALFORMED_SHED_CONFIG,
+        ) as d:
+            with DesktopClient(str(d.desktop_sock)) as app:
+                app.send_hello()
+                wait_for_consumer(d, connected=True, timeout=10.0)
+                app.send({"type": "token.get", "id": "q1", "server": "prod"})
+                resp = app.await_frame("token.response", timeout=10.0)
+
+    assert resp["type"] == "token.response"
+    assert resp["in_reply_to"] == "q1"
+    assert resp.get("token", "") == "", f"{impl}: a failed mint must not carry a token: {resp!r}"
+    err = resp.get("error", "")
+    assert "reading server config:" in err, (
+        f"{impl}: token.response.error {err!r} lacks the outer 'reading server config:' prefix"
+    )


### PR DESCRIPTION
Sub-plan 5 of the **3a.1 completion program** (stacked on #262 → #261 → #260 → #257): port the host-agent's **config loader + validation** to real YAML semantics and close the config-parse / config-validate / malformed-config parity cells.

Plan: `~/.claude/plans/monorepo-phase3-host-agent-config.md`, panel-reviewed by **Codex + Kimi K2.6 + CodeRabbit** (all source-verified).

## The dependency decision (user-approved)

The panel surfaced the decisive fact: the repo's **own shipped `configs/extensions.example.yaml`** uses block-style YAML lists (`registries:\n  - index.docker.io\n  - ghcr.io`) that the hand-rolled `yaml_lite` **silently drops** — so Rust parsed an empty allowlist where Go loads `[index.docker.io, ghcr.io]`, a real uncaught divergence on the default config. That, plus the malformed-detection and inline-flow cells being structurally impossible for a line/colon reader, decided it. **Adopted `saphyr-parser`** (the low-level event API, `default-features = false` — no `encoding_rs`) behind the existing `Node` interface. Dep is pure-Rust / no-serde / no-C, MIT-OR-Apache, MSRV 1.85 == workspace, +3 net crates; `cargo tree -i` proves it reaches only `shed-host-agent` (leaf bin — no shed-core/shed-app/Tauri). The no-YAML-dep posture always targeted serde_yaml/serde_norway; carve-out recorded in `crates/CLAUDE.md`. shed-core's separate reader is untouched.

## Commits

1. `f6e3708` — **saphyr-parser reader**: `parse` fallible, `Node` gains `Null`. Adapter invariants each verified against saphyr events + Go LoadConfig: null-vs-empty via scalar style (plain-null → keep DefaultConfig default; quoted `""` → keep empty — fixing a previously-backwards `default_if_empty`); null key still inserted; duplicate keys → Err; multi-doc → first doc; empty flow `[]` → `Sequence(vec![])`.
2. `d4a5bcc` — **Validate parity**: `HostAgentConfig::validate()` ports `config.go`'s Validate byte-for-byte (same check order; per-namespace policy allowed-sets with ssh-only biometrics; `aws.sheds` len>0 reject; `validateMode`; `approval_timeout` raw-string retention + a strict integer duration parser matching `time.ParseDuration` — no whitespace trim, checked arithmetic, overflow→err). `config_validate.json` golden (named per-vector substrings) runs through the real Go LoadConfig+Validate and the Rust load/validate in both runners. Also folds a CodeRabbit commit-1 fix: bare `discovery:` (YAML null) → single-server, matching Go's nil `*DiscoveryConfig`.
3. (this commit) — **harness flips** (64 → 93 cells): config-validate matrix (13 bad configs × both daemons → exit 1); a fully flow-style config → masked `LiveStatus` canonical-equal; the minter malformed-config cell (`reading server config:` outer prefix). README's config gaps rewritten.

## Evidence

Introspected exit-1 pairs show Rust's error strings byte-identical to Go (`ssh.approval.policy "maybe" is not one of deny-all, approve-all, biometrics, biometrics-or-password, shed-desktop`; `aws.mode "bogus" is not one of assume-role, passthrough`; `approval_timeout "-5s" must be positive`), modulo the op-log `invalid config:` wrapper which isn't diffed. Inline-flow LiveStatus matched; minter malformed outer prefix present on both.

## Honest scope

Real YAML retires the **structural** divergence sub-class (flow maps, block sequences, malformed-detection, null-vs-empty) and adds full `validate()` exit-1 parity. A **typed-decode residue** remains documented-open (scalar-into-typed-field coercion; bool alternate forms `yes`/`on`/`True` where yaml.v3 resolves to bool but Rust's `opt_bool` only takes lowercase `true`) — candidates for the hardening sub-plan. Duplicate-key (→err) and multi-doc (→first-doc) are closed. The two-readers-on-the-shared-`~/.shed/config.yaml` inconsistency with shed-core's reader is flagged for a future shed-core convergence slice.

No server/guest changes; Go host-agent unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED6csoQ3peM3GHc4c1CtqY
