### PR TITLE
feat(host-agent): native Touch-ID gate in pure Rust — objc2, no CGO (Phase 3 leg 3a.1 sub-plan 7)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -824,6 +824,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,6 +1186,16 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -2275,6 +2294,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-local-authentication"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48e0b8b339e0d9d2ed4416b7f93f9d4daadff7d4dd797f89867cde11aeac607"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-security",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,11 +3220,15 @@ dependencies = [
  "aws-smithy-http-client",
  "aws-smithy-types",
  "base64 0.22.1",
+ "block2",
  "ed25519-dalek",
  "futures-util",
  "httpmock",
  "libc",
  "notify",
+ "objc2",
+ "objc2-foundation",
+ "objc2-local-authentication",
  "p256",
  "p384",
  "p521",

--- a/crates/shed-host-agent/Cargo.toml
+++ b/crates/shed-host-agent/Cargo.toml
@@ -140,6 +140,22 @@ aws-sdk-sts = { version = "1", default-features = false, features = ["behavior-v
 aws-smithy-http-client = { version = "1", default-features = false, features = ["rustls-ring"] }
 aws-smithy-types = "1"
 
+# --- Native Touch-ID / biometrics gate (touchid.rs) ------------------------------
+# macOS-ONLY: the LocalAuthentication `LAContext.evaluatePolicy` gate for the
+# `biometrics` / `biometrics-or-password` SSH approval policies (Go's CGO
+# touchid_darwin.go, now pure objc2 → the Rust binary needs NO C toolchain / no
+# `import "C"`). These are Apple-framework bindings only (LocalAuthentication /
+# Foundation) — NO WebKitGTK / GTK / Tauri — so they stay on the clean side of the
+# crates/ dependency line and reach ONLY this leaf crate (see the DEP_DELTA reverse-
+# dep proof). `[target.'cfg(target_os="macos")']` means a Linux/headless build NEVER
+# resolves them. Versions match desktop/tauri/src-tauri/Cargo.toml (the proven B3
+# gate) so cargo could unify one build if the graphs ever merged.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+block2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSString", "NSError"] }
+objc2-local-authentication = { version = "0.3", features = ["LAContext", "LAError", "block2"] }
+
 [dev-dependencies]
 # Throwaway socket dirs for the status "not running" exit-code test.
 tempfile = "3"

--- a/crates/shed-host-agent/src/config.rs
+++ b/crates/shed-host-agent/src/config.rs
@@ -4,8 +4,10 @@
 //! also runs [`HostAgentConfig::validate`] — a faithful port of Go's
 //! `Config.Validate` (the three policy allow-sets, `aws.sheds`/`aws.mode`, and
 //! `approval_timeout`), so the Rust daemon rejects (exit 1) exactly the configs the
-//! Go daemon rejects. The remaining schema (discovery-block contents, per-server
-//! biometric scope/ttl) stays structurally out of this headless reader.
+//! Go daemon rejects. The reader also surfaces the native-biometric approval knobs
+//! (`ssh.approval.{scope,session_ttl}`) that feed `touchid::new_biometric_gate`; the
+//! remaining schema (discovery-block contents) stays structurally out of this
+//! headless reader.
 //!
 //! Parsing: the `yaml_lite` mod exposes the same tiny `Node` model shed-core's
 //! reader uses, but its parser is backed by `saphyr-parser` (a pure-Rust,
@@ -317,6 +319,18 @@ pub struct HostAgentConfig {
     /// (auto-detect). Mirrors Go's `SSHConfig.Mode`; consumed by
     /// `ssh_backend::resolve_ssh_backend`.
     ssh_mode: String,
+    /// The native-biometric approval scope (`ssh.approval.scope`): `per-request`,
+    /// `per-session` (default), or `per-shed`. Applies ONLY to the biometric policies
+    /// (validate confines them to ssh); passed to `touchid::new_biometric_gate`. Read
+    /// NULL-AWARE to mirror Go's `DefaultConfig`-then-overlay: absent/null →
+    /// `per-session`, an explicit `scope: ""` is kept verbatim (→ the gate always
+    /// prompts). Mirrors Go's `ApprovalConfig.Scope`.
+    ssh_scope: String,
+    /// The RAW native-biometric session TTL (`ssh.approval.session_ttl`), default
+    /// `4h`. Kept verbatim: the gate parses it (parse-fail → 4h) AND audits the raw
+    /// text (`out.TTL = cfg.SessionTTL`). Same null-aware defaulting as `ssh_scope`.
+    /// Mirrors Go's `ApprovalConfig.SessionTTL`.
+    ssh_session_ttl_raw: String,
     pub logging_enabled: bool,
     pub logging_path: String,
     // Read only by `approval_timeout()`, which only the desktop server calls.
@@ -456,6 +470,24 @@ impl HostAgentConfig {
             Some(s) if !s.is_empty() => s.to_string(),
             _ => DEFAULT_SERVER_URL.to_string(),
         };
+        // The native-biometric knobs under `ssh.approval.*`, read NULL-AWARE (the same
+        // `scalar_or_default` shape `AwsConfig::from_node` uses): an explicit `Scalar`
+        // (including `""`) is kept verbatim; absent / null / non-scalar falls back to
+        // the `DefaultConfig` default (`per-session` / `4h`). This reproduces Go's
+        // `DefaultConfig`-then-overlay so `scope: ""` → always-prompt while absent →
+        // `per-session`.
+        let ssh_approval = root
+            .as_map()
+            .and_then(|m| m.get("ssh"))
+            .and_then(yaml_lite::Node::as_map)
+            .and_then(|m| m.get("approval"))
+            .and_then(yaml_lite::Node::as_map);
+        let ssh_scalar_or_default = |key: &str, d: &str| -> String {
+            match ssh_approval.and_then(|m| m.get(key)) {
+                Some(yaml_lite::Node::Scalar(s)) => s.clone(),
+                _ => d.to_string(),
+            }
+        };
         HostAgentConfig {
             ssh_policy: policy("ssh"),
             aws_policy: policy("aws"),
@@ -464,6 +496,8 @@ impl HostAgentConfig {
                 .get_path(&["ssh", "mode"])
                 .unwrap_or_default()
                 .to_string(),
+            ssh_scope: ssh_scalar_or_default("scope", "per-session"),
+            ssh_session_ttl_raw: ssh_scalar_or_default("session_ttl", "4h"),
             logging_enabled,
             logging_path,
             approval_timeout: parse_approval_timeout(&approval_timeout_raw),
@@ -529,6 +563,22 @@ impl HostAgentConfig {
     /// `ssh_backend::resolve_ssh_backend_from_env` at daemon startup.
     pub fn ssh_mode(&self) -> &str {
         &self.ssh_mode
+    }
+
+    /// The native-biometric approval scope (`ssh.approval.scope`), null-aware
+    /// defaulted to `per-session`. Passed to `touchid::new_biometric_gate` in
+    /// `main.rs`'s `select_gate` (the biometric arm); ignored by every non-biometric
+    /// gate. Mirrors Go's `ApprovalConfig.Scope`.
+    pub(crate) fn ssh_scope(&self) -> &str {
+        &self.ssh_scope
+    }
+
+    /// The RAW native-biometric session TTL (`ssh.approval.session_ttl`), null-aware
+    /// defaulted to `4h`. Passed verbatim to `touchid::new_biometric_gate`, which
+    /// parses it for the cache TTL (parse-fail → 4h) and audits the raw text. Mirrors
+    /// Go's `ApprovalConfig.SessionTTL`.
+    pub(crate) fn ssh_session_ttl(&self) -> &str {
+        &self.ssh_session_ttl_raw
     }
 
     /// `effective_policy` returns the configured policy for a namespace, defaulting
@@ -2697,8 +2747,9 @@ aws:
     /// Mirrors `config_test.go:TestExampleConfigIsValid`. The shipped default config
     /// loads + validates and carries the documented, CARRIED defaults (ssh
     /// biometrics-or-password, aws off/deny-all, docker approve-all + the block-seq
-    /// `registries == [index.docker.io, ghcr.io]`). (P: HONEST SCOPE) it CANNOT assert
-    /// `session_ttl == "1h"` (native-biometric, not in `HostAgentConfig`).
+    /// `registries == [index.docker.io, ghcr.io]`). Now that the reader surfaces the
+    /// native-biometric knobs, it ALSO asserts `ssh.approval.{scope,session_ttl}` from
+    /// the example (`per-session` / `1h`, `configs/extensions.example.yaml:67-68`).
     #[test]
     fn example_config_loads_and_validates() {
         let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -2713,6 +2764,48 @@ aws:
             cfg.docker.registries,
             vec!["index.docker.io".to_string(), "ghcr.io".to_string()]
         );
+        assert_eq!(cfg.ssh_scope(), "per-session");
+        assert_eq!(cfg.ssh_session_ttl(), "1h");
+    }
+
+    /// The native-biometric knobs default null-aware (Go's `DefaultConfig`-then-
+    /// overlay): an ABSENT `ssh.approval.{scope,session_ttl}` → `per-session` / `4h`;
+    /// a bare `scope:` / `session_ttl:` (YAML null) also → the defaults. Mirrors Go's
+    /// `applyDefaults` seeding.
+    #[test]
+    fn biometric_knobs_default_when_absent_or_null() {
+        // Absent (only a policy under ssh.approval).
+        let cfg = HostAgentConfig::parse("ssh:\n  approval:\n    policy: biometrics\n");
+        assert_eq!(cfg.ssh_scope(), "per-session");
+        assert_eq!(cfg.ssh_session_ttl(), "4h");
+        // Explicit YAML null → still the defaults (null-aware read).
+        let cfg =
+            HostAgentConfig::parse("ssh:\n  approval:\n    scope:\n    session_ttl: null\n");
+        assert_eq!(cfg.ssh_scope(), "per-session");
+        assert_eq!(cfg.ssh_session_ttl(), "4h");
+    }
+
+    /// (H2) An EXPLICIT empty `scope: ""` / `session_ttl: ""` is kept verbatim — it
+    /// overwrites the `DefaultConfig` default with `""` (Go's overlay), so the gate
+    /// always-prompts and the raw `""` is what `session_ttl` audits. The null-aware
+    /// read must NOT re-default an explicit empty string.
+    #[test]
+    fn biometric_knobs_keep_explicit_empty() {
+        let cfg = HostAgentConfig::parse(
+            "ssh:\n  approval:\n    scope: \"\"\n    session_ttl: \"\"\n",
+        );
+        assert_eq!(cfg.ssh_scope(), "");
+        assert_eq!(cfg.ssh_session_ttl(), "");
+    }
+
+    /// A non-default scope/ttl round-trips verbatim through the accessors.
+    #[test]
+    fn biometric_knobs_read_explicit_values() {
+        let cfg = HostAgentConfig::parse(
+            "ssh:\n  approval:\n    scope: per-shed\n    session_ttl: 30m\n",
+        );
+        assert_eq!(cfg.ssh_scope(), "per-shed");
+        assert_eq!(cfg.ssh_session_ttl(), "30m");
     }
 
     /// Mirrors `config_test.go:TestLoadConfigDeprecatedDesktopKeysIgnored`. A config

--- a/crates/shed-host-agent/src/main.rs
+++ b/crates/shed-host-agent/src/main.rs
@@ -47,6 +47,10 @@ mod sockets;
 mod ssh_backend;
 mod ssh_backend_agent;
 mod status;
+// The native macOS Touch-ID / biometrics approval gate (always-on, `#[cfg(target_os=
+// "macos")]` inside — NOT feature-gated: a headless mac daemon needs no desktop app to
+// do biometrics). On non-mac the biometric policies fail closed to deny-all.
+mod touchid;
 // The multi-server supervisor: reconciles per-server watcher groups against the desired
 // set the discovery source resolves to. Always-on (the daemon drives it in BOTH modes —
 // single-server is just a discovery config that reconciles once and never reloads).
@@ -342,6 +346,15 @@ fn run_daemon(config_path: &str, log_file: &str) -> i32 {
     let select_gate = |policy: &str| -> Arc<dyn approval::ApprovalGate> {
         match policy {
             config::POLICY_APPROVE_ALL => Arc::new(approval::ApproveAllGate),
+            // The two native-biometric policies route to the Touch-ID gate. UNCONDITIONAL
+            // match arm (NO `#[cfg]` here) — mirroring Go's `gateFor → newApprovalGate`;
+            // the single `#[cfg(target_os="macos")]` seam lives inside
+            // `touchid::new_biometric_gate` (macos → TouchIdGate; non-mac → DenyAllGate).
+            // Only the ssh gate can ever reach here — `validate` rejects biometrics for
+            // aws/docker.
+            config::POLICY_BIOMETRICS | config::POLICY_BIOMETRICS_OR_PASSWORD => {
+                touchid::new_biometric_gate(policy, cfg.ssh_scope(), cfg.ssh_session_ttl())
+            }
             #[cfg(feature = "desktop-forwarding")]
             config::POLICY_SHED_DESKTOP => {
                 Arc::new(desktop::DesktopGate::new(desktop_server.clone()))

--- a/crates/shed-host-agent/src/touchid.rs
+++ b/crates/shed-host-agent/src/touchid.rs
@@ -630,7 +630,6 @@ mod real {
 #[cfg(all(test, not(target_os = "macos")))]
 mod stub_tests {
     use super::new_biometric_gate;
-    use crate::approval::ApprovalGate;
     use crate::config::POLICY_DENY_ALL;
 
     #[tokio::test]

--- a/crates/shed-host-agent/src/touchid.rs
+++ b/crates/shed-host-agent/src/touchid.rs
@@ -1,0 +1,623 @@
+//! The native macOS Touch-ID / biometrics approval gate — a pure-`objc2` port of the
+//! Go daemon's CGO `touchid_darwin.go` (`LAContext.canEvaluatePolicy` /
+//! `evaluatePolicy`) + `touchid_stub.go` (the `!darwin` deny-all twin). This is the
+//! last CGO in `cmd/shed-host-agent`, so the Rust binary needs NO C toolchain: `objc2`
+//! links LocalAuthentication / Foundation at the linker level (`#[link(kind =
+//! "framework")]`) — no `import "C"`, no clang glue.
+//!
+//! Mirrors Go EXACTLY:
+//!   * LAPolicy map — `allow_password` (`biometrics-or-password`) →
+//!     `DeviceOwnerAuthentication` (biometrics + Apple-Watch / password fallback);
+//!     else (`biometrics`) → `DeviceOwnerAuthenticationWithBiometrics` (Touch-ID only).
+//!     `allow_password = policy != "biometrics"` (Go's `resolveAllowPassword`).
+//!   * COARSE result map — `canEvaluatePolicy` false → unavailable ("not available");
+//!     a reply `success` → approved; ANY non-success reply (every `LAError`) → denied.
+//!     No per-`LAError` branch (unlike the Tauri B3 reference's `map_la_error`): the
+//!     wire only ever sees the `approved` bool, so richness is non-parity.
+//!   * Scope / TTL cache — `per-session` (global) / `per-shed` (keyed `server/shed`) /
+//!     `per-request` (always prompt); a fresh prompt audits `decided_by:"touchid"`, a
+//!     cache hit `decided_by:"policy"`; an approve writes BOTH caches regardless of
+//!     scope; TTL parse-fail → 4h; the audited `ttl` is the RAW `session_ttl` text.
+//!   * (C1) deny AND unavailable BOTH return the EMPTY outcome (`decided_by:""`,
+//!     `scope:None`, `ttl:None`, carrying only `reason`) — Go returns
+//!     `ApprovalOutcome{}` on both (`touchid_darwin.go:129,131`), DISCARDING the built
+//!     scope/ttl. Only the approve + cache-hit paths populate them.
+//!
+//! The proven primitive is `desktop/tauri/src-tauri/src/approval.rs` (`macos::
+//! TouchIdGate`); this ADAPTS it (separate build worlds — the Tauri crate is its own
+//! workspace; duplicating the ~40-line ObjC seam keeps Tauri deps out of `crates/`).
+//! Deltas vs the reference: the coarse bool result (no `map_la_error`), the scope/TTL
+//! cache (the Tauri gate is cache-less), and this crate's own `ApprovalGate` /
+//! `ApprovalOutcome` types.
+//!
+//! The live prompt cannot be automated (a real fingerprint on a signed build); the
+//! `LocalAuth` seam makes everything UP TO the two ObjC calls unit-testable via
+//! `FakeAuth` (no prompt), on macOS AND Linux CI. The gate machinery is compiled on
+//! macOS (real) and in any `test` build (the fake); the ObjC `RealLocalAuth` is
+//! macOS-only. On non-macOS `new_biometric_gate` fails closed to `DenyAllGate`.
+
+use std::sync::Arc;
+
+use crate::approval::ApprovalGate;
+
+/// Build the native-biometric approval gate for the given policy (the darwin factory,
+/// mirroring `touchid_darwin.go:newApprovalGate`): `allow_password = policy !=
+/// "biometrics"`, TTL parsed from `session_ttl` (parse-fail → 4h). The single
+/// `#[cfg(target_os = "macos")]` seam lives HERE (not at the `main.rs` routing site,
+/// which is an unconditional match arm) — mirroring Go's `gateFor → newApprovalGate`,
+/// where the build tag picks the darwin gate vs the stub inside the factory.
+#[cfg(target_os = "macos")]
+pub fn new_biometric_gate(policy: &str, scope: &str, session_ttl: &str) -> Arc<dyn ApprovalGate> {
+    Arc::new(TouchIdGate::new(
+        Box::new(real::RealLocalAuth),
+        allow_password(policy),
+        scope,
+        session_ttl,
+    ))
+}
+
+/// The `touchid_stub.go` twin: off macOS there is no LocalAuthentication, so the
+/// biometric policies fail CLOSED to deny-all (never silent-approve). `main.rs`'s
+/// biometric `select_gate` arm is unconditional, so it routes here on Linux and the
+/// deny-safe fallback is uniform.
+#[cfg(not(target_os = "macos"))]
+pub fn new_biometric_gate(
+    _policy: &str,
+    _scope: &str,
+    _session_ttl: &str,
+) -> Arc<dyn ApprovalGate> {
+    Arc::new(crate::approval::DenyAllGate)
+}
+
+// The gate machinery is compiled on macOS (production) and in any `test` build (the
+// `FakeAuth`-driven units run on macOS AND Linux CI). On a non-macOS NON-test build it
+// is absent — `new_biometric_gate` there is the deny-all stub, so nothing references
+// it and there is no dead code.
+#[cfg(any(target_os = "macos", test))]
+mod gate {
+    use std::collections::HashMap;
+    use std::time::{Duration, Instant};
+
+    use crate::approval::{ApprovalGate, ApprovalOutcome};
+    use crate::config::{self, POLICY_BIOMETRICS, POLICY_BIOMETRICS_OR_PASSWORD};
+
+    /// Go's `resolveAllowPassword` (`config.go:414`): any policy other than the
+    /// biometrics-only policy allows the password / Apple-Watch fallback. `gateFor`
+    /// only routes the two biometric policies here, so in practice this is
+    /// `biometrics → false`, `biometrics-or-password → true`.
+    pub(super) fn allow_password(policy: &str) -> bool {
+        policy != POLICY_BIOMETRICS
+    }
+
+    /// A seam over `LAContext` so the gate's decision logic is unit-testable WITHOUT a
+    /// real biometric prompt (`canEvaluatePolicy` is true on any enrolled Mac, so the
+    /// real gate would fire a live prompt). Tests inject `FakeAuth`; production uses
+    /// `RealLocalAuth`. `Send + Sync` so `TouchIdGate` can back an `Arc<dyn
+    /// ApprovalGate>`. The result is COARSE (a plain bool) — Go collapses every
+    /// `LAError` into `success == false`, and the wire only sees `approved`.
+    #[async_trait::async_trait]
+    pub(super) trait LocalAuth: Send + Sync {
+        /// Can the device satisfy the policy right now (biometrics/passcode enrolled)?
+        /// `false` → the gate reports "not available" WITHOUT ever prompting.
+        fn can_evaluate(&self, allow_password: bool) -> bool;
+        /// Present the OS prompt + await the decision. `true` = approved; `false` =
+        /// denied (incl. every `LAError`, a 120s timeout, or a task failure — all
+        /// deny-safe).
+        async fn evaluate(&self, allow_password: bool, reason: &str) -> bool;
+    }
+
+    /// The scope/TTL approval cache (Go's `lastApproval` + `shedApprovals`), behind the
+    /// gate's `tokio::Mutex`. Per-shed keys are `server/shed` so identical shed names
+    /// on different servers don't share an approval; per-session stays global.
+    #[derive(Default)]
+    struct CacheState {
+        last_approval: Option<Instant>,
+        shed_approvals: HashMap<String, Instant>,
+    }
+
+    /// The macOS Touch-ID `ApprovalGate` — `LAContext.evaluatePolicy` behind the
+    /// [`LocalAuth`] seam plus the scope/TTL cache. Holds NO `objc2`/`LAContext` field
+    /// (L5) — only the `Box<dyn LocalAuth>` seam — so it stays `Send + Sync`; the ObjC
+    /// objects live only on the `spawn_blocking` stack inside `RealLocalAuth`.
+    pub(super) struct TouchIdGate {
+        auth: Box<dyn LocalAuth>,
+        allow_password: bool,
+        scope: String,
+        /// The RAW `session_ttl` string — what the approve/cache-hit outcome audits
+        /// (`out.TTL = cfg.SessionTTL`), NOT the parsed/defaulted duration (M3).
+        ttl_text: String,
+        /// The parsed cache TTL (parse-fail → 4h), used only for the cache math.
+        ttl: Duration,
+        cache: tokio::sync::Mutex<CacheState>,
+    }
+
+    impl TouchIdGate {
+        /// Mirror `touchid_darwin.go:newApprovalGate`: parse `session_ttl` for the
+        /// cache TTL (parse-fail / non-positive → 4h) via the shared Go-duration subset
+        /// (no second parser), retain the raw text for the audit.
+        pub(super) fn new(
+            auth: Box<dyn LocalAuth>,
+            allow_password: bool,
+            scope: &str,
+            session_ttl: &str,
+        ) -> TouchIdGate {
+            let ttl = match config::parse_go_duration_nanos(session_ttl) {
+                Some(n) if n > 0 => Duration::from_nanos(n as u64),
+                _ => Duration::from_secs(4 * 60 * 60),
+            };
+            TouchIdGate {
+                auth,
+                allow_password,
+                scope: scope.to_string(),
+                ttl_text: session_ttl.to_string(),
+                ttl,
+                cache: tokio::sync::Mutex::new(CacheState::default()),
+            }
+        }
+
+        /// The POPULATED approve / cache-hit outcome (M3: carries `scope` + the RAW
+        /// `ttl_text`, and `decided_by` = `"touchid"` for a fresh prompt / `"policy"`
+        /// for a cache hit).
+        fn approved(&self, decided_by: &str) -> ApprovalOutcome {
+            ApprovalOutcome {
+                approved: true,
+                decided_by: decided_by.to_string(),
+                scope: Some(self.scope.clone()),
+                ttl: Some(self.ttl_text.clone()),
+                reason: String::new(),
+            }
+        }
+
+        /// (C1) The EMPTY outcome returned on BOTH deny and unavailable — Go returns
+        /// `ApprovalOutcome{}` on both, DISCARDING the built scope/ttl; only `reason`
+        /// is set (the ssh deny audit ignores it, but it's kept for fidelity).
+        fn empty(reason: &str) -> ApprovalOutcome {
+            ApprovalOutcome {
+                approved: false,
+                decided_by: String::new(),
+                scope: None,
+                ttl: None,
+                reason: reason.to_string(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ApprovalGate for TouchIdGate {
+        async fn approve(
+            &self,
+            _ns: &str,
+            _op: &str,
+            server: &str,
+            shed: &str,
+            detail: &str,
+        ) -> ApprovalOutcome {
+            // ONE `tokio::Mutex` held across the WHOLE call (cache-check + evaluate +
+            // store) reproduces Go's whole-`Approve` `sync.Mutex`: at most one live
+            // Touch-ID prompt, and cache-hits serialize under the same lock. This is a
+            // Rust-only mechanism (Go gets serialization free from a blocking call
+            // under a sync lock); a `tokio::Mutex` held across `.await` is sound and
+            // does NOT trip `clippy::await_holding_lock` (that lint targets std /
+            // parking_lot locks). Monotonic `Instant` vs Go's wall-clock `time.Now()`
+            // for the TTL math is a benign, non-wire-observable divergence (L7).
+            let mut cache = self.cache.lock().await;
+            let now = Instant::now();
+            // The `server/shed` cache key is built lazily — only the `per-shed` lookup
+            // and the approve write-back consume it, so a `per-session` cache hit (the
+            // steady-state hot path) allocates nothing.
+            let cache_hit = match self.scope.as_str() {
+                "per-session" => cache
+                    .last_approval
+                    .is_some_and(|t| now.duration_since(t) < self.ttl),
+                "per-shed" => cache
+                    .shed_approvals
+                    .get(&format!("{server}/{shed}"))
+                    .is_some_and(|&t| now.duration_since(t) < self.ttl),
+                // per-request (and any unrecognized / empty scope) → always prompt.
+                _ => false,
+            };
+            if cache_hit {
+                return self.approved("policy");
+            }
+            // Deny-safe pre-check (Go's `canEvaluatePolicy` false → -1): never prompt.
+            if !self.auth.can_evaluate(self.allow_password) {
+                return Self::empty("touch ID not available on this device");
+            }
+            let reason = format!("shed-extensions: {detail} (server: {server}, shed: {shed})");
+            if self.auth.evaluate(self.allow_password, &reason).await {
+                // Go writes BOTH caches on approve, regardless of scope (so switching
+                // scope on a reload can serve a stale cross-scope approval within TTL).
+                cache.last_approval = Some(now);
+                cache.shed_approvals.insert(format!("{server}/{shed}"), now);
+                self.approved("touchid")
+            } else {
+                // Denied — incl. every `LAError`, the 120s timeout, and a task failure.
+                Self::empty("touch ID authentication denied")
+            }
+        }
+
+        fn method(&self) -> &str {
+            if self.allow_password {
+                POLICY_BIOMETRICS_OR_PASSWORD
+            } else {
+                POLICY_BIOMETRICS
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Mutex};
+        use std::time::Duration;
+
+        use super::{allow_password, LocalAuth, TouchIdGate};
+        use crate::approval::{ApprovalGate, ApprovalOutcome};
+        use crate::config::{POLICY_BIOMETRICS, POLICY_BIOMETRICS_OR_PASSWORD};
+
+        /// Shared, inspectable fake state (the gate moves the `Box<dyn LocalAuth>`, so
+        /// the test holds an `Arc` clone to read the call counter + captured reason).
+        struct FakeState {
+            can: bool,
+            approve: bool,
+            calls: AtomicUsize,
+            last_reason: Mutex<Option<String>>,
+        }
+
+        struct FakeAuth {
+            state: Arc<FakeState>,
+        }
+
+        #[async_trait::async_trait]
+        impl LocalAuth for FakeAuth {
+            fn can_evaluate(&self, _allow_password: bool) -> bool {
+                self.state.can
+            }
+            async fn evaluate(&self, _allow_password: bool, reason: &str) -> bool {
+                assert!(
+                    self.state.can,
+                    "evaluate() must not run when can_evaluate is false"
+                );
+                self.state.calls.fetch_add(1, Ordering::SeqCst);
+                *self.state.last_reason.lock().unwrap() = Some(reason.to_string());
+                self.state.approve
+            }
+        }
+
+        /// Build a gate over a `FakeAuth` and return the shared state for assertions.
+        fn gate_with(
+            can: bool,
+            approve: bool,
+            scope: &str,
+            ttl: &str,
+            allow_password: bool,
+        ) -> (TouchIdGate, Arc<FakeState>) {
+            let state = Arc::new(FakeState {
+                can,
+                approve,
+                calls: AtomicUsize::new(0),
+                last_reason: Mutex::new(None),
+            });
+            let gate = TouchIdGate::new(
+                Box::new(FakeAuth {
+                    state: state.clone(),
+                }),
+                allow_password,
+                scope,
+                ttl,
+            );
+            (gate, state)
+        }
+
+        /// The fixed ssh-sign call shape (`ns`/`op` unused by this gate; `detail` is
+        /// Go's fixed `"SSH sign request"`).
+        async fn approve(g: &TouchIdGate, server: &str, shed: &str) -> ApprovalOutcome {
+            g.approve("ssh-agent", "sign", server, shed, "SSH sign request")
+                .await
+        }
+
+        #[test]
+        fn allow_password_only_for_or_password() {
+            // Go's resolveAllowPassword: policy != biometrics.
+            assert!(!allow_password(POLICY_BIOMETRICS));
+            assert!(allow_password(POLICY_BIOMETRICS_OR_PASSWORD));
+            // Any other non-biometrics string is also true (gateFor only routes the two).
+            assert!(allow_password("anything-else"));
+        }
+
+        #[test]
+        fn new_biometric_gate_resolves_policy() {
+            // Mirrors TestNewApprovalGateResolvesPolicy: method() + carried scope, on
+            // the BUILT gate (never calling approve, which would prompt in production).
+            let (g, _) = gate_with(
+                true,
+                true,
+                "per-session",
+                "4h",
+                allow_password(POLICY_BIOMETRICS),
+            );
+            assert_eq!(g.method(), POLICY_BIOMETRICS);
+            assert_eq!(g.scope, "per-session");
+            let (g, _) = gate_with(
+                true,
+                true,
+                "per-shed",
+                "1h",
+                allow_password(POLICY_BIOMETRICS_OR_PASSWORD),
+            );
+            assert_eq!(g.method(), POLICY_BIOMETRICS_OR_PASSWORD);
+            assert_eq!(g.scope, "per-shed");
+        }
+
+        #[tokio::test]
+        async fn approved_sets_decided_by_touchid() {
+            let (g, state) = gate_with(true, true, "per-request", "4h", false);
+            let out = approve(&g, "srv", "web").await;
+            assert!(out.approved);
+            assert_eq!(out.decided_by, "touchid");
+            assert_eq!(out.scope.as_deref(), Some("per-request"));
+            assert_eq!(out.ttl.as_deref(), Some("4h"));
+            assert_eq!(state.calls.load(Ordering::SeqCst), 1);
+        }
+
+        #[tokio::test]
+        async fn only_real_success_yields_approved() {
+            // The single most important property: only a real `success` bool → approved.
+            // `Denied` and `Unavailable` NEVER approve.
+            for (can, appr) in [(true, true), (true, false), (false, true), (false, false)] {
+                let (g, _) = gate_with(can, appr, "per-request", "4h", false);
+                let out = approve(&g, "srv", "web").await;
+                assert_eq!(out.approved, can && appr, "can={can} approve={appr}");
+            }
+        }
+
+        #[tokio::test]
+        async fn denied_returns_empty_outcome() {
+            // (C1) deny discards the built scope/ttl → empty outcome, only `reason`.
+            let (g, _) = gate_with(true, false, "per-session", "4h", false);
+            let out = approve(&g, "srv", "web").await;
+            assert!(!out.approved);
+            assert_eq!(out.decided_by, "");
+            assert_eq!(out.scope, None);
+            assert_eq!(out.ttl, None);
+            assert_eq!(out.reason, "touch ID authentication denied");
+        }
+
+        #[tokio::test]
+        async fn unavailable_returns_empty_outcome() {
+            // (C1) unavailable also discards the built scope/ttl → empty outcome.
+            let (g, _) = gate_with(false, true, "per-session", "4h", false);
+            let out = approve(&g, "srv", "web").await;
+            assert!(!out.approved);
+            assert_eq!(out.decided_by, "");
+            assert_eq!(out.scope, None);
+            assert_eq!(out.ttl, None);
+            assert_eq!(out.reason, "touch ID not available on this device");
+        }
+
+        #[tokio::test]
+        async fn unavailable_never_calls_evaluate() {
+            // The deny-safe pre-check: can_evaluate false → evaluate() is never reached.
+            let (g, state) = gate_with(false, true, "per-request", "4h", false);
+            let out = approve(&g, "srv", "web").await;
+            assert!(!out.approved);
+            assert_eq!(state.calls.load(Ordering::SeqCst), 0);
+        }
+
+        #[tokio::test]
+        async fn per_session_cache_hit_sets_policy() {
+            let (g, state) = gate_with(true, true, "per-session", "4h", false);
+            // First prompts (touchid); second within TTL → cache hit (policy), NO prompt.
+            let first = approve(&g, "srv", "web").await;
+            assert_eq!(first.decided_by, "touchid");
+            let second = approve(&g, "srv", "web").await;
+            assert_eq!(second.decided_by, "policy");
+            // (M3) the cache-hit outcome STILL carries scope + ttl.
+            assert_eq!(second.scope.as_deref(), Some("per-session"));
+            assert_eq!(second.ttl.as_deref(), Some("4h"));
+            assert_eq!(state.calls.load(Ordering::SeqCst), 1, "only one prompt");
+        }
+
+        #[tokio::test]
+        async fn per_session_cache_expires_reprompts() {
+            let (g, state) = gate_with(true, true, "per-session", "4h", false);
+            approve(&g, "srv", "web").await;
+            // Age the cached approval past the TTL deterministically (no wall-clock
+            // sleep): push last_approval back well beyond 4h (or drop it on underflow).
+            {
+                let mut c = g.cache.lock().await;
+                c.last_approval = c
+                    .last_approval
+                    .and_then(|t| t.checked_sub(Duration::from_secs(5 * 60 * 60)));
+            }
+            let out = approve(&g, "srv", "web").await;
+            assert_eq!(out.decided_by, "touchid", "expired → re-prompt");
+            assert_eq!(state.calls.load(Ordering::SeqCst), 2);
+        }
+
+        #[tokio::test]
+        async fn per_shed_cache_keyed_by_server_shed() {
+            let (g, state) = gate_with(true, true, "per-shed", "4h", false);
+            approve(&g, "srv", "web").await; // caches srv/web
+            assert_eq!(approve(&g, "srv", "web").await.decided_by, "policy"); // hit
+            assert_eq!(approve(&g, "srv", "api").await.decided_by, "touchid"); // other shed
+            assert_eq!(approve(&g, "srv2", "web").await.decided_by, "touchid"); // other server
+                                                                                // srv/web hit (no prompt) + srv/api + srv2/web prompted = 3 prompts.
+            assert_eq!(state.calls.load(Ordering::SeqCst), 3);
+        }
+
+        #[tokio::test]
+        async fn per_request_always_prompts() {
+            let (g, state) = gate_with(true, true, "per-request", "4h", false);
+            assert_eq!(approve(&g, "srv", "web").await.decided_by, "touchid");
+            assert_eq!(approve(&g, "srv", "web").await.decided_by, "touchid");
+            assert_eq!(state.calls.load(Ordering::SeqCst), 2);
+        }
+
+        #[tokio::test]
+        async fn unknown_scope_always_prompts() {
+            // An empty / unrecognized scope has no cache arm → always prompt.
+            for scope in ["", "bogus"] {
+                let (g, state) = gate_with(true, true, scope, "4h", false);
+                approve(&g, "srv", "web").await;
+                approve(&g, "srv", "web").await;
+                assert_eq!(state.calls.load(Ordering::SeqCst), 2, "scope {scope:?}");
+            }
+        }
+
+        #[tokio::test]
+        async fn approve_populates_both_caches() {
+            // Go writes BOTH caches on approve, regardless of scope (per-request here).
+            let (g, _) = gate_with(true, true, "per-request", "4h", false);
+            approve(&g, "srv", "web").await;
+            let c = g.cache.lock().await;
+            assert!(c.last_approval.is_some());
+            assert!(c.shed_approvals.contains_key("srv/web"));
+        }
+
+        #[tokio::test]
+        async fn bad_session_ttl_defaults_to_4h() {
+            // (M3) parse-fail → the parsed cache TTL = 4h, BUT the approve outcome's
+            // ttl is the RAW `"nonsense"` text (`out.TTL = cfg.SessionTTL`), verbatim.
+            let (g, _) = gate_with(true, true, "per-request", "nonsense", false);
+            assert_eq!(g.ttl, Duration::from_secs(4 * 60 * 60));
+            let out = approve(&g, "srv", "web").await;
+            assert_eq!(out.ttl.as_deref(), Some("nonsense"));
+        }
+
+        #[tokio::test]
+        async fn prompt_string_matches_go() {
+            let (g, state) = gate_with(true, true, "per-request", "4h", false);
+            approve(&g, "srv", "web").await;
+            assert_eq!(
+                state.last_reason.lock().unwrap().as_deref(),
+                Some("shed-extensions: SSH sign request (server: srv, shed: web)")
+            );
+        }
+
+        #[test]
+        fn method_reflects_allow_password() {
+            let (g, _) = gate_with(true, true, "per-request", "4h", true);
+            assert_eq!(g.method(), POLICY_BIOMETRICS_OR_PASSWORD);
+            let (g, _) = gate_with(true, true, "per-request", "4h", false);
+            assert_eq!(g.method(), POLICY_BIOMETRICS);
+        }
+    }
+}
+
+// Only `new_biometric_gate`'s macOS body references these; the gate module's own
+// tests reach them via `super::`, so scope the re-export to macOS to avoid an
+// unused-import warning in the Linux `test` build.
+#[cfg(target_os = "macos")]
+use gate::{allow_password, TouchIdGate};
+
+// The real ObjC gate — macOS-only (objc2 links LocalAuthentication / Foundation at the
+// linker level). A near-verbatim adaptation of the proven Tauri B3 `RealLocalAuth`,
+// but returning Go's COARSE bool (no `map_la_error`).
+#[cfg(target_os = "macos")]
+mod real {
+    use block2::RcBlock;
+    use objc2::runtime::Bool;
+    use objc2_foundation::{NSError, NSString};
+    use objc2_local_authentication::{LAContext, LAPolicy};
+
+    use super::gate::LocalAuth;
+
+    /// `allow_password` (biometrics-or-password) → `DeviceOwnerAuthentication`
+    /// (biometrics + Apple-Watch / account-password fallback — works clamshell / no
+    /// sensor); else (biometrics) → `DeviceOwnerAuthenticationWithBiometrics` (Touch-ID
+    /// only). NOTE the Go sense: the Tauri reference names the inverse (`biometrics_only`).
+    pub(super) fn la_policy(allow_password: bool) -> LAPolicy {
+        if allow_password {
+            LAPolicy::DeviceOwnerAuthentication
+        } else {
+            LAPolicy::DeviceOwnerAuthenticationWithBiometrics
+        }
+    }
+
+    pub(super) struct RealLocalAuth;
+
+    #[async_trait::async_trait]
+    impl LocalAuth for RealLocalAuth {
+        fn can_evaluate(&self, allow_password: bool) -> bool {
+            // `canEvaluatePolicy` is a cheap thread-safe read; `Err` = not enrolled /
+            // no passcode → the gate reports "not available" without ever prompting.
+            let ctx = unsafe { LAContext::new() };
+            unsafe { ctx.canEvaluatePolicy_error(la_policy(allow_password)) }.is_ok()
+        }
+
+        async fn evaluate(&self, allow_password: bool, reason: &str) -> bool {
+            let policy = la_policy(allow_password);
+            let reason = reason.to_string();
+            // The `LAContext` + reply block are `!Send` and the reply lands on an
+            // arbitrary GCD thread — so confine ALL ObjC to one blocking thread and
+            // hand back only the (Send) bool. `TouchIdGate` holds no ObjC field, so the
+            // async future stays Send; `ctx` lives on the blocking thread's stack, kept
+            // alive by `recv_timeout` until the reply fires.
+            tokio::task::spawn_blocking(move || {
+                let (tx, rx) = std::sync::mpsc::channel::<bool>();
+                let ctx = unsafe { LAContext::new() };
+                let reason = NSString::from_str(&reason);
+                // Go's COARSE map: `success` → approved; ANY failure (every `LAError`,
+                // e.g. user cancel / auth-failed / lockout) → denied. Deliberately NO
+                // per-error branch (no `map_la_error`, L1) — the wire only sees the bool.
+                let reply = RcBlock::new(move |success: Bool, _error: *mut NSError| {
+                    let _ = tx.send(success.as_bool());
+                });
+                unsafe { ctx.evaluatePolicy_localizedReason_reply(policy, &reason, &reply) };
+                // 120s bound: a DOCUMENTED, SAFER divergence from Go's
+                // `DISPATCH_TIME_FOREVER` (M1). Go never times out, so a hung reply
+                // would wedge the gate AND hold the mutex forever; the bound caps the
+                // mutex hold. On timeout, cancel the lingering OS prompt and fail closed
+                // (denied). Go emits no timeout outcome, so there is no wire-parity
+                // conflict. Generous vs a human interaction (seconds); the request's own
+                // TTL expires it upstream regardless.
+                match rx.recv_timeout(std::time::Duration::from_secs(120)) {
+                    Ok(v) => v,
+                    Err(_) => {
+                        unsafe { ctx.invalidate() };
+                        false
+                    }
+                }
+            })
+            .await
+            .unwrap_or(false) // task-fail → deny-safe
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::la_policy;
+        use objc2_local_authentication::LAPolicy;
+
+        #[test]
+        fn la_policy_maps_biometrics_and_password() {
+            // allow_password=true → DeviceOwnerAuthentication (password fallback);
+            // false → WithBiometrics (Touch-ID only). The Go LAPolicy map, verbatim.
+            assert_eq!(la_policy(true), LAPolicy::DeviceOwnerAuthentication);
+            assert_eq!(
+                la_policy(false),
+                LAPolicy::DeviceOwnerAuthenticationWithBiometrics
+            );
+        }
+    }
+}
+
+// The non-macOS deny-all twin (`touchid_stub.go`) — a fail-closed unit that runs on
+// Linux CI (where the biometric arm routes to `DenyAllGate`).
+#[cfg(all(test, not(target_os = "macos")))]
+mod stub_tests {
+    use super::new_biometric_gate;
+    use crate::approval::ApprovalGate;
+    use crate::config::POLICY_DENY_ALL;
+
+    #[tokio::test]
+    async fn non_mac_gate_is_deny_all() {
+        let g = new_biometric_gate("biometrics", "per-session", "4h");
+        assert_eq!(g.method(), POLICY_DENY_ALL);
+        let out = g
+            .approve("ssh-agent", "sign", "srv", "web", "SSH sign request")
+            .await;
+        assert!(!out.approved);
+    }
+}

--- a/crates/shed-host-agent/src/touchid.rs
+++ b/crates/shed-host-agent/src/touchid.rs
@@ -141,9 +141,16 @@ mod gate {
             scope: &str,
             session_ttl: &str,
         ) -> TouchIdGate {
+            // Go: `time.ParseDuration` succeeds → keep the value (incl. 0 / negative);
+            // only a PARSE ERROR (or empty) falls back to 4h (`touchid_darwin.go:64`).
+            // A zero/negative TTL clamps to `Duration::ZERO`, so the strict `< ttl`
+            // cache check is always false → always re-prompt — matching Go, where a
+            // `session_ttl: "0"` is the natural "no caching" hardening choice
+            // (`now.Sub(t) < 0` is always false). The earlier `n > 0` guard wrongly
+            // rewrote 0/negative to 4h (CodeRabbit F1).
             let ttl = match config::parse_go_duration_nanos(session_ttl) {
-                Some(n) if n > 0 => Duration::from_nanos(n as u64),
-                _ => Duration::from_secs(4 * 60 * 60),
+                Some(n) => Duration::from_nanos(n.max(0) as u64),
+                None => Duration::from_secs(4 * 60 * 60),
             };
             TouchIdGate {
                 auth,
@@ -433,6 +440,21 @@ mod gate {
             let out = approve(&g, "srv", "web").await;
             assert_eq!(out.decided_by, "touchid", "expired → re-prompt");
             assert_eq!(state.calls.load(Ordering::SeqCst), 2);
+        }
+
+        #[tokio::test]
+        async fn zero_and_negative_ttl_always_reprompt() {
+            // Go: ParseDuration("0")=(0,nil) → sessionTTL=0 → cache check `now.Sub(t)<0`
+            // always false → always re-prompt (the "no caching" hardening choice).
+            // Must NOT fall back to 4h (CodeRabbit F1). Same for a negative TTL.
+            for ttl in ["0", "-5m"] {
+                let (g, state) = gate_with(true, true, "per-session", ttl, false);
+                assert_eq!(g.ttl, Duration::ZERO, "ttl={ttl}");
+                assert_eq!(approve(&g, "srv", "web").await.decided_by, "touchid");
+                // Second sign in the same instant: strict `< ZERO` is always false → prompt again.
+                assert_eq!(approve(&g, "srv", "web").await.decided_by, "touchid");
+                assert_eq!(state.calls.load(Ordering::SeqCst), 2, "ttl={ttl}: re-prompted");
+            }
         }
 
         #[tokio::test]


### PR DESCRIPTION
Sub-plan 7 of the **3a.1 completion program** (stacked on #268 → #267 → …): port the host-agent's native macOS **Touch-ID / biometrics approval gate** from Go CGO to pure-Rust objc2 — removing the last CGO from the daemon (the Rust binary is now C-toolchain-free).

Plan: `~/.claude/plans/monorepo-phase3-host-agent-touchid.md`, panel-reviewed by **Kimi K2.6 + CodeRabbit** (both source-verified; Codex usage-limited).

## What it does

`touchid.rs`: a `LocalAuth` seam trait + a macOS `RealLocalAuth` adapted from the already-shipping Tauri B3 gate (`LAContext.canEvaluatePolicy`/`evaluatePolicy`, `RcBlock` reply → mpsc, `spawn_blocking` + `recv_timeout(120s)` → `ctx.invalidate()`+deny on timeout — a documented safer divergence from Go's `DISPATCH_TIME_FOREVER`, which also bounds the mutex hold). `TouchIdGate` holds no objc2 field (Send+Sync — ObjC lives only on the `spawn_blocking` stack) and serializes `Approve` under one `tokio::Mutex` (Go's whole-`Approve` `sync.Mutex` parity). Coarse result map: both `success==false` arms → Denied (no `map_la_error` — the wire only sees the approved bool). LAPolicy `allow_password(=policy!="biometrics")` → `DeviceOwnerAuthentication` else `WithBiometrics`; reason string byte-matches Go.

**Wire-critical (CodeRabbit C1):** deny AND unavailable return the *empty* outcome (`decided_by:""`, `scope:None`, `ttl:None`, only `reason`) — the deny audit is wire-visible; only approve + cache-hit populate scope/ttl (raw `ttl_text` on approve). Scope/TTL cache: per-session / per-shed(`server/shed`) / per-request, both caches written on approve, TTL via `parse_go_duration_nanos` (parse-error/empty → 4h; a successfully-parsed `0`/negative is *kept* → always re-prompt, matching Go — F1 fix).

`config.rs` reads `ssh.approval.{scope,session_ttl}` null-aware (explicit `""` kept → always-prompt; absent/null → per-session/4h). `main.rs` `select_gate` gains the unconditional biometrics arm (the single `#[cfg(target_os=macos)]` seam lives inside `new_biometric_gate`; non-mac → `DenyAllGate`).

## Commits
- `f03181f` — the gate + seam + config + routing + objc2 deps + 18 units.
- `f4b72f9` — CodeRabbit F1 fix: `session_ttl: "0"`/negative always re-prompts (was wrongly cached 4h).

## Automatable coverage (green)
18 gate units via a `FakeAuth` seam (LAPolicy map, coarse result, C1 empty-outcome on deny/unavailable, cache scope/ttl/expiry, both-caches-on-approve, raw-ttl, zero/negative-ttl, routing, null-aware config) + config tests; both feature configs clippy-clean; 101 harness cells green, zero flips. objc2 deps darwin-cfg-gated, Apple-framework-only, leaf-verified (`cargo tree -i objc2` reaches only shed-host-agent, only on macos; Linux resolves zero). Ad-hoc `codesign --force --sign -` verifies (LocalAuthentication needs no entitlement). CodeRabbit review: **one real bug found (F1, fixed); everything else verified correct** including no reachable UB in the objc2 blocks.

---

## ⚠️ REQUIRED: manual Touch-ID sign-off (the live prompt cannot be automated)

Run on an Apple-Silicon Mac with Touch ID enrolled, from the `wt-touchid` worktree, and paste your observed outcomes below.

- [ ] **Step 0 — build + ad-hoc-sign both binaries.** `cargo build -p shed-host-agent` → `codesign --force --sign - crates/target/debug/shed-host-agent` (no entitlements). **Positive control:** build + sign the *Go* binary the same way; confirm IT prompts (Step 2). If Go prompts, signing is correct → any Rust "unavailable" is a real Rust bug; if Go *also* doesn't prompt, the signing is wrong (fix first).
- [ ] **Step 2 — approve:** `policy: biometrics`, drive a sign → dialog reads exactly `shed-extensions: SSH sign request (server: <srv>, shed: <shed>)`, approve → sign succeeds, audit `{approval:"biometrics", decided_by:"touchid"}`.
- [ ] **Step 3 — deny:** cancel → denied, audit `result:"denied"` with **empty** decided_by/scope/ttl, **no** `code`, error response `SIGN_FAILED`; recovers on the next request.
- [ ] **Step 4 — fallback:** `policy: biometrics-or-password` → dialog offers password/Apple-Watch.
- [ ] **Step 5 — cache:** `scope: per-session, session_ttl: 1h` → first sign prompts, second within TTL does not (audit `decided_by:"policy"`); repeat for `per-shed`.
- [ ] **Step 7 — parity:** Go and Rust dialogs + audit fields match across steps 2–5; Rust built with no `import "C"`/cgo.

**Sign-off:** ________________ (name / date)

The full checklist with exact expected values is in the plan file. No server/guest changes; the Go touchid stays until its retirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED6csoQ3peM3GHc4c1CtqY
