### PR TITLE
feat(release): ship the Rust shed-host-agent via goreleaser builder:rust (Phase 3 · 3a.1 · sub-plan 9) [NO TAG]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,12 @@ jobs:
               # harness, the committed wire reference, and the shared build
               # manifests/locks/toolchain a dependency bump would ride in on.
               - 'crates/shed-host-agent/**'
+              # The Rust host-agent has a path-dep on shed-core, and the release
+              # build (builder: rust) reads rust-toolchain.toml — a change to
+              # either can break the shipped binary, so both must trigger the
+              # differential + the release-snapshot (which is gated on this filter).
+              - 'crates/shed-core/**'
+              - 'crates/rust-toolchain.toml'
               - 'crates/Cargo.toml'
               - 'crates/Cargo.lock'
               - 'cmd/shed-host-agent/**'
@@ -182,12 +188,19 @@ jobs:
       # `rustup target add`, but pre-adding fails fast if a target is unavailable.
       - name: Rust toolchain + zig cross tooling
         run: |
-          rustup toolchain install stable --profile minimal
+          # components: crates/rust-toolchain.toml declares rustfmt+clippy, which
+          # rustup would auto-install on first cargo use in crates/ (a flaky-network
+          # CI-only failure risk); install them explicitly up front.
+          rustup toolchain install stable --profile minimal --component rustfmt --component clippy
           rustup default stable
           rustup target add aarch64-apple-darwin x86_64-apple-darwin \
                             aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
+          # cargo-zigbuild pinned to the locally-validated version (reproducibility).
+          # zig itself is brew-current: a zig bump is a LOUD build failure caught
+          # by this snapshot job before any tag (not a silent ship); pinning zig
+          # harder is a tracked follow-up (see .goreleaser.yaml glibc-floor note).
           brew install zig
-          cargo install --locked cargo-zigbuild
+          cargo install --locked --version 0.23.0 cargo-zigbuild
       # First-ever CI exercise of the darwin build-tag half (the Go rollback
       # shed-host-agent's touchid_darwin.go, CGO) — de-risks the macos release job.
       - name: Run tests
@@ -215,10 +228,7 @@ jobs:
           # (ii) per-arch shed-machine-rc .debs, named to match apt-charliek's glob.
           ls dist/shed-machine-rc_*_amd64.deb dist/shed-machine-rc_*_arm64.deb
           # (iii) ALL FOUR shed-host-agent archives (now Rust) carry the binary AND
-          # the example config. Extract + run `version` on the darwin ones (this is
-          # a macos runner) to catch a present-but-broken cross-build that still
-          # passes `tar tzf`; assert the arm64 binary keeps its linker ad-hoc
-          # signature (matches the Go baseline — no explicit codesign step).
+          # the example config.
           workdir="$(mktemp -d)"
           for os in darwin linux; do
             for arch in amd64 arm64; do
@@ -228,16 +238,23 @@ jobs:
               tar tzf "$tgz" | grep -qx 'extensions.example.yaml' || { echo "::error::$tgz missing extensions.example.yaml"; tar tzf "$tgz"; exit 1; }
             done
           done
-          for arch in amd64 arm64; do
-            rm -f "$workdir/shed-host-agent"
-            tar xzf "dist/shed-host-agent_darwin_${arch}.tar.gz" -C "$workdir" shed-host-agent
-            out="$("$workdir/shed-host-agent" version)"
-            echo "darwin/${arch}: $out"
-            case "$out" in shed-host-agent\ *) ;; *) echo "::error::darwin/${arch} version output unexpected: $out"; exit 1;; esac
-          done
-          # The loop above ends on arm64, so $workdir/shed-host-agent is the arm64
-          # binary — assert its linker ad-hoc signature survived packaging.
+          # Runtime check for the DARWIN binaries. macos-latest is arm64 (Apple
+          # Silicon) with no guaranteed Rosetta, so only the NATIVE arm64 binary is
+          # executed (`version` — catches a present-but-broken cross-build that
+          # passes `tar tzf`); the x86_64 one is validated structurally with `file`
+          # (never executed, so no Rosetta dependency). Assert the arm64 binary
+          # keeps its linker ad-hoc signature (matches the Go baseline — no explicit
+          # codesign step; a future zig that drops it fails loudly here, pre-tag).
+          tar xzf dist/shed-host-agent_darwin_arm64.tar.gz -C "$workdir" shed-host-agent
+          arm64_out="$("$workdir/shed-host-agent" version)"
+          echo "darwin/arm64: $arm64_out"
+          case "$arm64_out" in shed-host-agent\ *) ;; *) echo "::error::darwin/arm64 version output unexpected: $arm64_out"; exit 1;; esac
           codesign -dv "$workdir/shed-host-agent" 2>&1 | grep -q 'Signature=adhoc' || { echo "::error::arm64 shed-host-agent lost its ad-hoc signature"; codesign -dv "$workdir/shed-host-agent" 2>&1; exit 1; }
+          rm -f "$workdir/shed-host-agent"
+          tar xzf dist/shed-host-agent_darwin_amd64.tar.gz -C "$workdir" shed-host-agent
+          amd64_file="$(file "$workdir/shed-host-agent")"
+          echo "$amd64_file" | grep -q 'Mach-O.*x86_64' || { echo "::error::darwin/amd64 is not a well-formed x86_64 Mach-O: $amd64_file"; exit 1; }
+          echo "darwin/amd64: $amd64_file"
           # (iv) rollback insurance: the detached Go ids still compiled.
           python3 - <<'PY'
           import json,sys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,10 +159,15 @@ jobs:
   release-snapshot:
     name: GoReleaser snapshot (artifact sanity)
     needs: changes
-    if: ${{ needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' }}
-    # macos-latest matches the real release runner: shed-host-agent's darwin build
-    # needs CGO (Touch ID), which can't cross-compile from linux. goreleaser's
-    # snapshot cross-builds the linux ids fine (CGO off for those).
+    # Also gated on `hostagent`: the SHIPPED shed-host-agent binary is now built
+    # from crates/shed-host-agent/ (builder: rust), so a crates-only PR must run
+    # this snapshot to prove the release build still resolves. The `hostagent`
+    # filter already scopes crates/shed-host-agent/** (+ cmd/shed-host-agent/**).
+    if: ${{ needs.changes.outputs.go == 'true' || needs.changes.outputs.hostagent == 'true' || needs.changes.outputs.ci == 'true' }}
+    # macos-latest matches the real release runner. The shipped shed-host-agent is
+    # Rust (builder: rust / cargo zigbuild — cross-builds the linux targets from
+    # macOS via zig); the detached Go rollback ids still compile here (darwin needs
+    # CGO for Touch ID). goreleaser cross-builds the Go linux ids (CGO off) fine.
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -172,8 +177,19 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      # First-ever CI exercise of the darwin build-tag half (shed-host-agent's
-      # touchid_darwin.go, CGO) — de-risks the macos release job before a tag.
+      # Rust + cross tooling for `builder: rust`. goreleaser's rust builder shells
+      # out to `cargo zigbuild`, which needs zig + cargo-zigbuild; it auto-runs
+      # `rustup target add`, but pre-adding fails fast if a target is unavailable.
+      - name: Rust toolchain + zig cross tooling
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup target add aarch64-apple-darwin x86_64-apple-darwin \
+                            aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
+          brew install zig
+          cargo install --locked cargo-zigbuild
+      # First-ever CI exercise of the darwin build-tag half (the Go rollback
+      # shed-host-agent's touchid_darwin.go, CGO) — de-risks the macos release job.
       - name: Run tests
         run: go test ./...
       - name: GoReleaser snapshot build
@@ -198,13 +214,45 @@ jobs:
           done
           # (ii) per-arch shed-machine-rc .debs, named to match apt-charliek's glob.
           ls dist/shed-machine-rc_*_amd64.deb dist/shed-machine-rc_*_arm64.deb
-          # (iii) shed-host-agent darwin archives carry the binary AND the example config.
-          for arch in amd64 arm64; do
-            tgz="dist/shed-host-agent_darwin_${arch}.tar.gz"
-            ls "$tgz" >/dev/null || { echo "::error::missing $tgz"; exit 1; }
-            tar tzf "$tgz" | grep -qx 'shed-host-agent' || { echo "::error::$tgz missing shed-host-agent binary"; tar tzf "$tgz"; exit 1; }
-            tar tzf "$tgz" | grep -qx 'extensions.example.yaml' || { echo "::error::$tgz missing extensions.example.yaml"; tar tzf "$tgz"; exit 1; }
+          # (iii) ALL FOUR shed-host-agent archives (now Rust) carry the binary AND
+          # the example config. Extract + run `version` on the darwin ones (this is
+          # a macos runner) to catch a present-but-broken cross-build that still
+          # passes `tar tzf`; assert the arm64 binary keeps its linker ad-hoc
+          # signature (matches the Go baseline — no explicit codesign step).
+          workdir="$(mktemp -d)"
+          for os in darwin linux; do
+            for arch in amd64 arm64; do
+              tgz="dist/shed-host-agent_${os}_${arch}.tar.gz"
+              ls "$tgz" >/dev/null || { echo "::error::missing $tgz"; exit 1; }
+              tar tzf "$tgz" | grep -qx 'shed-host-agent' || { echo "::error::$tgz missing shed-host-agent binary"; tar tzf "$tgz"; exit 1; }
+              tar tzf "$tgz" | grep -qx 'extensions.example.yaml' || { echo "::error::$tgz missing extensions.example.yaml"; tar tzf "$tgz"; exit 1; }
+            done
           done
+          for arch in amd64 arm64; do
+            rm -f "$workdir/shed-host-agent"
+            tar xzf "dist/shed-host-agent_darwin_${arch}.tar.gz" -C "$workdir" shed-host-agent
+            out="$("$workdir/shed-host-agent" version)"
+            echo "darwin/${arch}: $out"
+            case "$out" in shed-host-agent\ *) ;; *) echo "::error::darwin/${arch} version output unexpected: $out"; exit 1;; esac
+          done
+          # The loop above ends on arm64, so $workdir/shed-host-agent is the arm64
+          # binary — assert its linker ad-hoc signature survived packaging.
+          codesign -dv "$workdir/shed-host-agent" 2>&1 | grep -q 'Signature=adhoc' || { echo "::error::arm64 shed-host-agent lost its ad-hoc signature"; codesign -dv "$workdir/shed-host-agent" 2>&1; exit 1; }
+          # (iv) rollback insurance: the detached Go ids still compiled.
+          python3 - <<'PY'
+          import json,sys
+          arts=json.load(open('dist/artifacts.json'))
+          seen={}
+          for a in arts:
+              ex=a.get('extra') or {}
+              if a.get('type')=='Binary' and ex.get('ID') in ('shed-host-agent-darwin','shed-host-agent-linux'):
+                  seen.setdefault(ex['ID'],set()).add(f"{a.get('goos')}/{a.get('goarch')}")
+          want={'shed-host-agent-darwin':{'darwin/amd64','darwin/arm64'},'shed-host-agent-linux':{'linux/amd64','linux/arm64'}}
+          if {k:seen.get(k) for k in want}!={k:v for k,v in want.items()}:
+              print(f"::error::Go rollback builds missing from artifacts.json: got {seen}");sys.exit(1)
+          print("Go rollback ids present:",{k:sorted(v) for k,v in seen.items()})
+          PY
+          rm -rf "$workdir"
           echo "release snapshot artifacts OK"
 
   # ---- desktop / crates legs (imported from shed-desktop's ci.yml) ----------

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -435,10 +435,11 @@ jobs:
     name: Build and Release
     needs: [release-plan, publish-build-tools, publish-vz, publish-fc, smoke]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && needs.release-plan.outputs.ship_go == 'true'
-    # macos-latest: shed-host-agent's darwin build needs CGO (Touch ID), which
-    # can't cross-compile from linux. The shed-extensions release pipeline ran on
-    # macos-latest — this is the proven shape. The image-publish jobs above keep
-    # their linux runners (they build the guest binaries with CGO off).
+    # macos-latest: the shipped shed-host-agent is Rust (builder: rust / cargo
+    # zigbuild — cross-builds the linux targets from macOS via zig), and the
+    # detached Go rollback ids still compile here (darwin needs CGO for Touch ID).
+    # This mirrors the ci.yml release-snapshot job so the snapshot is a faithful
+    # dry-run. The image-publish jobs above keep their linux runners.
     runs-on: macos-latest
     permissions:
       contents: write
@@ -454,6 +455,21 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      # Rust + cross tooling for `builder: rust` (mirrors release-snapshot).
+      # goreleaser's rust builder shells out to `cargo zigbuild`, needing zig +
+      # cargo-zigbuild; it auto-runs `rustup target add`, but pre-adding fails
+      # fast if a target is unavailable. The build env SHED_HOST_AGENT_VERSION=
+      # {{ .Version }} lives in .goreleaser.yaml, so it applies identically to
+      # the snapshot and this release — no per-job version munging.
+      - name: Rust toolchain + zig cross tooling
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup target add aarch64-apple-darwin x86_64-apple-darwin \
+                            aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
+          brew install zig
+          cargo install --locked cargo-zigbuild
 
       # The old inline "Verify plugin.json matches tag" step is gone: the
       # release-plan job owns that gate now (this job only runs when

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -464,12 +464,16 @@ jobs:
       # the snapshot and this release — no per-job version munging.
       - name: Rust toolchain + zig cross tooling
         run: |
-          rustup toolchain install stable --profile minimal
+          # Kept byte-identical to ci.yml's release-snapshot step (see the note
+          # there): explicit rustfmt+clippy (rust-toolchain.toml declares them),
+          # and cargo-zigbuild pinned to the validated version. zig is brew-current;
+          # a zig bump is a loud failure caught by release-snapshot pre-tag.
+          rustup toolchain install stable --profile minimal --component rustfmt --component clippy
           rustup default stable
           rustup target add aarch64-apple-darwin x86_64-apple-darwin \
                             aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
           brew install zig
-          cargo install --locked cargo-zigbuild
+          cargo install --locked --version 0.23.0 cargo-zigbuild
 
       # The old inline "Verify plugin.json matches tag" step is gone: the
       # release-plan job owns that gate now (this job only runs when

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -119,13 +119,24 @@ builds:
     builder: rust
     binary: shed-host-agent
     dir: crates
-    # -p= is REQUIRED: crates/ is a Cargo workspace and goreleaser's rust builder
-    # refuses a workspace build without --package/-p. --locked pins the committed
-    # Cargo.lock; --release is the builder default but explicit here.
+    # --package= is REQUIRED: crates/ is a Cargo workspace and goreleaser's rust
+    # builder refuses a workspace build without --package/-p (it detects the
+    # `--package=`/`-p=` prefix). --locked pins the committed Cargo.lock;
+    # --release is the builder default but explicit here.
     flags:
       - --release
       - --locked
-      - -p=shed-host-agent
+      - --package=shed-host-agent
+    # NOTE (linux glibc floor): the two *-unknown-linux-gnu targets currently link
+    # against cargo-zigbuild's default glibc (~2.30 — modern distros: Ubuntu 20.04+,
+    # RHEL 9+). The Go rollback build was CGO_ENABLED=0 (static), so the linux
+    # tarball's floor rose. Pinning it lower (e.g. `x86_64-unknown-linux-gnu.2.17`)
+    # is NOT possible on the pinned goreleaser v2.15.2 — its rust builder passes the
+    # raw glibc-suffixed triple to `rustup target add`, which rejects it (only
+    # `cargo zigbuild` itself strips the suffix). Tracked follow-up: pin the floor
+    # once goreleaser's rust builder strips the suffix before rustup. The linux
+    # tarball is a secondary GH-release download (no apt; brew/macOS is the only
+    # wired install path), so this does not affect the primary install identity.
     targets:
       - aarch64-apple-darwin
       - x86_64-apple-darwin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -107,6 +107,38 @@ builds:
       - -X github.com/charliek/shed/internal/version.GitCommit={{.ShortCommit}}
       - -X github.com/charliek/shed/internal/version.BuildDate={{.Date}}
 
+  # The SHIPPED host-agent binary — Rust (crates/shed-host-agent), built by
+  # goreleaser's OSS `builder: rust` (which runs `cargo zigbuild`) on the
+  # macos-latest release runner; it cross-compiles all four targets, linux via
+  # zig (probe-proven: linux ELF from macOS). The two Go ids above stay defined
+  # (goreleaser compiles every build regardless of archive refs) as ~2-release
+  # rollback insurance, but are detached from the archive below — flip
+  # archives[shed-host-agent].ids back to them to revert. See RELEASING.md
+  # "Host-agent: Rust binary, Go rollback". No `main:` (rust builder rejects it).
+  - id: shed-host-agent
+    builder: rust
+    binary: shed-host-agent
+    dir: crates
+    # -p= is REQUIRED: crates/ is a Cargo workspace and goreleaser's rust builder
+    # refuses a workspace build without --package/-p. --locked pins the committed
+    # Cargo.lock; --release is the builder default but explicit here.
+    flags:
+      - --release
+      - --locked
+      - -p=shed-host-agent
+    targets:
+      - aarch64-apple-darwin
+      - x86_64-apple-darwin
+      - aarch64-unknown-linux-gnu
+      - x86_64-unknown-linux-gnu
+    env:
+      # Baked into `shed-host-agent version` at compile time (version.rs
+      # option_env!). {{ .Version }} is the tag, already v-stripped (a snapshot
+      # pseudo-version under --snapshot), so the shipped version tracks the go
+      # release tag rather than CARGO_PKG_VERSION (which follows the desktop
+      # selector and is not bumped on a go-only tag).
+      - SHED_HOST_AGENT_VERSION={{ .Version }}
+
   - id: shed-machine-rc
     binary: shed-machine-rc
     main: ./cmd/shed-machine-rc
@@ -164,9 +196,12 @@ archives:
       - none*
 
   - id: shed-host-agent
+    # Ships the RUST build (id: shed-host-agent) — the Go ids
+    # (shed-host-agent-{darwin,linux}) stay defined + compiled as rollback
+    # insurance; flip this back to them to revert. Archive name/layout and the
+    # bundled extensions.example.yaml are UNCHANGED (install-identity anchor).
     ids:
-      - shed-host-agent-darwin
-      - shed-host-agent-linux
+      - shed-host-agent
     formats:
       - tar.gz
     name_template: "shed-host-agent_{{ .Os }}_{{ .Arch }}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -140,12 +140,49 @@ by GoReleaser via `.goreleaser.yaml`'s `builds[].ldflags`. The Docker
 images are tagged from `GITHUB_REF_NAME` at workflow time. None of
 those need a source-tree bump.
 
+> **Cross-selector subtlety — the Rust `shed-host-agent`.** Its source
+> version (`crates/Cargo.toml [workspace.package].version`) tracks the
+> **desktop** selector, but the binary **ships on the go selector** (see
+> "Host-agent: Rust binary, Go rollback" below). The shipped `shed-host-agent
+> version` is **not** `CARGO_PKG_VERSION`; GoReleaser's `builder: rust` build
+> sets `SHED_HOST_AGENT_VERSION={{ .Version }}` (the go tag), which
+> `crates/shed-host-agent/src/version.rs` reads via `option_env!`. So no
+> source bump is needed for the host-agent's shipped version either.
+
 `CHANGELOG.md` is maintained by the release skill for human-readable
 in-repo history. GoReleaser's auto-generated release notes (filtered:
 skip `docs:`, `test:`, `chore:`, `ci:`) go on the GitHub Release body.
 
 `pyproject.toml` is for mkdocs only and has its own version cadence;
 not touched by `update-version.sh`.
+
+## Host-agent: Rust binary, Go rollback
+
+Since the Phase-3 leg-3a.1 release-wiring change, the shipped
+`shed-host-agent` homebrew binary is built from the **Rust**
+`crates/shed-host-agent` (not the Go `cmd/shed-host-agent`), via
+GoReleaser's OSS `builder: rust` (which runs `cargo zigbuild`; the
+`release` + `release-snapshot` jobs install `zig` + `cargo-zigbuild`).
+`builder: prebuilt` is GoReleaser **Pro-only** and was not an option.
+
+- **Install identity is unchanged.** Same binary/formula/archive name, same
+  `brew services` `service` block (run args, PATH env, `keep_alive`, log
+  paths), same bundled `extensions.example.yaml` → `etc/shed/extensions.yaml`,
+  same `shed-host-agent status`/`version` surface. The swap only changed where
+  the binary is compiled from. No apt/`.deb` (the host-agent is brew-only).
+- **The Go build is kept as rollback insurance.** The Go ids
+  `shed-host-agent-{darwin,linux}` stay defined in `.goreleaser.yaml` (GoReleaser
+  compiles every `builds[]` entry regardless of archive references, so they are
+  still built + CI-exercised every snapshot; `release-snapshot` asserts them in
+  `dist/artifacts.json`) but are **detached from the archive**. To revert to the
+  Go binary, flip `archives[shed-host-agent].ids` back to the two Go ids — a
+  one-line change that already compiles green.
+- **Retirement trigger (a SEPARATE future task, not yet done).** Once the Rust
+  `shed-host-agent` has shipped clean for ~2 releases, delete `cmd/shed-host-agent`,
+  the two Go goreleaser ids, and the `hostagent`-filter's `cmd/shed-host-agent/**`
+  entry; the Go-vs-Rust differential harness (`tests/host-agent-diff/`) retires
+  with the Go daemon. Do this deliberately in its own PR — do NOT bundle it with
+  a feature change.
 
 ## Snapshot / dev versioning
 

--- a/crates/shed-host-agent/src/version.rs
+++ b/crates/shed-host-agent/src/version.rs
@@ -1,11 +1,28 @@
 //! Build/version identity for the daemon. The Go-vs-Rust differential harness
-//! masks the version value (§1 of the wire catalog), so slice 0 just emits a
-//! nonempty, stable line — the analog of the Go `version.FullInfo()`.
+//! masks the version value (§1 of the wire catalog), so the value itself is
+//! never wire-compared — this is the analog of the Go `version.FullInfo()`.
+//!
+//! Version source: the release pipeline builds this binary with
+//! `builder: rust` and sets `SHED_HOST_AGENT_VERSION={{ .Version }}` (the
+//! goreleaser tag version, already `v`-stripped; a snapshot pseudo-version in
+//! `--snapshot`). We read it at compile time via `option_env!` so the shipped
+//! `version` reports the release version rather than `CARGO_PKG_VERSION` — which
+//! tracks the *desktop* selector (`crates/Cargo.toml [workspace.package]`) and
+//! is NOT bumped on a go-only release. Local dev (var unset) falls back to
+//! `CARGO_PKG_VERSION`.
+
+/// Choose the version string: the release-injected value when present, else the
+/// crate's compiled `CARGO_PKG_VERSION`. Pure so both branches are unit-testable
+/// in a single build (a compiled `option_env!` fixes only one branch per build).
+fn pick_version<'a>(injected: Option<&'a str>, fallback: &'a str) -> &'a str {
+    injected.filter(|v| !v.is_empty()).unwrap_or(fallback)
+}
 
 /// `full_info` returns the daemon's version line, printed by the `version`
 /// subcommand and carried in the LiveStatus `version` field.
 pub fn full_info() -> String {
-    format!("shed-host-agent {}", env!("CARGO_PKG_VERSION"))
+    let version = pick_version(option_env!("SHED_HOST_AGENT_VERSION"), env!("CARGO_PKG_VERSION"));
+    format!("shed-host-agent {version}")
 }
 
 #[cfg(test)]
@@ -16,5 +33,19 @@ mod tests {
     fn full_info_is_nonempty() {
         assert!(full_info().starts_with("shed-host-agent "));
         assert!(full_info().len() > "shed-host-agent ".len());
+    }
+
+    #[test]
+    fn pick_version_prefers_injected() {
+        assert_eq!(pick_version(Some("0.8.0"), "0.7.10"), "0.8.0");
+        assert_eq!(pick_version(Some("0.0.0-snapshot-abc"), "0.7.10"), "0.0.0-snapshot-abc");
+    }
+
+    #[test]
+    fn pick_version_falls_back_when_absent_or_empty() {
+        assert_eq!(pick_version(None, "0.7.10"), "0.7.10");
+        // An empty injected var (e.g. `SHED_HOST_AGENT_VERSION=`) must not
+        // produce a `shed-host-agent ` line with a blank version.
+        assert_eq!(pick_version(Some(""), "0.7.10"), "0.7.10");
     }
 }

--- a/docs/discovery/monorepo-consolidation.md
+++ b/docs/discovery/monorepo-consolidation.md
@@ -140,7 +140,7 @@ Every release is a `vX.Y.Z` tag on shed's existing track (v0.7.x → …). What 
 | Desktop | `desktop/VERSION` (+ `crates/` Cargo versions in lockstep) | macOS DMG + EdDSA-signed Sparkle appcast entry + notarization; Linux `shed-desktop` .deb; apt dispatch |
 | Mobile | — (ad hoc, unchanged from today's shed-mobile flow) | manual / existing workflow, carried over at import |
 
-¹ until Phase 3 removes the standalone host-agent artifact.
+¹ `shed-host-agent` is now built from the **Rust** crate (`builder: rust`) as of leg 3a.1's release-wiring change — same brew formula + tarballs, Go kept as time-boxed rollback (see §6 · 3a.1 Status). The standalone artifact is retired only at 3a.2 (absorbed into the desktop app; the headless standalone persists for server/no-desktop use).
 
 So `v0.1.8` may bump both manifests (shed + desktop ship together — the default when both changed); `v0.1.9` may bump only `plugin.json` (server-only). The release skill takes a component list and bumps only those manifests; the changelog entry states what shipped.
 
@@ -272,6 +272,7 @@ The consolidation thesis (§1) is one shared client-side implementation — the 
 **Leg 3a — host-agent → Rust**, in two plans:
 
 - **3a.1 — port.** A standalone Rust host-agent daemon (`crates/shed-host-agent`), **wire-compatible** with the Go server, guest extensions, and desktop client, across the daemon's **two wire surfaces**: (A) the desktop/status **UDS** (approval / `token.get` / status / audit — wire types + client already in Rust), and (B) the shed-server **plugin bus** via `sdk.HostClient` (where the credential backends live — networked HTTP-streaming subscribe/respond, TLS-pinned, green-field in Rust). Shipped opt-in, diffed against the Go daemon via a differential + golden-fixture harness, then default. `objc2-local-authentication` replaces the Go CGO Touch-ID path (removes the CGO-on-darwin dependency). Ships **no user-visible change** — the install win is 3a.2.
+    - **Status (release-wiring done, pre-tag).** The port + full parity/differential harness are complete, and the release pipeline now builds the shipped `shed-host-agent` homebrew binary from the Rust crate via GoReleaser's OSS `builder: rust` (`cargo zigbuild`; `builder: prebuilt` is Pro-only). The Go `cmd/shed-host-agent` stays in-tree as ~2-release **rollback insurance** (its goreleaser ids are compiled + CI-asserted every snapshot but detached from the archive; revert = one-line `archives[].ids` flip). Retirement of the Go daemon + the differential harness is a **separate, later** task once the Rust binary has shipped clean for ~2 releases. See `RELEASING.md` § "Host-agent: Rust binary, Go rollback". No tag has been cut for this yet — the first tag that ships the Rust binary is a deliberate maintainer action.
 - **3a.2 — absorb into the desktop clients.** Move the daemon in-process into the desktop app (mac Swift + Tauri Linux; the Rust `HostAgentClient` already exists → process-to-in-process). **This is where the install-story win lands for desktop users**: the separate host-agent install step disappears (its brew formula + launchd/systemd unit retire for the desktop path) → `brew install shed` + the app. The **headless standalone host-agent** distribution stays available for server / no-desktop environments (see the Headless brokering bullet).
 
 Consequences to design for:


### PR DESCRIPTION
> ⚠️ **NO TAG / NO DEPLOY.** This PR makes the pipeline **ready** so the *next* `vX.Y.Z` go-component tag ships the **Rust** `shed-host-agent` as the homebrew binary. It **cuts no tag and publishes nothing** — the `publish-images.yaml` `release` job's goreleaser-publish + apt-dispatch steps are `refs/tags/`-gated. Validation is entirely no-tag (goreleaser `--snapshot`, `release-plan.sh` dry-run, CI). **The first tag that ships the Rust binary is a deliberate maintainer action, after this merges.**

Sub-plan 9 of the **3a.1 completion program** (stacked on #270). Swap the shipped `shed-host-agent` homebrew binary from Go (`cmd/shed-host-agent`) to the **Rust** `crates/shed-host-agent`, **without changing the install identity**, keep the Go build as ~2-release rollback insurance, and validate the whole build/package path without tagging.

Plan: `~/.claude/plans/monorepo-phase3-host-agent-release-wiring.md` (panel-reviewed by Codex + Kimi K2.6 + CodeRabbit).

## The panel forced a mechanism pivot (orchestrator-probed)

The plan originally proposed goreleaser's `builder: prebuilt` + a per-runner matrix. **`builder: prebuilt` is GoReleaser Pro-only** — Kimi + Codex flagged it, and a direct probe against the **CI-pinned v2.15.2** binary confirmed it (`goreleaser check` → `field prebuilt not found in type config.Build`; `builder: rust` parses clean). So this PR uses OSS **`builder: rust`** (which runs `cargo zigbuild`) on the single existing `macos-latest` runner. That dissolves the matrix, the artifact-plumbing, and the leading-`v` bug (goreleaser `{{ .Version }}` is v-stripped and injected at cargo-compile time).

**Viability proven locally** (zig 0.16.0 + cargo-zigbuild 0.23.0): `cargo zigbuild -p shed-host-agent` cross-compiled a real linux ELF **from macOS in 47 s** against the 5-member workspace (ring/rustls/aws-sdk/etc.), and a full `goreleaser release --snapshot --clean` rendered all four archives + an **unchanged** `Formula/shed-host-agent.rb`.

## Commits

1. **`d44e597`** — `version.rs` reads `option_env!("SHED_HOST_AGENT_VERSION")` (no `build.rs`; a pure `pick_version` helper is unit-tested both branches). Empirically validated the var triggers a rebuild-on-change on the pinned toolchain.
2. **`151793d`** — `.goreleaser.yaml` `builder: rust` build (`--package=shed-host-agent`, 4 targets, `env: SHED_HOST_AGENT_VERSION={{ .Version }}`); archive repointed to it; the two Go ids stay defined-but-detached (goreleaser still compiles them → rollback). `ci.yml` `release-snapshot` gains the rust/zig toolchain, a widened gate, and extended assertions.
3. **`75c2599`** — the same toolchain into the tag-gated `release` job + `RELEASING.md`/discovery-doc notes.
4. **`ec36b73`** — hardening from CodeRabbit + Kimi review (below).

## Install identity — preserved (verified)

Binary/formula/archive name, the brew-services `service` block (run args, PATH env, `keep_alive`, log paths), the bundled `extensions.example.yaml` → `etc/shed/extensions.yaml`, and `shed-host-agent status`/`version` are all unchanged. The `brews[shed-host-agent]` block is **byte-identical across the whole branch** (diff-verified); only the binary's build provenance changed. arm64 keeps its linker ad-hoc signature (matches Go — no explicit codesign). Selector unchanged: the host-agent ships on the **go/plugin.json** selector; `release-plan.sh` is untouched.

## Review dispositions (Codex + Kimi + CodeRabbit; contradictions resolved by direct probe)

- **Rosetta (CodeRabbit HIGH) — FIXED.** `macos-latest` is arm64 with no guaranteed Rosetta; the snapshot no longer executes the x86_64 darwin binary (would "bad CPU type"). arm64 is executed + codesign-checked; amd64 is validated with `file` (never run).
- **`hostagent` filter gap (Kimi) — FIXED.** Added `crates/shed-core/**` (the Rust host-agent's path-dep) + `crates/rust-toolchain.toml` so a shed-core/toolchain change triggers the snapshot.
- **`-p=` → `--package=shed-host-agent` (Kimi) — DONE.** Both work (goreleaser detects either prefix; the snapshot proved `-p=` built the right package), switched for clarity.
- **Pins — cargo-zigbuild pinned `--version 0.23.0`; rustfmt/clippy installed explicitly.**
- **codesign contradiction — Codex right, DROPPED the explicit step.** Probe: the arm64 binary is already `adhoc,linker-signed`; an explicit `codesign -s -` is a no-op. The snapshot asserts the signature so a future regression fails loudly.
- **Version identity — SEMANTIC, not byte-identity (Codex).** Go's `version` was already a different format; the goal is reporting the release version, done via the injection.

## Known follow-ups (tracked, not blockers for pipeline-ready)

- **Linux glibc floor is cargo-zigbuild's default (~2.30 — modern distros).** The Go build was `CGO_ENABLED=0` (static). Pinning lower via a `.2.17` target suffix is **not possible on the pinned goreleaser v2.15.2** — its rust builder passes the raw suffixed triple to `rustup target add`, which rejects it (verified). The linux tarball is a secondary GH-release download (no apt; brew/macOS is the only wired install path), so the **primary install identity is unaffected**. Follow-up: pin once goreleaser's rust builder strips the suffix.
- **zig itself is brew-current** (a bump is a *loud* pre-tag CI failure, not a silent ship); a harder pin + Rust/cargo build caching for the snapshot job are follow-ups.

## Validation (no tag)

- `cargo test -p shed-host-agent` (both feature configs) + clippy clean; `make test-host-agent-diff` **108/108** (version stays masked — no wire change).
- `goreleaser release --snapshot --clean` (v2.15.2): 4 `--package=` cargo-zigbuild builds, all 4 archives (binary + config), unchanged formula, arm64 adhoc, `artifacts.json` carries the Rust build + both Go rollback ids × 4 targets.
- `release-plan.sh "v$(jq -r .version .claude-plugin/plugin.json)"` → `ship_go=true` (unchanged).
- `actionlint` adds no new finding. **No tag cut, nothing published.**

Stacked on #270 — retarget to `main` when the stack lands. **The maintainer merges and tags.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED6csoQ3peM3GHc4c1CtqY
