### PR TITLE
feat(shed-core): mobile-parity gap-fill — overview, sessions, rc-events, token FSM (Phase A)

### DIFF
--- a/crates/fixtures/overview.json
+++ b/crates/fixtures/overview.json
@@ -1,0 +1,74 @@
+{
+  "server": {
+    "version": "0.8.0",
+    "features": ["overview", "rc-enrich", "rc-events", "rc-proxy"]
+  },
+  "df": {
+    "server_name": "test-server",
+    "backend": "vz",
+    "totals": {
+      "images": { "physical_bytes": 1323184128 },
+      "sheds": { "physical_bytes": 6615306240 },
+      "all": { "physical_bytes": 14506430464 }
+    }
+  },
+  "sheds": [
+    {
+      "name": "proj",
+      "status": "running",
+      "backend": "vz",
+      "sessions": [
+        {
+          "name": "rc-abc234",
+          "shed_name": "proj",
+          "created_at": "2026-06-19T18:53:00Z",
+          "rc": {
+            "kind": "claude-rc",
+            "state": "ready",
+            "managed": true,
+            "display_name": "proj/abc234",
+            "url": "https://claude.ai/code/session_01RCkTDrdZ2Rr12sD5dfMjgr",
+            "created_by": "shed-remote-agent/0.1.0",
+            "activity": "working",
+            "activity_at": "2026-06-19T18:54:12Z",
+            "last_message": "Running the test suite now."
+          }
+        },
+        {
+          "name": "rc-cdx777",
+          "shed_name": "proj",
+          "created_at": "2026-06-19T19:10:00Z",
+          "rc": {
+            "kind": "codex",
+            "state": "needs-auth",
+            "managed": true,
+            "display_name": "proj/cdx777"
+          }
+        },
+        {
+          "name": "default",
+          "shed_name": "proj"
+        }
+      ],
+      "rc_capabilities": {
+        "rc_version": 3,
+        "kinds": ["claude-broker", "claude-rc", "codex", "opencode", "cursor", "shell"],
+        "agents": {
+          "claude": { "installed": true, "version": "2.1.206" },
+          "codex": { "installed": true, "version": "0.142.4" }
+        },
+        "features": ["generic-perm", "plan-stdin", "prompt-b64", "serve", "activity", "messages"],
+        "kind_features": {
+          "claude-rc": { "post_input": true, "approvals": "tui" },
+          "codex": { "post_input": true, "approvals": "tui", "watch": true, "input": "gated" }
+        }
+      }
+    },
+    {
+      "name": "asleep",
+      "status": "stopped",
+      "sessions": []
+    }
+  ],
+  "warnings": []
+}

--- a/crates/shed-app/src/host_agent.rs
+++ b/crates/shed-app/src/host_agent.rs
@@ -418,7 +418,7 @@ fn our_uid() -> u32 {
 
 /// The peer (server) UID on a connected Unix socket. `None` on error → treated as
 /// untrusted (fail closed). Linux uses `SO_PEERCRED` (glibc has no `getpeereid`);
-/// macOS/BSD use `getpeereid`.
+/// macOS/iOS use `getpeereid`. Other targets (mobile Android, etc.) return `None`.
 fn peer_uid(stream: &UnixStream) -> Option<u32> {
     use std::os::fd::AsRawFd;
     let fd = stream.as_raw_fd();
@@ -443,13 +443,37 @@ fn peer_uid(stream: &UnixStream) -> Option<u32> {
         };
         (rc == 0).then_some(cred.uid)
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    ))]
     {
         let mut uid: libc::uid_t = 0;
         let mut gid: libc::gid_t = 0;
         // SAFETY: `fd` is a valid connected AF_UNIX fd; the out-params are valid slots.
         let rc = unsafe { libc::getpeereid(fd, &mut uid, &mut gid) };
         (rc == 0).then_some(uid)
+    }
+    // Remaining targets — those without `getpeereid` (bionic/Android and other mobile,
+    // Windows) — that never bind the host-agent UDS server, so `peer_uid` is never
+    // called here. Returning `None` (untrusted) is the correct fail-closed default, and
+    // keeps shed-app compiling for those targets (e.g. `aarch64-linux-android`).
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    )))]
+    {
+        let _ = fd;
+        None
     }
 }
 

--- a/crates/shed-app/src/lib.rs
+++ b/crates/shed-app/src/lib.rs
@@ -15,6 +15,7 @@ pub mod fakes;
 pub mod host_agent;
 #[cfg(feature = "rc")]
 pub mod rc;
+pub mod rc_events_watcher;
 pub mod timefmt;
 pub mod token_minter;
 pub mod traits;
@@ -31,6 +32,7 @@ pub use rc::{RcRunner, RcRunnerRef, RcService, RunOutput, TokioProcessRunner};
 pub use coordinator::{Coordinator, CoordinatorDeps, SshPrefs};
 pub use fakes::{AlwaysApprovedGate, FakeNotifier, NoopEventSink};
 pub use host_agent::{HelloClientInfo, HostAgentClient, HostAgentClientError, HostAgentEvent};
+pub use rc_events_watcher::{RcEventsWatcher, RcWatcherUpdate};
 pub use token_minter::HostAgentTokenMinter;
 pub use traits::{
     AuthGate, AuthGateRef, AuthOutcome, AuthPrompt, Clock, ClockRef, CoordinatorEvent, EventSink,

--- a/crates/shed-app/src/rc.rs
+++ b/crates/shed-app/src/rc.rs
@@ -232,7 +232,7 @@ impl RcService {
                 slug: slug.clone(),
                 tmux_session: rc::tmux_name(&slug),
                 display_name: name,
-                workdir: workdir.unwrap_or_else(|| rc::DEFAULT_WORKDIR.to_string()),
+                workdir: Some(workdir.unwrap_or_else(|| rc::DEFAULT_WORKDIR.to_string())),
                 kind,
                 state: RcState::Ready,
                 url,
@@ -240,6 +240,9 @@ impl RcService {
                 created_by: Some(created_by),
                 created_at: Some(self.clock.now_iso8601()),
                 target_label: Some(target_label),
+                activity: None,
+                activity_at: None,
+                last_message: None,
                 managed: true,
             };
             self.store
@@ -613,6 +616,9 @@ mod tests {
                 created_by: None,
                 created_at: None,
                 target_label: None,
+                activity: None,
+                activity_at: None,
+                last_message: None,
             },
             "srv",
             "web",

--- a/crates/shed-app/src/rc.rs
+++ b/crates/shed-app/src/rc.rs
@@ -255,6 +255,9 @@ impl RcService {
         // Real path — serialized against list/kill.
         let _guard = self.op_guard.lock().await;
         // Build argv + stdin together so `--prompt-stdin` and the payload can't disagree.
+        // The invocation is the permission-mode validating gate; desktop has no
+        // permission-mode UI yet, and a `None` mode can never fail validation, so
+        // the `?` here is unreachable in practice (argv stays byte-identical).
         let (argv, stdin) = rc::create_invocation(
             &binary_name(),
             &kind,
@@ -263,8 +266,9 @@ impl RcService {
             workdir.as_deref(),
             &created_by,
             &target_label,
+            None,
             prompt.as_deref(),
-        );
+        )?;
         let out = self
             .runner
             .run(ssh_for(shed, &target, &argv), stdin, CREATE_TIMEOUT)

--- a/crates/shed-app/src/rc_events_watcher.rs
+++ b/crates/shed-app/src/rc_events_watcher.rs
@@ -1,0 +1,933 @@
+//! Reconnecting rc-events watcher — the shed-app half of the live-activity
+//! layer (plan 001 §3.3; the pure decode + fold half is
+//! `shed_core::rc_events`, the single-connection SSE transport is
+//! [`Client::rc_events`]).
+//!
+//! Ported from mobile's `liveActivityProvider` loop
+//! (`shed-mobile/lib/providers.dart:274-365`): one watcher per (server,
+//! subscription) drives `GET /api/rc/events`, folds each decoded [`RcEvent`]
+//! into a held [`ActivityOverlay`], and emits typed [`RcWatcherUpdate`]s on an
+//! unbounded channel. On disconnect it emits [`RcWatcherUpdate::Down`] and
+//! reconnects under exponential backoff (500ms doubling to a 30s ceiling,
+//! `providers.dart:238-239`), resetting to the initial delay on the first
+//! data of a connection (`providers.dart:338`).
+//!
+//! **Resync contract** (mobile's `gotData` semantics,
+//! `providers.dart:337-349`): on the first real event of a new connection —
+//! not on stream-open — and only when an earlier connection already delivered
+//! data (`connected_before`), the watcher clears the held overlay and emits
+//! [`RcWatcherUpdate::Resynced`] BEFORE folding/emitting that event, so stale
+//! pre-drop patches can never override the consumer's fresh snapshot. The
+//! first-ever data-bearing connection skips `Resynced` (the consumer just
+//! loaded a fresh overview). The overlay is deliberately NOT cleared on
+//! disconnect — only on the first data of the next connection — so the
+//! consumer keeps rendering the last snapshot across a blip (no
+//! cleared-overlay update is ever emitted during the gap). There is no
+//! buffering/ack protocol around the consumer's resync refetch: overlay
+//! snapshots keep flowing while it refetches, because consumers render
+//! base + overlay (same model as mobile; a patch for a row the refetched base
+//! doesn't know yet simply lands when the base catches up). Mobile's
+//! unknown-slug debounced overview refetch (`providers.dart:241-247`) stays
+//! consumer-side — it requires overview knowledge the watcher doesn't have.
+//!
+//! **Spawn-once, non-restartable by construction:** [`RcEventsWatcher::spawn`]
+//! is the constructor AND the start — there is no `start()` to call twice, so
+//! "restart" cannot arise. This deliberately diverges from
+//! [`HostAgentClient`]'s restart-safe `start()` (`host_agent.rs`): the FRB
+//! bridge constructs one watcher per subscription and drops it on
+//! unsubscribe; there is no in-place-reconfigure consumer. [`stop`] (and
+//! `Drop`) aborts the loop task; aborting drops the in-flight connection
+//! future, which closes the underlying HTTP connection.
+//!
+//! **Channel choice:** unbounded mpsc, per the repo precedent
+//! (`host_agent.rs` event stream). The accepted risk — a stalled consumer
+//! buffers updates — is fine here because the FRB/Tauri consumers drain
+//! eagerly; the bounded-with-drop alternative was considered and rejected
+//! (plan 001, panel round 2). The loop STOPS when a send fails (the receiver
+//! was dropped), AND it watches `updates.closed()` while awaiting the
+//! connection and the backoff sleep — a healthy heartbeat-only stream
+//! delivers no events (comments are swallowed by the SSE parser), so a
+//! send-failure alone would never be observed there and an abandoned
+//! receiver would otherwise leak the task + connection for as long as the
+//! server kept the quiet stream open.
+//!
+//! [`Client::rc_events`]: shed_core::http::Client::rc_events
+//! [`HostAgentClient`]: crate::host_agent::HostAgentClient
+//! [`stop`]: RcEventsWatcher::stop
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use shed_core::http::{Client, RcEventSink, ShedError};
+use shed_core::rc_events::{ActivityOverlay, RcEvent};
+
+/// First reconnect delay (`providers.dart:238`): small so a transient blip
+/// resyncs quickly.
+const INITIAL_BACKOFF: Duration = Duration::from_millis(500);
+/// Reconnect-delay ceiling (`providers.dart:239`): a hub that stays down (or
+/// an old server without rc-events) can't retry-storm.
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+/// One update from the watcher loop (pinned shape, plan 001 §3.3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RcWatcherUpdate {
+    /// The first event of a data-bearing reconnect is about to arrive and the
+    /// held overlay was just cleared: the consumer should refetch its base
+    /// overview (mobile invalidates `overviewProvider` here). Never emitted
+    /// for the first-ever data-bearing connection, and never for a reconnect
+    /// that delivers no data.
+    Resynced,
+    /// A decoded event plus the overlay snapshot AFTER folding it in.
+    Event {
+        event: RcEvent,
+        overlay: ActivityOverlay,
+    },
+    /// The connection ended (clean EOF or error); the watcher backs off and
+    /// reconnects. Emitted once per disconnect. The held overlay is NOT
+    /// cleared — the consumer keeps rendering the last snapshot until the
+    /// next connection's first data resyncs it.
+    Down { reason: String },
+}
+
+/// Handle to one spawned rc-events watcher loop. Constructing it
+/// ([`RcEventsWatcher::spawn`]) starts the loop; dropping it (or [`stop`])
+/// aborts it. Not restartable — build a new one per subscription.
+///
+/// [`stop`]: RcEventsWatcher::stop
+pub struct RcEventsWatcher {
+    server_name: String,
+    running: Arc<AtomicBool>,
+    task: tokio::task::JoinHandle<Result<(), LoopExit>>,
+}
+
+impl RcEventsWatcher {
+    /// Spawn the reconnect-and-fold loop for `client` (one shed-server host)
+    /// onto `handle`, returning the watcher handle and the update stream.
+    /// `server_name` identifies the host to the consumer (see
+    /// [`server_name`]); the loop itself keys nothing off it.
+    ///
+    /// [`server_name`]: RcEventsWatcher::server_name
+    pub fn spawn(
+        handle: &tokio::runtime::Handle,
+        client: Client,
+        server_name: String,
+    ) -> (RcEventsWatcher, mpsc::UnboundedReceiver<RcWatcherUpdate>) {
+        Self::spawn_with(
+            handle,
+            Arc::new(ClientConnector { client }),
+            Arc::new(TokioSleeper),
+            server_name,
+        )
+    }
+
+    /// The seam-injected constructor behind [`spawn`]: tests script the
+    /// connection outcomes ([`EventsConnector`]) and capture/gate the backoff
+    /// waits ([`Sleeper`]) so every loop test is deterministic.
+    ///
+    /// [`spawn`]: RcEventsWatcher::spawn
+    fn spawn_with(
+        handle: &tokio::runtime::Handle,
+        connector: Arc<dyn EventsConnector>,
+        sleeper: Arc<dyn Sleeper>,
+        server_name: String,
+    ) -> (RcEventsWatcher, mpsc::UnboundedReceiver<RcWatcherUpdate>) {
+        let (updates_tx, updates_rx) = mpsc::unbounded_channel();
+        let running = Arc::new(AtomicBool::new(true));
+        let task = handle.spawn(run_loop(connector, sleeper, running.clone(), updates_tx));
+        (
+            RcEventsWatcher {
+                server_name,
+                running,
+                task,
+            },
+            updates_rx,
+        )
+    }
+
+    /// The server this watcher was spawned for.
+    pub fn server_name(&self) -> &str {
+        &self.server_name
+    }
+
+    /// Stop the loop: clears `running` and aborts the task (the
+    /// `host_agent.rs` `stop()` precedent). Aborting drops whatever the loop
+    /// was awaiting — an in-flight SSE connection (closing it) or a backoff
+    /// sleep — so termination is prompt in either phase. Idempotent.
+    ///
+    /// **Soft-stop contract:** `stop()` returns without joining the task, so
+    /// a poll already in flight can still deliver a final update — or launch
+    /// one more connection attempt, immediately dropped — before the abort
+    /// lands (this also covers the backoff→reconnect launch race). The loop
+    /// re-checks `running` before every send to shrink that window, but
+    /// consumers must tolerate stragglers. In practice the FRB bridge drops
+    /// the receiver alongside `stop()`, which both discards stragglers and
+    /// is itself a teardown signal the loop watches (`updates.closed()`). A
+    /// hard cutoff would need an async stop-and-join — deliberately not
+    /// offered (no consumer needs it).
+    pub fn stop(&self) {
+        self.running.store(false, Ordering::SeqCst);
+        self.task.abort();
+    }
+}
+
+impl Drop for RcEventsWatcher {
+    /// Dropping the handle stops the loop — the FRB bridge's unsubscribe path
+    /// is simply dropping the watcher.
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+/// The pure per-disconnect backoff transition: `(wait_now, next_backoff)` —
+/// wait the CURRENT backoff, then double it up to [`MAX_BACKOFF`]. Mirrors
+/// mobile's retry timer (`providers.dart:325-332`: waits `backoff`, then
+/// doubles). The reset-to-initial on first data lives in the fold
+/// ([`FoldState::on_event`]), not here.
+fn backoff_step(prev: Duration) -> (Duration, Duration) {
+    (prev, (prev * 2).min(MAX_BACKOFF))
+}
+
+/// One SSE connection attempt, running until the stream ends. The prod impl
+/// is [`Client::rc_events`]; tests inject a scripted connector so the
+/// reconnect/resync/backoff loop is exercised without real sockets or the
+/// transport's own timing (which has its own test matrix in shed-core).
+///
+/// [`Client::rc_events`]: shed_core::http::Client::rc_events
+#[async_trait::async_trait]
+trait EventsConnector: Send + Sync {
+    async fn connect(&self, sink: &dyn RcEventSink) -> Result<(), ShedError>;
+}
+
+struct ClientConnector {
+    client: Client,
+}
+
+#[async_trait::async_trait]
+impl EventsConnector for ClientConnector {
+    async fn connect(&self, sink: &dyn RcEventSink) -> Result<(), ShedError> {
+        self.client.rc_events(sink).await
+    }
+}
+
+/// Injectable sleep seam for deterministic backoff tests (the pattern
+/// `shed-broker/src/egress.rs` uses — replicated, not imported: the broker
+/// crate is unreachable from default-features shed-app by design).
+#[async_trait::async_trait]
+trait Sleeper: Send + Sync {
+    async fn sleep(&self, d: Duration);
+}
+
+struct TokioSleeper;
+
+#[async_trait::async_trait]
+impl Sleeper for TokioSleeper {
+    async fn sleep(&self, d: Duration) {
+        tokio::time::sleep(d).await;
+    }
+}
+
+/// Bridges the synchronous [`RcEventSink`] callback into the loop task:
+/// `Client::rc_events` calls `on_event` inline while the loop awaits the
+/// connection future, so the sink forwards each event through an unbounded
+/// channel the loop `select!`s on alongside the connection. Send failures are
+/// ignored here — the loop side owns shutdown (it stops when ITS sends fail).
+struct ChannelSink {
+    tx: mpsc::UnboundedSender<RcEvent>,
+}
+
+impl RcEventSink for ChannelSink {
+    fn on_event(&self, ev: RcEvent) {
+        let _ = self.tx.send(ev);
+    }
+}
+
+/// The loop must exit: the [`RcWatcherUpdate`] receiver was dropped (the
+/// subscription is gone — observed as a failed send or via
+/// `updates.closed()`), or `running` was cleared by a racing `stop()` whose
+/// abort hasn't landed yet. Bubbles up through `?`.
+struct LoopExit;
+
+/// Emit one update, mapping a closed channel to [`LoopExit`].
+fn send(
+    updates: &mpsc::UnboundedSender<RcWatcherUpdate>,
+    update: RcWatcherUpdate,
+) -> Result<(), LoopExit> {
+    updates.send(update).map_err(|_| LoopExit)
+}
+
+/// The cross-connection fold + resync state (mobile's `overlay` /
+/// `connectedBefore` / `backoff` closure vars, `providers.dart:287-289`).
+/// `got_data` is per-connection (mobile's `gotData`, `:323`) and is reset by
+/// [`run_connection`] at each connect.
+struct FoldState {
+    overlay: ActivityOverlay,
+    /// True once ANY connection has delivered data (mobile sets
+    /// `connectedBefore` on first data, not on stream-open — a connection
+    /// that dies dataless does not count).
+    connected_before: bool,
+    /// First-data-of-this-connection latch; reset per connection.
+    got_data: bool,
+    /// The NEXT reconnect wait ([`backoff_step`] doubles it as it's spent;
+    /// first data resets it to [`INITIAL_BACKOFF`]).
+    backoff: Duration,
+}
+
+impl FoldState {
+    fn new() -> FoldState {
+        FoldState {
+            overlay: ActivityOverlay::empty(),
+            connected_before: false,
+            got_data: false,
+            backoff: INITIAL_BACKOFF,
+        }
+    }
+
+    /// Handle one decoded event (mobile's listen callback,
+    /// `providers.dart:335-359`): first data of a connection resets the
+    /// backoff and — when a prior connection delivered data — clears the
+    /// overlay and emits `Resynced` BEFORE the event; then folds and emits
+    /// the event with the post-fold snapshot.
+    fn on_event(
+        &mut self,
+        ev: RcEvent,
+        updates: &mpsc::UnboundedSender<RcWatcherUpdate>,
+    ) -> Result<(), LoopExit> {
+        if !self.got_data {
+            self.got_data = true;
+            self.backoff = INITIAL_BACKOFF;
+            if self.connected_before {
+                self.overlay = ActivityOverlay::empty();
+                send(updates, RcWatcherUpdate::Resynced)?;
+            }
+            self.connected_before = true;
+        }
+        self.overlay = self.overlay.apply(&ev);
+        send(
+            updates,
+            RcWatcherUpdate::Event {
+                event: ev,
+                overlay: self.overlay.clone(),
+            },
+        )
+    }
+}
+
+/// One connection attempt: connect, fold/forward each event as it arrives,
+/// and — once the connection future completes — drain the queued tail.
+/// Returns the connection's outcome for the caller's `Down`. (The caller's
+/// `while running` condition is the entry-side `running` re-check.)
+async fn run_connection(
+    connector: &dyn EventsConnector,
+    state: &mut FoldState,
+    updates: &mpsc::UnboundedSender<RcWatcherUpdate>,
+    running: &AtomicBool,
+) -> Result<Result<(), ShedError>, LoopExit> {
+    state.got_data = false;
+    let (ev_tx, mut ev_rx) = mpsc::unbounded_channel::<RcEvent>();
+    let sink = ChannelSink { tx: ev_tx };
+    let mut conn = connector.connect(&sink);
+    let outcome = loop {
+        tokio::select! {
+            res = &mut conn => break res,
+            // `recv` can't yield None while the connection runs (the sink
+            // holds the sender); if it somehow did, the branch disables and
+            // the select waits out the connection.
+            Some(ev) = ev_rx.recv() => {
+                // The running re-check shrinks the soft-stop window (see
+                // `stop()`): a poll in flight when stop() raced must not
+                // emit after `running` cleared.
+                if !running.load(Ordering::SeqCst) {
+                    return Err(LoopExit);
+                }
+                state.on_event(ev, updates)?;
+            }
+            // The consumer unsubscribed (receiver dropped). A healthy
+            // heartbeat-only stream delivers no events (the SSE parser
+            // swallows comments), so a send-failure would never be observed
+            // on it — without this arm an abandoned receiver would leak the
+            // task + TCP connection for as long as the server kept the quiet
+            // stream open.
+            () = updates.closed() => return Err(LoopExit),
+        }
+    };
+    // The connection future is done, so every sink.on_event send has already
+    // happened (rc_events calls the sink inline, including the final
+    // unterminated-record flush) — drain the queued tail so those events are
+    // emitted BEFORE the Down. (No closed() watch needed here: these sends
+    // observe a dropped receiver directly.)
+    while let Ok(ev) = ev_rx.try_recv() {
+        if !running.load(Ordering::SeqCst) {
+            return Err(LoopExit);
+        }
+        state.on_event(ev, updates)?;
+    }
+    Ok(outcome)
+}
+
+/// The watcher loop: connect → forward/fold events as they arrive → on
+/// stream end emit `Down` → back off → reconnect. Exits when the receiver is
+/// dropped (a failed send, or `updates.closed()` during the connection /
+/// backoff awaits — [`LoopExit`] via `?`) or `running` clears; `stop()`/
+/// `Drop` additionally abort it mid-await.
+async fn run_loop(
+    connector: Arc<dyn EventsConnector>,
+    sleeper: Arc<dyn Sleeper>,
+    running: Arc<AtomicBool>,
+    updates: mpsc::UnboundedSender<RcWatcherUpdate>,
+) -> Result<(), LoopExit> {
+    let mut state = FoldState::new();
+    while running.load(Ordering::SeqCst) {
+        let outcome = run_connection(&*connector, &mut state, &updates, &running).await?;
+        // Soft-stop window shrink: no Down for a stop()-initiated teardown.
+        if !running.load(Ordering::SeqCst) {
+            break;
+        }
+        let reason = match outcome {
+            Ok(()) => "stream ended".to_string(),
+            Err(e) => e.to_string(),
+        };
+        send(&updates, RcWatcherUpdate::Down { reason })?;
+        let (wait, next) = backoff_step(state.backoff);
+        state.backoff = next;
+        tokio::select! {
+            () = sleeper.sleep(wait) => {}
+            // An unsubscribe during the backoff must neither wait out the
+            // sleep nor launch one more connection for a gone subscription.
+            () = updates.closed() => return Err(LoopExit),
+        }
+    }
+    Ok(())
+}
+
+// Deterministic loop tests via the scripted-connector + sleeper seams
+// (backoff/resync/lifecycle), plus real-transport end-to-end tests (httpmock
+// + a raw-TCP held-open stream) for the connect→fold→emit path and the
+// abort-closes-the-connection guarantee. Covers plan 001 AC#7.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::VecDeque;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Mutex;
+
+    use httpmock::prelude::*;
+    use tokio::runtime::Handle;
+
+    use shed_core::rc::{RcActivity, RcState};
+
+    /// One scripted connection outcome.
+    enum Step {
+        /// Deliver these events to the sink, then return (Ok = clean EOF,
+        /// Err(msg) = `ShedError::Transport(msg)`).
+        Deliver(Vec<RcEvent>, Result<(), &'static str>),
+        /// Never return; sets the connector's `pending_dropped` flag when the
+        /// connection future is dropped (abort / loop exit).
+        Pend,
+    }
+
+    /// Scripted [`EventsConnector`]: each `connect` pops the next [`Step`];
+    /// an exhausted script pends (so a finished test scenario just idles
+    /// until the watcher is stopped/dropped).
+    struct ScriptedConnector {
+        steps: Mutex<VecDeque<Step>>,
+        connects: AtomicUsize,
+        pending_dropped: Arc<AtomicBool>,
+    }
+
+    impl ScriptedConnector {
+        fn new(steps: Vec<Step>) -> Arc<ScriptedConnector> {
+            Arc::new(ScriptedConnector {
+                steps: Mutex::new(steps.into()),
+                connects: AtomicUsize::new(0),
+                pending_dropped: Arc::new(AtomicBool::new(false)),
+            })
+        }
+
+        fn connects(&self) -> usize {
+            self.connects.load(Ordering::SeqCst)
+        }
+
+        fn pending_dropped(&self) -> bool {
+            self.pending_dropped.load(Ordering::SeqCst)
+        }
+    }
+
+    /// Sets a flag when dropped — held across the `Pend` await so a test can
+    /// prove the in-flight connection future was dropped (not leaked) on
+    /// abort.
+    struct SetOnDrop(Arc<AtomicBool>);
+    impl Drop for SetOnDrop {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl EventsConnector for ScriptedConnector {
+        async fn connect(&self, sink: &dyn RcEventSink) -> Result<(), ShedError> {
+            self.connects.fetch_add(1, Ordering::SeqCst);
+            let step = self.steps.lock().unwrap().pop_front();
+            match step {
+                Some(Step::Deliver(events, outcome)) => {
+                    for ev in events {
+                        sink.on_event(ev);
+                    }
+                    outcome.map_err(|msg| ShedError::Transport(msg.to_string()))
+                }
+                Some(Step::Pend) | None => {
+                    let _guard = SetOnDrop(self.pending_dropped.clone());
+                    std::future::pending().await
+                }
+            }
+        }
+    }
+
+    /// Records each requested wait and returns immediately — deterministic
+    /// backoff assertions with no real time.
+    #[derive(Default)]
+    struct RecordingSleeper {
+        waits: Mutex<Vec<Duration>>,
+    }
+
+    impl RecordingSleeper {
+        fn waits(&self) -> Vec<Duration> {
+            self.waits.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Sleeper for RecordingSleeper {
+        async fn sleep(&self, d: Duration) {
+            self.waits.lock().unwrap().push(d);
+        }
+    }
+
+    /// Records the wait, then pends forever — parks the loop "mid-backoff"
+    /// so stop-during-backoff is testable without real time.
+    #[derive(Default)]
+    struct ParkingSleeper {
+        waits: Mutex<Vec<Duration>>,
+        parked_dropped: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl Sleeper for ParkingSleeper {
+        async fn sleep(&self, d: Duration) {
+            self.waits.lock().unwrap().push(d);
+            let _guard = SetOnDrop(self.parked_dropped.clone());
+            std::future::pending::<()>().await;
+        }
+    }
+
+    fn spawn_scripted(
+        connector: &Arc<ScriptedConnector>,
+        sleeper: Arc<dyn Sleeper>,
+    ) -> (RcEventsWatcher, mpsc::UnboundedReceiver<RcWatcherUpdate>) {
+        RcEventsWatcher::spawn_with(&Handle::current(), connector.clone(), sleeper, "srv".into())
+    }
+
+    async fn recv(rx: &mut mpsc::UnboundedReceiver<RcWatcherUpdate>) -> RcWatcherUpdate {
+        tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("timed out waiting for an update")
+            .expect("update channel closed")
+    }
+
+    fn expect_event(u: RcWatcherUpdate) -> (RcEvent, ActivityOverlay) {
+        match u {
+            RcWatcherUpdate::Event { event, overlay } => (event, overlay),
+            other => panic!("expected Event, got {other:?}"),
+        }
+    }
+
+    fn expect_down(u: RcWatcherUpdate) -> String {
+        match u {
+            RcWatcherUpdate::Down { reason } => reason,
+            other => panic!("expected Down, got {other:?}"),
+        }
+    }
+
+    /// Real-time poll helper (the `host_agent.rs` test convention): bounded
+    /// at 4s so a hung condition fails the test instead of the suite.
+    async fn wait_until(mut cond: impl FnMut() -> bool) -> bool {
+        for _ in 0..400 {
+            if cond() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        false
+    }
+
+    fn activity_ev(shed: &str, slug: &str) -> RcEvent {
+        RcEvent::ActivityChanged {
+            shed: shed.into(),
+            slug: slug.into(),
+            activity: Some(RcActivity::Working),
+            activity_at: None,
+            state: Some(RcState::Ready),
+            last_message: None,
+        }
+    }
+
+    fn message_ev(shed: &str, slug: &str, seq: u64) -> RcEvent {
+        RcEvent::MessageAppended {
+            shed: shed.into(),
+            slug: slug.into(),
+            seq,
+        }
+    }
+
+    // ---- backoff ----
+
+    #[test]
+    fn backoff_step_doubles_from_initial_to_the_cap() {
+        // 500ms → 1s → 2s → 4s → 8s → 16s → 30s (capped, not 32s) → 30s.
+        let mut backoff = INITIAL_BACKOFF;
+        let mut waits = Vec::new();
+        for _ in 0..8 {
+            let (wait, next) = backoff_step(backoff);
+            waits.push(wait);
+            backoff = next;
+        }
+        let secs: Vec<f64> = waits.iter().map(Duration::as_secs_f64).collect();
+        assert_eq!(secs, [0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 30.0, 30.0]);
+    }
+
+    #[tokio::test]
+    async fn backoff_progresses_across_dataless_reconnects_and_resets_on_first_data() {
+        // conn1 (no data, err) → wait 500ms; conn2 (no data) → 1s; conn3
+        // delivers data (reset!) then dies → 500ms again; conn4 (no data) → 1s.
+        let connector = ScriptedConnector::new(vec![
+            Step::Deliver(vec![], Err("e1")),
+            Step::Deliver(vec![], Err("e2")),
+            Step::Deliver(vec![activity_ev("p", "a")], Err("e3")),
+            Step::Deliver(vec![], Err("e4")),
+        ]);
+        let sleeper = Arc::new(RecordingSleeper::default());
+        let (watcher, mut rx) = spawn_scripted(&connector, sleeper.clone());
+
+        expect_down(recv(&mut rx).await);
+        expect_down(recv(&mut rx).await);
+        // conn3's first (and only) data: no prior connection ever delivered
+        // data, so there is NO Resynced even though connections existed.
+        expect_event(recv(&mut rx).await);
+        expect_down(recv(&mut rx).await);
+        expect_down(recv(&mut rx).await);
+
+        assert!(wait_until(|| sleeper.waits().len() == 4).await);
+        let secs: Vec<f64> = sleeper.waits().iter().map(Duration::as_secs_f64).collect();
+        assert_eq!(secs, [0.5, 1.0, 0.5, 1.0]);
+        watcher.stop();
+    }
+
+    // ---- resync contract ----
+
+    #[tokio::test]
+    async fn first_ever_connection_emits_events_without_resynced() {
+        let connector = ScriptedConnector::new(vec![Step::Deliver(
+            vec![activity_ev("p", "a"), message_ev("p", "a", 5)],
+            Ok(()),
+        )]);
+        let (watcher, mut rx) = spawn_scripted(&connector, Arc::new(RecordingSleeper::default()));
+
+        let (ev1, o1) = expect_event(recv(&mut rx).await);
+        assert_eq!(ev1, activity_ev("p", "a"));
+        assert_eq!(
+            o1.lookup("p", "a").unwrap().activity,
+            Some(RcActivity::Working)
+        );
+        // Post-fold snapshot: the second event's overlay carries BOTH the
+        // prior fold and the new seq.
+        let (ev2, o2) = expect_event(recv(&mut rx).await);
+        assert_eq!(ev2, message_ev("p", "a", 5));
+        let patch = o2.lookup("p", "a").unwrap();
+        assert_eq!(patch.activity, Some(RcActivity::Working));
+        assert_eq!(patch.last_seq, Some(5));
+        // Clean EOF is a Down too (the watcher will reconnect either way).
+        assert_eq!(expect_down(recv(&mut rx).await), "stream ended");
+        watcher.stop();
+    }
+
+    #[tokio::test]
+    async fn resynced_clears_overlay_before_first_event_of_data_bearing_reconnect_only() {
+        // conn1 delivers data (connected_before latches) and dies; conn2 dies
+        // DATALESS (must emit no Resynced); conn3 delivers data → exactly one
+        // Resynced, before conn3's first Event, whose overlay was rebuilt
+        // from empty.
+        let connector = ScriptedConnector::new(vec![
+            Step::Deliver(vec![activity_ev("p", "a")], Err("d1")),
+            Step::Deliver(vec![], Err("d2")),
+            Step::Deliver(vec![message_ev("p", "b", 7)], Err("d3")),
+        ]);
+        let (watcher, mut rx) = spawn_scripted(&connector, Arc::new(RecordingSleeper::default()));
+
+        let (_, o1) = expect_event(recv(&mut rx).await);
+        assert!(o1.lookup("p", "a").is_some());
+        assert_eq!(expect_down(recv(&mut rx).await), "transport error: d1");
+        // The dataless reconnect: Down only, no Resynced in between.
+        assert_eq!(expect_down(recv(&mut rx).await), "transport error: d2");
+        // Data-bearing reconnect: Resynced FIRST, then the event folded onto
+        // a cleared overlay — conn1's (p,a) patch is gone.
+        assert_eq!(recv(&mut rx).await, RcWatcherUpdate::Resynced);
+        let (ev, o2) = expect_event(recv(&mut rx).await);
+        assert_eq!(ev, message_ev("p", "b", 7));
+        assert!(o2.lookup("p", "a").is_none(), "stale patch survived resync");
+        assert_eq!(o2.lookup("p", "b").unwrap().last_seq, Some(7));
+        assert_eq!(expect_down(recv(&mut rx).await), "transport error: d3");
+        watcher.stop();
+    }
+
+    #[tokio::test]
+    async fn overlay_persists_across_disconnect_no_cleared_snapshot_is_emitted() {
+        // After Down, the channel stays SILENT while the watcher is between
+        // connections: the consumer keeps rendering the last Event's overlay.
+        // (The internal overlay is cleared only by the next connection's
+        // first data — the resync test above pins that; this test pins that
+        // no cleared-overlay update leaks out during the gap.)
+        let connector = ScriptedConnector::new(vec![
+            Step::Deliver(vec![activity_ev("p", "a")], Err("blip")),
+            Step::Pend, // reconnects, then the "new connection" stays quiet
+        ]);
+        let (watcher, mut rx) = spawn_scripted(&connector, Arc::new(RecordingSleeper::default()));
+
+        let (_, o) = expect_event(recv(&mut rx).await);
+        assert!(o.lookup("p", "a").is_some());
+        expect_down(recv(&mut rx).await);
+        // The second connection is open-but-quiet: nothing may be emitted.
+        assert!(wait_until(|| connector.connects() == 2).await);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            matches!(rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+            "an update leaked during the disconnect gap"
+        );
+        watcher.stop();
+    }
+
+    // ---- Down reasons ----
+
+    #[tokio::test]
+    async fn down_carries_the_error_reason() {
+        let connector = ScriptedConnector::new(vec![Step::Deliver(vec![], Err("boom"))]);
+        let (watcher, mut rx) = spawn_scripted(&connector, Arc::new(RecordingSleeper::default()));
+        assert_eq!(expect_down(recv(&mut rx).await), "transport error: boom");
+        watcher.stop();
+    }
+
+    // ---- lifecycle ----
+
+    #[tokio::test]
+    async fn stop_during_an_idle_stream_terminates_promptly_and_drops_the_connection() {
+        let connector = ScriptedConnector::new(vec![Step::Pend]);
+        let (watcher, _rx) = spawn_scripted(&connector, Arc::new(RecordingSleeper::default()));
+        assert!(wait_until(|| connector.connects() == 1).await);
+        watcher.stop();
+        assert!(
+            wait_until(|| watcher.task.is_finished()).await,
+            "loop did not terminate after stop()"
+        );
+        // The in-flight connection future was dropped, not leaked.
+        assert!(connector.pending_dropped());
+    }
+
+    #[tokio::test]
+    async fn stop_during_the_backoff_sleep_terminates_promptly() {
+        let connector = ScriptedConnector::new(vec![Step::Deliver(vec![], Err("down"))]);
+        let sleeper = Arc::new(ParkingSleeper::default());
+        let parked_dropped = sleeper.parked_dropped.clone();
+        let (watcher, mut rx) = spawn_scripted(&connector, sleeper.clone());
+        expect_down(recv(&mut rx).await);
+        // The loop is parked inside the backoff sleep.
+        assert!(wait_until(|| !sleeper.waits.lock().unwrap().is_empty()).await);
+        watcher.stop();
+        assert!(
+            wait_until(|| watcher.task.is_finished()).await,
+            "loop did not terminate out of the backoff sleep"
+        );
+        assert!(parked_dropped.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn dropping_the_watcher_aborts_the_loop() {
+        let connector = ScriptedConnector::new(vec![Step::Pend]);
+        let (watcher, _rx) = spawn_scripted(&connector, Arc::new(RecordingSleeper::default()));
+        assert!(wait_until(|| connector.connects() == 1).await);
+        drop(watcher);
+        assert!(
+            wait_until(|| connector.pending_dropped()).await,
+            "Drop did not abort the loop"
+        );
+    }
+
+    #[test]
+    fn fold_send_failure_stops_the_loop() {
+        // The send-fail half of receiver-drop detection, pinned at the fold
+        // level (the loop-level paths race a send against `closed()`, either
+        // of which exits): both the Event send and the Resynced send map a
+        // dropped receiver to LoopExit.
+        let (tx, rx) = mpsc::unbounded_channel();
+        drop(rx);
+        let mut state = FoldState::new();
+        assert!(state.on_event(activity_ev("p", "a"), &tx).is_err());
+        // The Resynced path (a data-bearing reconnect) fails the same way.
+        let mut state = FoldState::new();
+        state.connected_before = true;
+        assert!(state.on_event(activity_ev("p", "a"), &tx).is_err());
+    }
+
+    #[tokio::test]
+    async fn receiver_drop_during_a_quiet_stream_stops_the_loop_and_drops_the_connection() {
+        // Codex C5 review finding 1 (the real-leak case): a healthy
+        // heartbeat-only stream never reaches the sink (the SSE parser
+        // swallows comments), so no send ever happens and a send-failure
+        // could never be observed — the loop must notice the dropped
+        // receiver via `updates.closed()` and exit, dropping the in-flight
+        // connection, instead of living as long as the server keeps the
+        // quiet stream open.
+        let connector = ScriptedConnector::new(vec![Step::Pend]);
+        let (watcher, rx) = spawn_scripted(&connector, Arc::new(RecordingSleeper::default()));
+        assert!(wait_until(|| connector.connects() == 1).await);
+        drop(rx);
+        assert!(
+            wait_until(|| watcher.task.is_finished()).await,
+            "loop kept running after the receiver was dropped mid-connection"
+        );
+        assert!(connector.pending_dropped(), "connection future leaked");
+    }
+
+    #[tokio::test]
+    async fn receiver_drop_during_the_backoff_sleep_stops_the_loop() {
+        // The sibling of the quiet-stream case: an unsubscribe while the
+        // loop is parked in the backoff sleep must neither wait out the
+        // sleep nor launch one more connection for the gone subscription.
+        let connector = ScriptedConnector::new(vec![Step::Deliver(vec![], Err("d1"))]);
+        let sleeper = Arc::new(ParkingSleeper::default());
+        let (watcher, mut rx) = spawn_scripted(&connector, sleeper.clone());
+        assert_eq!(expect_down(recv(&mut rx).await), "transport error: d1");
+        // The loop is parked inside the backoff sleep.
+        assert!(wait_until(|| !sleeper.waits.lock().unwrap().is_empty()).await);
+        drop(rx);
+        assert!(
+            wait_until(|| watcher.task.is_finished()).await,
+            "loop waited out the backoff after the receiver was dropped"
+        );
+        assert_eq!(
+            connector.connects(),
+            1,
+            "loop launched another connection for a gone subscription"
+        );
+    }
+
+    // ---- end-to-end over the real transport ----
+
+    #[tokio::test]
+    async fn end_to_end_connects_folds_and_emits_then_resyncs_on_reconnect() {
+        // Real Client + httpmock: the mock serves the same two-event body on
+        // every connection, so cycle 1 pins connect → decode → fold → emit
+        // ordering and cycle 2 (a real 500ms-backoff reconnect) pins the
+        // Resynced-then-rebuilt-overlay contract end-to-end.
+        let server = MockServer::start_async().await;
+        let sse = ": ok\n\n\
+                   event: activity.changed\n\
+                   data: {\"shed\":\"p\",\"slug\":\"a\",\"activity\":\"working\",\"state\":\"ready\"}\n\n\
+                   event: message.appended\n\
+                   data: {\"shed\":\"p\",\"slug\":\"a\",\"seq\":5}\n\n";
+        server
+            .mock_async(|w, t| {
+                w.method(GET)
+                    .path("/api/rc/events")
+                    .header("accept", "text/event-stream");
+                t.status(200)
+                    .header("content-type", "text/event-stream")
+                    .body(sse);
+            })
+            .await;
+        let client =
+            Client::new(server.base_url(), "srv".into(), String::new(), None, None).unwrap();
+        let (watcher, mut rx) = RcEventsWatcher::spawn(&Handle::current(), client, "srv".into());
+        assert_eq!(watcher.server_name(), "srv");
+
+        // Cycle 1: events in order, each with its post-fold snapshot.
+        let (ev1, o1) = expect_event(recv(&mut rx).await);
+        assert_eq!(ev1, activity_ev("p", "a"));
+        let p1 = o1.lookup("p", "a").unwrap();
+        assert_eq!(p1.activity, Some(RcActivity::Working));
+        assert_eq!(p1.last_seq, None);
+        let (ev2, o2) = expect_event(recv(&mut rx).await);
+        assert_eq!(ev2, message_ev("p", "a", 5));
+        let p2 = o2.lookup("p", "a").unwrap();
+        assert_eq!(p2.activity, Some(RcActivity::Working)); // held across the fold
+        assert_eq!(p2.last_seq, Some(5));
+        assert_eq!(expect_down(recv(&mut rx).await), "stream ended");
+
+        // Cycle 2 (after the real initial backoff): a data-bearing reconnect
+        // resyncs — and the first event's overlay proves the clear (last_seq
+        // from cycle 1 is gone until this cycle's message.appended re-folds).
+        assert_eq!(recv(&mut rx).await, RcWatcherUpdate::Resynced);
+        let (ev3, o3) = expect_event(recv(&mut rx).await);
+        assert_eq!(ev3, activity_ev("p", "a"));
+        assert_eq!(o3.lookup("p", "a").unwrap().last_seq, None);
+
+        watcher.stop();
+        assert!(wait_until(|| watcher.task.is_finished()).await);
+    }
+
+    #[tokio::test]
+    async fn stop_closes_a_live_real_connection() {
+        // Plan 001 §9's named risk: abort-based cancel must not leak the
+        // reqwest connection. A raw-TCP server (httpmock can't hold a stream
+        // open) writes one event and then BLOCKS reading the socket; it can
+        // only unblock when the peer closes. stop() → task abort → the
+        // connection future (and the Client) drop → TCP close → the server
+        // thread finishes. A bounded join proves the whole chain.
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let srv = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream.set_nodelay(true).unwrap();
+            let mut buf = [0u8; 4096];
+            let mut req = Vec::new();
+            loop {
+                let n = stream.read(&mut buf).unwrap_or(0);
+                assert!(n > 0, "client closed before sending a request");
+                req.extend_from_slice(&buf[..n]);
+                if req.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n\
+                      event: message.appended\ndata: {\"shed\":\"p\",\"slug\":\"a\",\"seq\":1}\n\n",
+                )
+                .unwrap();
+            // Block until the client closes the connection (read → 0/Err).
+            loop {
+                match stream.read(&mut buf) {
+                    Ok(0) | Err(_) => return,
+                    Ok(_) => {}
+                }
+            }
+        });
+        let client = Client::new(url, "srv".into(), String::new(), None, None).unwrap();
+        let (watcher, mut rx) = RcEventsWatcher::spawn(&Handle::current(), client, "srv".into());
+        // The stream is live: the event arrived, the connection is held open.
+        let (ev, _) = expect_event(recv(&mut rx).await);
+        assert_eq!(ev, message_ev("p", "a", 1));
+        watcher.stop();
+        assert!(wait_until(|| watcher.task.is_finished()).await);
+        // Bounded join: hangs (→ test failure) iff the connection leaked.
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            tokio::task::spawn_blocking(move || srv.join().expect("sse server thread panicked")),
+        )
+        .await
+        .expect("server thread did not observe the connection close")
+        .unwrap();
+    }
+}

--- a/crates/shed-core/src/http.rs
+++ b/crates/shed-core/src/http.rs
@@ -7,8 +7,11 @@
 //! Parity with Swift's `ShedServerClient`: an 8s GET timeout, an explicit
 //! User-Agent, an https-only redirect policy, leaf-cert pinning (fail-closed on
 //! a non-https URL), a control-token bearer with a 401 → invalidate + retry-once
-//! (provider-backed only), and `ShedError` matching `ShedClientError`.
-//! Lifecycle + SSE create land in M4.
+//! (provider-backed only; the invalidate is the stale-401-guarded
+//! `invalidate_if_current` on the token actually SENT, and the retry is
+//! skipped when the re-mint returns the same rejected token — plan 001 §3.4),
+//! and `ShedError` matching `ShedClientError`. Lifecycle + SSE create land in
+//! M4.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -105,6 +108,40 @@ impl Client {
         pin: Option<String>,
         minter: Option<Arc<dyn TokenMinter>>,
     ) -> Result<Self, ShedError> {
+        let token_provider =
+            minter.map(|m| Arc::new(ControlTokenProvider::new(server_name.clone(), m)));
+        Self::build(base_url, server_name, token, pin, token_provider)
+    }
+
+    /// Like [`Self::new`] but with a caller-tuned [`ControlTokenProvider`]
+    /// (plan 001 §3.4 Client plumbing): Phase B builds a provider with its
+    /// jitter/cooldown/seed/window knobs and hands it over; `new` keeps
+    /// constructing the default-knobbed provider from a bare minter.
+    /// Provider-backed by definition, so there is no static-token parameter.
+    ///
+    /// A `Client`+provider pair is immutable per transport identity — the
+    /// Dart provider's identity binding is deliberately NOT ported (§3.4):
+    /// the app layer constructs a NEW `Client` (and provider) when the
+    /// host/port/pin changes, deleting the identity-race class instead of
+    /// managing it (a Phase B invariant).
+    pub fn with_provider(
+        base_url: String,
+        server_name: String,
+        pin: Option<String>,
+        provider: Arc<ControlTokenProvider>,
+    ) -> Result<Self, ShedError> {
+        Self::build(base_url, server_name, String::new(), pin, Some(provider))
+    }
+
+    /// Shared tail of the constructors: pin validation (fail-closed on a
+    /// non-https URL) + the reqwest client build.
+    fn build(
+        base_url: String,
+        server_name: String,
+        token: String,
+        pin: Option<String>,
+        token_provider: Option<Arc<ControlTokenProvider>>,
+    ) -> Result<Self, ShedError> {
         let pin = pin.filter(|p| !p.is_empty());
         if pin.is_some() && !base_url.to_lowercase().starts_with("https://") {
             return Err(ShedError::Config(format!(
@@ -112,8 +149,6 @@ impl Client {
             )));
         }
         let http = build_http_client(pin.as_deref())?;
-        let token_provider =
-            minter.map(|m| Arc::new(ControlTokenProvider::new(server_name.clone(), m)));
         Ok(Self {
             base_url,
             server_name,
@@ -134,6 +169,28 @@ impl Client {
         } else {
             None
         }
+    }
+
+    /// 401 aftermath, shared by [`Self::request`], [`Self::create_stream`],
+    /// and [`Self::rc_events`]: drop the provider's cache for the token
+    /// actually SENT (`invalidate_if_current` — the stale-401 guard: a 401
+    /// racing a rotation must not erase the newer token; plan 001 §3.4),
+    /// BOUNDED by `bound`: invalidate only contends on the provider mutex,
+    /// but that mutex is held across a mint by design, so a concurrent
+    /// wedged mint could otherwise pin the await forever. Returns `false`
+    /// when the bound elapsed — the caller then surfaces the original 401
+    /// without retrying (the cache keeps the stale token one extra cycle and
+    /// the next 401 retries the invalidate). No-op `true` for provider-less
+    /// clients or when no token was sent. Retry policy stays with each
+    /// caller (request retries once; the streams don't — their watchers own
+    /// re-auth).
+    async fn invalidate_sent(&self, sent: Option<&str>, bound: Duration) -> bool {
+        let (Some(p), Some(tok)) = (&self.token_provider, sent) else {
+            return true;
+        };
+        tokio::time::timeout(bound, p.invalidate_if_current(tok))
+            .await
+            .is_ok()
     }
 
     /// Build a request URL from literal path `segments` and `query` pairs.
@@ -177,18 +234,22 @@ impl Client {
         Ok(url)
     }
 
+    /// One attempt with `bearer` (resolved by the CALLER — [`Self::request`]
+    /// resolves it per attempt so the 401 path knows exactly which token was
+    /// sent and can `invalidate_if_current` it; plan 001 §3.4).
     async fn send_once(
         &self,
         method: reqwest::Method,
         url: &reqwest::Url,
         timeout: Duration,
         body: Option<&serde_json::Value>,
+        bearer: Option<&str>,
     ) -> Result<Vec<u8>, ShedError> {
         let mut req = self.http.request(method, url.clone()).timeout(timeout);
         if let Some(b) = body {
             req = req.json(b);
         }
-        if let Some(tok) = self.bearer().await {
+        if let Some(tok) = bearer {
             req = req.bearer_auth(tok);
         }
         let resp = req
@@ -206,9 +267,26 @@ impl Client {
             .to_vec())
     }
 
-    /// Send once, and on a provider-backed 401 invalidate + retry once
-    /// (at-most-once, mirrors the SDK/CLI). Static/no-token clients don't retry.
-    /// `body`, when present, is a JSON request body (re-sent on the retry).
+    /// Send once, and on a provider-backed 401 invalidate the token actually
+    /// SENT ([`Self::invalidate_sent`], bounded by this request's own
+    /// `timeout`) then retry once with a re-resolved bearer (at-most-once,
+    /// mirrors the SDK/CLI). The retry is SKIPPED — surfacing the original
+    /// 401 — when:
+    ///   * the invalidate timed out (a wedged mint holds the provider mutex;
+    ///     the follow-up bearer resolution would block on the same mutex);
+    ///   * the re-resolved bearer is `None` — a provider-backed request never
+    ///     retries UNAUTHENTICATED: the re-mint failed, and dropping the
+    ///     Authorization header is a guaranteed second 401;
+    ///   * the re-resolved bearer equals the rejected one — a same-token
+    ///     retry is a guaranteed second 401 (Dart's `_mustMint` semantics
+    ///     make the provider force-mint here, so equality means the minter
+    ///     re-returned the rejected token). The successful same-token re-mint
+    ///     also re-CACHED the rejected token, so it is invalidated again
+    ///     before returning — the must-mint flag stays armed and no later
+    ///     call serves it.
+    ///
+    /// Static/no-token clients don't retry. `body`, when present, is a JSON
+    /// request body (re-sent on the retry).
     async fn request(
         &self,
         method: reqwest::Method,
@@ -216,12 +294,27 @@ impl Client {
         timeout: Duration,
         body: Option<&serde_json::Value>,
     ) -> Result<Vec<u8>, ShedError> {
-        match self.send_once(method.clone(), url, timeout, body).await {
+        let sent = self.bearer().await;
+        match self
+            .send_once(method.clone(), url, timeout, body, sent.as_deref())
+            .await
+        {
             Err(ShedError::BadStatus(401)) if self.token_provider.is_some() => {
-                if let Some(p) = &self.token_provider {
-                    p.invalidate().await;
+                if !self.invalidate_sent(sent.as_deref(), timeout).await {
+                    return Err(ShedError::BadStatus(401)); // wedged provider — no retry
                 }
-                self.send_once(method, url, timeout, body).await
+                let retry = self.bearer().await;
+                if retry.is_none() {
+                    return Err(ShedError::BadStatus(401)); // never retry unauthenticated
+                }
+                if retry == sent {
+                    // Re-arm the must-mint flag the same-token re-mint just
+                    // cleared, so the rejected token is never served again.
+                    let _ = self.invalidate_sent(sent.as_deref(), timeout).await;
+                    return Err(ShedError::BadStatus(401));
+                }
+                self.send_once(method, url, timeout, body, retry.as_deref())
+                    .await
             }
             other => other,
         }
@@ -405,8 +498,9 @@ impl Client {
     ///
     /// ONE connection — no in-method reconnect and no 401 retry: the reconnect
     /// loop (shed-app's `RcEventsWatcher`) owns backoff AND re-auth. On a 401
-    /// this invalidates the token provider and returns `BadStatus(401)`, so
-    /// the watcher's next connect re-mints; an in-method retry would double up
+    /// this invalidates the token it SENT (`invalidate_if_current` — the
+    /// stale-401 guard, plan §3.4) and returns `BadStatus(401)`, so the
+    /// watcher's next connect re-mints; an in-method retry would double up
     /// on the watcher's backoff and hide the auth failure from its Down
     /// signal.
     ///
@@ -454,37 +548,30 @@ impl Client {
         // outside the bound (a server that accepts but never responds is as
         // dead as a silent stream).
         let connect = async {
+            let bearer = self.bearer().await;
             let mut rb = self
                 .http
                 .get(url)
                 .header(reqwest::header::ACCEPT, "text/event-stream");
-            if let Some(tok) = self.bearer().await {
+            if let Some(tok) = &bearer {
                 rb = rb.bearer_auth(tok);
             }
-            rb.send().await
+            (bearer, rb.send().await)
         };
-        let resp = match tokio::time::timeout(idle, connect).await {
+        let (sent_bearer, resp) = match tokio::time::timeout(idle, connect).await {
             Err(_) => {
                 return Err(ShedError::Transport("rc-events connect timeout".into()));
             }
-            Ok(r) => r.map_err(|e| ShedError::Transport(e.to_string()))?,
+            Ok((bearer, r)) => (bearer, r.map_err(|e| ShedError::Transport(e.to_string()))?),
         };
         let status = resp.status().as_u16();
         if status == 401 {
-            // Stale token: invalidate so the NEXT connect re-mints, then
-            // surface the 401 — the watcher owns re-auth (no in-method retry).
-            // Bounded await: invalidate only contends on the provider mutex,
-            // but that mutex is held across a mint by design, so a wedged mint
-            // could otherwise pin this call forever. On timeout we fall
-            // through and surface the 401 anyway — the cache keeps the stale
-            // token one extra cycle and the watcher's next 401 retries the
-            // invalidate.
-            // NOTE(C6): becomes invalidate_if_current(sent_bearer) — the
-            // unconditional invalidate can erase a NEWER token when a stale
-            // 401 races a rotation (plan §3.4 stale-401 guard).
-            if let Some(p) = &self.token_provider {
-                let _ = tokio::time::timeout(idle, p.invalidate()).await;
-            }
+            // Stale token: invalidate the token we SENT ([`Self::invalidate_sent`],
+            // the stale-401 guard, bounded by `idle` — see the helper's docs)
+            // so the NEXT connect re-mints, then surface the 401 — the
+            // watcher owns re-auth (no in-method retry). On a timed-out
+            // invalidate we fall through and surface the 401 anyway.
+            let _ = self.invalidate_sent(sent_bearer.as_deref(), idle).await;
         }
         // Exactly 200, not any-2xx: SSE lives in a 200 response body — a
         // 204/206 minted by an intermediary carries no event stream, and
@@ -567,12 +654,13 @@ impl Client {
         sink: &dyn CreateSink,
     ) -> Result<(), ShedError> {
         let url = self.build_url(&["api", "sheds"], &[])?;
+        let bearer = self.bearer().await;
         let mut rb = self
             .http
             .post(url)
             .header(reqwest::header::ACCEPT, "text/event-stream")
             .json(req);
-        if let Some(tok) = self.bearer().await {
+        if let Some(tok) = &bearer {
             rb = rb.bearer_auth(tok);
         }
         let resp = match tokio::time::timeout(CREATE_IDLE_TIMEOUT, rb.send()).await {
@@ -583,9 +671,14 @@ impl Client {
         };
         let status = resp.status().as_u16();
         if status == 401 {
-            if let Some(p) = &self.token_provider {
-                p.invalidate().await;
-            }
+            // Invalidate the token we SENT ([`Self::invalidate_sent`], the
+            // stale-401 guard, bounded by the create idle timeout — see the
+            // helper's docs) so the next attempt re-mints; create stays
+            // one-shot (no retry), so a timed-out invalidate just falls
+            // through to the BadStatus below.
+            let _ = self
+                .invalidate_sent(bearer.as_deref(), CREATE_IDLE_TIMEOUT)
+                .await;
         }
         if !(200..300).contains(&status) {
             return Err(ShedError::BadStatus(status));
@@ -941,6 +1034,273 @@ mod tests {
         )
         .unwrap();
         assert_eq!(c.info().await.unwrap().name, "mini2"); // succeeds after retry
+    }
+
+    // A minter that always returns the SAME token, however often it's called.
+    struct SameMinter {
+        calls: AtomicUsize,
+    }
+    #[async_trait::async_trait]
+    impl TokenMinter for SameMinter {
+        async fn mint(&self, _server: &str) -> Result<MintedToken, ShedError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(MintedToken {
+                token: "tok-same".into(),
+                expires_at_unix: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_skipped_when_remint_returns_the_same_rejected_token() {
+        // Plan §3.4: after the 401 → invalidate_if_current, the forced re-mint
+        // yields the SAME rejected token — a retry would be a guaranteed
+        // second 401, so request() skips it: exactly ONE request hits the
+        // server and the original 401 surfaces.
+        let server = MockServer::start_async().await;
+        let m = server
+            .mock_async(|w, t| {
+                w.method(GET)
+                    .path("/api/info")
+                    .header("authorization", "Bearer tok-same");
+                t.status(401);
+            })
+            .await;
+        let minter = Arc::new(SameMinter {
+            calls: AtomicUsize::new(0),
+        });
+        let c = Client::new(
+            server.base_url(),
+            "mini2".into(),
+            String::new(),
+            None,
+            Some(minter.clone()),
+        )
+        .unwrap();
+        let err = c.info().await.unwrap_err();
+        assert!(matches!(err, ShedError::BadStatus(401)), "got {err:?}");
+        assert_eq!(
+            m.hits_async().await,
+            1,
+            "the same-token retry must be skipped"
+        );
+        // Two mints: the initial resolve + the forced post-invalidate re-mint
+        // that produced the identical token.
+        assert_eq!(minter.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn retry_never_proceeds_unauthenticated_when_the_remint_fails() {
+        // C6 adversarial review #2a: after the 401 → invalidate, the forced
+        // re-mint FAILS, so bearer() resolves None. The retry must be skipped
+        // — a provider-backed request never drops its Authorization header
+        // (an unauthenticated retry against a secure server is a guaranteed
+        // second 401 and ships the request with no proof of identity).
+        struct FlipMinter {
+            calls: AtomicUsize,
+        }
+        #[async_trait::async_trait]
+        impl TokenMinter for FlipMinter {
+            async fn mint(&self, _server: &str) -> Result<MintedToken, ShedError> {
+                let n = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+                if n == 1 {
+                    Ok(MintedToken {
+                        token: "tok-1".into(),
+                        expires_at_unix: None,
+                    })
+                } else {
+                    Err(ShedError::Transport("mint down".into()))
+                }
+            }
+        }
+        let server = MockServer::start_async().await;
+        // An unauthenticated retry would hit THIS mock and turn the result
+        // into Ok — assert it is never touched.
+        let unauth = server
+            .mock_async(|w, t| {
+                w.method(GET).path("/api/info").matches(|req| {
+                    !req.headers.as_ref().is_some_and(|h| {
+                        h.iter()
+                            .any(|(k, _)| k.eq_ignore_ascii_case("authorization"))
+                    })
+                });
+                t.status(200)
+                    .body(include_str!("../../fixtures/server_info.json"));
+            })
+            .await;
+        let authed = server
+            .mock_async(|w, t| {
+                w.method(GET)
+                    .path("/api/info")
+                    .header("authorization", "Bearer tok-1");
+                t.status(401);
+            })
+            .await;
+        let minter = Arc::new(FlipMinter {
+            calls: AtomicUsize::new(0),
+        });
+        let c = Client::new(
+            server.base_url(),
+            "mini2".into(),
+            String::new(),
+            None,
+            Some(minter.clone()),
+        )
+        .unwrap();
+        let err = c.info().await.unwrap_err();
+        assert!(matches!(err, ShedError::BadStatus(401)), "got {err:?}");
+        assert_eq!(authed.hits_async().await, 1, "exactly one authed attempt");
+        assert_eq!(unauth.hits_async().await, 0, "no unauthenticated retry");
+        assert_eq!(minter.calls.load(Ordering::SeqCst), 2); // initial + failed re-mint
+    }
+
+    #[tokio::test]
+    async fn rejected_token_is_not_served_after_a_same_token_retry_skip() {
+        // C6 adversarial review #2c: the successful same-token re-mint
+        // re-caches the rejected token and clears the must-mint flag; the
+        // equality-skip path must invalidate it AGAIN so a SUBSEQUENT call
+        // force-mints instead of serving the rejected token from cache.
+        struct ScriptMinter {
+            calls: AtomicUsize,
+            script: Vec<&'static str>,
+        }
+        #[async_trait::async_trait]
+        impl TokenMinter for ScriptMinter {
+            async fn mint(&self, _server: &str) -> Result<MintedToken, ShedError> {
+                let n = self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(MintedToken {
+                    token: self.script[n.min(self.script.len() - 1)].into(),
+                    expires_at_unix: None,
+                })
+            }
+        }
+        let server = MockServer::start_async().await;
+        let m = server
+            .mock_async(|w, t| {
+                w.method(GET)
+                    .path("/api/info")
+                    .header("authorization", "Bearer tok-same");
+                t.status(401);
+            })
+            .await;
+        let minter = Arc::new(ScriptMinter {
+            calls: AtomicUsize::new(0),
+            script: vec!["tok-same", "tok-same", "tok-fresh"],
+        });
+        let c = Client::new(
+            server.base_url(),
+            "mini2".into(),
+            String::new(),
+            None,
+            Some(minter.clone()),
+        )
+        .unwrap();
+        let err = c.info().await.unwrap_err();
+        assert!(matches!(err, ShedError::BadStatus(401)), "got {err:?}");
+        assert_eq!(m.hits_async().await, 1, "same-token retry skipped");
+        assert_eq!(minter.calls.load(Ordering::SeqCst), 2);
+        // The next bearer resolution must FORCE a mint (call 3 → tok-fresh),
+        // never serve the rejected tok-same from the re-populated cache.
+        assert_eq!(c.bearer().await.as_deref(), Some("tok-fresh"));
+        assert_eq!(minter.calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn invalidate_sent_is_bounded_when_the_provider_mutex_is_wedged() {
+        // C6 adversarial review #5b: invalidate_if_current contends on the
+        // provider mutex, which is held ACROSS a mint by design — a wedged
+        // concurrent mint must not pin the 401 path forever. Wedge the mutex
+        // with a never-resolving mint, then assert invalidate_sent returns
+        // false within its bound instead of hanging.
+        struct WedgeMinter {
+            entered: std::sync::atomic::AtomicBool,
+        }
+        #[async_trait::async_trait]
+        impl TokenMinter for WedgeMinter {
+            async fn mint(&self, _server: &str) -> Result<MintedToken, ShedError> {
+                self.entered.store(true, Ordering::SeqCst);
+                std::future::pending().await
+            }
+        }
+        let minter = Arc::new(WedgeMinter {
+            entered: std::sync::atomic::AtomicBool::new(false),
+        });
+        let provider = Arc::new(ControlTokenProvider::new("mini2".into(), minter.clone()));
+        let c = Client::with_provider(
+            "http://127.0.0.1:9".into(),
+            "mini2".into(),
+            None,
+            provider.clone(),
+        )
+        .unwrap();
+        // Wedge: this task acquires the provider lock and pends inside the
+        // mint forever (dropped with the test runtime).
+        let wedger = provider.clone();
+        tokio::spawn(async move {
+            let _ = wedger.token().await;
+        });
+        // Real-time poll (repo test convention) until the mint holds the lock.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !minter.entered.load(Ordering::SeqCst) {
+            assert!(std::time::Instant::now() < deadline, "wedge never started");
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        let invalidated = tokio::time::timeout(
+            Duration::from_secs(5),
+            c.invalidate_sent(Some("tok-x"), Duration::from_millis(100)),
+        )
+        .await
+        .expect("invalidate_sent must return within its bound, not hang");
+        assert!(
+            !invalidated,
+            "a wedged provider must report a timed-out invalidate"
+        );
+    }
+
+    #[tokio::test]
+    async fn with_provider_client_sends_the_tuned_providers_token() {
+        // Client::with_provider (plan §3.4 Client plumbing): a caller-tuned
+        // provider (here: seeded) backs the client — the seed is sent as the
+        // bearer with no mint.
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(GET)
+                    .path("/api/info")
+                    .header("authorization", "Bearer seeded-tok");
+                t.status(200)
+                    .body(include_str!("../../fixtures/server_info.json"));
+            })
+            .await;
+        let minter = Arc::new(SeqMinter {
+            calls: AtomicUsize::new(0),
+        });
+        let provider = Arc::new(
+            ControlTokenProvider::new("mini2".into(), minter.clone()).with_seed(MintedToken {
+                token: "seeded-tok".into(),
+                expires_at_unix: None,
+            }),
+        );
+        let c = Client::with_provider(server.base_url(), "mini2".into(), None, provider).unwrap();
+        assert_eq!(c.info().await.unwrap().name, "mini2");
+        assert_eq!(minter.calls.load(Ordering::SeqCst), 0, "seed used, no mint");
+    }
+
+    #[test]
+    fn with_provider_pin_on_non_https_is_config_error() {
+        let provider = Arc::new(ControlTokenProvider::new(
+            "s".into(),
+            Arc::new(SeqMinter {
+                calls: AtomicUsize::new(0),
+            }),
+        ));
+        let result = Client::with_provider(
+            "http://x".into(),
+            "s".into(),
+            Some("sha256:aa".into()),
+            provider,
+        );
+        assert!(matches!(result, Err(ShedError::Config(_))));
     }
 
     #[tokio::test]

--- a/crates/shed-core/src/http.rs
+++ b/crates/shed-core/src/http.rs
@@ -171,6 +171,19 @@ impl Client {
         }
     }
 
+    /// [`Self::bearer`] BOUNDED by `bound`, mirroring the connect-phase guard
+    /// [`Self::rc_events`] already applies: a foreign [`crate::TokenMinter`]
+    /// impl can hang indefinitely (the provider holds its mutex across a mint),
+    /// so an unbounded bearer resolution in a JSON/lifecycle request or a create
+    /// would wedge the whole call. On timeout surface a Transport error rather
+    /// than block forever. Used by [`Self::request`] for both the initial and
+    /// the 401-retry bearer resolution.
+    async fn bounded_bearer(&self, bound: Duration) -> Result<Option<String>, ShedError> {
+        tokio::time::timeout(bound, self.bearer())
+            .await
+            .map_err(|_| ShedError::Transport("bearer resolution timeout".into()))
+    }
+
     /// 401 aftermath, shared by [`Self::request`], [`Self::create_stream`],
     /// and [`Self::rc_events`]: drop the provider's cache for the token
     /// actually SENT (`invalidate_if_current` — the stale-401 guard: a 401
@@ -294,7 +307,10 @@ impl Client {
         timeout: Duration,
         body: Option<&serde_json::Value>,
     ) -> Result<Vec<u8>, ShedError> {
-        let sent = self.bearer().await;
+        // Bound the bearer resolution under this request's own `timeout` (GET 8s
+        // / WRITE 15s) so a wedged minter can't hang the call outside any bound
+        // — the same guard rc_events applies to its connect phase.
+        let sent = self.bounded_bearer(timeout).await?;
         match self
             .send_once(method.clone(), url, timeout, body, sent.as_deref())
             .await
@@ -303,7 +319,7 @@ impl Client {
                 if !self.invalidate_sent(sent.as_deref(), timeout).await {
                     return Err(ShedError::BadStatus(401)); // wedged provider — no retry
                 }
-                let retry = self.bearer().await;
+                let retry = self.bounded_bearer(timeout).await?;
                 if retry.is_none() {
                     return Err(ShedError::BadStatus(401)); // never retry unauthenticated
                 }
@@ -654,20 +670,26 @@ impl Client {
         sink: &dyn CreateSink,
     ) -> Result<(), ShedError> {
         let url = self.build_url(&["api", "sheds"], &[])?;
-        let bearer = self.bearer().await;
-        let mut rb = self
-            .http
-            .post(url)
-            .header(reqwest::header::ACCEPT, "text/event-stream")
-            .json(req);
-        if let Some(tok) = &bearer {
-            rb = rb.bearer_auth(tok);
-        }
-        let resp = match tokio::time::timeout(CREATE_IDLE_TIMEOUT, rb.send()).await {
+        // Bound the WHOLE connect phase — bearer resolution (a foreign
+        // TokenMinter can hang) plus the request send — under CREATE_IDLE_TIMEOUT,
+        // mirroring rc_events, so no pre-stream await sits outside the bound.
+        let connect = async {
+            let bearer = self.bearer().await;
+            let mut rb = self
+                .http
+                .post(url)
+                .header(reqwest::header::ACCEPT, "text/event-stream")
+                .json(req);
+            if let Some(tok) = &bearer {
+                rb = rb.bearer_auth(tok);
+            }
+            (bearer, rb.send().await)
+        };
+        let (bearer, resp) = match tokio::time::timeout(CREATE_IDLE_TIMEOUT, connect).await {
             Err(_) => {
                 return Err(ShedError::Create("create stream idle timeout".into()));
             }
-            Ok(r) => r.map_err(|e| ShedError::Transport(e.to_string()))?,
+            Ok((bearer, r)) => (bearer, r.map_err(|e| ShedError::Transport(e.to_string()))?),
         };
         let status = resp.status().as_u16();
         if status == 401 {
@@ -2244,6 +2266,43 @@ mod tests {
         match err {
             ShedError::Transport(msg) => assert!(msg.contains("connect"), "got: {msg}"),
             other => panic!("expected Transport connect timeout, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn request_bearer_resolution_is_bounded_against_a_hung_mint() {
+        // The bearer resolution in request() is bounded by the request's own
+        // timeout: a foreign TokenMinter that never resolves must surface as an
+        // error within the bound, not hang every JSON/lifecycle call. Mirrors
+        // rc_events_connect_timeout_covers_a_hung_bearer_mint for the JSON path.
+        struct NeverMinter;
+        #[async_trait::async_trait]
+        impl TokenMinter for NeverMinter {
+            async fn mint(&self, _server: &str) -> Result<MintedToken, ShedError> {
+                std::future::pending().await
+            }
+        }
+        let c = Client::new(
+            "http://127.0.0.1:9".into(),
+            "s".into(),
+            String::new(),
+            None,
+            Some(Arc::new(NeverMinter)),
+        )
+        .unwrap();
+        let url = c.build_url(&["api", "info"], &[]).unwrap();
+        // Outer guard: if the fix regressed, request() would hang and this
+        // 2s timeout would fire with the expect message instead of deadlocking.
+        let err = tokio::time::timeout(
+            Duration::from_secs(2),
+            c.request(reqwest::Method::GET, &url, Duration::from_millis(100), None),
+        )
+        .await
+        .expect("request must return within the bound, not hang")
+        .unwrap_err();
+        match err {
+            ShedError::Transport(msg) => assert!(msg.contains("bearer"), "got: {msg}"),
+            other => panic!("expected Transport bearer timeout, got {other:?}"),
         }
     }
 

--- a/crates/shed-core/src/http.rs
+++ b/crates/shed-core/src/http.rs
@@ -17,9 +17,10 @@ use futures_util::StreamExt;
 use thiserror::Error;
 
 use crate::models::{
-    CreateShedRequest, EgressProfileInfo, ImageList, ServerInfo, Shed, ShedImage, ShedList,
-    SystemDiskUsage,
+    CreateShedRequest, EgressProfileInfo, ImageList, Overview, ServerInfo, SessionsResponse, Shed,
+    ShedImage, ShedList, SystemDiskUsage,
 };
+use crate::rc::RcMessagesPage;
 use crate::sse::SseParser;
 use crate::token::{ControlTokenProvider, TokenMinter};
 
@@ -110,14 +111,58 @@ impl Client {
         }
     }
 
+    /// Build a request URL from literal path `segments` and `query` pairs.
+    /// Each segment is appended via the url crate's `path_segments_mut`, which
+    /// percent-encodes it as exactly ONE path segment (a `/` inside a value
+    /// becomes `%2F`, never a new segment), and bare `""`/`.`/`..` segments
+    /// are rejected outright (a `..` that survived to the wire would be
+    /// dot-normalized by the server's router into a DIFFERENT route — e.g. a
+    /// session-delete crossing into a shed-delete). Identifiers here are
+    /// server-vended (validated shed/session names, hub-generated slugs), but
+    /// the client enforces one-segment encoding anyway — defense in depth,
+    /// matching mobile's Dart client, which component-encodes every segment.
+    fn build_url(
+        &self,
+        segments: &[&str],
+        query: &[(&str, String)],
+    ) -> Result<reqwest::Url, ShedError> {
+        let mut url = reqwest::Url::parse(&self.base_url).map_err(|e| {
+            ShedError::Config(format!("invalid base URL {}: {e}", self.base_url))
+        })?;
+        {
+            let mut parts = url.path_segments_mut().map_err(|_| {
+                ShedError::Config(format!(
+                    "base URL {} cannot carry a path",
+                    self.base_url
+                ))
+            })?;
+            parts.pop_if_empty(); // tolerate a trailing slash on base_url
+            for seg in segments {
+                if seg.is_empty() || *seg == "." || *seg == ".." {
+                    return Err(ShedError::Config(format!(
+                        "invalid URL path segment {seg:?}"
+                    )));
+                }
+                parts.push(seg);
+            }
+        }
+        for (k, v) in query {
+            url.query_pairs_mut().append_pair(k, v);
+        }
+        Ok(url)
+    }
+
     async fn send_once(
         &self,
         method: reqwest::Method,
-        path: &str,
+        url: &reqwest::Url,
         timeout: Duration,
+        body: Option<&serde_json::Value>,
     ) -> Result<Vec<u8>, ShedError> {
-        let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
-        let mut req = self.http.request(method, &url).timeout(timeout);
+        let mut req = self.http.request(method, url.clone()).timeout(timeout);
+        if let Some(b) = body {
+            req = req.json(b);
+        }
         if let Some(tok) = self.bearer().await {
             req = req.bearer_auth(tok);
         }
@@ -138,44 +183,56 @@ impl Client {
 
     /// Send once, and on a provider-backed 401 invalidate + retry once
     /// (at-most-once, mirrors the SDK/CLI). Static/no-token clients don't retry.
+    /// `body`, when present, is a JSON request body (re-sent on the retry).
     async fn request(
         &self,
         method: reqwest::Method,
-        path: &str,
+        url: &reqwest::Url,
         timeout: Duration,
+        body: Option<&serde_json::Value>,
     ) -> Result<Vec<u8>, ShedError> {
-        match self.send_once(method.clone(), path, timeout).await {
+        match self.send_once(method.clone(), url, timeout, body).await {
             Err(ShedError::BadStatus(401)) if self.token_provider.is_some() => {
                 if let Some(p) = &self.token_provider {
                     p.invalidate().await;
                 }
-                self.send_once(method, path, timeout).await
+                self.send_once(method, url, timeout, body).await
             }
             other => other,
         }
     }
 
-    async fn get_json<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T, ShedError> {
+    /// GET the segment-built URL ([`Self::build_url`]) and decode JSON.
+    async fn get_json<T: serde::de::DeserializeOwned>(
+        &self,
+        segments: &[&str],
+        query: &[(&str, String)],
+    ) -> Result<T, ShedError> {
+        let url = self.build_url(segments, query)?;
         let bytes = self
-            .request(reqwest::Method::GET, path, GET_TIMEOUT)
+            .request(reqwest::Method::GET, &url, GET_TIMEOUT, None)
             .await?;
         serde_json::from_slice(&bytes).map_err(|e| ShedError::Decode(e.to_string()))
     }
 
-    /// A lifecycle mutation (POST/DELETE, no response body). 15s timeout.
-    async fn lifecycle(&self, method: reqwest::Method, path: &str) -> Result<(), ShedError> {
-        self.request(method, path, WRITE_TIMEOUT).await.map(|_| ())
+    /// A lifecycle mutation (POST/DELETE, no request body; any response body
+    /// ignored — success is any 2xx). 15s timeout.
+    async fn lifecycle(&self, method: reqwest::Method, segments: &[&str]) -> Result<(), ShedError> {
+        let url = self.build_url(segments, &[])?;
+        self.request(method, &url, WRITE_TIMEOUT, None)
+            .await
+            .map(|_| ())
     }
 
     /// `GET /api/info`.
     pub async fn info(&self) -> Result<ServerInfo, ShedError> {
-        self.get_json("/api/info").await
+        self.get_json(&["api", "info"], &[]).await
     }
 
     /// `GET /api/sheds` -> sheds stamped with this host's config name (the server
     /// omits `host`; the client stamps it, as Swift's `listSheds` does).
     pub async fn list_sheds(&self) -> Result<Vec<Shed>, ShedError> {
-        let list: ShedList = self.get_json("/api/sheds").await?;
+        let list: ShedList = self.get_json(&["api", "sheds"], &[]).await?;
         Ok(list
             .sheds
             .into_iter()
@@ -188,41 +245,145 @@ impl Client {
 
     /// `GET /api/system/df`.
     pub async fn system_df(&self) -> Result<SystemDiskUsage, ShedError> {
-        self.get_json("/api/system/df").await
+        self.get_json(&["api", "system", "df"], &[]).await
     }
 
     /// `GET /api/images`.
     pub async fn list_images(&self) -> Result<Vec<ShedImage>, ShedError> {
-        let list: ImageList = self.get_json("/api/images").await?;
+        let list: ImageList = self.get_json(&["api", "images"], &[]).await?;
         Ok(list.images)
     }
 
     /// `GET /api/egress/profiles`.
     pub async fn egress_profiles(&self) -> Result<Vec<EgressProfileInfo>, ShedError> {
-        self.get_json("/api/egress/profiles").await
+        self.get_json(&["api", "egress", "profiles"], &[]).await
+    }
+
+    // Path-building note: every method below hands `shed`/`session`/`slug`
+    // values to `build_url`, which percent-encodes each as exactly ONE path
+    // segment and rejects ""/"."/"..". The values are server-vended
+    // identifiers (validated shed/session names, hub-generated slugs), but
+    // the client enforces one-segment encoding anyway — defense in depth
+    // against a traversal like `delete_session(shed, "../../victim")`
+    // rewriting the route (mobile's Dart client component-encodes too).
+
+    /// `GET /api/overview` — the single-call host snapshot (server identity +
+    /// features, disk usage, every shed with its rc-enriched sessions and
+    /// capabilities; Go `internal/api/overview.go:38-63`). The decode is the
+    /// tolerant, never-failing [`Overview`] adapter.
+    ///
+    /// On an old server (pre-`overview`) the unrouted path falls through to
+    /// chi's default NotFound handler — a `text/plain` "404 page not found"
+    /// body that the server's ContentTypeJSON middleware has already labeled
+    /// `application/json`. That surfaces here as `BadStatus(404)`, never a
+    /// `Decode` error: the non-2xx check short-circuits before any body parse.
+    /// Don't feature-probe with this 404 — the reliable capability signal is
+    /// `ServerInfo::features` from the unauthenticated `/api/info` bootstrap
+    /// call ([`crate::models::FEATURE_OVERVIEW`]).
+    pub async fn overview(&self) -> Result<Overview, ShedError> {
+        self.get_json(&["api", "overview"], &[]).await
+    }
+
+    /// `GET /api/sheds/{shed}/sessions` — the shed's tmux sessions, rc-enriched
+    /// by default (Go `internal/api/handlers.go:592-610`; wire shapes
+    /// `internal/config/types.go:182-215, 287-291`). `warnings` carries
+    /// enrichment degradations (the rc rows then lack their `rc` block).
+    /// Errors are status-only per `mapSessionError`
+    /// (`handlers.go:765-786`): 404 unknown shed, 409 shed stopped, 503 tmux
+    /// unavailable.
+    pub async fn list_sessions(&self, shed: &str) -> Result<SessionsResponse, ShedError> {
+        self.get_json(&["api", "sheds", shed, "sessions"], &[]).await
+    }
+
+    /// `DELETE /api/sheds/{shed}/sessions/{session}` — kill one tmux session
+    /// (Go `internal/api/handlers.go:614-632`). The server replies 204; any
+    /// 2xx is success (consistent with the other lifecycle mutations). Errors
+    /// are status-only per `mapSessionError` (`handlers.go:765-786`): 400
+    /// invalid session name, 404 unknown session/shed, 409 shed stopped, 503
+    /// tmux unavailable.
+    pub async fn delete_session(&self, shed: &str, session: &str) -> Result<(), ShedError> {
+        self.lifecycle(
+            reqwest::Method::DELETE,
+            &["api", "sheds", shed, "sessions", session],
+        )
+        .await
+    }
+
+    /// `GET /api/sheds/{shed}/rc/v1/sessions/{slug}/messages?since=N[&limit=M]`
+    /// — one page of an RC session's message feed, reverse-proxied into the
+    /// guest's rc hub (proxy `internal/api/rchub.go:280-375`; hub handler
+    /// `internal/ext/rc/hub.go:332-385`). `since` is the exclusive seq cursor
+    /// (0 = from the start); `limit` defaults to 100 server-side (capped at
+    /// 200) when `None`. Decode is the tolerant [`RcMessagesPage`].
+    ///
+    /// Errors are status-only (plan §3.2 — the hub's flat `{code,message}`
+    /// bodies are deliberately not decoded): 400 malformed since/limit, 404
+    /// unknown slug/shed, 503 shed not running / hub unavailable, 502 proxy
+    /// failed / oversized upstream body.
+    pub async fn rc_messages(
+        &self,
+        shed: &str,
+        slug: &str,
+        since: u64,
+        limit: Option<u32>,
+    ) -> Result<RcMessagesPage, ShedError> {
+        let mut query = vec![("since", since.to_string())];
+        if let Some(limit) = limit {
+            query.push(("limit", limit.to_string()));
+        }
+        self.get_json(
+            &["api", "sheds", shed, "rc", "v1", "sessions", slug, "messages"],
+            &query,
+        )
+        .await
+    }
+
+    /// `POST /api/sheds/{shed}/rc/v1/sessions/{slug}/input` with
+    /// `{"text": …}` — deliver a line of feed input to a gated RC session
+    /// (proxy `internal/api/rchub.go:280-375`; hub handler
+    /// `internal/ext/rc/hub.go:391-521`). Success is any 2xx; the 200 body
+    /// (`{"delivered":true}`) is ignored. Goes through the standard `request`
+    /// pipeline (WRITE_TIMEOUT, provider-backed 401 → invalidate +
+    /// retry-once, body re-sent).
+    ///
+    /// Errors are status-only (plan §3.2 — hub `{code,message}` bodies not
+    /// decoded; `BadStatus` carries the status): 400 invalid/unsafe text, 404
+    /// unknown slug/shed, 409 not accepting (`not_accepting` — wrong
+    /// activity, recreated identity, or a non-input-gated kind), 413 body too
+    /// large (`too_large`, >16 KiB), 503 shed not running / hub unavailable,
+    /// 502 proxy failed.
+    pub async fn rc_input(&self, shed: &str, slug: &str, text: &str) -> Result<(), ShedError> {
+        let body = serde_json::json!({ "text": text });
+        let url = self.build_url(
+            &["api", "sheds", shed, "rc", "v1", "sessions", slug, "input"],
+            &[],
+        )?;
+        self.request(reqwest::Method::POST, &url, WRITE_TIMEOUT, Some(&body))
+            .await
+            .map(|_| ())
     }
 
     /// `POST /api/sheds/{name}/start`.
     pub async fn start(&self, name: &str) -> Result<(), ShedError> {
-        self.lifecycle(reqwest::Method::POST, &format!("/api/sheds/{name}/start"))
+        self.lifecycle(reqwest::Method::POST, &["api", "sheds", name, "start"])
             .await
     }
 
     /// `POST /api/sheds/{name}/stop`.
     pub async fn stop(&self, name: &str) -> Result<(), ShedError> {
-        self.lifecycle(reqwest::Method::POST, &format!("/api/sheds/{name}/stop"))
+        self.lifecycle(reqwest::Method::POST, &["api", "sheds", name, "stop"])
             .await
     }
 
     /// `POST /api/sheds/{name}/reset`.
     pub async fn reset(&self, name: &str) -> Result<(), ShedError> {
-        self.lifecycle(reqwest::Method::POST, &format!("/api/sheds/{name}/reset"))
+        self.lifecycle(reqwest::Method::POST, &["api", "sheds", name, "reset"])
             .await
     }
 
     /// `DELETE /api/sheds/{name}`.
     pub async fn delete(&self, name: &str) -> Result<(), ShedError> {
-        self.lifecycle(reqwest::Method::DELETE, &format!("/api/sheds/{name}"))
+        self.lifecycle(reqwest::Method::DELETE, &["api", "sheds", name])
             .await
     }
 
@@ -243,10 +404,10 @@ impl Client {
         req: &CreateShedRequest,
         sink: &dyn CreateSink,
     ) -> Result<(), ShedError> {
-        let url = format!("{}/api/sheds", self.base_url.trim_end_matches('/'));
+        let url = self.build_url(&["api", "sheds"], &[])?;
         let mut rb = self
             .http
-            .post(&url)
+            .post(url)
             .header(reqwest::header::ACCEPT, "text/event-stream")
             .json(req);
         if let Some(tok) = self.bearer().await {
@@ -829,5 +990,385 @@ mod tests {
             2,
             "401 on create must invalidate so the next bearer remints"
         );
+    }
+
+    // ---- overview (fetchOverview cases ported from mobile's
+    // overview_test.dart:119-134) ----
+
+    #[tokio::test]
+    async fn overview_decodes_golden_200() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(GET).path("/api/overview");
+                t.status(200)
+                    .header("content-type", "application/json")
+                    .body(include_str!("../../fixtures/overview.json"));
+            })
+            .await;
+        let o = client(&server).overview().await.unwrap();
+        assert_eq!(o.sheds.len(), 2);
+        assert_eq!(o.server.version, "0.8.0");
+    }
+
+    #[tokio::test]
+    async fn overview_404_old_server_is_bad_status_never_decode() {
+        // AC#9: an old server has no /api/overview route — chi's default
+        // NotFound handler writes a text/plain "404 page not found" body, but
+        // the server's ContentTypeJSON middleware has ALREADY stamped
+        // Content-Type: application/json on the response. The client must
+        // surface BadStatus(404) (the provider maps it to "unsupported"), and
+        // must never try to decode the mislabeled non-JSON body.
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(GET).path("/api/overview");
+                t.status(404)
+                    .header("content-type", "application/json")
+                    .body("404 page not found");
+            })
+            .await;
+        let err = client(&server).overview().await.unwrap_err();
+        assert!(matches!(err, ShedError::BadStatus(404)), "got {err:?}");
+    }
+
+    // ---- sessions read-plane ----
+
+    #[tokio::test]
+    async fn list_sessions_decodes_rc_enriched_and_plain_rows() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(GET).path("/api/sheds/proj/sessions");
+                t.status(200).body(
+                    r#"{"sessions":[
+                        {"name":"default","shed_name":"proj",
+                         "created_at":"2026-06-19T18:52:00Z","attached":true},
+                        {"name":"rc-abc234","shed_name":"proj",
+                         "created_at":"2026-06-19T18:53:00Z","attached":false,
+                         "rc":{"kind":"claude-rc","state":"ready","managed":true,
+                               "activity":"working",
+                               "last_message":"Running the test suite now."}}
+                    ],"warnings":null}"#,
+                );
+            })
+            .await;
+        let r = client(&server).list_sessions("proj").await.unwrap();
+        assert_eq!(r.sessions.len(), 2);
+        assert!(r.warnings.is_empty()); // null → []
+        assert!(r.sessions[0].rc.is_none()); // plain tmux row
+        let rc = r.sessions[1].rc.as_ref().unwrap();
+        assert_eq!(rc.kind.as_deref(), Some("claude-rc"));
+        assert!(rc.managed);
+        assert_eq!(rc.activity.as_deref(), Some("working"));
+    }
+
+    #[tokio::test]
+    async fn list_sessions_warnings_present_and_error_map() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(GET).path("/api/sheds/degraded/sessions");
+                t.status(200).body(
+                    r#"{"sessions":[{"name":"rc-x","shed_name":"degraded",
+                                     "created_at":"2026-01-01T00:00:00Z","attached":false}],
+                        "warnings":["degraded: rc enrichment degraded"]}"#,
+                );
+            })
+            .await;
+        let r = client(&server).list_sessions("degraded").await.unwrap();
+        assert_eq!(r.warnings, ["degraded: rc enrichment degraded"]);
+        assert!(r.sessions[0].rc.is_none()); // enrichment degraded → no rc block
+                                             // Unknown shed → status-only 404 (mapSessionError).
+        server
+            .mock_async(|w, t| {
+                w.method(GET).path("/api/sheds/missing/sessions");
+                t.status(404);
+            })
+            .await;
+        assert!(matches!(
+            client(&server).list_sessions("missing").await,
+            Err(ShedError::BadStatus(404))
+        ));
+    }
+
+    #[tokio::test]
+    async fn delete_session_204_ok_and_404_maps() {
+        let server = MockServer::start_async().await;
+        let m = server
+            .mock_async(|w, t| {
+                w.method(DELETE).path("/api/sheds/proj/sessions/rc-abc234");
+                t.status(204); // the server's success shape (handlers.go:631)
+            })
+            .await;
+        client(&server)
+            .delete_session("proj", "rc-abc234")
+            .await
+            .unwrap();
+        m.assert_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(DELETE).path("/api/sheds/proj/sessions/nope");
+                t.status(404);
+            })
+            .await;
+        assert!(matches!(
+            client(&server).delete_session("proj", "nope").await,
+            Err(ShedError::BadStatus(404))
+        ));
+    }
+
+    // ---- rc proxy: messages + input ----
+
+    #[tokio::test]
+    async fn rc_messages_happy_path_with_query_params() {
+        let server = MockServer::start_async().await;
+        let m = server
+            .mock_async(|w, t| {
+                w.method(GET)
+                    .path("/api/sheds/proj/rc/v1/sessions/abc234/messages")
+                    .query_param("since", "7")
+                    .query_param("limit", "50");
+                t.status(200).body(
+                    r#"{"messages":[
+                        {"seq":8,"ts":"2026-06-19T18:53:00Z","role":"user","type":"text","text":"hi"},
+                        {"seq":9,"role":"tool","type":"tool_use",
+                         "tool":{"name":"shell","detail":"ls -la"}}
+                    ],"truncated":false}"#,
+                );
+            })
+            .await;
+        let p = client(&server)
+            .rc_messages("proj", "abc234", 7, Some(50))
+            .await
+            .unwrap();
+        m.assert_async().await;
+        assert_eq!(p.messages.len(), 2);
+        assert!(!p.truncated);
+        assert_eq!(p.messages[0].seq, 8);
+        assert_eq!(
+            p.messages[1].tool.as_ref().unwrap().name.as_deref(),
+            Some("shell")
+        );
+    }
+
+    #[tokio::test]
+    async fn rc_messages_omits_limit_when_none() {
+        let server = MockServer::start_async().await;
+        let m = server
+            .mock_async(|w, t| {
+                w.method(GET)
+                    .path("/api/sheds/proj/rc/v1/sessions/abc234/messages")
+                    .query_param("since", "0")
+                    // The server defaults limit (100, cap 200) — the client
+                    // must not send one.
+                    .matches(|req| {
+                        !req.query_params
+                            .as_ref()
+                            .is_some_and(|q| q.iter().any(|(k, _)| k == "limit"))
+                    });
+                t.status(200).body(r#"{"messages":[],"truncated":true}"#);
+            })
+            .await;
+        let p = client(&server)
+            .rc_messages("proj", "abc234", 0, None)
+            .await
+            .unwrap();
+        m.assert_async().await;
+        assert!(p.messages.is_empty());
+        assert!(p.truncated);
+    }
+
+    #[tokio::test]
+    async fn rc_messages_tolerates_missing_keys_and_maps_errors() {
+        let server = MockServer::start_async().await;
+        // A body with no messages key decodes to the empty page (tolerant).
+        server
+            .mock_async(|w, t| {
+                w.method(GET)
+                    .path("/api/sheds/proj/rc/v1/sessions/sparse/messages");
+                t.status(200).body(r#"{"truncated":false}"#);
+            })
+            .await;
+        let p = client(&server)
+            .rc_messages("proj", "sparse", 0, None)
+            .await
+            .unwrap();
+        assert!(p.messages.is_empty());
+        assert!(!p.truncated);
+        // Unknown slug → status-only 404 (hub `{code,message}` body ignored).
+        server
+            .mock_async(|w, t| {
+                w.method(GET)
+                    .path("/api/sheds/proj/rc/v1/sessions/nope/messages");
+                t.status(404)
+                    .body(r#"{"code":"unknown_slug","message":"no such rc session"}"#);
+            })
+            .await;
+        assert!(matches!(
+            client(&server).rc_messages("proj", "nope", 0, None).await,
+            Err(ShedError::BadStatus(404))
+        ));
+    }
+
+    #[tokio::test]
+    async fn rc_input_posts_json_body_and_ignores_delivered_body() {
+        let server = MockServer::start_async().await;
+        let m = server
+            .mock_async(|w, t| {
+                w.method(POST)
+                    .path("/api/sheds/proj/rc/v1/sessions/abc234/input")
+                    .header("content-type", "application/json")
+                    .json_body(serde_json::json!({"text": "looks good, continue"}));
+                t.status(200).body(r#"{"delivered":true}"#);
+            })
+            .await;
+        client(&server)
+            .rc_input("proj", "abc234", "looks good, continue")
+            .await
+            .unwrap();
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn rc_input_status_code_errors_are_bad_status() {
+        // Status-only dispatch (plan §3.2): the hub's flat {code,message}
+        // bodies (hub.go:404-521) are NOT decoded; BadStatus carries the
+        // status the caller keys off.
+        let server = MockServer::start_async().await;
+        for (slug, status, body) in [
+            (
+                "busy",
+                409,
+                r#"{"code":"not_accepting","message":"session is not waiting for input"}"#,
+            ),
+            (
+                "big",
+                413,
+                r#"{"code":"too_large","message":"input body exceeds 16 KiB"}"#,
+            ),
+            (
+                "gone",
+                404,
+                r#"{"code":"unknown_slug","message":"no such rc session"}"#,
+            ),
+        ] {
+            server
+                .mock_async(|w, t| {
+                    w.method(POST)
+                        .path(format!("/api/sheds/proj/rc/v1/sessions/{slug}/input"));
+                    t.status(status).body(body);
+                })
+                .await;
+            let err = client(&server)
+                .rc_input("proj", slug, "x")
+                .await
+                .unwrap_err();
+            match err {
+                ShedError::BadStatus(s) => assert_eq!(s, status),
+                other => panic!("expected BadStatus({status}), got {other:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn rc_input_retries_once_on_401_resending_body() {
+        // Same 401 → invalidate + retry-once contract as every request()
+        // path; the JSON body must be re-sent on the retried attempt.
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(POST)
+                    .path("/api/sheds/proj/rc/v1/sessions/abc234/input")
+                    .header("authorization", "Bearer tok-1");
+                t.status(401);
+            })
+            .await;
+        let ok = server
+            .mock_async(|w, t| {
+                w.method(POST)
+                    .path("/api/sheds/proj/rc/v1/sessions/abc234/input")
+                    .header("authorization", "Bearer tok-2")
+                    .json_body(serde_json::json!({"text": "hi"}));
+                t.status(200).body(r#"{"delivered":true}"#);
+            })
+            .await;
+        let minter = Arc::new(SeqMinter {
+            calls: AtomicUsize::new(0),
+        });
+        let c = Client::new(
+            server.base_url(),
+            "mini2".into(),
+            String::new(),
+            None,
+            Some(minter),
+        )
+        .unwrap();
+        c.rc_input("proj", "abc234", "hi").await.unwrap();
+        ok.assert_async().await;
+    }
+
+    // ---- URL path-segment safety (build_url defense in depth) ----
+
+    #[tokio::test]
+    async fn delete_session_traversal_is_encoded_as_one_segment() {
+        // A malicious/corrupt session name must never rewrite the route: with
+        // naive string interpolation, `../../victim` would dot-normalize into
+        // DELETE /api/sheds/victim — a session-delete crossing into a
+        // shed-delete. build_url percent-encodes the value as ONE segment.
+        let server = MockServer::start_async().await;
+        let victim = server
+            .mock_async(|w, t| {
+                w.method(DELETE).path("/api/sheds/victim");
+                t.status(200);
+            })
+            .await;
+        let encoded = server
+            .mock_async(|w, t| {
+                w.method(DELETE)
+                    .path("/api/sheds/proj/sessions/..%2F..%2Fvictim");
+                t.status(204);
+            })
+            .await;
+        client(&server)
+            .delete_session("proj", "../../victim")
+            .await
+            .unwrap();
+        encoded.assert_async().await; // the encoded single segment was sent
+        assert_eq!(victim.hits_async().await, 0, "traversal must not escape");
+    }
+
+    #[tokio::test]
+    async fn rc_input_slug_with_slash_stays_one_segment() {
+        // A '/' inside a (remote-influenced) slug is %2F, never a new segment.
+        let server = MockServer::start_async().await;
+        let m = server
+            .mock_async(|w, t| {
+                w.method(POST)
+                    .path("/api/sheds/proj/rc/v1/sessions/a%2Fb/input")
+                    .json_body(serde_json::json!({"text": "hi"}));
+                t.status(200).body(r#"{"delivered":true}"#);
+            })
+            .await;
+        client(&server).rc_input("proj", "a/b", "hi").await.unwrap();
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn bare_dot_and_empty_segments_are_rejected_client_side() {
+        // ""/"."/".." can't be neutralized by encoding alone (a raw ".." that
+        // reached the wire would be dot-normalized by the server's router into
+        // a different route) — build_url refuses them outright.
+        let c = Client::new("http://x".into(), "s".into(), String::new(), None, None).unwrap();
+        assert!(matches!(c.delete("..").await, Err(ShedError::Config(_))));
+        assert!(matches!(
+            c.delete_session("proj", ".").await,
+            Err(ShedError::Config(_))
+        ));
+        assert!(matches!(c.list_sessions("").await, Err(ShedError::Config(_))));
+        assert!(matches!(
+            c.rc_messages("proj", "..", 0, None).await,
+            Err(ShedError::Config(_))
+        ));
     }
 }

--- a/crates/shed-core/src/http.rs
+++ b/crates/shed-core/src/http.rs
@@ -21,6 +21,7 @@ use crate::models::{
     ShedImage, ShedList, SystemDiskUsage,
 };
 use crate::rc::RcMessagesPage;
+use crate::rc_events::{parse_rc_event, RcEvent};
 use crate::sse::SseParser;
 use crate::token::{ControlTokenProvider, TokenMinter};
 
@@ -44,6 +45,22 @@ const WRITE_TIMEOUT: Duration = Duration::from_secs(15);
 /// Max gap between SSE bytes during a create before we give up (a hung stream);
 /// generous so a healthy provision with periodic progress never trips it.
 const CREATE_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
+/// Max gap between SSE BYTES on the long-lived rc-events stream before the
+/// client treats the connection as silently dead. The server heartbeats every
+/// 25s with a `: heartbeat` comment (`internal/api/rcevents.go:188-206`), and
+/// those comment bytes reset this timer even though the parser swallows them
+/// without emitting an event — the timeout wraps the byte-chunk future, never
+/// the parsed-event future (plan 001 §3.3; see [`Client::rc_events`]). 60s is
+/// two missed heartbeats plus slack.
+const RC_EVENTS_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+/// Cap on the bytes buffered for a single rc-events SSE event, matching the
+/// broker bus's `MAX_SSE_EVENT_BYTES` (`shed-broker/src/bus.rs`): 1 MiB, the
+/// same bound Go's `bufio.Scanner` enforces. rc-events is a long-lived stream
+/// carrying guest-influenced payloads (unlike the bounded one-shot create
+/// stream, which stays uncapped), so an oversized / never-terminating event
+/// surfaces as an error → the watcher disconnects + reconnects, instead of
+/// buffering unboundedly.
+const RC_EVENTS_MAX_EVENT_BYTES: usize = 1 << 20;
 const USER_AGENT: &str = concat!("shed-desktop-core/", env!("CARGO_PKG_VERSION"));
 
 /// Sink for create progress. shed-core streams the SSE and drives these; the FFI
@@ -52,6 +69,14 @@ pub trait CreateSink: Send + Sync {
     fn on_progress(&self, message: String);
     fn on_complete(&self, shed: Shed);
     fn on_error(&self, message: String);
+}
+
+/// Sink for the rc-events live-activity stream (mirrors [`CreateSink`]):
+/// shed-core drives the SSE connection ([`Client::rc_events`]) and hands each
+/// decoded [`RcEvent`] here in arrival order; the fold + reconnect layer
+/// (shed-app's `RcEventsWatcher`) implements it.
+pub trait RcEventSink: Send + Sync {
+    fn on_event(&self, ev: RcEvent);
 }
 
 /// A read client for one shed-server host. `Clone` is cheap (reqwest::Client and
@@ -361,6 +386,143 @@ impl Client {
         self.request(reqwest::Method::POST, &url, WRITE_TIMEOUT, Some(&body))
             .await
             .map(|_| ())
+    }
+
+    /// `GET /api/rc/events` with `Accept: text/event-stream` — the host-wide
+    /// aggregate rc live-activity stream (Go `internal/api/rcevents.go:170-208`:
+    /// the server opens with a `: ok` comment preamble, heartbeats every 25s
+    /// with `: heartbeat` comments, and never sends a `retry:` hint — reconnect
+    /// policy is entirely the client's). Each SSE record is decoded via
+    /// [`parse_rc_event`] and delivered to `sink` in arrival order; a
+    /// malformed/unknown frame is skipped WITHOUT ending the stream (the decode
+    /// is tolerant by design — one bad guest frame must not become a reconnect
+    /// storm), and comment frames never reach the sink (the parser swallows
+    /// them). Success is exactly a 200 SSE response — any other status,
+    /// including a body-less 2xx like 204, is `BadStatus` (an empty-stream Ok
+    /// would mask the fault from the watcher). Returns `Ok(())` on clean EOF,
+    /// after flushing any final unterminated record to the sink. The idle
+    /// duration also bounds the whole connect phase (bearer mint + send).
+    ///
+    /// ONE connection — no in-method reconnect and no 401 retry: the reconnect
+    /// loop (shed-app's `RcEventsWatcher`) owns backoff AND re-auth. On a 401
+    /// this invalidates the token provider and returns `BadStatus(401)`, so
+    /// the watcher's next connect re-mints; an in-method retry would double up
+    /// on the watcher's backoff and hide the auth failure from its Down
+    /// signal.
+    ///
+    /// Liveness (plan 001 §3.3, panel-critical pin): the
+    /// [`RC_EVENTS_IDLE_TIMEOUT`] idle timer wraps the BYTE-chunk future
+    /// (`bytes_stream().next()`, the `create_stream` pattern), NOT the
+    /// parsed-event future — the server's 25s heartbeat comments arrive as
+    /// bytes and reset it even though the parser emits no event for them. An
+    /// event-level timer would falsely kill every healthy-but-quiet stream; the
+    /// byte-level timer converts a silently-dead connection into
+    /// disconnect → reconnect → resync (a liveness watchdog mobile's Dart loop
+    /// lacks). Idle/transport failures surface as [`ShedError::Transport`]
+    /// (`Create` is create-specific; to the reconnecting watcher every
+    /// teardown is the same "connection died" condition). Events are parsed
+    /// through a 1 MiB-capped [`SseParser`] ([`RC_EVENTS_MAX_EVENT_BYTES`]);
+    /// an overflow is an error, ending the stream.
+    pub async fn rc_events(&self, sink: &dyn RcEventSink) -> Result<(), ShedError> {
+        self.rc_events_with_idle(sink, RC_EVENTS_IDLE_TIMEOUT).await
+    }
+
+    /// [`Self::rc_events`] with an injectable idle timeout — the test seam
+    /// (deterministic timer tests must not wait out the 60s production value).
+    pub(crate) async fn rc_events_with_idle(
+        &self,
+        sink: &dyn RcEventSink,
+        idle: Duration,
+    ) -> Result<(), ShedError> {
+        self.rc_events_with_limits(sink, idle, RC_EVENTS_MAX_EVENT_BYTES)
+            .await
+    }
+
+    /// The full rc-events implementation with both knobs injectable (the cap
+    /// seam exists only for tests — an oversized-event test must not build a
+    /// >1 MiB body).
+    async fn rc_events_with_limits(
+        &self,
+        sink: &dyn RcEventSink,
+        idle: Duration,
+        max_event_bytes: usize,
+    ) -> Result<(), ShedError> {
+        let url = self.build_url(&["api", "rc", "events"], &[])?;
+        // Connection-open timeout: the same duration bounds the WHOLE connect
+        // phase — bearer resolution (a foreign `TokenMinter` impl can hang
+        // indefinitely) plus the request send — so no pre-stream await sits
+        // outside the bound (a server that accepts but never responds is as
+        // dead as a silent stream).
+        let connect = async {
+            let mut rb = self
+                .http
+                .get(url)
+                .header(reqwest::header::ACCEPT, "text/event-stream");
+            if let Some(tok) = self.bearer().await {
+                rb = rb.bearer_auth(tok);
+            }
+            rb.send().await
+        };
+        let resp = match tokio::time::timeout(idle, connect).await {
+            Err(_) => {
+                return Err(ShedError::Transport("rc-events connect timeout".into()));
+            }
+            Ok(r) => r.map_err(|e| ShedError::Transport(e.to_string()))?,
+        };
+        let status = resp.status().as_u16();
+        if status == 401 {
+            // Stale token: invalidate so the NEXT connect re-mints, then
+            // surface the 401 — the watcher owns re-auth (no in-method retry).
+            // Bounded await: invalidate only contends on the provider mutex,
+            // but that mutex is held across a mint by design, so a wedged mint
+            // could otherwise pin this call forever. On timeout we fall
+            // through and surface the 401 anyway — the cache keeps the stale
+            // token one extra cycle and the watcher's next 401 retries the
+            // invalidate.
+            // NOTE(C6): becomes invalidate_if_current(sent_bearer) — the
+            // unconditional invalidate can erase a NEWER token when a stale
+            // 401 races a rotation (plan §3.4 stale-401 guard).
+            if let Some(p) = &self.token_provider {
+                let _ = tokio::time::timeout(idle, p.invalidate()).await;
+            }
+        }
+        // Exactly 200, not any-2xx: SSE lives in a 200 response body — a
+        // 204/206 minted by an intermediary carries no event stream, and
+        // treating it as success would end as a silent empty-stream Ok,
+        // masking the fault from the watcher's Down/backoff signal.
+        if status != 200 {
+            return Err(ShedError::BadStatus(status));
+        }
+        let mut stream = resp.bytes_stream();
+        let mut parser = SseParser::new().with_max_event_bytes(max_event_bytes);
+        loop {
+            // The idle timer wraps the BYTE-chunk future (see rc_events docs):
+            // heartbeat comment bytes reset it even though they emit no event.
+            match tokio::time::timeout(idle, stream.next()).await {
+                Err(_) => {
+                    return Err(ShedError::Transport("rc-events stream idle timeout".into()));
+                }
+                Ok(None) => break, // clean EOF
+                Ok(Some(chunk)) => {
+                    let chunk = chunk.map_err(|e| ShedError::Transport(e.to_string()))?;
+                    let events = parser
+                        .try_feed(&chunk)
+                        .map_err(|e| ShedError::Transport(format!("rc-events stream: {e}")))?;
+                    for ev in &events {
+                        if let Some(rc) = parse_rc_event(ev) {
+                            sink.on_event(rc);
+                        }
+                    }
+                }
+            }
+        }
+        // Flush a final record that lacked its trailing blank line.
+        for ev in parser.finish() {
+            if let Some(rc) = parse_rc_event(&ev) {
+                sink.on_event(rc);
+            }
+        }
+        Ok(())
     }
 
     /// `POST /api/sheds/{name}/start`.
@@ -1370,5 +1532,377 @@ mod tests {
             c.rc_messages("proj", "..", 0, None).await,
             Err(ShedError::Config(_))
         ));
+    }
+
+    // ---- rc-events SSE stream (plan §3.3 test matrix + AC#8) ----
+
+    use crate::rc_events::RcEvent;
+
+    #[derive(Default)]
+    struct RecordingRcSink {
+        events: std::sync::Mutex<Vec<RcEvent>>,
+    }
+    impl RecordingRcSink {
+        fn events(&self) -> Vec<RcEvent> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+    impl RcEventSink for RecordingRcSink {
+        fn on_event(&self, ev: RcEvent) {
+            self.events.lock().unwrap().push(ev);
+        }
+    }
+
+    /// A minimal raw-TCP SSE server for the streaming-TIMING tests httpmock
+    /// can't express (httpmock only serves complete pre-built bodies — it
+    /// cannot trickle bytes with real gaps): accepts ONE connection, reads the
+    /// request headers, writes an HTTP/1.1 200 SSE response head, then runs
+    /// `script` against the raw socket on a plain OS thread (std sleeps
+    /// between writes = real inter-chunk gaps). Dropping the socket at the end
+    /// of `script` is the clean EOF (`connection: close`). Every script runs
+    /// for a bounded time by construction; the caller MUST end its test with
+    /// [`join_sse_server`] so no thread or listener outlives the test.
+    fn spawn_sse_server(
+        script: impl FnOnce(&mut std::net::TcpStream) + Send + 'static,
+    ) -> (String, std::thread::JoinHandle<()>) {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream.set_nodelay(true).unwrap(); // each write = one prompt chunk
+            let mut req = Vec::new();
+            let mut buf = [0u8; 4096];
+            loop {
+                let n = stream.read(&mut buf).unwrap_or(0);
+                if n == 0 {
+                    return;
+                }
+                req.extend_from_slice(&buf[..n]);
+                if req.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break; // headers complete (GET — no body follows)
+                }
+            }
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n",
+                )
+                .unwrap();
+            script(&mut stream);
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    /// Join the raw-TCP server thread with a bound (std's `JoinHandle` has no
+    /// timed join, so the blocking join runs on the blocking pool under a
+    /// tokio timeout): a wedged script fails the test instead of hanging the
+    /// suite, and a panic inside the server thread is propagated, not lost.
+    async fn join_sse_server(handle: std::thread::JoinHandle<()>) {
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            tokio::task::spawn_blocking(move || handle.join().expect("sse server thread panicked")),
+        )
+        .await
+        .expect("sse server thread did not finish within the bound")
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn rc_events_delivers_decoded_events_in_order_and_clean_eof_is_ok() {
+        // Happy path: the server's `: ok` preamble (rcevents.go:185), two data
+        // frames, then EOF. The comment preamble produces no sink call; the
+        // events arrive decoded, in order; the ended stream is Ok(()).
+        let server = MockServer::start_async().await;
+        let sse = ": ok\n\n\
+                   event: activity.changed\n\
+                   data: {\"shed\":\"proj\",\"slug\":\"cdx777\",\"activity\":\"working\",\"state\":\"ready\"}\n\n\
+                   event: session.updated\n\
+                   data: {\"shed\":\"proj\",\"slug\":\"cdx777\",\"session\":{\"state\":\"ready\",\"activity\":\"idle\"}}\n\n";
+        server
+            .mock_async(|w, t| {
+                w.method(GET)
+                    .path("/api/rc/events")
+                    .header("accept", "text/event-stream");
+                t.status(200)
+                    .header("content-type", "text/event-stream")
+                    .body(sse);
+            })
+            .await;
+        let sink = RecordingRcSink::default();
+        client(&server).rc_events(&sink).await.unwrap();
+        let evs = sink.events();
+        assert_eq!(evs.len(), 2, "got {evs:?}");
+        match &evs[0] {
+            RcEvent::ActivityChanged {
+                shed,
+                slug,
+                activity,
+                ..
+            } => {
+                assert_eq!(shed, "proj");
+                assert_eq!(slug, "cdx777");
+                assert_eq!(*activity, Some(crate::rc::RcActivity::Working));
+            }
+            other => panic!("wrong first event: {other:?}"),
+        }
+        match &evs[1] {
+            RcEvent::SessionUpdated { removed, .. } => assert!(!removed),
+            other => panic!("wrong second event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rc_events_skips_malformed_and_unknown_frames_without_ending_stream() {
+        // An unknown event name, a non-JSON payload, and a frame missing its
+        // required keys are each skipped (parse_rc_event → None) — the stream
+        // keeps going and a LATER valid event is still delivered, then Ok.
+        let server = MockServer::start_async().await;
+        let sse = "event: totally.unknown\ndata: {\"shed\":\"p\"}\n\n\
+                   event: activity.changed\ndata: not-json\n\n\
+                   event: activity.changed\ndata: {\"shed\":\"p\"}\n\n\
+                   event: message.appended\ndata: {\"shed\":\"p\",\"slug\":\"s\",\"seq\":7}\n\n";
+        server
+            .mock_async(|w, t| {
+                w.method(GET).path("/api/rc/events");
+                t.status(200).body(sse);
+            })
+            .await;
+        let sink = RecordingRcSink::default();
+        client(&server).rc_events(&sink).await.unwrap();
+        assert_eq!(
+            sink.events(),
+            vec![RcEvent::MessageAppended {
+                shed: "p".into(),
+                slug: "s".into(),
+                seq: 7,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn rc_events_clean_eof_flushes_final_unterminated_record() {
+        // A final record with no trailing blank line is flushed to the sink
+        // via parser.finish() on EOF — delivered, not dropped.
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(GET).path("/api/rc/events");
+                t.status(200)
+                    .body("event: shed.stopped\ndata: {\"shed\":\"p\"}");
+            })
+            .await;
+        let sink = RecordingRcSink::default();
+        client(&server).rc_events(&sink).await.unwrap();
+        assert_eq!(
+            sink.events(),
+            vec![RcEvent::ShedStopped { shed: "p".into() }]
+        );
+    }
+
+    #[tokio::test]
+    async fn rc_events_oversized_event_is_an_error() {
+        // The capped parser (with_max_event_bytes + try_feed — the broker
+        // bus's convention): an event exceeding the cap ends the stream as an
+        // error (the watcher reconnects with a fresh parser), never buffers
+        // on. Cap injected via the private seam so the test body stays small.
+        let server = MockServer::start_async().await;
+        let sse = format!("event: activity.changed\ndata: {}\n\n", "x".repeat(1024));
+        server
+            .mock_async(|w, t| {
+                w.method(GET).path("/api/rc/events");
+                t.status(200).body(sse);
+            })
+            .await;
+        let sink = RecordingRcSink::default();
+        let err = client(&server)
+            .rc_events_with_limits(&sink, Duration::from_secs(5), 64)
+            .await
+            .unwrap_err();
+        match err {
+            ShedError::Transport(msg) => {
+                assert!(msg.contains("exceeded 64 bytes"), "got: {msg}");
+            }
+            other => panic!("expected Transport overflow, got {other:?}"),
+        }
+        assert!(sink.events().is_empty());
+    }
+
+    #[tokio::test]
+    async fn rc_events_401_invalidates_provider_with_no_second_request() {
+        // 401 → invalidate + Err(BadStatus(401)), and NO in-method retry (the
+        // C5 watcher owns reconnect/re-auth): exactly one request hits the
+        // server, and the next bearer() re-mints.
+        let server = MockServer::start_async().await;
+        let m = server
+            .mock_async(|w, t| {
+                w.method(GET)
+                    .path("/api/rc/events")
+                    .header("authorization", "Bearer tok-1");
+                t.status(401);
+            })
+            .await;
+        let minter = Arc::new(SeqMinter {
+            calls: AtomicUsize::new(0),
+        });
+        let c = Client::new(
+            server.base_url(),
+            "mini2".into(),
+            String::new(),
+            None,
+            Some(minter.clone()),
+        )
+        .unwrap();
+        let sink = RecordingRcSink::default();
+        let err = c.rc_events(&sink).await.unwrap_err();
+        assert!(matches!(err, ShedError::BadStatus(401)), "got {err:?}");
+        assert_eq!(m.hits_async().await, 1, "401 must not retry in-method");
+        assert!(sink.events().is_empty());
+        // Invalidated: one mint so far, the next bearer() re-mints.
+        assert_eq!(minter.calls.load(Ordering::SeqCst), 1);
+        let _ = c.bearer().await;
+        assert_eq!(
+            minter.calls.load(Ordering::SeqCst),
+            2,
+            "401 must invalidate so the watcher's next connect re-mints"
+        );
+    }
+
+    #[tokio::test]
+    async fn rc_events_connection_open_timeout() {
+        // A server that accepts but never responds trips the connection-open
+        // timeout (the same idle duration bounds the initial send).
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(GET).path("/api/rc/events");
+                t.status(200).body(": ok\n\n").delay(Duration::from_secs(2));
+            })
+            .await;
+        let sink = RecordingRcSink::default();
+        let err = client(&server)
+            .rc_events_with_idle(&sink, Duration::from_millis(150))
+            .await
+            .unwrap_err();
+        match err {
+            ShedError::Transport(msg) => assert!(msg.contains("connect"), "got: {msg}"),
+            other => panic!("expected Transport connect timeout, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rc_events_idle_timeout_fires_on_a_silent_stream() {
+        // Mid-stream silence: the server delivers one event then goes quiet
+        // while HOLDING the socket open (a silently-dead connection — the case
+        // the watchdog exists for). httpmock can't hold a stream open, so this
+        // uses the raw-TCP helper. The pre-silence event was delivered; the
+        // silence surfaces as the idle-timeout Transport error. Margin: the
+        // 2s silence is ~7x the 300ms idle, so the timeout fires well inside
+        // the quiet stretch even on a loaded worker.
+        let (base, server) = spawn_sse_server(|s| {
+            use std::io::Write;
+            s.write_all(b": ok\n\nevent: hub.unavailable\ndata: {\"shed\":\"p\"}\n\n")
+                .unwrap();
+            std::thread::sleep(Duration::from_secs(2)); // silence >> idle
+        });
+        let c = Client::new(base, "mini2".into(), String::new(), None, None).unwrap();
+        let sink = RecordingRcSink::default();
+        let err = c
+            .rc_events_with_idle(&sink, Duration::from_millis(300))
+            .await
+            .unwrap_err();
+        match err {
+            ShedError::Transport(msg) => assert!(msg.contains("idle timeout"), "got: {msg}"),
+            other => panic!("expected Transport idle timeout, got {other:?}"),
+        }
+        assert_eq!(
+            sink.events(),
+            vec![RcEvent::HubUnavailable { shed: "p".into() }]
+        );
+        join_sse_server(server).await;
+    }
+
+    #[tokio::test]
+    async fn rc_events_heartbeat_comments_reset_the_idle_timer() {
+        // AC#8, the panel-critical pin: comment-only `: heartbeat` frames must
+        // NOT trip the idle timer, even though the parser swallows them
+        // without emitting an event — the timer wraps the BYTE-chunk future.
+        // Real streaming gaps via the raw-TCP helper: 2.5s of comment-only
+        // traffic (25 × 100ms) against a 1.5s idle. Margins (both directions,
+        // CI-scheduling-safe): an event-level timer fires deterministically —
+        // zero parsed events for 2.5s, a full 1s past the idle window — while
+        // a false-fail of the byte-level timer needs the writer thread
+        // descheduled >1.5s, 15× its 100ms cadence. The event after the quiet
+        // stretch still arrives, then clean EOF → Ok.
+        let (base, server) = spawn_sse_server(|s| {
+            use std::io::Write;
+            s.write_all(b": ok\n\n").unwrap();
+            for _ in 0..25 {
+                std::thread::sleep(Duration::from_millis(100));
+                s.write_all(b": heartbeat\n\n").unwrap();
+            }
+            s.write_all(b"event: shed.stopped\ndata: {\"shed\":\"p\"}\n\n")
+                .unwrap();
+        });
+        let c = Client::new(base, "mini2".into(), String::new(), None, None).unwrap();
+        let sink = RecordingRcSink::default();
+        c.rc_events_with_idle(&sink, Duration::from_millis(1500))
+            .await
+            .unwrap();
+        assert_eq!(
+            sink.events(),
+            vec![RcEvent::ShedStopped { shed: "p".into() }]
+        );
+        join_sse_server(server).await;
+    }
+
+    #[tokio::test]
+    async fn rc_events_connect_timeout_covers_a_hung_bearer_mint() {
+        // The connect bound wraps the WHOLE connect phase, bearer resolution
+        // included: a foreign TokenMinter that never resolves must surface as
+        // the connect timeout, not hang rc_events forever. (The mint pends
+        // before any dial, so the unroutable base URL is never touched.)
+        struct NeverMinter;
+        #[async_trait::async_trait]
+        impl TokenMinter for NeverMinter {
+            async fn mint(&self, _server: &str) -> Result<MintedToken, ShedError> {
+                std::future::pending().await
+            }
+        }
+        let c = Client::new(
+            "http://127.0.0.1:9".into(),
+            "s".into(),
+            String::new(),
+            None,
+            Some(Arc::new(NeverMinter)),
+        )
+        .unwrap();
+        let sink = RecordingRcSink::default();
+        let err = c
+            .rc_events_with_idle(&sink, Duration::from_millis(100))
+            .await
+            .unwrap_err();
+        match err {
+            ShedError::Transport(msg) => assert!(msg.contains("connect"), "got: {msg}"),
+            other => panic!("expected Transport connect timeout, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rc_events_non_200_success_status_is_bad_status() {
+        // Exactly-200 contract: SSE lives in a 200 response body. A 204/206
+        // minted by an intermediary carries no event stream — any-2xx
+        // acceptance would end as a silent empty-stream Ok, masking the fault
+        // from the watcher's Down/backoff signal.
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|w, t| {
+                w.method(GET).path("/api/rc/events");
+                t.status(204);
+            })
+            .await;
+        let sink = RecordingRcSink::default();
+        let err = client(&server).rc_events(&sink).await.unwrap_err();
+        assert!(matches!(err, ShedError::BadStatus(204)), "got {err:?}");
+        assert!(sink.events().is_empty());
     }
 }

--- a/crates/shed-core/src/lib.rs
+++ b/crates/shed-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod create;
 pub mod http;
 pub mod models;
 pub mod rc;
+pub mod rc_events;
 pub mod sse;
 pub mod terminal;
 pub mod tls;

--- a/crates/shed-core/src/models.rs
+++ b/crates/shed-core/src/models.rs
@@ -226,6 +226,83 @@ pub struct CreateShedRequest {
     pub no_provision: Option<bool>,
 }
 
+// ---- sessions read-plane (GET /api/sheds/{name}/sessions) ------------------
+
+/// One tmux session row from `GET /api/sheds/{name}/sessions` (and
+/// `GET /api/sessions`). Wire shape: Go `config.Session`
+/// (`internal/config/types.go:182-197`). Serde-derive like the other read
+/// DTOs — strict field types with defensive defaults where the Go side is
+/// `omitempty` (and on `created_at`, which Go always emits but we keep
+/// `Option` per crate convention: timestamps are carried VERBATIM as strings,
+/// never parsed on the decode path).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct Session {
+    /// The tmux session name (`rc-<slug>` for RC sessions).
+    pub name: String,
+    /// The owning shed. Not `omitempty` in Go, but defaulted here so a
+    /// malformed row degrades a field instead of the whole page.
+    #[serde(default)]
+    pub shed_name: String,
+    /// Stamped only by the CLI's cross-server aggregation; the HTTP handlers
+    /// leave it empty (`omitempty` → absent).
+    pub server_name: Option<String>,
+    /// RFC3339, verbatim. Go marshals `time.Time` unconditionally (never
+    /// `omitempty`), so it is always present on the wire — `Option` is
+    /// defensiveness, not an expected absence.
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub attached: bool,
+    /// `omitempty` → absent when 0.
+    #[serde(default)]
+    pub window_count: i64,
+    /// RC Session Convention metadata for `rc-*` rows, populated by the
+    /// server's enrichment leg (`internal/api/rcenrich.go`). `None` for plain
+    /// tmux sessions and for rc rows on a shed whose enrichment degraded (a
+    /// `warnings` entry is added in that case).
+    pub rc: Option<SessionRC>,
+}
+
+/// The RC display subset inside a [`Session`] row. Wire shape: Go
+/// `config.SessionRC` (`internal/config/types.go:199-215`) — every field but
+/// `managed` is `omitempty`. `kind`/`state`/`activity` stay raw wire strings
+/// here (this is the read-plane row, not the enriched [`crate::rc::RcSession`]
+/// model — the overview adapter owns that mapping).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct SessionRC {
+    pub kind: Option<String>,
+    pub state: Option<String>,
+    /// The only non-`omitempty` Go field; still defaulted (defensive per crate
+    /// style). `false` for legacy/unmanaged rc-* sessions.
+    #[serde(default)]
+    pub managed: bool,
+    pub display_name: Option<String>,
+    pub url: Option<String>,
+    pub created_by: Option<String>,
+    /// Live-activity dimension (`working|needs_input|idle|unknown`), absent
+    /// when no hub is running / the kind is unsupported / a blocking state
+    /// suppresses it.
+    pub activity: Option<String>,
+    /// RFC3339, verbatim; absent with `activity`.
+    pub activity_at: Option<String>,
+    /// Hub-sanitized ≤200-rune preview. NOTE: sanitized for ANSI/C0C1 only —
+    /// a renderer should still pass it through
+    /// [`crate::rc::strip_format_chars`] before display (the enriched paths
+    /// do this at decode; this raw row does not).
+    pub last_message: Option<String>,
+}
+
+/// The `GET /api/sheds/{name}/sessions` envelope (Go
+/// `config.SessionsResponse`, `internal/config/types.go:287-291`).
+/// `warnings` carries per-shed RC-enrichment degradations (`omitempty`);
+/// null/absent lists decode to `[]`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SessionsResponse {
+    #[serde(default, deserialize_with = "null_default")]
+    pub sessions: Vec<Session>,
+    #[serde(default, deserialize_with = "null_default")]
+    pub warnings: Vec<String>,
+}
+
 // ---- GET /api/overview single-call host snapshot ---------------------------
 
 /// Server feature token for the `GET /api/overview` endpoint itself. The
@@ -263,16 +340,19 @@ fn non_empty_str(v: Option<&Value>) -> Option<&str> {
 }
 
 /// [`non_empty_str`], owned (the Dart `_str` used for the session's optional
-/// string fields).
-fn opt_trimmed(v: Option<&Value>) -> Option<String> {
+/// string fields; `rc_feed.dart:85-89` carries a byte-identical `_str`, so
+/// the feed decoders in [`crate::rc`] share this helper).
+pub(crate) fn opt_trimmed(v: Option<&Value>) -> Option<String> {
     non_empty_str(v).map(str::to_string)
 }
 
 /// Dart `_cleanDisplay` (`rc_models.dart:284-290`): [`opt_trimmed`] plus a
 /// strip of Unicode format characters (category Cf) — for guest-controlled
 /// display text that could carry bidi-override spoofers. A value that is ONLY
-/// format characters degrades to `None`.
-fn clean_display(v: Option<&Value>) -> Option<String> {
+/// format characters degrades to `None`. `rc_feed.dart:93-98` carries a
+/// byte-identical `_text`, so the feed decoders in [`crate::rc`] share this
+/// helper too.
+pub(crate) fn clean_display(v: Option<&Value>) -> Option<String> {
     let stripped = strip_format_chars(non_empty_str(v)?);
     let trimmed = stripped.trim();
     if trimmed.is_empty() {
@@ -839,6 +919,88 @@ mod tests {
         );
         assert_eq!(profiles[1].source, "user");
         assert_eq!(profiles[1].profile.mode, None); // omitted
+    }
+
+    // ---- sessions read-plane ----
+
+    #[test]
+    fn sessions_response_rc_enriched_and_plain_rows() {
+        // One plain tmux row (no rc block, omitempty fields absent) + one
+        // rc-enriched row carrying the Phase C activity fields.
+        let r: SessionsResponse = serde_json::from_str(
+            r#"{"sessions":[
+                {"name":"default","shed_name":"proj",
+                 "created_at":"2026-06-19T18:52:00Z","attached":true},
+                {"name":"rc-abc234","shed_name":"proj",
+                 "created_at":"2026-06-19T18:53:00Z","attached":false,
+                 "window_count":2,
+                 "rc":{"kind":"claude-rc","state":"ready","managed":true,
+                       "display_name":"proj/abc234",
+                       "url":"https://claude.ai/code/session_abc234",
+                       "created_by":"shed-mobile/1.0",
+                       "activity":"working",
+                       "activity_at":"2026-06-19T18:54:12Z",
+                       "last_message":"Running the test suite now."}}
+            ]}"#,
+        )
+        .unwrap();
+        assert_eq!(r.sessions.len(), 2);
+        assert!(r.warnings.is_empty()); // absent → []
+        let plain = &r.sessions[0];
+        assert_eq!(plain.name, "default");
+        assert_eq!(plain.shed_name, "proj");
+        assert!(plain.attached);
+        assert_eq!(plain.window_count, 0); // omitempty absent → 0
+        assert_eq!(plain.server_name, None); // HTTP handlers leave it empty
+        assert!(plain.rc.is_none());
+        let rc_row = &r.sessions[1];
+        assert_eq!(rc_row.window_count, 2);
+        assert_eq!(rc_row.created_at.as_deref(), Some("2026-06-19T18:53:00Z"));
+        let rc = rc_row.rc.as_ref().unwrap();
+        assert_eq!(rc.kind.as_deref(), Some("claude-rc"));
+        assert_eq!(rc.state.as_deref(), Some("ready"));
+        assert!(rc.managed);
+        assert_eq!(rc.display_name.as_deref(), Some("proj/abc234"));
+        assert_eq!(rc.activity.as_deref(), Some("working"));
+        assert_eq!(rc.activity_at.as_deref(), Some("2026-06-19T18:54:12Z"));
+        assert_eq!(
+            rc.last_message.as_deref(),
+            Some("Running the test suite now.")
+        );
+    }
+
+    #[test]
+    fn sessions_response_null_and_absent_lists() {
+        let r: SessionsResponse =
+            serde_json::from_str(r#"{"sessions":null,"warnings":null}"#).unwrap();
+        assert!(r.sessions.is_empty());
+        assert!(r.warnings.is_empty());
+        let r: SessionsResponse = serde_json::from_str("{}").unwrap();
+        assert!(r.sessions.is_empty());
+        // A degraded shed: rc rows WITHOUT an rc block + a warnings entry.
+        let r: SessionsResponse = serde_json::from_str(
+            r#"{"sessions":[{"name":"rc-abc","shed_name":"proj",
+                             "created_at":"2026-01-01T00:00:00Z","attached":false}],
+                "warnings":["proj: rc enrichment degraded"]}"#,
+        )
+        .unwrap();
+        assert!(r.sessions[0].rc.is_none());
+        assert_eq!(r.warnings, ["proj: rc enrichment degraded"]);
+    }
+
+    #[test]
+    fn session_rc_sparse_block_defaults() {
+        // A legacy/unmanaged rc row: bare block → every optional None,
+        // managed false (the only non-omitempty Go field, still defensive).
+        let s: Session =
+            serde_json::from_str(r#"{"name":"rc-old","shed_name":"p","rc":{}}"#).unwrap();
+        let rc = s.rc.as_ref().unwrap();
+        assert_eq!(rc.kind, None);
+        assert_eq!(rc.state, None);
+        assert!(!rc.managed);
+        assert_eq!(rc.activity, None);
+        assert_eq!(rc.last_message, None);
+        assert_eq!(s.created_at, None); // defensive, though Go always emits it
     }
 
     // ---- overview (golden fixture; assertions ported from mobile's

--- a/crates/shed-core/src/models.rs
+++ b/crates/shed-core/src/models.rs
@@ -330,12 +330,25 @@ fn string_list(v: Option<&Value>) -> Vec<String> {
     }
 }
 
+/// Trim on Dart's `String.trim()` set: Unicode White_Space PLUS U+FEFF (BOM).
+/// Rust's `str::trim` uses only the White_Space property, which U+FEFF lost in
+/// Unicode 6.3 — Dart keeps it in its trim set for legacy reasons (documented
+/// on `String.trim`). Every `_str`/`_nonEmpty`-parity helper below must trim
+/// on this set, or a BOM-padded guest value decodes differently here than on
+/// mobile (e.g. a `"\u{FEFF}"` shed name would survive as non-empty). FEFF is
+/// the only practical divergence — both languages otherwise share the Unicode
+/// whitespace set.
+pub(crate) fn dart_trim(s: &str) -> &str {
+    s.trim_matches(|c: char| c.is_whitespace() || c == '\u{FEFF}')
+}
+
 /// Trim a maybe-string to a non-empty value (Dart's `_nonEmpty`,
 /// `shed_dtos.dart:421-422`, and `_str`, `rc_models.dart:278-282` — identical
-/// semantics): non-string, absent, or blank → `None`.
+/// semantics): non-string, absent, or blank → `None`. Trims on Dart's set via
+/// [`dart_trim`].
 fn non_empty_str(v: Option<&Value>) -> Option<&str> {
     v.and_then(Value::as_str)
-        .map(str::trim)
+        .map(dart_trim)
         .filter(|s| !s.is_empty())
 }
 
@@ -354,7 +367,9 @@ pub(crate) fn opt_trimmed(v: Option<&Value>) -> Option<String> {
 /// helper too.
 pub(crate) fn clean_display(v: Option<&Value>) -> Option<String> {
     let stripped = strip_format_chars(non_empty_str(v)?);
-    let trimmed = stripped.trim();
+    // Dart-set trim for parity ([`dart_trim`]) — though FEFF is Cf, so the
+    // strip above already removed it and this pass only sees whitespace.
+    let trimmed = dart_trim(&stripped);
     if trimmed.is_empty() {
         None
     } else {
@@ -734,6 +749,22 @@ impl<'de> Deserialize<'de> for Overview {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn opt_trimmed_trims_on_darts_set_including_bom() {
+        // Dart's `String.trim` strips U+FEFF (BOM); Rust's `str::trim` does
+        // not (FEFF lost White_Space in Unicode 6.3). The shared helpers trim
+        // on Dart's set via `dart_trim` — a BOM-padded value trims clean and a
+        // BOM-only value is blank (`None`), matching mobile's `_str`.
+        let v = Value::String("\u{FEFF} x \u{FEFF}".to_string());
+        assert_eq!(opt_trimmed(Some(&v)).as_deref(), Some("x"));
+        let bom_only = Value::String("\u{FEFF}".to_string());
+        assert_eq!(opt_trimmed(Some(&bom_only)), None);
+        assert_eq!(clean_display(Some(&bom_only)), None);
+        // Ordinary whitespace behavior is unchanged.
+        let ws = Value::String("  hi  ".to_string());
+        assert_eq!(opt_trimmed(Some(&ws)).as_deref(), Some("hi"));
+    }
 
     #[test]
     fn server_info_full_fixture() {

--- a/crates/shed-core/src/models.rs
+++ b/crates/shed-core/src/models.rs
@@ -15,6 +15,12 @@
 //! body) lands with the create flow in M4.
 
 use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+use crate::rc::{
+    strip_format_chars, RcActivity, RcAgentInfo, RcCapabilities, RcKind, RcKindFeatures, RcSession,
+    RcState, TMUX_PREFIX,
+};
 
 /// Deserialize `T`, mapping an explicit JSON `null` to `T::default()`. serde's
 /// `#[serde(default)]` only covers an ABSENT field; shed-server sends `null` for
@@ -56,6 +62,20 @@ pub struct ServerInfo {
     pub backend: Option<String>,
     pub ssh_port: Option<i64>,
     pub http_port: Option<i64>,
+    /// Server feature tokens (`overview`, `rc-enrich`, `rc-events`,
+    /// `rc-proxy`, … — the `FEATURE_*` consts below). Emitted since the
+    /// overview work (Go `internal/api/handlers.go` info handler); absent/null
+    /// on older servers → `[]`. `/api/info` is the unauthenticated bootstrap
+    /// call, making this the reliable capability signal (vs probing for 404s).
+    #[serde(default, deserialize_with = "null_default")]
+    pub features: Vec<String>,
+}
+
+impl ServerInfo {
+    /// Whether `feature` is advertised (endpoint discovery, replacing probing).
+    pub fn has_feature(&self, feature: &str) -> bool {
+        self.features.iter().any(|f| f == feature)
+    }
 }
 
 /// A shed. `host` is absent from shed-server JSON (the client stamps it after
@@ -206,6 +226,431 @@ pub struct CreateShedRequest {
     pub no_provision: Option<bool>,
 }
 
+// ---- GET /api/overview single-call host snapshot ---------------------------
+
+/// Server feature token for the `GET /api/overview` endpoint itself. The
+/// canonical token list is the Go server's `serverFeatures`
+/// (`internal/api/overview.go:17-34`); a client gates endpoint use on these
+/// (via [`OverviewServer::has_feature`]) instead of probing for 404s.
+pub const FEATURE_OVERVIEW: &str = "overview";
+/// rc-enriched session rows (the `rc` block) in overview/sessions responses.
+pub const FEATURE_RC_ENRICH: &str = "rc-enrich";
+/// The `GET /api/rc/events` live-activity SSE stream.
+pub const FEATURE_RC_EVENTS: &str = "rc-events";
+/// The rc hub proxy endpoints (messages/input).
+pub const FEATURE_RC_PROXY: &str = "rc-proxy";
+
+/// Keep only the string elements of a maybe-list; a non-list/absent value
+/// degrades to `[]` (Dart's `if (raw is List) for (f in raw) if (f is String)`).
+fn string_list(v: Option<&Value>) -> Vec<String> {
+    match v.and_then(Value::as_array) {
+        Some(items) => items
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect(),
+        None => Vec::new(),
+    }
+}
+
+/// Trim a maybe-string to a non-empty value (Dart's `_nonEmpty`,
+/// `shed_dtos.dart:421-422`, and `_str`, `rc_models.dart:278-282` — identical
+/// semantics): non-string, absent, or blank → `None`.
+fn non_empty_str(v: Option<&Value>) -> Option<&str> {
+    v.and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+}
+
+/// [`non_empty_str`], owned (the Dart `_str` used for the session's optional
+/// string fields).
+fn opt_trimmed(v: Option<&Value>) -> Option<String> {
+    non_empty_str(v).map(str::to_string)
+}
+
+/// Dart `_cleanDisplay` (`rc_models.dart:284-290`): [`opt_trimmed`] plus a
+/// strip of Unicode format characters (category Cf) — for guest-controlled
+/// display text that could carry bidi-override spoofers. A value that is ONLY
+/// format characters degrades to `None`.
+fn clean_display(v: Option<&Value>) -> Option<String> {
+    let stripped = strip_format_chars(non_empty_str(v)?);
+    let trimmed = stripped.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Dart `_asInt` / `_int` (`shed_dtos.dart:424`, `rc_capabilities.dart:146`):
+/// an integer as-is, another number truncated, anything else `0`.
+fn int_or_zero(v: Option<&Value>) -> i64 {
+    v.and_then(|v| v.as_i64().or_else(|| v.as_f64().map(|f| f as i64)))
+        .unwrap_or(0)
+}
+
+/// Dart's `j['k'] == true`: `true` only for exactly boolean `true`.
+fn is_true(v: Option<&Value>) -> bool {
+    matches!(v, Some(Value::Bool(true)))
+}
+
+/// Read a maybe-string VERBATIM — no trim, absent/non-string → `""` (Dart's
+/// `as String? ?? ''` reads, `rc_models.dart:249-259`).
+fn raw_str(v: Option<&Value>) -> &str {
+    v.and_then(Value::as_str).unwrap_or("")
+}
+
+/// Field-tolerant decode of a synthesized flat session object (the overview
+/// adapter's merge of the derived slug/tmux/outer-created_at with the `rc`
+/// block). Ported field-for-field from mobile's `RcSession.fromJson`
+/// (`rc_models.dart:245-273`) — deliberately NOT the strict [`crate::rc::RcSessionDto`]
+/// serde path (that is the `shed-ext-rc` stdout contract): a server-enriched
+/// row must decode per-field so a future/unknown enum value or a missing field
+/// degrades that FIELD, never vanishes the session (forward-compat: an old
+/// client still renders a session a newer server enriches). Tolerances:
+/// missing/unknown `kind` → preserved raw via [`RcKind::Other`] (`""` when
+/// absent); missing/unknown `state` → `Starting` ([`RcState::from_wire`]);
+/// `managed` → `false` unless exactly boolean `true`; every optional string is
+/// trimmed-or-`None` — including `workdir`, which stays `None` when
+/// absent/blank (`rc_models.dart:261`; NO `DEFAULT_WORKDIR` injection — that
+/// fallback belongs to the `from_dto` stdout path only); `activity`
+/// absent/blank → `None`, unrecognized → `Unknown`; `last_message` gets the
+/// full `_cleanDisplay` treatment (trim → Cf-strip → trim → empty→`None`).
+fn rc_session_from_flat(j: &serde_json::Map<String, Value>, shed_name: &str) -> RcSession {
+    // slug/tmux_session are synthesized by the caller (or overridden by the rc
+    // block); Dart reads them as plain strings, no trim (`rc_models.dart:249-253`).
+    let slug = raw_str(j.get("slug")).to_string();
+    let display_name =
+        opt_trimmed(j.get("display_name")).unwrap_or_else(|| format!("{shed_name}/{slug}")); // `<shed>/<slug>` fallback
+    RcSession {
+        // host is absent on the wire — stamped by the client after decode
+        // (same convention as `Shed.host`).
+        host: String::new(),
+        shed: shed_name.to_string(),
+        tmux_session: raw_str(j.get("tmux_session")).to_string(),
+        display_name,
+        workdir: opt_trimmed(j.get("workdir")),
+        // kind/state take the raw wire string (no trim — Dart passes the value
+        // straight to fromWire, rc_models.dart:258-259); absent → "".
+        kind: RcKind::from_wire(raw_str(j.get("kind"))),
+        state: RcState::from_wire(raw_str(j.get("state"))),
+        url: opt_trimmed(j.get("url")),
+        rc_id: opt_trimmed(j.get("id")), // id → rc_id, as in `from_dto`
+        created_by: opt_trimmed(j.get("created_by")),
+        created_at: opt_trimmed(j.get("created_at")),
+        target_label: opt_trimmed(j.get("target_label")),
+        // Absent/blank → None ("no activity dimension at all"); an unrecognized
+        // token → Unknown (rc_models.dart:140-146).
+        activity: non_empty_str(j.get("activity")).map(RcActivity::from_wire),
+        activity_at: opt_trimmed(j.get("activity_at")),
+        // Guest-controlled preview text: strip Unicode format characters (bidi
+        // overrides like U+202E) the hub's ANSI/C0C1 sanitizer does not cover
+        // (`rc_models.dart:269-271`).
+        last_message: clean_display(j.get("last_message")),
+        managed: j.get("managed").and_then(Value::as_bool).unwrap_or(false),
+        slug,
+    }
+}
+
+/// Overview-tolerant decode of one `sheds[]` row into the shared [`Shed`] —
+/// per-field like Dart's `Shed.fromJson` (`shed_dtos.dart:31-41`: missing/blank
+/// `name` → `"?"`, missing/invalid `status` → `Unknown`, wrong-typed scalars →
+/// `None`), so a malformed shed row never vanishes from the snapshot. The
+/// strict serde derive on [`Shed`] stays the `/api/sheds` + Swift-parity
+/// contract; this hand-decode is the overview path only.
+fn overview_shed_record(obj: &serde_json::Map<String, Value>) -> Shed {
+    let opt_verbatim =
+        |key: &str| -> Option<String> { obj.get(key).and_then(Value::as_str).map(str::to_string) };
+    Shed {
+        host: opt_verbatim("host").unwrap_or_default(), // absent on the wire; client stamps it
+        name: non_empty_str(obj.get("name")).unwrap_or("?").to_string(),
+        // Lenient two ways: an unknown status STRING hits the `#[serde(other)]`
+        // arm; a non-string/missing status is Unknown here directly.
+        status: non_empty_str(obj.get("status"))
+            .and_then(|s| serde_json::from_value(Value::String(s.to_string())).ok())
+            .unwrap_or_default(),
+        backend: opt_verbatim("backend"),
+        repo: opt_verbatim("repo"),
+        image: opt_verbatim("image"),
+        image_digest: opt_verbatim("image_digest"),
+        local_dir: opt_verbatim("local_dir"),
+        ip_address: opt_verbatim("ip_address"),
+        cpus: obj.get("cpus").and_then(Value::as_i64),
+        memory_mb: obj.get("memory_mb").and_then(Value::as_i64),
+        // Timestamps carried verbatim, as on the strict path.
+        created_at: opt_verbatim("created_at"),
+        started_at: opt_verbatim("started_at"),
+        active_namespaces: string_list(obj.get("active_namespaces")),
+    }
+}
+
+/// Overview-tolerant decode of one [`DiskSize`] (Dart `DiskSize.fromJson`,
+/// `shed_dtos.dart:345-348`): non-map/missing halves → 0.
+fn overview_disk_size(v: Option<&Value>) -> DiskSize {
+    let o = v.and_then(Value::as_object);
+    DiskSize {
+        logical_bytes: int_or_zero(o.and_then(|o| o.get("logical_bytes"))),
+        physical_bytes: int_or_zero(o.and_then(|o| o.get("physical_bytes"))),
+    }
+}
+
+/// Overview-tolerant decode of a disk-entry list: non-list → `[]`, non-map
+/// elements skipped, per-entry defaults matching the strict DTO's
+/// (`name` → `"?"`, absent size → zeros).
+fn overview_disk_entries(v: Option<&Value>) -> Vec<DiskEntry> {
+    v.and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .filter_map(Value::as_object)
+                .map(|o| DiskEntry {
+                    name: non_empty_str(o.get("name")).unwrap_or("?").to_string(),
+                    docker_ref: o
+                        .get("docker_ref")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    size: overview_disk_size(o.get("size")),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Overview-tolerant decode of the `df` block into the shared
+/// [`SystemDiskUsage`] — constructed whenever `df` is a map, zero-defaulting
+/// every malformed/missing substructure (Dart `SystemDiskUsage.fromJson` +
+/// `DiskTotals.fromJson`, `shed_dtos.dart:345-392`), so a bad nested field
+/// degrades that field instead of discarding the whole disk block. The strict
+/// serde derive stays the `/api/system/df` + Swift-parity contract.
+fn overview_df(obj: &serde_json::Map<String, Value>) -> SystemDiskUsage {
+    let totals = obj.get("totals").and_then(Value::as_object);
+    let total = |key: &str| overview_disk_size(totals.and_then(|t| t.get(key)));
+    SystemDiskUsage {
+        server_name: opt_trimmed(obj.get("server_name")),
+        backend: opt_trimmed(obj.get("backend")),
+        images: overview_disk_entries(obj.get("images")),
+        sheds: overview_disk_entries(obj.get("sheds")),
+        orphans: overview_disk_entries(obj.get("orphans")),
+        totals: DiskTotals {
+            images: total("images"),
+            sheds: total("sheds"),
+            snapshots: total("snapshots"),
+            orphans: total("orphans"),
+            all: total("all"),
+        },
+    }
+}
+
+/// Overview-tolerant decode of the `rc_capabilities` block into the shared
+/// [`RcCapabilities`] — per-field like Dart's `RcCapabilities.fromJson`
+/// (`rc_capabilities.dart:56-93, 138-143`): missing/non-numeric `rc_version` →
+/// 0, wrong-typed list/map entries filtered, per-kind feature fields
+/// defaulted. An empty `{}` map yields tolerant capabilities, never `None`
+/// (absence is decided by the caller on map-ness). The strict serde derive
+/// stays the `shed-ext-rc` stdout (`decode_list_response`) contract.
+fn overview_capabilities(obj: &serde_json::Map<String, Value>) -> RcCapabilities {
+    let map_of_maps = |key: &str| -> Vec<(String, &serde_json::Map<String, Value>)> {
+        obj.get(key)
+            .and_then(Value::as_object)
+            .map(|m| {
+                m.iter()
+                    .filter_map(|(k, v)| v.as_object().map(|o| (k.clone(), o)))
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    RcCapabilities {
+        rc_version: int_or_zero(obj.get("rc_version")),
+        kinds: obj
+            .get("kinds")
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(Value::as_str)
+                    .map(RcKind::from_wire)
+                    .collect()
+            })
+            .unwrap_or_default(),
+        agents: map_of_maps("agents")
+            .into_iter()
+            .map(|(tool, o)| {
+                (
+                    tool,
+                    RcAgentInfo {
+                        installed: is_true(o.get("installed")),
+                        version: opt_trimmed(o.get("version")),
+                    },
+                )
+            })
+            .collect(),
+        features: string_list(obj.get("features")),
+        kind_features: map_of_maps("kind_features")
+            .into_iter()
+            .map(|(kind, o)| {
+                (
+                    kind,
+                    RcKindFeatures {
+                        post_input: is_true(o.get("post_input")),
+                        approvals: opt_trimmed(o.get("approvals")).unwrap_or_default(),
+                        watch: is_true(o.get("watch")),
+                        input: opt_trimmed(o.get("input")).unwrap_or_default(),
+                    },
+                )
+            })
+            .collect(),
+    }
+}
+
+/// The `server` block of `GET /api/overview`: the server's version and the
+/// feature-token set (mirrored from `GET /api/info`). A client learns which
+/// endpoints/behaviors a server supports from `features` without probing each.
+///
+/// Ported from mobile's `OverviewServer.fromJson` (`shed_dtos.dart:221-239`):
+/// a missing/blank `version` → `""`; a non-list/missing `features` → `[]`,
+/// keeping only the string elements.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct OverviewServer {
+    pub version: String,
+    pub features: Vec<String>,
+}
+
+impl OverviewServer {
+    /// Whether `feature` is advertised (endpoint discovery, replacing probing).
+    pub fn has_feature(&self, feature: &str) -> bool {
+        self.features.iter().any(|f| f == feature)
+    }
+
+    fn from_value(v: Option<&Value>) -> OverviewServer {
+        let obj = v.and_then(Value::as_object);
+        OverviewServer {
+            version: opt_trimmed(obj.and_then(|o| o.get("version"))).unwrap_or_default(),
+            features: string_list(obj.and_then(|o| o.get("features"))),
+        }
+    }
+}
+
+/// One shed in `GET /api/overview`: the full shed record plus the shed's RC
+/// sessions (only the rc-enriched tmux rows are surfaced) and, for a running
+/// shed, its rc capabilities. A stopped shed carries no sessions and omits
+/// capabilities (`capabilities == None`), which a create form treats as
+/// "absent" (fall back to claude + shell).
+///
+/// Ported from mobile's `OverviewShed.fromJson` (`shed_dtos.dart:246-294`);
+/// reuses [`RcSession`]/[`RcSessionDto`]/[`RcCapabilities`] from `rc.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OverviewShed {
+    pub shed: Shed,
+    pub sessions: Vec<RcSession>,
+    pub capabilities: Option<RcCapabilities>,
+}
+
+impl OverviewShed {
+    /// Decode one `sheds[]` element. The [`Shed`] decodes field-tolerantly from
+    /// the same outer map via [`overview_shed_record`] (missing name → `"?"`,
+    /// per Dart's `Shed.fromJson` defaults) — a malformed shed row degrades,
+    /// it never vanishes. Only a non-map element yields `None`.
+    fn from_value(v: &Value) -> Option<OverviewShed> {
+        let obj = v.as_object()?;
+        let shed = overview_shed_record(obj);
+
+        let sessions = obj
+            .get("sessions")
+            .and_then(Value::as_array)
+            .map(|rows| {
+                rows.iter()
+                    .filter_map(|row| Self::session_from_row(row, &shed.name))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // `rc_capabilities` is decoded only when it is a map (else None —
+        // absence is the create form's claude+shell fallback signal); a map
+        // decodes field-tolerantly, so a malformed block degrades per field.
+        let capabilities = obj
+            .get("rc_capabilities")
+            .and_then(Value::as_object)
+            .map(overview_capabilities);
+
+        Some(OverviewShed {
+            shed,
+            sessions,
+            capabilities,
+        })
+    }
+
+    /// Adapt one `sessions[]` row (a tmux session) to an [`RcSession`], or
+    /// `None` to skip it. Only rc-enriched tmux rows carry an `rc` block; a
+    /// plain tmux session (e.g. "default"), an un-enriched rc-* row on a
+    /// degraded shed, or a non-map element has none — skipped, so the sessions
+    /// list holds exactly the RC sessions (parity with the old `shed-ext-rc
+    /// list` fan-out). Mirrors `shed_dtos.dart:263-269`.
+    fn session_from_row(row: &Value, shed_name: &str) -> Option<RcSession> {
+        let row = row.as_object()?;
+        let rc = row.get("rc").and_then(Value::as_object)?;
+        let name = non_empty_str(row.get("name")).unwrap_or("");
+        let slug = name.strip_prefix(TMUX_PREFIX).unwrap_or(name);
+        // The server's SessionRC is a display subset (no slug/tmux/id);
+        // derive slug + tmux from the session name and pull created_at
+        // from the OUTER row, then let the rc-block fields override
+        // (`shed_dtos.dart:270-282`) and decode FIELD-TOLERANTLY — a
+        // future/unknown enum value or missing field degrades that
+        // field, it never drops the session (see [`rc_session_from_flat`]).
+        let mut flat = serde_json::Map::new();
+        flat.insert("slug".to_string(), Value::String(slug.to_string()));
+        flat.insert("tmux_session".to_string(), Value::String(name.to_string()));
+        if let Some(created_at) = row.get("created_at") {
+            flat.insert("created_at".to_string(), created_at.clone());
+        }
+        for (k, val) in rc {
+            flat.insert(k.clone(), val.clone());
+        }
+        Some(rc_session_from_flat(&flat, shed_name))
+    }
+}
+
+/// `GET /api/overview` — a single call a client renders a whole host from:
+/// server identity + feature set, disk usage, and every shed with its
+/// (rc-enriched) sessions and capabilities. Each sub-block degrades
+/// independently into `warnings` server-side (`internal/api/overview.go:38-63`),
+/// so a `None` `df` or an empty session list is a tolerated partial, not a
+/// failure — the decode has NO error path (a wrong-typed/missing block
+/// defaults). Ported from mobile's `Overview.fromJson`
+/// (`shed_dtos.dart:301-333`); hand-rolled (like [`crate::rc::RcKind`]'s manual
+/// impl) because the flatten-plus-filter session rule and the per-block
+/// tolerance aren't expressible with derive.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Overview {
+    pub server: OverviewServer,
+    pub df: Option<SystemDiskUsage>,
+    pub sheds: Vec<OverviewShed>,
+    pub warnings: Vec<String>,
+}
+
+impl Overview {
+    /// Tolerant decode of the overview body; never fails (a non-object value
+    /// yields the all-default snapshot).
+    pub fn from_value(v: &Value) -> Overview {
+        let Some(obj) = v.as_object() else {
+            return Overview::default();
+        };
+        Overview {
+            server: OverviewServer::from_value(obj.get("server")),
+            df: obj.get("df").and_then(Value::as_object).map(overview_df),
+            sheds: obj
+                .get("sheds")
+                .and_then(Value::as_array)
+                .map(|rows| rows.iter().filter_map(OverviewShed::from_value).collect())
+                .unwrap_or_default(),
+            warnings: string_list(obj.get("warnings")),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Overview {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Ok(Overview::from_value(&Value::deserialize(d)?))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -219,6 +664,7 @@ mod tests {
         assert_eq!(v.backend.as_deref(), Some("firecracker"));
         assert_eq!(v.ssh_port, Some(2222));
         assert_eq!(v.http_port, Some(8080));
+        assert!(v.features.is_empty()); // pre-overview server: absent → []
     }
 
     #[test]
@@ -226,6 +672,23 @@ mod tests {
         let v: ServerInfo = serde_json::from_str(r#"{"name":"m","version":"1"}"#).unwrap();
         assert_eq!(v.backend, None);
         assert_eq!(v.ssh_port, None);
+    }
+
+    #[test]
+    fn server_info_features_present_and_null() {
+        let v: ServerInfo = serde_json::from_str(
+            r#"{"name":"m","version":"0.8.0",
+                "features":["overview","rc-enrich","rc-events","rc-proxy"]}"#,
+        )
+        .unwrap();
+        assert!(v.has_feature(FEATURE_OVERVIEW));
+        assert!(v.has_feature(FEATURE_RC_EVENTS));
+        assert!(!v.has_feature("nope"));
+        // Explicit null (not just absent) also decodes to [].
+        let v: ServerInfo =
+            serde_json::from_str(r#"{"name":"m","version":"1","features":null}"#).unwrap();
+        assert!(v.features.is_empty());
+        assert!(!v.has_feature(FEATURE_OVERVIEW));
     }
 
     #[test]
@@ -376,5 +839,307 @@ mod tests {
         );
         assert_eq!(profiles[1].source, "user");
         assert_eq!(profiles[1].profile.mode, None); // omitted
+    }
+
+    // ---- overview (golden fixture; assertions ported from mobile's
+    // overview_test.dart:38-116 — the fetchOverview HTTP cases land with the
+    // Client method) ----
+
+    fn golden_overview() -> Overview {
+        serde_json::from_str(include_str!("../../fixtures/overview.json")).unwrap()
+    }
+
+    fn proj(o: &Overview) -> &OverviewShed {
+        o.sheds.iter().find(|s| s.shed.name == "proj").unwrap()
+    }
+
+    #[test]
+    fn overview_server_block_version_and_features() {
+        let o = golden_overview();
+        assert_eq!(o.server.version, "0.8.0");
+        assert!(o.server.has_feature(FEATURE_OVERVIEW));
+        assert!(o.server.has_feature(FEATURE_RC_ENRICH));
+        // Endpoint-discovery tokens that drive the live-events subscription.
+        assert!(o.server.has_feature(FEATURE_RC_EVENTS));
+        assert!(o.server.has_feature(FEATURE_RC_PROXY));
+        assert!(!o.server.has_feature("nope"));
+    }
+
+    #[test]
+    fn overview_activity_flows_through_rc_block_into_session() {
+        let o = golden_overview();
+        let claude = proj(&o)
+            .sessions
+            .iter()
+            .find(|s| s.slug == "abc234")
+            .unwrap();
+        assert_eq!(claude.activity, Some(RcActivity::Working));
+        assert_eq!(claude.activity_at.as_deref(), Some("2026-06-19T18:54:12Z"));
+        assert_eq!(
+            claude.last_message.as_deref(),
+            Some("Running the test suite now.")
+        );
+    }
+
+    #[test]
+    fn overview_kind_features_carries_codex_watch_and_gated_input() {
+        let o = golden_overview();
+        let caps = proj(&o).capabilities.as_ref().unwrap();
+        let codex = &caps.kind_features["codex"];
+        assert!(codex.watch);
+        assert!(codex.input_gated());
+        // claude-rc carries neither hint → additive defaults.
+        let claude = &caps.kind_features["claude-rc"];
+        assert!(!claude.watch);
+        assert!(!claude.input_gated());
+    }
+
+    #[test]
+    fn overview_df_block_parses() {
+        let o = golden_overview();
+        let df = o.df.as_ref().unwrap();
+        assert_eq!(df.server_name.as_deref(), Some("test-server"));
+        assert_eq!(df.backend.as_deref(), Some("vz"));
+        assert_eq!(df.totals.all.physical_bytes, 14506430464);
+    }
+
+    #[test]
+    fn overview_running_shed_carries_only_rc_enriched_sessions() {
+        let o = golden_overview();
+        let p = proj(&o);
+        assert_eq!(p.shed.status, ShedStatus::Running);
+        // The plain "default" tmux row (no rc block) is dropped; the two rc
+        // rows remain, with slug/tmux derived from the session name.
+        let slugs: Vec<&str> = p.sessions.iter().map(|s| s.slug.as_str()).collect();
+        assert_eq!(slugs, ["abc234", "cdx777"]);
+        let claude = &p.sessions[0];
+        assert_eq!(claude.tmux_session, "rc-abc234");
+        assert_eq!(claude.kind, RcKind::ClaudeRc);
+        assert_eq!(claude.state, RcState::Ready);
+        assert!(claude.managed);
+        assert!(claude.url.is_some());
+        assert_eq!(claude.display_name, "proj/abc234");
+        // created_at comes from the OUTER session row (the rc block has none).
+        assert_eq!(claude.created_at.as_deref(), Some("2026-06-19T18:53:00Z"));
+        // Second row: the codex kind, needs-auth, no url.
+        let codex = &p.sessions[1];
+        assert_eq!(codex.kind, RcKind::Codex);
+        assert_eq!(codex.state, RcState::NeedsAuth);
+        assert!(codex.url.is_none());
+    }
+
+    #[test]
+    fn overview_running_shed_carries_rc_capabilities() {
+        let o = golden_overview();
+        let caps = proj(&o).capabilities.as_ref().unwrap();
+        assert_eq!(caps.rc_version, 3);
+        // codex advertised + installed → offered; opencode not installed → not.
+        assert!(caps.offers(&RcKind::Codex));
+        assert!(caps.creatable_kinds().contains(&RcKind::Codex));
+        assert!(!caps.offers(&RcKind::Opencode));
+    }
+
+    #[test]
+    fn overview_stopped_shed_has_no_sessions_and_absent_capabilities() {
+        let o = golden_overview();
+        let asleep = o.sheds.iter().find(|s| s.shed.name == "asleep").unwrap();
+        assert_eq!(asleep.shed.status, ShedStatus::Stopped);
+        assert!(asleep.sessions.is_empty());
+        assert!(asleep.capabilities.is_none()); // absent → tolerated
+    }
+
+    #[test]
+    fn overview_session_display_name_fallback_and_slug_derivation() {
+        // An rc block with no display_name falls back to `<shed>/<slug>`; a
+        // session name without the `rc-` prefix keeps the full name as slug.
+        let o: Overview = serde_json::from_str(
+            r#"{"sheds":[{"name":"web","status":"running","sessions":[
+                {"name":"rc-abc","created_at":"2026-01-01T00:00:00Z",
+                 "rc":{"kind":"shell","state":"ready","managed":false}},
+                {"name":"plain","rc":{"kind":"shell","state":"ready","managed":true}}
+            ]}]}"#,
+        )
+        .unwrap();
+        let s = &o.sheds[0].sessions[0];
+        assert_eq!(s.slug, "abc");
+        assert_eq!(s.tmux_session, "rc-abc");
+        assert_eq!(s.display_name, "web/abc");
+        assert_eq!(s.created_at.as_deref(), Some("2026-01-01T00:00:00Z"));
+        assert_eq!(s.host, ""); // absent on the wire; client stamps it
+        assert!(!s.managed);
+        let p = &o.sheds[0].sessions[1];
+        assert_eq!(p.slug, "plain"); // no rc- prefix to strip
+        assert_eq!(p.tmux_session, "plain");
+        assert_eq!(p.display_name, "web/plain");
+    }
+
+    #[test]
+    fn overview_session_decode_is_field_tolerant_forward_compat() {
+        // A newer server enriching a session with a future enum value (or a
+        // sparse rc block) must NOT vanish the session on this client: each
+        // field degrades independently (rc_models.dart:245-273) — unknown
+        // state → Starting, missing managed → false, missing kind → the
+        // preserved-raw unknown kind — the row is always present.
+        let o: Overview = serde_json::from_str(
+            r#"{"sheds":[{"name":"web","status":"running","sessions":[
+                {"name":"rc-fut1","rc":{"kind":"codex","state":"some-future-state"}},
+                {"name":"rc-bare","rc":{}}
+            ]}]}"#,
+        )
+        .unwrap();
+        let sessions = &o.sheds[0].sessions;
+        assert_eq!(sessions.len(), 2); // nothing dropped
+        let fut = &sessions[0];
+        assert_eq!(fut.slug, "fut1");
+        assert_eq!(fut.kind, RcKind::Codex);
+        assert_eq!(fut.state, RcState::Starting); // unknown state → transient
+        assert!(!fut.managed); // absent → false
+        assert_eq!(fut.workdir, None); // absent → None, NO DEFAULT_WORKDIR injection
+        let bare = &sessions[1];
+        assert_eq!(bare.state, RcState::Starting); // absent state → transient
+        assert_eq!(bare.kind, RcKind::Other(String::new())); // absent kind tolerated
+        assert!(!bare.kind.is_known());
+        assert_eq!(bare.display_name, "web/bare");
+    }
+
+    #[test]
+    fn overview_session_workdir_stays_none_and_last_message_is_cf_stripped() {
+        // workdir: missing/blank → None (rc_models.dart:261) — the
+        // DEFAULT_WORKDIR fallback belongs to the from_dto stdout path only.
+        // last_message: _cleanDisplay (rc_models.dart:269-271) — trim, strip
+        // Unicode-Cf (bidi-override spoofers), trim; Cf-only → None.
+        let o: Overview = serde_json::from_str(
+            "{\"sheds\":[{\"name\":\"web\",\"status\":\"running\",\"sessions\":[
+                {\"name\":\"rc-a\",\"rc\":{\"kind\":\"shell\",\"state\":\"ready\",\"managed\":true,
+                 \"workdir\":\"  \",\"last_message\":\"safe\u{202E}txt\"}},
+                {\"name\":\"rc-b\",\"rc\":{\"kind\":\"shell\",\"state\":\"ready\",\"managed\":true,
+                 \"workdir\":\"/w\",\"last_message\":\"\u{202E}\"}}
+            ]}]}",
+        )
+        .unwrap();
+        let a = &o.sheds[0].sessions[0];
+        assert_eq!(a.workdir, None); // blank → None
+        assert_eq!(a.last_message.as_deref(), Some("safetxt"));
+        let b = &o.sheds[0].sessions[1];
+        assert_eq!(b.workdir.as_deref(), Some("/w"));
+        assert_eq!(b.last_message, None); // Cf-only → None
+    }
+
+    #[test]
+    fn overview_shed_row_missing_name_defaults_to_question_mark() {
+        // A malformed shed row must not vanish: missing/blank name → "?"
+        // (Shed.fromJson defaults, shed_dtos.dart:31-41).
+        let o: Overview = serde_json::from_str(r#"{"sheds":[{"status":"running"}]}"#).unwrap();
+        assert_eq!(o.sheds.len(), 1);
+        assert_eq!(o.sheds[0].shed.name, "?");
+        assert_eq!(o.sheds[0].shed.status, ShedStatus::Running);
+        // Wrong-typed status degrades to Unknown, row still present.
+        let o: Overview = serde_json::from_str(r#"{"sheds":[{"name":"x","status":42}]}"#).unwrap();
+        assert_eq!(o.sheds[0].shed.name, "x");
+        assert_eq!(o.sheds[0].shed.status, ShedStatus::Unknown);
+    }
+
+    #[test]
+    fn overview_df_with_malformed_totals_zero_defaults() {
+        // A malformed field inside df degrades THAT field — never the whole
+        // disk block (SystemDiskUsage/DiskTotals.fromJson, shed_dtos.dart:345-392).
+        let o: Overview =
+            serde_json::from_str(r#"{"df":{"server_name":"srv","totals":null}}"#).unwrap();
+        let df = o.df.as_ref().expect("df present despite null totals");
+        assert_eq!(df.server_name.as_deref(), Some("srv"));
+        assert_eq!(df.totals, DiskTotals::default()); // zero-defaulted
+                                                      // Wrong-typed nested pieces zero-default too.
+        let o: Overview = serde_json::from_str(
+            r#"{"df":{"server_name":"srv","backend":7,
+                 "totals":{"all":{"physical_bytes":"x","logical_bytes":9}},
+                 "images":"nope"}}"#,
+        )
+        .unwrap();
+        let df = o.df.as_ref().unwrap();
+        assert_eq!(df.backend, None);
+        assert_eq!(df.totals.all.physical_bytes, 0);
+        assert_eq!(df.totals.all.logical_bytes, 9);
+        assert!(df.images.is_empty());
+    }
+
+    #[test]
+    fn overview_empty_capabilities_map_is_tolerant_not_absent() {
+        // rc_capabilities: {} is a PRESENT block (rc_version 0, empty
+        // collections) — only a non-map is None (rc_capabilities.dart:56-93).
+        let o: Overview = serde_json::from_str(
+            r#"{"sheds":[{"name":"web","status":"running","rc_capabilities":{}}]}"#,
+        )
+        .unwrap();
+        let caps = o.sheds[0]
+            .capabilities
+            .as_ref()
+            .expect("empty map decodes to tolerant capabilities");
+        assert_eq!(caps.rc_version, 0);
+        assert!(caps.kinds.is_empty());
+        assert!(caps.agents.is_empty());
+        assert!(caps.features.is_empty());
+        assert!(caps.kind_features.is_empty());
+        assert!(caps.creatable_kinds().is_empty());
+        // Wrong-typed entries are filtered, valid ones kept.
+        let o: Overview = serde_json::from_str(
+            r#"{"sheds":[{"name":"web","status":"running","rc_capabilities":{
+                "rc_version":"three",
+                "kinds":["codex",7],
+                "agents":{"codex":{"installed":true},"bad":"nope"},
+                "kind_features":{"codex":{"watch":true},"bad":4}}}]}"#,
+        )
+        .unwrap();
+        let caps = o.sheds[0].capabilities.as_ref().unwrap();
+        assert_eq!(caps.rc_version, 0); // non-numeric → 0
+        assert_eq!(caps.kinds, vec![RcKind::Codex]);
+        assert_eq!(caps.agents.len(), 1);
+        assert!(caps.offers(&RcKind::Codex));
+        let kf = &caps.kind_features["codex"];
+        assert!(kf.watch);
+        assert!(!kf.post_input); // absent → false
+        assert_eq!(kf.approvals, ""); // absent → ""
+        assert!(!kf.input_gated());
+    }
+
+    #[test]
+    fn overview_wrong_typed_blocks_degrade_to_defaults() {
+        // Every sub-block degrades independently — a wrong-typed block is a
+        // tolerated partial, never a decode error.
+        let o: Overview =
+            serde_json::from_str(r#"{"server":42,"df":"nope","sheds":{"a":1},"warnings":"w"}"#)
+                .unwrap();
+        assert_eq!(o.server, OverviewServer::default());
+        assert!(o.df.is_none());
+        assert!(o.sheds.is_empty());
+        assert!(o.warnings.is_empty());
+        // Non-string feature/warning elements are skipped; non-map session
+        // rows and rc blocks are skipped too.
+        let o: Overview = serde_json::from_str(
+            r#"{"server":{"version":"  ","features":["a",1,"b"]},
+                "warnings":["w1",2,"w2"],
+                "sheds":[{"name":"web","status":"running",
+                          "sessions":[42,{"name":"x"},{"name":"y","rc":"nope"}]}]}"#,
+        )
+        .unwrap();
+        assert_eq!(o.server.version, ""); // blank → ""
+        assert_eq!(o.server.features, ["a", "b"]);
+        assert_eq!(o.warnings, ["w1", "w2"]);
+        assert!(o.sheds[0].sessions.is_empty());
+    }
+
+    #[test]
+    fn overview_null_blocks_degrade_to_defaults() {
+        let o: Overview =
+            serde_json::from_str(r#"{"server":null,"df":null,"sheds":null,"warnings":null}"#)
+                .unwrap();
+        assert_eq!(o.server, OverviewServer::default());
+        assert!(o.df.is_none());
+        assert!(o.sheds.is_empty());
+        assert!(o.warnings.is_empty());
+        // Empty and non-object bodies also yield the all-default snapshot.
+        let o: Overview = serde_json::from_str("{}").unwrap();
+        assert_eq!(o, Overview::default());
+        let o: Overview = serde_json::from_str("[]").unwrap();
+        assert_eq!(o, Overview::default());
     }
 }

--- a/crates/shed-core/src/rc.rs
+++ b/crates/shed-core/src/rc.rs
@@ -752,6 +752,27 @@ pub fn kill_argv(bin: &str, slug: &str) -> Vec<String> {
     ]
 }
 
+/// Argv for a `prompt` — the kickoff line sent to an already-ready claude-rc/shell
+/// session on `slug`. The prompt text goes on **stdin**, not argv (like the other
+/// builders, this only produces argv). `session_id`, when present and non-empty,
+/// guards against a slug that was recreated under a new session. Mirrors mobile's
+/// `prompt()` (`rc_service.dart:201-209`).
+pub fn prompt_argv(bin: &str, slug: &str, session_id: Option<&str>) -> Vec<String> {
+    let mut argv = vec![
+        bin.to_string(),
+        "prompt".to_string(),
+        "--slug".to_string(),
+        slug.to_string(),
+    ];
+    if let Some(id) = session_id {
+        if !id.is_empty() {
+            argv.push("--session-id".to_string());
+            argv.push(id.to_string());
+        }
+    }
+    argv
+}
+
 /// Map a non-zero exit code + stderr to an `RcError`. SSH-transport failures (the
 /// binary never ran) surface as `Failed` with the ssh stderr. Mirrors Swift's
 /// `RemoteControl.error`.
@@ -1645,6 +1666,23 @@ mod tests {
     fn list_and_kill_argv() {
         assert_eq!(list_argv("b"), ["b", "list"]);
         assert_eq!(kill_argv("b", "abc"), ["b", "kill", "--slug", "abc"]);
+    }
+
+    #[test]
+    fn prompt_argv_builder() {
+        assert_eq!(
+            prompt_argv("b", "abc", None),
+            ["b", "prompt", "--slug", "abc"]
+        );
+        assert_eq!(
+            prompt_argv("b", "abc", Some("sid")),
+            ["b", "prompt", "--slug", "abc", "--session-id", "sid"]
+        );
+        // An empty session id is guarded — no `--session-id` flag emitted.
+        assert_eq!(
+            prompt_argv("b", "abc", Some("")),
+            ["b", "prompt", "--slug", "abc"]
+        );
     }
 
     // ---- exit-code mapping ----

--- a/crates/shed-core/src/rc.rs
+++ b/crates/shed-core/src/rc.rs
@@ -14,7 +14,7 @@ use std::sync::LazyLock;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use crate::models::{clean_display, opt_trimmed};
+use crate::models::{clean_display, dart_trim, opt_trimmed};
 use crate::terminal::{shell_quote, ssh_host_key_opts};
 
 /// Fallback workdir for a legacy/unmanaged session whose DTO omits one (the
@@ -486,7 +486,20 @@ impl RcSession {
             target_label: dto.target_label,
             activity: dto.activity,
             activity_at: dto.activity_at,
-            last_message: dto.last_message,
+            // Sanitize the guest-controlled preview text exactly as the
+            // overview adapter's `clean_display` does — strip Unicode format
+            // characters (category Cf: bidi overrides, zero-widths, BOM), then
+            // trim; a value that is only such chars degrades to None. The feed
+            // decoder and the overview path both clean this text, so the
+            // shed-ext-rc stdout path (`from_dto`) must not be laxer.
+            last_message: dto.last_message.and_then(|m| {
+                let cleaned = dart_trim(&strip_format_chars(&m)).to_string();
+                if cleaned.is_empty() {
+                    None
+                } else {
+                    Some(cleaned)
+                }
+            }),
             managed: dto.managed,
         }
     }
@@ -1973,6 +1986,38 @@ mod tests {
         assert!(j.get("activity").is_none());
         assert!(j.get("activity_at").is_none());
         assert!(j.get("last_message").is_none());
+    }
+
+    // Finding 3: the guest-controlled last_message on the shed-ext-rc stdout
+    // path must be sanitized exactly like the overview / feed paths — a bidi
+    // override (U+202E) that could visually reverse the preview is stripped.
+    #[test]
+    fn from_dto_strips_format_chars_from_last_message() {
+        // U+202E (right-to-left override) embedded via a Rust escape so the
+        // source stays reviewable — the guest ships it in the rc stdout JSON.
+        let json = format!(
+            r#"{{"slug":"a","tmux_session":"rc-a","kind":"codex","state":"ready",
+                "managed":true,"last_message":"run{}evil"}}"#,
+            '\u{202E}'
+        );
+        let dto = decode_session(&json).unwrap();
+        // The DTO carries the raw guest text verbatim…
+        assert_eq!(dto.last_message.as_deref(), Some("run\u{202E}evil"));
+        // …and from_dto sanitizes it (Cf stripped) before it reaches RcSession.
+        let s = RcSession::from_dto(dto, "srv", "web");
+        assert_eq!(s.last_message.as_deref(), Some("runevil"));
+
+        // A value that is ONLY format characters degrades to None.
+        let json = format!(
+            r#"{{"slug":"b","tmux_session":"rc-b","kind":"shell","state":"ready",
+                "managed":true,"last_message":"{}{}"}}"#,
+            '\u{202E}', '\u{200B}'
+        );
+        let only_cf = decode_session(&json).unwrap();
+        assert_eq!(
+            RcSession::from_dto(only_cf, "srv", "web").last_message,
+            None
+        );
     }
 
     // ---- capabilities ----

--- a/crates/shed-core/src/rc.rs
+++ b/crates/shed-core/src/rc.rs
@@ -63,6 +63,23 @@ impl RcKind {
         !matches!(self, RcKind::Other(_))
     }
 
+    /// Whether this kind runs claude — i.e. one of the two claude kinds (and so
+    /// gets claude's full `--permission-mode` set and URL affordances). NOT true
+    /// for codex/cursor/opencode. Mirrors the guest's `IsClaudeKind` and mobile's
+    /// `RcKind.runsClaude` (`rc_models.dart:76`).
+    pub fn runs_claude(&self) -> bool {
+        matches!(self, RcKind::ClaudeBroker | RcKind::ClaudeRc)
+    }
+
+    /// Whether this kind carries an autonomy/permission posture: every known
+    /// agent kind does; `shell` has none, and an unknown kind renders neutrally
+    /// with none — a caller-supplied mode is dropped silently for both (see
+    /// [`validate_permission_mode`]). Mirrors mobile's `RcKind.hasPermissionMode`
+    /// (`rc_models.dart:81`).
+    pub fn has_permission_mode(&self) -> bool {
+        self.is_known() && !matches!(self, RcKind::Shell)
+    }
+
     /// The tool token this kind's agent maps to under `capabilities.agents`, or
     /// `None` for a kind with no installable agent (`shell`) or an unknown kind.
     pub fn tool(&self) -> Option<&'static str> {
@@ -555,12 +572,74 @@ pub fn normalize_rc_prompt(raw: Option<&str>, kind: &RcKind) -> Result<Option<St
     Ok(Some(trimmed.to_string()))
 }
 
+// ---- permission modes ----
+
+/// The generic permission tri-state accepted by EVERY kind and mapped per agent
+/// to that tool's real flags by shed-ext-rc (the VM is already the sandbox).
+/// Mirrors the guest's `genericPermModes` (`internal/ext/rc/rc.go`) and mobile's
+/// `rcGenericPermissionModes` (`rc_service.dart:22`).
+pub const GENERIC_PERMISSION_MODES: [&str; 3] = ["default", "auto", "skip"];
+
+/// claude's historical `--permission-mode` values, accepted on top of the
+/// generic tri-state by the claude kinds ONLY. Mirrors the claude spec's
+/// `ExtraModes` and mobile's `rcClaudeExtraModes` (`rc_service.dart:27-32`).
+pub const CLAUDE_EXTRA_MODES: [&str; 4] = ["acceptEdits", "plan", "dontAsk", "bypassPermissions"];
+
+/// The create-time default permission mode. `auto` keeps a session running
+/// autonomously rather than blocking on permission prompts; it is a member of
+/// both the generic tri-state and the claude set, so it is valid for every
+/// agent kind. Mirrors mobile's `defaultRcPermissionMode` (`rc_service.dart:65`).
+pub const DEFAULT_RC_PERMISSION_MODE: &str = "auto";
+
+/// The permission modes valid for `kind`: the full claude set (generic
+/// tri-state + historical extras, in that display order) for the claude kinds,
+/// else the generic tri-state (codex/cursor/opencode/shell). Mirrors the
+/// guest's `PermModeAcceptedBy` and mobile's `permissionModesFor`
+/// (`rc_service.dart:58-59`).
+pub fn permission_modes_for(kind: &RcKind) -> Vec<&'static str> {
+    let mut modes = GENERIC_PERMISSION_MODES.to_vec();
+    if kind.runs_claude() {
+        modes.extend(CLAUDE_EXTRA_MODES);
+    }
+    modes
+}
+
+/// Validate a caller-supplied permission mode against `kind`, returning the
+/// EFFECTIVE mode to pass to [`create_argv`]/[`create_invocation`]. A kind
+/// without a permission posture (`shell`, unknown) silently drops the mode —
+/// `Ok(None)`, no error (the UI hides the picker, but state can linger across a
+/// kind switch; same posture as a claude-broker's dropped prompt). For a
+/// supporting kind, a mode outside [`permission_modes_for`] is rejected with
+/// [`RcError::BadRequest`] before any SSH call. Mirrors mobile's `RcService.create`
+/// gate (`rc_service.dart:142-145`). [`create_invocation`] calls this itself (the
+/// single validating entry point); only [`create_argv`], the low-level builder,
+/// requires the pre-validated effective mode.
+pub fn validate_permission_mode<'a>(
+    kind: &RcKind,
+    mode: Option<&'a str>,
+) -> Result<Option<&'a str>, RcError> {
+    if !kind.has_permission_mode() {
+        return Ok(None);
+    }
+    match mode {
+        None => Ok(None),
+        Some(m) if permission_modes_for(kind).contains(&m) => Ok(Some(m)),
+        Some(_) => Err(RcError::BadRequest("invalid permission mode".to_string())),
+    }
+}
+
 // ---- shed-ext-rc argv ----
 
 /// argv for `shed-ext-rc create --wait` (the binary resolves the workdir,
 /// pre-seeds trust, polls to ready, accepts trust, and delivers a stdin prompt).
 /// `bin` is resolved by the caller (`shed-app` reads `SHED_EXT_RC_BIN`) so this
 /// stays pure. `slug` is caller-supplied (generated in `shed-app::rc`, not here).
+/// `permission_mode` is the already-EFFECTIVE mode and must only ever be the
+/// output of [`validate_permission_mode`] (the validating gate is
+/// [`create_invocation`]; this stays the low-level infallible builder): `Some`
+/// emits `--permission-mode <mode>` between `--workdir` and `--prompt-stdin`
+/// (mobile's exact ordering, `rc_service.dart:168-174`), `None` emits no flag
+/// (each tool's own default).
 #[allow(clippy::too_many_arguments)]
 pub fn create_argv(
     bin: &str,
@@ -570,6 +649,7 @@ pub fn create_argv(
     workdir: Option<&str>,
     created_by: &str,
     target: &str,
+    permission_mode: Option<&str>,
     has_prompt: bool,
 ) -> Vec<String> {
     let mut a = vec![
@@ -591,6 +671,10 @@ pub fn create_argv(
         a.push("--workdir".to_string());
         a.push(w.to_string());
     }
+    if let Some(m) = permission_mode {
+        a.push("--permission-mode".to_string());
+        a.push(m.to_string());
+    }
     if has_prompt {
         a.push("--prompt-stdin".to_string());
     }
@@ -601,6 +685,15 @@ pub fn create_argv(
 /// and the stdin payload can never disagree. `prompt` must already be normalized
 /// (see [`normalize_rc_prompt`]); it is dropped for a kind that doesn't accept
 /// typed input.
+///
+/// This is the **validating gate** for `permission_mode` (a deliberate, safer
+/// deviation from the plan's "both builders infallible"): the raw
+/// caller-supplied mode is run through [`validate_permission_mode`] here —
+/// silently dropped for a kind without a permission posture, rejected with
+/// [`RcError::BadRequest`] when outside the kind's set (no argv is built) — and
+/// only the returned EFFECTIVE mode reaches [`create_argv`]. Mirrors mobile's
+/// derive-then-validate-then-emit order (`rc_service.dart:142-145`, `:171-173`);
+/// [`create_argv`] stays the low-level infallible builder.
 #[allow(clippy::too_many_arguments)]
 pub fn create_invocation(
     bin: &str,
@@ -610,11 +703,27 @@ pub fn create_invocation(
     workdir: Option<&str>,
     created_by: &str,
     target: &str,
+    permission_mode: Option<&str>,
     prompt: Option<&str>,
-) -> (Vec<String>, Option<String>) {
-    let effective = if kind.accepts_typed_input() { prompt } else { None };
-    let argv = create_argv(bin, kind, name, slug, workdir, created_by, target, effective.is_some());
-    (argv, effective.map(str::to_string))
+) -> Result<(Vec<String>, Option<String>), RcError> {
+    let mode = validate_permission_mode(kind, permission_mode)?;
+    let effective = if kind.accepts_typed_input() {
+        prompt
+    } else {
+        None
+    };
+    let argv = create_argv(
+        bin,
+        kind,
+        name,
+        slug,
+        workdir,
+        created_by,
+        target,
+        mode,
+        effective.is_some(),
+    );
+    Ok((argv, effective.map(str::to_string)))
 }
 
 pub fn list_argv(bin: &str) -> Vec<String> {
@@ -847,7 +956,8 @@ pub fn ssh_argv(
 
 static RE_TRUST_FOLDER: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)Yes,\s*I trust this folder").unwrap());
-static RE_RECONNECTING: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\bReconnecting\b").unwrap());
+static RE_RECONNECTING: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bReconnecting\b").unwrap());
 static RE_URL_BROKER: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"https?://claude\.ai/code\?environment=env_[A-Za-z0-9_-]+").unwrap()
 });
@@ -976,8 +1086,15 @@ mod tests {
 
     #[test]
     fn classify_needs_auth() {
-        for pane in ["not logged in", "run claude auth login", "requires a claude.ai subscription"] {
-            assert_eq!(classify_pane(&RcKind::ClaudeRc, pane).state, RcState::NeedsAuth);
+        for pane in [
+            "not logged in",
+            "run claude auth login",
+            "requires a claude.ai subscription",
+        ] {
+            assert_eq!(
+                classify_pane(&RcKind::ClaudeRc, pane).state,
+                RcState::NeedsAuth
+            );
         }
     }
 
@@ -993,7 +1110,10 @@ mod tests {
         let pane = "Remote Control active\nhttps://claude.ai/code/session_XYZ789";
         let c = classify_pane(&RcKind::ClaudeRc, pane);
         assert_eq!(c.state, RcState::Ready);
-        assert_eq!(c.url.as_deref(), Some("https://claude.ai/code/session_XYZ789"));
+        assert_eq!(
+            c.url.as_deref(),
+            Some("https://claude.ai/code/session_XYZ789")
+        );
     }
 
     #[test]
@@ -1005,10 +1125,16 @@ mod tests {
 
     #[test]
     fn classify_shell_empty_vs_content() {
-        assert_eq!(classify_pane(&RcKind::Shell, "   \n ").state, RcState::Starting);
+        assert_eq!(
+            classify_pane(&RcKind::Shell, "   \n ").state,
+            RcState::Starting
+        );
         assert_eq!(classify_pane(&RcKind::Shell, "$ ls").state, RcState::Ready);
         // A shell never runs the trust/auth heuristics.
-        assert_eq!(classify_pane(&RcKind::Shell, "not logged in").state, RcState::Ready);
+        assert_eq!(
+            classify_pane(&RcKind::Shell, "not logged in").state,
+            RcState::Ready
+        );
     }
 
     #[test]
@@ -1144,7 +1270,10 @@ mod tests {
 
     #[test]
     fn normalize_prompt_blank_is_none() {
-        assert_eq!(normalize_rc_prompt(Some("   \n\t"), &RcKind::ClaudeRc).unwrap(), None);
+        assert_eq!(
+            normalize_rc_prompt(Some("   \n\t"), &RcKind::ClaudeRc).unwrap(),
+            None
+        );
         assert_eq!(normalize_rc_prompt(None, &RcKind::Shell).unwrap(), None);
     }
 
@@ -1164,7 +1293,9 @@ mod tests {
             Err(RcError::BadRequest(_))
         ));
         // Exactly 2000 bytes is fine.
-        assert!(normalize_rc_prompt(Some(&"a".repeat(2000)), &RcKind::Shell).unwrap().is_some());
+        assert!(normalize_rc_prompt(Some(&"a".repeat(2000)), &RcKind::Shell)
+            .unwrap()
+            .is_some());
     }
 
     #[test]
@@ -1182,10 +1313,15 @@ mod tests {
         let remote = vec!["shed-ext-rc".to_string(), "list".to_string()];
         let argv = ssh_argv("web", "10.0.0.5", 2222, "/k/known_hosts", &remote, 10);
         // No `-t` (a PTY would corrupt the JSON DTO decode).
-        assert!(!argv.contains(&"-t".to_string()), "RC ssh must not allocate a PTY");
+        assert!(
+            !argv.contains(&"-t".to_string()),
+            "RC ssh must not allocate a PTY"
+        );
         assert!(argv.windows(2).any(|w| w == ["-o", "BatchMode=yes"]));
         assert!(argv.contains(&"ConnectTimeout=10".to_string()));
-        assert!(argv.windows(2).any(|w| w == ["-o", "StrictHostKeyChecking=yes"]));
+        assert!(argv
+            .windows(2)
+            .any(|w| w == ["-o", "StrictHostKeyChecking=yes"]));
         // The remote command is a single shell-quoted string after `--`.
         let dd = argv.iter().position(|a| a == "--").unwrap();
         assert_eq!(argv[dd + 1], "shed-ext-rc list");
@@ -1196,7 +1332,11 @@ mod tests {
 
     #[test]
     fn ssh_argv_shell_quotes_a_prompt_arg() {
-        let remote = vec!["shed-ext-rc".to_string(), "create".to_string(), "a b".to_string()];
+        let remote = vec![
+            "shed-ext-rc".to_string(),
+            "create".to_string(),
+            "a b".to_string(),
+        ];
         let argv = ssh_argv("s", "h", 22, "/k", &remote, 10);
         assert_eq!(argv.last().unwrap(), "shed-ext-rc create 'a b'");
     }
@@ -1213,6 +1353,7 @@ mod tests {
             Some("/work"),
             "shed-desktop/1.0",
             "shed:web@srv",
+            None,
             true,
         );
         assert_eq!(a[0], "shed-ext-rc");
@@ -1227,7 +1368,15 @@ mod tests {
     #[test]
     fn create_argv_omits_empty_workdir_and_promptless() {
         let a = create_argv(
-            "b", &RcKind::Shell, "n", "s", Some(""), "c", "t", false,
+            "b",
+            &RcKind::Shell,
+            "n",
+            "s",
+            Some(""),
+            "c",
+            "t",
+            None,
+            false,
         );
         assert!(!a.contains(&"--workdir".to_string()));
         assert!(!a.contains(&"--prompt-stdin".to_string()));
@@ -1236,10 +1385,247 @@ mod tests {
     #[test]
     fn create_invocation_drops_prompt_for_broker() {
         let (argv, stdin) = create_invocation(
-            "b", &RcKind::ClaudeBroker, "n", "s", None, "c", "t", Some("hi"),
-        );
+            "b",
+            &RcKind::ClaudeBroker,
+            "n",
+            "s",
+            None,
+            "c",
+            "t",
+            None,
+            Some("hi"),
+        )
+        .unwrap();
         assert_eq!(stdin, None);
         assert!(!argv.contains(&"--prompt-stdin".to_string()));
+    }
+
+    // ---- permission modes (ported from mobile's rc_service_test.dart:58-253) ----
+
+    #[test]
+    fn default_permission_mode_is_a_member_of_both_sets() {
+        // rc_service_test.dart:59-64: the picker pre-selects the default; it must
+        // be a member of the full claude set AND (being generic) every kind's set.
+        assert_eq!(DEFAULT_RC_PERMISSION_MODE, "auto");
+        assert!(GENERIC_PERMISSION_MODES.contains(&DEFAULT_RC_PERMISSION_MODE));
+        assert!(permission_modes_for(&RcKind::ClaudeRc).contains(&DEFAULT_RC_PERMISSION_MODE));
+        assert!(permission_modes_for(&RcKind::Codex).contains(&DEFAULT_RC_PERMISSION_MODE));
+    }
+
+    #[test]
+    fn permission_modes_for_claude_is_union_others_generic_only() {
+        // rc_service.dart:58-59: claude kinds get generic ∪ extras (display
+        // order: tri-state first); the other kinds get the tri-state only.
+        for kind in [RcKind::ClaudeRc, RcKind::ClaudeBroker] {
+            assert!(kind.runs_claude());
+            assert_eq!(
+                permission_modes_for(&kind),
+                vec![
+                    "default",
+                    "auto",
+                    "skip",
+                    "acceptEdits",
+                    "plan",
+                    "dontAsk",
+                    "bypassPermissions"
+                ]
+            );
+        }
+        for kind in [
+            RcKind::Codex,
+            RcKind::Opencode,
+            RcKind::Cursor,
+            RcKind::Shell,
+            RcKind::Other("borg".into()),
+        ] {
+            assert!(!kind.runs_claude());
+            assert_eq!(permission_modes_for(&kind), vec!["default", "auto", "skip"]);
+        }
+    }
+
+    #[test]
+    fn has_permission_mode_excludes_shell_and_unknown() {
+        // rc_models.dart:81: every known agent kind has a permission posture;
+        // shell has none, and an unknown kind renders neutrally with none.
+        for kind in [
+            RcKind::ClaudeRc,
+            RcKind::ClaudeBroker,
+            RcKind::Codex,
+            RcKind::Opencode,
+            RcKind::Cursor,
+        ] {
+            assert!(kind.has_permission_mode());
+        }
+        assert!(!RcKind::Shell.has_permission_mode());
+        assert!(!RcKind::Other("borg".into()).has_permission_mode());
+    }
+
+    #[test]
+    fn validate_permission_mode_accepts_valid_modes() {
+        // rc_service_test.dart:183-201: codex takes the generic tri-state;
+        // rc_service_test.dart:145-158, 231-241: claude takes its full set.
+        assert_eq!(
+            validate_permission_mode(&RcKind::Codex, Some("auto")),
+            Ok(Some("auto"))
+        );
+        assert_eq!(
+            validate_permission_mode(&RcKind::Codex, Some("skip")),
+            Ok(Some("skip"))
+        );
+        assert_eq!(
+            validate_permission_mode(&RcKind::ClaudeRc, Some("bypassPermissions")),
+            Ok(Some("bypassPermissions"))
+        );
+        assert_eq!(
+            validate_permission_mode(&RcKind::ClaudeRc, Some("auto")),
+            Ok(Some("auto"))
+        );
+        assert_eq!(
+            validate_permission_mode(&RcKind::ClaudeRc, Some("plan")),
+            Ok(Some("plan"))
+        );
+        // No mode chosen → no flag (each tool's own default),
+        // rc_service_test.dart:243-253.
+        assert_eq!(validate_permission_mode(&RcKind::ClaudeRc, None), Ok(None));
+    }
+
+    #[test]
+    fn validate_permission_mode_rejects_invalid_before_any_argv() {
+        // rc_service_test.dart:171-181 (unknown mode) + 203-217 (a claude-only
+        // mode on a non-claude kind) → RC_BAD_REQUEST, never reaching SSH.
+        assert_eq!(
+            validate_permission_mode(&RcKind::Codex, Some("plan")),
+            Err(RcError::BadRequest("invalid permission mode".to_string()))
+        );
+        assert_eq!(
+            validate_permission_mode(&RcKind::ClaudeRc, Some("nope")),
+            Err(RcError::BadRequest("invalid permission mode".to_string()))
+        );
+    }
+
+    #[test]
+    fn validate_permission_mode_drops_silently_for_shell_and_unknown() {
+        // rc_service_test.dart:160-169: a shell has no permission mode; the mode
+        // is silently dropped (no error, no flag) even if a caller passes one —
+        // state can linger across a kind switch. Same for an unknown kind.
+        assert_eq!(
+            validate_permission_mode(&RcKind::Shell, Some("auto")),
+            Ok(None)
+        );
+        assert_eq!(
+            validate_permission_mode(&RcKind::Shell, Some("plan")),
+            Ok(None)
+        );
+        assert_eq!(
+            validate_permission_mode(&RcKind::Other("borg".into()), Some("auto")),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn create_argv_emits_permission_mode_between_workdir_and_prompt_stdin() {
+        // rc_service_test.dart:145-158 + the emission ordering of
+        // rc_service.dart:168-174: --workdir, then --permission-mode, then
+        // --prompt-stdin.
+        let a = create_argv(
+            "shed-ext-rc",
+            &RcKind::ClaudeRc,
+            "web/abc",
+            "abc",
+            Some("/work/dir"),
+            "shed-desktop/1.0",
+            "shed:web@srv",
+            Some("bypassPermissions"),
+            true,
+        );
+        assert!(a
+            .windows(2)
+            .any(|w| w == ["--permission-mode", "bypassPermissions"]));
+        let wd = a.iter().position(|x| x == "--workdir").unwrap();
+        let pm = a.iter().position(|x| x == "--permission-mode").unwrap();
+        let ps = a.iter().position(|x| x == "--prompt-stdin").unwrap();
+        assert!(
+            wd < pm && pm < ps,
+            "ordering must be --workdir < --permission-mode < --prompt-stdin"
+        );
+    }
+
+    #[test]
+    fn create_argv_omits_permission_mode_when_none() {
+        // rc_service_test.dart:243-253: a null mode means "pass no flag at all".
+        let a = create_argv(
+            "shed-ext-rc",
+            &RcKind::ClaudeRc,
+            "n",
+            "s",
+            None,
+            "c",
+            "t",
+            None,
+            false,
+        );
+        assert!(!a.contains(&"--permission-mode".to_string()));
+    }
+
+    #[test]
+    fn create_invocation_passes_permission_mode_through() {
+        // rc_service_test.dart:183-193: codex passes a generic mode; the
+        // invocation gate validates it and emits the flag.
+        let (argv, stdin) = create_invocation(
+            "b",
+            &RcKind::Codex,
+            "n",
+            "s",
+            None,
+            "c",
+            "t",
+            Some("auto"),
+            None,
+        )
+        .unwrap();
+        assert!(argv.windows(2).any(|w| w == ["--permission-mode", "auto"]));
+        assert_eq!(stdin, None);
+    }
+
+    #[test]
+    fn create_invocation_rejects_invalid_mode_and_builds_no_argv() {
+        // rc_service_test.dart:203-217: a claude-only mode on a non-claude kind
+        // is rejected (RC_BAD_REQUEST) BEFORE any argv/SSH — the invocation gate
+        // validates, it does not forward raw modes.
+        assert_eq!(
+            create_invocation(
+                "b",
+                &RcKind::Codex,
+                "n",
+                "s",
+                None,
+                "c",
+                "t",
+                Some("plan"),
+                None
+            ),
+            Err(RcError::BadRequest("invalid permission mode".to_string()))
+        );
+    }
+
+    #[test]
+    fn create_invocation_silently_drops_mode_for_shell() {
+        // rc_service_test.dart:160-169: a shell has no permission mode; even a
+        // GARBAGE mode is dropped silently (Ok, no flag, no error) — Dart derives
+        // the effective mode BEFORE validating (rc_service.dart:142).
+        let (argv, _) = create_invocation(
+            "b",
+            &RcKind::Shell,
+            "n",
+            "s",
+            None,
+            "c",
+            "t",
+            Some("garbage"),
+            None,
+        )
+        .unwrap();
+        assert!(!argv.contains(&"--permission-mode".to_string()));
     }
 
     #[test]
@@ -1252,17 +1638,32 @@ mod tests {
 
     #[test]
     fn error_from_exit_maps_codes() {
-        assert_eq!(error_from_exit(3, "taken", ""), RcError::SlugTaken("taken".into()));
-        assert_eq!(error_from_exit(4, "gone", ""), RcError::NotFound("gone".into()));
-        assert_eq!(error_from_exit(2, "bad", ""), RcError::BadRequest("bad".into()));
+        assert_eq!(
+            error_from_exit(3, "taken", ""),
+            RcError::SlugTaken("taken".into())
+        );
+        assert_eq!(
+            error_from_exit(4, "gone", ""),
+            RcError::NotFound("gone".into())
+        );
+        assert_eq!(
+            error_from_exit(2, "bad", ""),
+            RcError::BadRequest("bad".into())
+        );
         assert_eq!(error_from_exit(127, "", ""), RcError::MissingBinary);
         assert_eq!(
             error_from_exit(1, "bash: shed-ext-rc: command not found", ""),
             RcError::MissingBinary
         );
-        assert_eq!(error_from_exit(1, "", ""), RcError::Failed("shed-ext-rc exited 1".into()));
+        assert_eq!(
+            error_from_exit(1, "", ""),
+            RcError::Failed("shed-ext-rc exited 1".into())
+        );
         // stdout is the fallback detail when stderr is empty.
-        assert_eq!(error_from_exit(5, "", "boom"), RcError::Failed("boom".into()));
+        assert_eq!(
+            error_from_exit(5, "", "boom"),
+            RcError::Failed("boom".into())
+        );
     }
 
     // ---- DTO → RcSession ----
@@ -1347,9 +1748,15 @@ mod tests {
 
     #[test]
     fn decode_session_rejects_garbage() {
-        assert!(matches!(decode_session("not json"), Err(RcError::Failed(_))));
+        assert!(matches!(
+            decode_session("not json"),
+            Err(RcError::Failed(_))
+        ));
         // A missing required field is not a valid DTO.
-        assert!(matches!(decode_session(r#"{"slug":"x"}"#), Err(RcError::Failed(_))));
+        assert!(matches!(
+            decode_session(r#"{"slug":"x"}"#),
+            Err(RcError::Failed(_))
+        ));
     }
 
     /// Decode the canonical golden fixture (byte-identical to shed-remote-agent's
@@ -1382,7 +1789,10 @@ mod tests {
         assert!(full.managed);
         assert_eq!(full.kind, RcKind::ClaudeRc);
         assert_eq!(full.display_name, "charliek/abc234"); // present, not the fallback
-        assert_eq!(full.rc_id.as_deref(), Some("9f1c0e7a-1111-4222-8333-444455556666"));
+        assert_eq!(
+            full.rc_id.as_deref(),
+            Some("9f1c0e7a-1111-4222-8333-444455556666")
+        );
         assert_eq!(full.created_by.as_deref(), Some("shed-remote-agent/0.1.0"));
         // Minimal legacy session: absent optionals default, fallbacks applied.
         assert!(!dtos[1].managed);

--- a/crates/shed-core/src/rc.rs
+++ b/crates/shed-core/src/rc.rs
@@ -168,6 +168,20 @@ impl RcState {
             _ => RcState::Starting, // incl. "starting" and any future value
         }
     }
+
+    /// Whether this lifecycle state permits showing the live activity
+    /// dimension. The server already drops activity for a blocking state
+    /// (needs-trust / needs-auth / dead — lifecycle trumps activity); the
+    /// client mirrors that gate so it never invents — or leaves on screen — an
+    /// activity or last-message a blocking state should hide. Mirrors mobile's
+    /// `rcStatePermitsActivity` (`rc_models.dart:154-157`); consumed by the
+    /// [`crate::rc_events`] fold's suppression rule.
+    pub fn permits_activity(&self) -> bool {
+        !matches!(
+            self,
+            RcState::NeedsTrust | RcState::NeedsAuth | RcState::Dead
+        )
+    }
 }
 
 /// A session's live *work* dimension, orthogonal to the lifecycle [`RcState`].
@@ -1512,6 +1526,18 @@ mod tests {
         assert_eq!(RcState::from_wire("starting"), RcState::Starting);
         assert_eq!(RcState::from_wire("some-future-state"), RcState::Starting);
         assert_eq!(RcState::from_wire(""), RcState::Starting);
+    }
+
+    #[test]
+    fn rc_state_permits_activity_blocks_gating_states() {
+        // Blocking states (lifecycle trumps activity) — rc_models.dart:154-157.
+        assert!(!RcState::NeedsTrust.permits_activity());
+        assert!(!RcState::NeedsAuth.permits_activity());
+        assert!(!RcState::Dead.permits_activity());
+        // Everything else permits the live activity dimension.
+        assert!(RcState::Starting.permits_activity());
+        assert!(RcState::Ready.permits_activity());
+        assert!(RcState::Reconnecting.permits_activity());
     }
 
     #[test]

--- a/crates/shed-core/src/rc.rs
+++ b/crates/shed-core/src/rc.rs
@@ -150,6 +150,79 @@ pub enum RcState {
     Dead,
 }
 
+impl RcState {
+    /// Tolerant wire decode: an unknown state from a newer binary/server is
+    /// treated as `Starting` (transient) rather than `Dead`, so a forward-compat
+    /// session is never shown as gone. Mirrors mobile's `RcState.fromWire`
+    /// (`rc_models.dart:176-181`). The strict serde derive above stays the
+    /// contract for `shed-ext-rc` stdout (golden-pinned); this is for the
+    /// tolerant server-enrichment paths (overview `rc` blocks, rc-events).
+    pub fn from_wire(s: &str) -> RcState {
+        match s {
+            "ready" => RcState::Ready,
+            "reconnecting" => RcState::Reconnecting,
+            "needs-trust" => RcState::NeedsTrust,
+            "needs-auth" => RcState::NeedsAuth,
+            "dead" => RcState::Dead,
+            _ => RcState::Starting, // incl. "starting" and any future value
+        }
+    }
+}
+
+/// A session's live *work* dimension, orthogonal to the lifecycle [`RcState`].
+/// Derived live by the rc hub and reported additively inside a session's `rc`
+/// block. Mirrors the guest's `rc.Activity` (`internal/ext/rc/activity.go`) and
+/// mobile's `RcActivity` (`rc_models.dart:125-147`): `working` (producing
+/// output), `needs_input` (idle at a prompt anchor), `idle` (quiescent), and
+/// `unknown` (live but indeterminate).
+///
+/// Deliberately NO `Other(String)` case (unlike [`RcKind`]'s unknown-kind
+/// policy): an UNRECOGNIZED token — a future value, or the reserved
+/// `needs_approval` the hub does not derive yet — maps to
+/// [`RcActivity::Unknown`] (Dart parity, `rc_models.dart:125-146`), so it
+/// renders neutrally (no badge) and consumers key off a single variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RcActivity {
+    Working,
+    NeedsInput,
+    Idle,
+    Unknown,
+}
+
+impl RcActivity {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RcActivity::Working => "working",
+            RcActivity::NeedsInput => "needs_input",
+            RcActivity::Idle => "idle",
+            RcActivity::Unknown => "unknown",
+        }
+    }
+
+    /// Parse a wire activity string; any unrecognized value maps to
+    /// [`RcActivity::Unknown`] rather than failing (never-throw decode).
+    pub fn from_wire(s: &str) -> RcActivity {
+        match s {
+            "working" => RcActivity::Working,
+            "needs_input" => RcActivity::NeedsInput,
+            "idle" => RcActivity::Idle,
+            _ => RcActivity::Unknown,
+        }
+    }
+}
+
+impl Serialize for RcActivity {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for RcActivity {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Ok(RcActivity::from_wire(&String::deserialize(d)?))
+    }
+}
+
 /// A pane-derived `(state, url)` — backs the pure `rc.classify` IPC utility.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RcClassification {
@@ -196,6 +269,17 @@ pub struct RcSessionDto {
     pub created_by: Option<String>,
     pub created_at: Option<String>,
     pub target_label: Option<String>,
+    /// Live-activity dimension (additive inside the `rc` block; derived by the
+    /// rc hub). Absent when no hub is running, the kind is unsupported, or the
+    /// server suppressed it (a blocking lifecycle state trumps activity).
+    /// Mirrors mobile's `RcSession.activity` (`rc_models.dart:222-234`).
+    pub activity: Option<RcActivity>,
+    /// RFC3339 timestamp the activity was last derived/changed; absent with
+    /// `activity`.
+    pub activity_at: Option<String>,
+    /// A short, hub-sanitized (ANSI/control-stripped, ≤200 runes) preview of
+    /// the session's most recent message. Absent when the hub has none.
+    pub last_message: Option<String>,
 }
 
 /// The `shed-ext-rc list` response shape. Strict on `rc_sessions` like Swift's
@@ -222,12 +306,36 @@ pub struct RcAgentInfo {
 }
 
 /// Per-kind UI hints from [`RcCapabilities::kind_features`]. Mirrors the guest's
-/// `rc.KindFeatures`: `post_input` reports whether a typed line reaches the pane,
-/// `approvals` is where approvals surface (v1 agents are TUI-only → `"tui"`).
+/// `rc.KindFeatures` and mobile's `KindFeatures` (`rc_capabilities.dart:116-144`):
+/// `post_input` reports whether a typed line reaches the pane, `approvals` is
+/// where approvals surface (v1 agents are TUI-only → `"tui"`).
+///
+/// `watch` and `input` are additive hub hints (codex-only in this phase; absent
+/// → `false` / `""`): `watch` reports whether the hub produces a live message
+/// feed for the kind (`GET /messages` + `message.appended`), and `input` is the
+/// feed-input posting **mode string** — `"gated"` means `POST /input` is
+/// accepted only while the session is waiting, `""` means no feed input. Note
+/// the distinction from the adjacent `post_input`: `post_input` is the
+/// typed-input *capability* bool (a typed line reaches the pane over the
+/// TUI-only path), while `input` is the *gating mode* of the separate feed-input
+/// channel — a kind can have `post_input: true` with no feed input at all.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RcKindFeatures {
     pub post_input: bool,
     pub approvals: String,
+    #[serde(default)]
+    pub watch: bool,
+    #[serde(default)]
+    pub input: String,
+}
+
+impl RcKindFeatures {
+    /// Whether feed input is gated (`input == "gated"`) — a watch view's input
+    /// bar is only ever enabled for a gated kind waiting for input. Mirrors
+    /// mobile's `KindFeatures.inputGated` (`rc_capabilities.dart:136`).
+    pub fn input_gated(&self) -> bool {
+        self.input == "gated"
+    }
 }
 
 /// The `shed-ext-rc capabilities` payload, also embedded in the `list` envelope.
@@ -289,7 +397,12 @@ pub struct RcSession {
     pub slug: String,
     pub tmux_session: String,
     pub display_name: String,
-    pub workdir: String,
+    /// The session's working directory when known. `None` for a server-enriched
+    /// overview row that carries none (Dart parity, `rc_models.dart:261`);
+    /// [`RcSession::from_dto`] (the `shed-ext-rc` stdout path) still fills the
+    /// [`DEFAULT_WORKDIR`] fallback, so it is always `Some` there.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workdir: Option<String>,
     pub kind: RcKind,
     pub state: RcState,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -302,6 +415,13 @@ pub struct RcSession {
     pub created_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_label: Option<String>,
+    /// Live-activity dimension (see [`RcSessionDto::activity`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activity: Option<RcActivity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activity_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_message: Option<String>,
     #[serde(default)]
     pub managed: bool,
 }
@@ -324,7 +444,7 @@ impl RcSession {
             slug: dto.slug,
             tmux_session: dto.tmux_session,
             display_name,
-            workdir: dto.workdir.unwrap_or_else(|| DEFAULT_WORKDIR.to_string()),
+            workdir: Some(dto.workdir.unwrap_or_else(|| DEFAULT_WORKDIR.to_string())),
             kind: dto.kind,
             state: dto.state,
             url: dto.url,
@@ -332,6 +452,9 @@ impl RcSession {
             created_by: dto.created_by,
             created_at: dto.created_at,
             target_label: dto.target_label,
+            activity: dto.activity,
+            activity_at: dto.activity_at,
+            last_message: dto.last_message,
             managed: dto.managed,
         }
     }
@@ -358,6 +481,21 @@ pub fn synthetic_url(kind: &RcKind, slug: &str) -> Option<String> {
         RcKind::ClaudeRc => Some(format!("https://claude.ai/code/session_{slug}")),
         _ => None,
     }
+}
+
+// ---- guest-text sanitization ----
+
+static RE_FORMAT_CHARS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\p{Cf}").unwrap());
+
+/// Remove every Unicode format character (category Cf — bidi overrides like
+/// U+202E, zero-widths, BOM, soft hyphen, …) from `s`. Client-side defense for
+/// guest-controlled display text (last-message previews, feed messages): the
+/// rc hub strips ANSI escapes and C0/C1 control characters but NOT Cf, and a
+/// bidi override can visually reverse rendered text to spoof what a message
+/// appears to say. Mirrors mobile's `stripFormatChars` (`text_sanitize.dart`).
+/// Shared by the overview session adapter and the rc feed decoder.
+pub fn strip_format_chars(s: &str) -> String {
+    RE_FORMAT_CHARS.replace_all(s, "").into_owned()
 }
 
 // ---- prompt normalization ----
@@ -742,6 +880,18 @@ mod tests {
         assert!(j.get("url").is_none());
     }
 
+    // ---- guest-text sanitization ----
+
+    #[test]
+    fn strip_format_chars_removes_cf_category() {
+        // Bidi override (U+202E), zero-width space (U+200B), BOM (U+FEFF).
+        assert_eq!(strip_format_chars("safe\u{202E}txt"), "safetxt");
+        assert_eq!(strip_format_chars("a\u{200B}b\u{FEFF}c"), "abc");
+        assert_eq!(strip_format_chars("\u{202E}"), "");
+        // Non-Cf text passes through untouched (incl. non-ASCII).
+        assert_eq!(strip_format_chars("héllo → wörld"), "héllo → wörld");
+    }
+
     // ---- prompt normalization ----
 
     #[test]
@@ -892,12 +1042,15 @@ mod tests {
             created_by: Some("shed-desktop/1.0".into()),
             created_at: Some("2026-01-01T00:00:00Z".into()),
             target_label: None,
+            activity: None,
+            activity_at: None,
+            last_message: None,
         };
         let s = RcSession::from_dto(dto, "srv", "web");
         assert_eq!(s.host, "srv");
         assert_eq!(s.shed, "web");
         assert_eq!(s.display_name, "web/abc"); // fallback
-        assert_eq!(s.workdir, DEFAULT_WORKDIR); // fallback
+        assert_eq!(s.workdir.as_deref(), Some(DEFAULT_WORKDIR)); // fallback
         assert_eq!(s.rc_id.as_deref(), Some("id-1")); // id → rc_id
         assert_eq!(s.id(), "srv/web/abc");
     }
@@ -918,6 +1071,9 @@ mod tests {
                 created_by: None,
                 created_at: None,
                 target_label: None,
+                activity: None,
+                activity_at: None,
+                last_message: None,
             },
             "srv",
             "web",
@@ -992,7 +1148,7 @@ mod tests {
         assert!(!dtos[1].managed);
         let minimal = RcSession::from_dto(dtos[1].clone(), "h", "demo");
         assert_eq!(minimal.display_name, "demo/brk900"); // <shed>/<slug> fallback
-        assert_eq!(minimal.workdir, DEFAULT_WORKDIR); // fallback
+        assert_eq!(minimal.workdir.as_deref(), Some(DEFAULT_WORKDIR)); // fallback
         assert!(minimal.rc_id.is_none());
     }
 
@@ -1057,6 +1213,104 @@ mod tests {
         assert_eq!(dtos.len(), 2);
         assert_eq!(dtos[0].kind, RcKind::Codex);
         assert_eq!(dtos[1].kind, RcKind::Other("borg".into()));
+    }
+
+    // ---- kind_features watch/input hints ----
+
+    #[test]
+    fn kind_features_watch_input_absent_default() {
+        // A pre-hub payload carries neither hint → additive defaults (false/"").
+        let f: RcKindFeatures =
+            serde_json::from_str(r#"{"post_input":true,"approvals":"tui"}"#).unwrap();
+        assert!(f.post_input);
+        assert!(!f.watch);
+        assert_eq!(f.input, "");
+        assert!(!f.input_gated());
+    }
+
+    #[test]
+    fn kind_features_gated_input() {
+        let f: RcKindFeatures = serde_json::from_str(
+            r#"{"post_input":true,"approvals":"tui","watch":true,"input":"gated"}"#,
+        )
+        .unwrap();
+        assert!(f.watch);
+        assert!(f.input_gated());
+        // A non-"gated" mode string is preserved verbatim but not gated.
+        let f: RcKindFeatures =
+            serde_json::from_str(r#"{"post_input":false,"approvals":"","input":"open"}"#).unwrap();
+        assert_eq!(f.input, "open");
+        assert!(!f.input_gated());
+    }
+
+    // ---- activity dimension ----
+
+    #[test]
+    fn rc_activity_wire_round_trip() {
+        for (wire, activity) in [
+            ("working", RcActivity::Working),
+            ("needs_input", RcActivity::NeedsInput),
+            ("idle", RcActivity::Idle),
+            ("unknown", RcActivity::Unknown),
+        ] {
+            assert_eq!(RcActivity::from_wire(wire), activity);
+            assert_eq!(activity.as_str(), wire);
+            assert_eq!(serde_json::to_value(activity).unwrap(), wire);
+            assert_eq!(
+                serde_json::from_value::<RcActivity>(wire.into()).unwrap(),
+                activity
+            );
+        }
+        // Any unrecognized token — the reserved needs_approval, a future value,
+        // or garbage — maps to Unknown (Dart parity, rc_models.dart:125-146;
+        // deliberately NOT RcKind's preserve-raw policy), and Unknown
+        // round-trips as the real "unknown" wire value.
+        assert_eq!(RcActivity::from_wire("needs_approval"), RcActivity::Unknown);
+        assert_eq!(RcActivity::from_wire("borg"), RcActivity::Unknown);
+        assert_eq!(
+            serde_json::from_value::<RcActivity>("needs_approval".into()).unwrap(),
+            RcActivity::Unknown
+        );
+        assert_eq!(
+            serde_json::to_value(RcActivity::Unknown).unwrap(),
+            "unknown"
+        );
+    }
+
+    #[test]
+    fn rc_state_from_wire_is_tolerant() {
+        assert_eq!(RcState::from_wire("ready"), RcState::Ready);
+        assert_eq!(RcState::from_wire("needs-auth"), RcState::NeedsAuth);
+        assert_eq!(RcState::from_wire("dead"), RcState::Dead);
+        // Unknown/missing states read as transient, never as gone.
+        assert_eq!(RcState::from_wire("starting"), RcState::Starting);
+        assert_eq!(RcState::from_wire("some-future-state"), RcState::Starting);
+        assert_eq!(RcState::from_wire(""), RcState::Starting);
+    }
+
+    #[test]
+    fn dto_carries_activity_fields_and_session_flows_them_through() {
+        let dto = decode_session(
+            r#"{"slug":"a","tmux_session":"rc-a","kind":"codex","state":"ready",
+                "managed":true,"activity":"working",
+                "activity_at":"2026-06-19T18:54:12Z","last_message":"hi"}"#,
+        )
+        .unwrap();
+        assert_eq!(dto.activity, Some(RcActivity::Working));
+        let s = RcSession::from_dto(dto, "srv", "web");
+        assert_eq!(s.activity, Some(RcActivity::Working));
+        assert_eq!(s.activity_at.as_deref(), Some("2026-06-19T18:54:12Z"));
+        assert_eq!(s.last_message.as_deref(), Some("hi"));
+        // Absent activity → None, and None keys stay off the serialized wire.
+        let plain = decode_session(
+            r#"{"slug":"b","tmux_session":"rc-b","kind":"shell","state":"ready","managed":true}"#,
+        )
+        .unwrap();
+        assert_eq!(plain.activity, None);
+        let j = serde_json::to_value(RcSession::from_dto(plain, "srv", "web")).unwrap();
+        assert!(j.get("activity").is_none());
+        assert!(j.get("activity_at").is_none());
+        assert!(j.get("last_message").is_none());
     }
 
     // ---- capabilities ----

--- a/crates/shed-core/src/rc.rs
+++ b/crates/shed-core/src/rc.rs
@@ -14,6 +14,7 @@ use std::sync::LazyLock;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
+use crate::models::{clean_display, opt_trimmed};
 use crate::terminal::{shell_quote, ssh_host_key_opts};
 
 /// Fallback workdir for a legacy/unmanaged session whose DTO omits one (the
@@ -663,6 +664,133 @@ pub fn decode_list_response(stdout: &str) -> Result<RcSessionListDto, RcError> {
         .map_err(|_| RcError::Failed("shed-ext-rc returned an invalid session list".to_string()))
 }
 
+// ---- rc hub messages feed ----
+//
+// The codex message feed served by the rc hub through the server proxy
+// (`GET /api/sheds/{name}/rc/v1/sessions/{slug}/messages`,
+// `internal/api/rchub.go:280-375`). Mirrors the guest's `feedMessage` /
+// `hubMessagesResponse` (`internal/ext/rc/hub_messages.go:44-201`,
+// handler `hub.go:332-385`) and mobile's decoder (`rc_feed.dart`): each
+// message is already hub-sanitized (ANSI/control-stripped, per-field capped),
+// so a client renders it as plain text. The one client-side addition: Unicode
+// format characters (category Cf — bidi overrides like U+202E) are stripped
+// from display text at decode via [`strip_format_chars`], because the hub's
+// sanitizer covers ANSI + C0/C1 controls but not Cf.
+//
+// Tolerant field readers: Dart's feed `_str`/`_text` (`rc_feed.dart:85-98`)
+// are byte-identical to `rc_models.dart`'s `_str`/`_cleanDisplay`, so this
+// section reuses [`crate::models::opt_trimmed`] / [`crate::models::clean_display`]
+// rather than re-declaring them.
+
+/// Dart's feed `_int` (`rc_feed.dart:83`), narrowed to the wire's non-negative
+/// seq: an integer as-is, another number truncated (negatives saturate to 0),
+/// anything else `0`. NOT shared with `models.rs`'s `int_or_zero` — that one
+/// mirrors a signed Dart `_int` and keeps negatives.
+fn feed_u64(v: Option<&serde_json::Value>) -> u64 {
+    v.and_then(|v| v.as_u64().or_else(|| v.as_f64().map(|f| f as u64)))
+        .unwrap_or(0)
+}
+
+/// One tool call/result block on a feed message: a name plus a compact detail
+/// (invocation args for a `tool_use`, output for a `tool_result`). Both are
+/// hub-sanitized AND Cf-stripped here; either may be absent. Mirrors mobile's
+/// `RcFeedTool` (`rc_feed.dart:16-23`).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RcFeedTool {
+    pub name: Option<String>,
+    pub detail: Option<String>,
+}
+
+impl RcFeedTool {
+    fn from_map(o: &serde_json::Map<String, serde_json::Value>) -> RcFeedTool {
+        RcFeedTool {
+            name: clean_display(o.get("name")),
+            detail: clean_display(o.get("detail")),
+        }
+    }
+}
+
+/// One normalized conversation message in the feed. `role` ∈ {user, assistant,
+/// tool, system}; `msg_type` (wire key `type`) ∈ {text, tool_use, tool_result,
+/// reasoning, status}. `seq` is monotonic per hub run (restarts from 1 on hub
+/// restart — a client that sees a seq lower than one it holds does a full
+/// refetch). Mirrors mobile's `RcFeedMessage` (`rc_feed.dart:29-58`); every
+/// field decodes tolerantly (wrong-typed → default/`None`, never an error).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RcFeedMessage {
+    pub seq: u64,
+    /// RFC3339, verbatim (crate convention: timestamps are never parsed here).
+    pub ts: Option<String>,
+    pub role: String,
+    /// The wire's `type` field (renamed: `type` is a Rust keyword).
+    pub msg_type: String,
+    pub text: Option<String>,
+    pub tool: Option<RcFeedTool>,
+}
+
+impl RcFeedMessage {
+    fn from_map(o: &serde_json::Map<String, serde_json::Value>) -> RcFeedMessage {
+        RcFeedMessage {
+            seq: feed_u64(o.get("seq")),
+            ts: opt_trimmed(o.get("ts")),
+            role: opt_trimmed(o.get("role")).unwrap_or_default(),
+            msg_type: opt_trimmed(o.get("type")).unwrap_or_default(),
+            text: clean_display(o.get("text")),
+            // Only a map decodes; anything else is no tool block
+            // (`rc_feed.dart:54-56`).
+            tool: o
+                .get("tool")
+                .and_then(serde_json::Value::as_object)
+                .map(RcFeedTool::from_map),
+        }
+    }
+}
+
+/// A page of the feed: `GET …/messages?since=<seq>[&limit=<n>]`. `truncated`
+/// means the requested `since` cursor predates the ring (drop-oldest discarded
+/// unseen messages) OR points beyond the ring's current tail (the ring
+/// restarted) — in either case the client must refetch from the earliest
+/// retained message (`internal/ext/rc/hub_messages.go:129-140`). Mirrors
+/// mobile's `RcMessagesPage` (`rc_feed.dart:65-81`).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RcMessagesPage {
+    pub messages: Vec<RcFeedMessage>,
+    pub truncated: bool,
+}
+
+impl RcMessagesPage {
+    /// Tolerant decode; never fails. A non-object body, a missing/non-list
+    /// `messages` key → `[]`; only map elements decode to messages
+    /// (`rc_feed.dart:70-80`); `truncated` is `true` only when literally
+    /// boolean `true`.
+    pub fn from_value(v: &serde_json::Value) -> RcMessagesPage {
+        let Some(obj) = v.as_object() else {
+            return RcMessagesPage::default();
+        };
+        RcMessagesPage {
+            messages: obj
+                .get("messages")
+                .and_then(serde_json::Value::as_array)
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(serde_json::Value::as_object)
+                        .map(RcFeedMessage::from_map)
+                        .collect()
+                })
+                .unwrap_or_default(),
+            truncated: matches!(obj.get("truncated"), Some(serde_json::Value::Bool(true))),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RcMessagesPage {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Ok(RcMessagesPage::from_value(&serde_json::Value::deserialize(
+            d,
+        )?))
+    }
+}
+
 // ---- SSH ----
 
 /// Build the **non-interactive** ssh argv that runs `remote_argv` on the target.
@@ -890,6 +1018,104 @@ mod tests {
         assert_eq!(strip_format_chars("\u{202E}"), "");
         // Non-Cf text passes through untouched (incl. non-ASCII).
         assert_eq!(strip_format_chars("héllo → wörld"), "héllo → wörld");
+    }
+
+    // ---- rc hub messages feed (ported from mobile's rc_feed_test.dart:9-67) ----
+
+    fn page(json: &str) -> RcMessagesPage {
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn feed_page_decodes_mixed_text_and_tool_blocks() {
+        // rc_feed_test.dart:11-31.
+        let p = page(
+            r#"{
+              "messages": [
+                {"seq": 1, "ts": "2026-06-19T18:53:00Z", "role": "user", "type": "text", "text": "hi"},
+                {"seq": 2, "role": "assistant", "type": "reasoning", "text": "thinking"},
+                {"seq": 3, "role": "tool", "type": "tool_use",
+                 "tool": {"name": "shell", "detail": "ls -la"}}
+              ],
+              "truncated": false
+            }"#,
+        );
+        assert_eq!(p.messages.len(), 3);
+        assert!(!p.truncated);
+        assert_eq!(p.messages[0].role, "user");
+        assert_eq!(p.messages[0].text.as_deref(), Some("hi"));
+        assert_eq!(p.messages[0].ts.as_deref(), Some("2026-06-19T18:53:00Z"));
+        assert_eq!(p.messages[1].msg_type, "reasoning");
+        let tool = p.messages[2].tool.as_ref().unwrap();
+        assert_eq!(tool.name.as_deref(), Some("shell"));
+        assert_eq!(tool.detail.as_deref(), Some("ls -la"));
+        assert_eq!(p.messages[2].text, None);
+    }
+
+    #[test]
+    fn feed_page_truncated_flag_and_empty_list_not_null() {
+        // rc_feed_test.dart:33-37: [] decodes to an empty page, flag carried.
+        let p = page(r#"{"messages": [], "truncated": true}"#);
+        assert!(p.messages.is_empty());
+        assert!(p.truncated);
+        // truncated is true ONLY when literally boolean true.
+        let p = page(r#"{"messages": [], "truncated": "yes"}"#);
+        assert!(!p.truncated);
+    }
+
+    #[test]
+    fn feed_page_tolerates_missing_messages_key_and_absent_fields() {
+        // rc_feed_test.dart:39-49.
+        let p = page(r#"{"truncated": false}"#);
+        assert!(p.messages.is_empty());
+        let one = page(r#"{"messages":[{"seq":5,"role":"system","type":"status"}]}"#);
+        assert_eq!(one.messages.len(), 1);
+        assert_eq!(one.messages[0].seq, 5);
+        assert_eq!(one.messages[0].ts, None);
+        assert_eq!(one.messages[0].text, None);
+        assert!(one.messages[0].tool.is_none());
+    }
+
+    #[test]
+    fn feed_page_skips_non_map_elements_and_wrong_types() {
+        // Only Map elements decode (rc_feed.dart:74-77); wrong-typed fields
+        // degrade per-field, never error.
+        let p = page(
+            r#"{"messages":[42,"nope",{"seq":"x","role":7,"type":null,"tool":"bad"}],
+                "truncated":null}"#,
+        );
+        assert_eq!(p.messages.len(), 1); // non-maps skipped
+        let m = &p.messages[0];
+        assert_eq!(m.seq, 0); // non-numeric → 0
+        assert_eq!(m.role, ""); // non-string → ""
+        assert_eq!(m.msg_type, "");
+        assert!(m.tool.is_none()); // non-map tool → None
+        assert!(!p.truncated); // null → false
+                               // A non-object body degrades to the empty page.
+        assert_eq!(
+            RcMessagesPage::from_value(&serde_json::json!([1, 2])),
+            RcMessagesPage::default()
+        );
+    }
+
+    #[test]
+    fn feed_page_strips_format_chars_from_text_and_tool_fields() {
+        // rc_feed_test.dart:51-65: the hub strips ANSI + C0/C1 controls but
+        // not category Cf — a U+202E (RLO) can visually reverse rendered
+        // text; U+200B hides content.
+        let p = page(
+            "{\"messages\":[{\"seq\":1,\"role\":\"assistant\",\"type\":\"text\",\
+              \"text\":\"safe\u{202E} EVIL\"},\
+             {\"seq\":2,\"role\":\"tool\",\"type\":\"tool_use\",\
+              \"tool\":{\"name\":\"sh\u{200B}ell\",\"detail\":\"rm\u{202E} x\"}}]}",
+        );
+        assert_eq!(p.messages[0].text.as_deref(), Some("safe EVIL"));
+        let tool = p.messages[1].tool.as_ref().unwrap();
+        assert_eq!(tool.name.as_deref(), Some("shell"));
+        assert_eq!(tool.detail.as_deref(), Some("rm x"));
+        // Cf-only text degrades to None.
+        let p = page("{\"messages\":[{\"seq\":1,\"role\":\"assistant\",\"type\":\"text\",\"text\":\"\u{202E}\"}]}");
+        assert_eq!(p.messages[0].text, None);
     }
 
     // ---- prompt normalization ----

--- a/crates/shed-core/src/rc_events.rs
+++ b/crates/shed-core/src/rc_events.rs
@@ -1,0 +1,822 @@
+//! rc-events decode + activity fold — the pure half of the live-activity layer.
+//!
+//! The server-side aggregate rc activity stream (`GET /api/rc/events`, SSE):
+//! one stream a client subscribes to for live rc activity across every shed on
+//! a host. Each upstream hub envelope has its `shed` field server-filled by the
+//! aggregator's frame rewrite, and the synthetic `hub.unavailable` /
+//! `shed.stopped` events are server-minted, outside the forwardable allowlist,
+//! so a guest hub can't spoof them (`internal/api/rcevents.go:454-503`). The
+//! hub-side payload shapes are `internal/ext/rc/hub_events.go:69-95`. Ported
+//! from mobile's `rc_events.dart` (decode `:109-158`, fold `:185-277`).
+//!
+//! SSE here is best-effort notification, not durable delivery: on reconnect the
+//! client refetches snapshots (overview / messages) rather than replaying.
+//!
+//! The forwarded payload fields (slug/activity/seq/…) are guest-controlled and
+//! treated as untrusted; the decode is tolerant and NEVER errors — a malformed
+//! frame is dropped ([`parse_rc_event`] → `None`) or its wrong-typed fields are
+//! nulled, because a decode failure that tore down the stream would turn one
+//! bad frame into a perpetual reconnect storm. The HTTP half (the
+//! `Client::rc_events` SSE connection) lives in [`crate::http`]; the
+//! reconnect-and-refold watcher lives in `shed-app`.
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::models::{clean_display, opt_trimmed};
+use crate::rc::{RcActivity, RcState};
+use crate::sse::SseEvent;
+
+/// A parsed rc event (`rc_events.dart:18-104`). The `shed` a variant carries is
+/// server-corrected; everything else is guest-controlled display data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RcEvent {
+    /// `event: activity.changed` — a session's live activity (and lifecycle
+    /// state) moved. `data: {shed, slug, activity, activity_at, state}`, plus
+    /// an optional `last_message` (the sanitized preview that rides with the
+    /// activity dimension) when the hub includes it — decoded tolerantly so a
+    /// card's subtitle can patch live alongside the badge instead of waiting
+    /// for an overview refetch.
+    ActivityChanged {
+        shed: String,
+        slug: String,
+        activity: Option<RcActivity>,
+        activity_at: Option<String>,
+        state: Option<RcState>,
+        last_message: Option<String>,
+    },
+    /// `event: session.updated` — a session was created/killed or its
+    /// lifecycle changed. `data: {shed, slug, session}`. The nested `session`
+    /// is the display subset; the activity/state/last_message dimensions are
+    /// extracted from it. An absent/null `session` means the session is GONE
+    /// (a kill): `removed` is set and the overlay drops its patch entirely
+    /// instead of merging stale fields.
+    SessionUpdated {
+        shed: String,
+        slug: String,
+        activity: Option<RcActivity>,
+        state: Option<RcState>,
+        last_message: Option<String>,
+        removed: bool,
+    },
+    /// `event: message.appended` — a new feed message landed. `data: {shed,
+    /// slug, seq}`. Notification only: the body comes from a targeted
+    /// /messages fetch, so fan-out stays tiny and drop-safe.
+    MessageAppended {
+        shed: String,
+        slug: String,
+        seq: u64,
+    },
+    /// `event: hub.unavailable` — a shed's upstream hub connection dropped;
+    /// that host's live activity is stale until it reconnects.
+    HubUnavailable { shed: String },
+    /// `event: shed.stopped` — a shed left candidacy (stopped/deleted); its
+    /// reader tore down.
+    ShedStopped { shed: String },
+}
+
+impl RcEvent {
+    /// The host (shed name) an event pertains to — server-filled on every event.
+    pub fn shed(&self) -> &str {
+        match self {
+            RcEvent::ActivityChanged { shed, .. }
+            | RcEvent::SessionUpdated { shed, .. }
+            | RcEvent::MessageAppended { shed, .. }
+            | RcEvent::HubUnavailable { shed }
+            | RcEvent::ShedStopped { shed } => shed,
+        }
+    }
+}
+
+/// Decode one SSE record into a typed [`RcEvent`], or `None` for an unknown
+/// event name, a non-object data payload, or a payload missing its required
+/// keys (so a malformed frame is dropped, never rendered). Mirrors
+/// `parseRcEvent` (`rc_events.dart:109-158`): tolerant reads throughout — a
+/// wrong-typed optional field is nulled, never an error, because a throw here
+/// would kill the SSE stream and turn one bad guest frame into a reconnect
+/// storm.
+pub fn parse_rc_event(e: &SseEvent) -> Option<RcEvent> {
+    let data: Value = serde_json::from_str(&e.data).ok()?;
+    let data = data.as_object()?;
+    let shed = opt_trimmed(data.get("shed"));
+    let slug = opt_trimmed(data.get("slug"));
+    match e.event.as_str() {
+        "activity.changed" => Some(RcEvent::ActivityChanged {
+            shed: shed?,
+            slug: slug?,
+            activity: activity_of(data.get("activity")),
+            activity_at: opt_trimmed(data.get("activity_at")),
+            state: state_of(data.get("state")),
+            last_message: clean_display(data.get("last_message")),
+        }),
+        "session.updated" => {
+            // No session body (absent, null, or non-object) = the session is
+            // gone (killed): signal removal so the overlay drops the patch
+            // instead of retaining every stale field.
+            let sess = data.get("session").and_then(Value::as_object);
+            Some(RcEvent::SessionUpdated {
+                shed: shed?,
+                slug: slug?,
+                activity: sess.and_then(|s| activity_of(s.get("activity"))),
+                state: sess.and_then(|s| state_of(s.get("state"))),
+                last_message: sess.and_then(|s| clean_display(s.get("last_message"))),
+                removed: sess.is_none(),
+            })
+        }
+        "message.appended" => {
+            let (shed, slug) = (shed?, slug?);
+            let seq = seq_of(data.get("seq")?)?;
+            Some(RcEvent::MessageAppended { shed, slug, seq })
+        }
+        "hub.unavailable" => Some(RcEvent::HubUnavailable { shed: shed? }),
+        "shed.stopped" => Some(RcEvent::ShedStopped { shed: shed? }),
+        _ => None,
+    }
+}
+
+/// Dart `seq is! num → drop; seq.toInt()` (`rc_events.dart:144-148`): any
+/// JSON number is accepted and truncated toward zero, so a fractional seq
+/// keeps the event (`42.9` → `42`) exactly as Dart's `toInt()` does; a
+/// non-number drops the event in both. Two narrowings on top of Dart, per the
+/// wire's actual type (uint64 — `messageAppendedData.Seq`,
+/// `hub_events.go:94`): a negative seq is dropped (Dart's `toInt()` would
+/// keep it, but a negative cursor is meaningless — same disposition as the C2
+/// feed decoder's non-negative `seq`, `rc.rs::feed_u64`), and a value beyond
+/// u64 range is dropped rather than wrapped or saturated.
+fn seq_of(v: &Value) -> Option<u64> {
+    if let Some(u) = v.as_u64() {
+        return Some(u);
+    }
+    // Not directly a u64: a float, a negative, or not a number at all
+    // (`as_f64` → None drops the event, Dart's `is! num`).
+    let f = v.as_f64()?;
+    // u64::MAX as f64 is exactly 2^64; anything strictly below it truncates
+    // into range. serde_json numbers are always finite, but stay explicit.
+    if f.is_finite() && f >= 0.0 && f < u64::MAX as f64 {
+        Some(f.trunc() as u64)
+    } else {
+        None
+    }
+}
+
+/// Dart `RcActivity.fromWire(_str(v))` (`rc_events.dart:124`): non-string /
+/// blank → `None` ("no activity dimension at all"); any non-blank string
+/// decodes via [`RcActivity::from_wire`]'s unknown→`Unknown` path.
+fn activity_of(v: Option<&Value>) -> Option<RcActivity> {
+    opt_trimmed(v).map(|s| RcActivity::from_wire(&s))
+}
+
+/// Dart `_state` (`rc_events.dart:279-280`): a non-empty string decodes via
+/// [`RcState::from_wire`] (whose unknown values map to `Starting`); anything
+/// else — absent, null, wrong-typed, empty — is `None`. Deliberately an
+/// UNtrimmed non-empty check (unlike the `_str`-based fields), matching the
+/// Dart exactly: a whitespace-only state is "non-empty" and decodes to
+/// `Starting` through the unknown-value path.
+fn state_of(v: Option<&Value>) -> Option<RcState> {
+    v.and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(RcState::from_wire)
+}
+
+/// The live overlay a session card merges over its base overview snapshot: the
+/// last activity/state/message the SSE stream reported, plus the latest feed
+/// seq (which the watch view watches to trigger a targeted /messages fetch).
+/// Absent fields fall through to the base session. Mirrors mobile's
+/// `LiveActivity` (`rc_events.dart:167-178`).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct LiveActivity {
+    pub activity: Option<RcActivity>,
+    pub state: Option<RcState>,
+    pub last_message: Option<String>,
+    pub last_seq: Option<u64>,
+}
+
+/// A host's live-activity overlay: a map of `(shed, slug)` → [`LiveActivity`],
+/// folded from the SSE event stream. Immutable semantics — [`apply`] returns a
+/// new overlay (clone-on-write of the map). Degrading events (hub.unavailable /
+/// shed.stopped) drop that shed's patches so cards fall back to the last
+/// overview snapshot rather than showing stale live badges. Mirrors mobile's
+/// `ActivityOverlay` (`rc_events.dart:185-277`) with one deliberate
+/// non-port: Dart returns the SAME object (`identical`) when a drop matches
+/// nothing — a Riverpod rebuild optimization, not part of the fold contract.
+/// Here only the *contents* contract is ported; a no-op apply returns an
+/// equal-contents overlay, not necessarily a shared allocation.
+///
+/// [`apply`]: ActivityOverlay::apply
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ActivityOverlay {
+    patches: HashMap<(String, String), LiveActivity>,
+}
+
+impl ActivityOverlay {
+    /// The empty overlay (Dart's `ActivityOverlay.empty`).
+    pub fn empty() -> ActivityOverlay {
+        ActivityOverlay::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.patches.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.patches.len()
+    }
+
+    /// The live patch for a session, keyed by `(shed, slug)`.
+    pub fn lookup(&self, shed: &str, slug: &str) -> Option<&LiveActivity> {
+        self.patches.get(&(shed.to_string(), slug.to_string()))
+    }
+
+    /// Fold one event into the overlay, returning the next overlay
+    /// (`rc_events.dart:196-248`):
+    ///
+    /// * `ActivityChanged` — the payload's activity REPLACES the held one (the
+    ///   hub always carries the current activity on this event); state and
+    ///   last_message fall back to the held values when absent (a frame
+    ///   without a preview must not wipe the held one); `last_seq` is kept.
+    ///   The merged patch then passes through the suppression rule.
+    /// * `SessionUpdated` with `removed` — a kill drops the patch entirely
+    ///   (merging over a gone session would keep stale live fields alive
+    ///   forever); otherwise every dimension falls back to the held value,
+    ///   then suppression.
+    /// * `MessageAppended` — bumps `last_seq` only, preserving the other held
+    ///   dimensions; deliberately NOT suppressed (the feed history stays
+    ///   readable on a blocked/dead session).
+    /// * `HubUnavailable` / `ShedStopped` — drops every patch for that shed so
+    ///   cards fall back to the base snapshot.
+    pub fn apply(&self, ev: &RcEvent) -> ActivityOverlay {
+        match ev {
+            RcEvent::ActivityChanged {
+                shed,
+                slug,
+                activity,
+                state,
+                last_message,
+                ..
+            } => {
+                let key = (shed.clone(), slug.clone());
+                let prev = self.patches.get(&key);
+                // Activity REPLACES (the hub always carries the current one).
+                let next = suppressed(merge_over(prev, *activity, *state, last_message));
+                self.with(key, next)
+            }
+            RcEvent::SessionUpdated {
+                shed,
+                slug,
+                activity,
+                state,
+                last_message,
+                removed,
+            } => {
+                let key = (shed.clone(), slug.clone());
+                // A kill (no session body) removes the patch entirely —
+                // merging over a gone session would keep stale live fields
+                // alive forever.
+                if *removed {
+                    return self.drop_key(&key);
+                }
+                let prev = self.patches.get(&key);
+                // Activity falls back to the held value when absent.
+                let activity = activity.or_else(|| prev.and_then(|p| p.activity));
+                let next = suppressed(merge_over(prev, activity, *state, last_message));
+                self.with(key, next)
+            }
+            RcEvent::MessageAppended { shed, slug, seq } => {
+                let key = (shed.clone(), slug.clone());
+                // Bump last_seq only; every other held dimension is preserved.
+                let mut next = self.patches.get(&key).cloned().unwrap_or_default();
+                next.last_seq = Some(*seq);
+                self.with(key, next)
+            }
+            RcEvent::HubUnavailable { shed } | RcEvent::ShedStopped { shed } => {
+                self.drop_shed(shed)
+            }
+        }
+    }
+
+    fn with(&self, key: (String, String), v: LiveActivity) -> ActivityOverlay {
+        let mut patches = self.patches.clone();
+        patches.insert(key, v);
+        ActivityOverlay { patches }
+    }
+
+    fn drop_key(&self, key: &(String, String)) -> ActivityOverlay {
+        let mut patches = self.patches.clone();
+        patches.remove(key);
+        ActivityOverlay { patches }
+    }
+
+    fn drop_shed(&self, shed: &str) -> ActivityOverlay {
+        let mut patches = self.patches.clone();
+        patches.retain(|(s, _), _| s != shed);
+        ActivityOverlay { patches }
+    }
+}
+
+/// The shared merge half of the `ActivityChanged` / `SessionUpdated` fold
+/// arms: `state` falls back to the held value when absent, a payload-carried
+/// `last_message` supersedes the held preview (this is what lets a card's
+/// subtitle update live with the badge) but an absent one must not wipe it,
+/// and `last_seq` is always the held one (only `MessageAppended` moves it).
+/// The two events differ only in their activity policy — replace vs fall
+/// back — so the caller passes the already-resolved activity.
+fn merge_over(
+    prev: Option<&LiveActivity>,
+    activity: Option<RcActivity>,
+    state: Option<RcState>,
+    last_message: &Option<String>,
+) -> LiveActivity {
+    LiveActivity {
+        activity,
+        state: state.or_else(|| prev.and_then(|p| p.state)),
+        last_message: last_message
+            .clone()
+            .or_else(|| prev.and_then(|p| p.last_message.clone())),
+        last_seq: prev.and_then(|p| p.last_seq),
+    }
+}
+
+/// The whole-dimension suppression rule, mirroring the Go server's
+/// `DisplayActivity` + `toSessionRC` and mobile's `_suppressed`
+/// (`rc_events.dart:255-259`): a blocking lifecycle state
+/// (needs-trust/needs-auth/dead — [`RcState::permits_activity`]) drops
+/// activity AND last_message — a stale last_message on a dead/gated row would
+/// present pre-death context as current. The state itself (and `last_seq`) is
+/// retained.
+fn suppressed(v: LiveActivity) -> LiveActivity {
+    match v.state {
+        Some(st) if !st.permits_activity() => LiveActivity {
+            activity: None,
+            state: Some(st),
+            last_message: None,
+            last_seq: v.last_seq,
+        },
+        _ => v,
+    }
+}
+
+// Ported from mobile's `test/rc/rc_events_test.dart:9-289` — every case, same
+// inputs and assertions.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(event: &str, data: &str) -> Option<RcEvent> {
+        parse_rc_event(&SseEvent {
+            event: event.to_string(),
+            data: data.to_string(),
+        })
+    }
+
+    /// An `ActivityChanged` with only the fields the fold tests vary.
+    fn activity_changed(
+        shed: &str,
+        slug: &str,
+        activity: Option<RcActivity>,
+        state: Option<RcState>,
+        last_message: Option<&str>,
+    ) -> RcEvent {
+        RcEvent::ActivityChanged {
+            shed: shed.to_string(),
+            slug: slug.to_string(),
+            activity,
+            activity_at: None,
+            state,
+            last_message: last_message.map(str::to_string),
+        }
+    }
+
+    // ---- parse_rc_event (rc_events_test.dart:10-138) ----
+
+    #[test]
+    fn activity_changed_decodes_typed_patch() {
+        let ev = parse(
+            "activity.changed",
+            r#"{"shed":"proj","slug":"cdx777","activity":"needs_input",
+                "activity_at":"2026-06-19T18:54:12Z","state":"ready"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            ev,
+            RcEvent::ActivityChanged {
+                shed: "proj".into(),
+                slug: "cdx777".into(),
+                activity: Some(RcActivity::NeedsInput),
+                activity_at: Some("2026-06-19T18:54:12Z".into()),
+                state: Some(RcState::Ready),
+                last_message: None, // not carried on this frame
+            }
+        );
+        assert_eq!(ev.shed(), "proj");
+    }
+
+    #[test]
+    fn activity_changed_payload_last_message_supersedes_held() {
+        let ev = parse(
+            "activity.changed",
+            r#"{"shed":"proj","slug":"cdx777","activity":"working",
+                "state":"ready","last_message":"Running tests."}"#,
+        )
+        .unwrap();
+        match &ev {
+            RcEvent::ActivityChanged { last_message, .. } => {
+                assert_eq!(last_message.as_deref(), Some("Running tests."));
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+
+        let mut o = ActivityOverlay::empty().apply(&activity_changed(
+            "proj",
+            "cdx777",
+            Some(RcActivity::Working),
+            Some(RcState::Ready),
+            Some("older preview"),
+        ));
+        o = o.apply(&ev);
+        assert_eq!(
+            o.lookup("proj", "cdx777").unwrap().last_message.as_deref(),
+            Some("Running tests.")
+        );
+
+        // A frame WITHOUT last_message keeps the held preview (no wipe).
+        o = o.apply(&activity_changed(
+            "proj",
+            "cdx777",
+            Some(RcActivity::NeedsInput),
+            Some(RcState::Ready),
+            None,
+        ));
+        assert_eq!(
+            o.lookup("proj", "cdx777").unwrap().last_message.as_deref(),
+            Some("Running tests.")
+        );
+    }
+
+    #[test]
+    fn session_updated_extracts_fields_from_session() {
+        let ev = parse(
+            "session.updated",
+            r#"{"shed":"proj","slug":"cdx777","session":
+                {"state":"dead","activity":"idle","last_message":"bye"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            ev,
+            RcEvent::SessionUpdated {
+                shed: "proj".into(),
+                slug: "cdx777".into(),
+                activity: Some(RcActivity::Idle),
+                state: Some(RcState::Dead),
+                last_message: Some("bye".into()),
+                removed: false,
+            }
+        );
+    }
+
+    #[test]
+    fn message_appended_decodes_seq() {
+        assert_eq!(
+            parse("message.appended", r#"{"shed":"p","slug":"s","seq":42}"#),
+            Some(RcEvent::MessageAppended {
+                shed: "p".into(),
+                slug: "s".into(),
+                seq: 42,
+            })
+        );
+    }
+
+    #[test]
+    fn message_appended_seq_accepts_any_json_number_truncating() {
+        // Dart `seq.toInt()` truncation parity: a fractional seq keeps the
+        // event, truncated toward zero.
+        assert_eq!(
+            parse("message.appended", r#"{"shed":"p","slug":"s","seq":42.9}"#),
+            Some(RcEvent::MessageAppended {
+                shed: "p".into(),
+                slug: "s".into(),
+                seq: 42,
+            })
+        );
+        // Narrowings beyond Dart (documented on `seq_of`): a negative seq and
+        // a value beyond u64 range are dropped, never truncated in or wrapped.
+        assert_eq!(
+            parse("message.appended", r#"{"shed":"p","slug":"s","seq":-1}"#),
+            None
+        );
+        assert_eq!(
+            parse("message.appended", r#"{"shed":"p","slug":"s","seq":1e300}"#),
+            None
+        );
+    }
+
+    #[test]
+    fn bom_padded_values_trim_on_darts_set() {
+        // Dart's `String.trim` strips U+FEFF; Rust's `str::trim` does not —
+        // the shared helpers trim on Dart's set (`models.rs::dart_trim`), so a
+        // BOM-only shed is blank (required key missing → event dropped) and a
+        // BOM-padded activity decodes clean. JSON \u escapes, decoded by
+        // serde_json.
+        assert_eq!(parse("shed.stopped", r#"{"shed":"\uFEFF"}"#), None);
+        let ev = parse(
+            "activity.changed",
+            r#"{"shed":"p","slug":"a","activity":"\uFEFFworking\uFEFF"}"#,
+        )
+        .unwrap();
+        match &ev {
+            RcEvent::ActivityChanged { activity, .. } => {
+                assert_eq!(*activity, Some(RcActivity::Working));
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn synthetic_hub_unavailable_and_shed_stopped_decode() {
+        assert_eq!(
+            parse("hub.unavailable", r#"{"shed":"p"}"#),
+            Some(RcEvent::HubUnavailable { shed: "p".into() })
+        );
+        assert_eq!(
+            parse("shed.stopped", r#"{"shed":"p"}"#),
+            Some(RcEvent::ShedStopped { shed: "p".into() })
+        );
+    }
+
+    #[test]
+    fn drops_unknown_events_non_object_data_and_missing_keys() {
+        assert_eq!(parse("heartbeat", r#"{"shed":"p"}"#), None);
+        assert_eq!(parse("activity.changed", "not-json"), None);
+        assert_eq!(parse("activity.changed", r#"{"shed":"p"}"#), None); // no slug
+        assert_eq!(
+            parse("message.appended", r#"{"shed":"p","slug":"s"}"#),
+            None
+        ); // no seq
+    }
+
+    #[test]
+    fn non_string_field_values_are_tolerated_nulled_never_errors() {
+        // Guest-controlled frames: a wrong-typed value must be dropped/nulled —
+        // an error here would kill the SSE stream and turn one malformed frame
+        // into a perpetual reconnect storm.
+        let ev = parse(
+            "activity.changed",
+            r#"{"shed":"p","slug":"a","activity":42,"activity_at":[],"state":7}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            ev,
+            RcEvent::ActivityChanged {
+                shed: "p".into(),
+                slug: "a".into(),
+                activity: None,
+                activity_at: None,
+                state: None,
+                last_message: None,
+            }
+        );
+    }
+
+    #[test]
+    fn session_updated_null_or_absent_session_signals_removal() {
+        for data in [
+            r#"{"shed":"p","slug":"a","session":null}"#,
+            r#"{"shed":"p","slug":"a"}"#,
+        ] {
+            let ev = parse("session.updated", data).unwrap();
+            assert_eq!(
+                ev,
+                RcEvent::SessionUpdated {
+                    shed: "p".into(),
+                    slug: "a".into(),
+                    activity: None,
+                    state: None,
+                    last_message: None,
+                    removed: true,
+                },
+                "data: {data}"
+            );
+        }
+    }
+
+    #[test]
+    fn session_updated_last_message_strips_unicode_format_chars() {
+        // JSON \u escapes: RLO (U+202E) + zero-width space (U+200B). The raw
+        // string keeps the backslashes literal, so serde_json — not Rust —
+        // decodes the escapes, exactly like the Dart original.
+        let ev = parse(
+            "session.updated",
+            r#"{"shed":"p","slug":"a","session":
+                {"state":"ready","last_message":"a\u202erev\u200bersed"}}"#,
+        )
+        .unwrap();
+        match &ev {
+            RcEvent::SessionUpdated { last_message, .. } => {
+                assert_eq!(last_message.as_deref(), Some("areversed"));
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    // ---- ActivityOverlay::apply (rc_events_test.dart:140-288) ----
+
+    #[test]
+    fn activity_changed_patches_exactly_one_row() {
+        let o = ActivityOverlay::empty()
+            .apply(&activity_changed(
+                "p",
+                "a",
+                Some(RcActivity::Working),
+                Some(RcState::Ready),
+                None,
+            ))
+            .apply(&activity_changed(
+                "p",
+                "b",
+                Some(RcActivity::Idle),
+                Some(RcState::Ready),
+                None,
+            ));
+        assert_eq!(
+            o.lookup("p", "a").unwrap().activity,
+            Some(RcActivity::Working)
+        );
+        assert_eq!(o.lookup("p", "b").unwrap().activity, Some(RcActivity::Idle));
+
+        let next = o.apply(&activity_changed(
+            "p",
+            "a",
+            Some(RcActivity::NeedsInput),
+            Some(RcState::Ready),
+            None,
+        ));
+        // Only row a moved; b is untouched; the source overlay is not mutated.
+        assert_eq!(
+            next.lookup("p", "a").unwrap().activity,
+            Some(RcActivity::NeedsInput)
+        );
+        assert_eq!(
+            next.lookup("p", "b").unwrap().activity,
+            Some(RcActivity::Idle)
+        );
+        assert_eq!(
+            o.lookup("p", "a").unwrap().activity,
+            Some(RcActivity::Working)
+        );
+        assert_ne!(next, o);
+    }
+
+    #[test]
+    fn message_appended_bumps_last_seq_without_wiping_activity() {
+        let mut o = ActivityOverlay::empty().apply(&activity_changed(
+            "p",
+            "a",
+            Some(RcActivity::Working),
+            Some(RcState::Ready),
+            None,
+        ));
+        o = o.apply(&RcEvent::MessageAppended {
+            shed: "p".into(),
+            slug: "a".into(),
+            seq: 7,
+        });
+        assert_eq!(o.lookup("p", "a").unwrap().last_seq, Some(7));
+        assert_eq!(
+            o.lookup("p", "a").unwrap().activity,
+            Some(RcActivity::Working)
+        ); // preserved
+    }
+
+    #[test]
+    fn hub_unavailable_and_shed_stopped_drop_that_shed_only() {
+        let o = ActivityOverlay::empty()
+            .apply(&activity_changed(
+                "p",
+                "a",
+                Some(RcActivity::Working),
+                None,
+                None,
+            ))
+            .apply(&activity_changed(
+                "q",
+                "b",
+                Some(RcActivity::Idle),
+                None,
+                None,
+            ));
+        let after_hub = o.apply(&RcEvent::HubUnavailable { shed: "p".into() });
+        assert!(after_hub.lookup("p", "a").is_none()); // degraded → falls back to base
+        assert!(after_hub.lookup("q", "b").is_some());
+
+        let after_stop = after_hub.apply(&RcEvent::ShedStopped { shed: "q".into() });
+        assert!(after_stop.is_empty());
+        // Dropping a shed with no patches is a no-op with equal contents (Dart
+        // asserts object identity — a Riverpod optimization not ported).
+        assert_eq!(
+            after_stop.apply(&RcEvent::HubUnavailable { shed: "p".into() }),
+            after_stop
+        );
+    }
+
+    #[test]
+    fn lookup_keys_by_shed_and_slug() {
+        let o = ActivityOverlay::empty().apply(&activity_changed(
+            "p",
+            "a",
+            Some(RcActivity::Working),
+            None,
+            None,
+        ));
+        assert!(o.lookup("p", "a").is_some());
+        assert!(o.lookup("p", "z").is_none());
+        assert!(o.lookup("q", "a").is_none()); // shed is part of the key
+        assert_eq!(o.len(), 1);
+    }
+
+    #[test]
+    fn session_updated_removal_drops_the_patch_entirely() {
+        let mut o = ActivityOverlay::empty()
+            .apply(&activity_changed(
+                "p",
+                "a",
+                Some(RcActivity::Working),
+                Some(RcState::Ready),
+                None,
+            ))
+            .apply(&activity_changed(
+                "p",
+                "b",
+                Some(RcActivity::Idle),
+                None,
+                None,
+            ));
+        // A kill (session:null) must REMOVE the patch — retaining the previous
+        // fields would keep a dead session's live badge alive forever.
+        o = o.apply(&RcEvent::SessionUpdated {
+            shed: "p".into(),
+            slug: "a".into(),
+            activity: None,
+            state: None,
+            last_message: None,
+            removed: true,
+        });
+        assert!(o.lookup("p", "a").is_none());
+        assert!(o.lookup("p", "b").is_some()); // others untouched
+    }
+
+    #[test]
+    fn blocking_state_suppresses_activity_and_last_message() {
+        // Whole-dimension suppression, mirroring the Go server.
+        let mut o = ActivityOverlay::empty().apply(&RcEvent::SessionUpdated {
+            shed: "p".into(),
+            slug: "a".into(),
+            activity: Some(RcActivity::Working),
+            state: Some(RcState::Ready),
+            last_message: Some("pre-death context".into()),
+            removed: false,
+        });
+        o = o.apply(&RcEvent::MessageAppended {
+            shed: "p".into(),
+            slug: "a".into(),
+            seq: 5,
+        });
+        // The session dies: the patch keeps the state (and last_seq) but must
+        // clear activity and last_message — stale context is not current context.
+        o = o.apply(&activity_changed(
+            "p",
+            "a",
+            Some(RcActivity::Working),
+            Some(RcState::Dead),
+            None,
+        ));
+        let p = o.lookup("p", "a").unwrap();
+        assert_eq!(p.state, Some(RcState::Dead));
+        assert_eq!(p.activity, None);
+        assert_eq!(p.last_message, None);
+        assert_eq!(p.last_seq, Some(5)); // retained — the feed history stays readable
+    }
+
+    #[test]
+    fn rc_event_shed_accessor_covers_every_variant() {
+        let events = [
+            activity_changed("s1", "a", None, None, None),
+            RcEvent::SessionUpdated {
+                shed: "s2".into(),
+                slug: "a".into(),
+                activity: None,
+                state: None,
+                last_message: None,
+                removed: true,
+            },
+            RcEvent::MessageAppended {
+                shed: "s3".into(),
+                slug: "a".into(),
+                seq: 1,
+            },
+            RcEvent::HubUnavailable { shed: "s4".into() },
+            RcEvent::ShedStopped { shed: "s5".into() },
+        ];
+        let sheds: Vec<&str> = events.iter().map(RcEvent::shed).collect();
+        assert_eq!(sheds, ["s1", "s2", "s3", "s4", "s5"]);
+    }
+}

--- a/crates/shed-core/src/token.rs
+++ b/crates/shed-core/src/token.rs
@@ -30,17 +30,22 @@
 //! no still-valid cached token yields an error and the client then sends NO
 //! token — never a static downgrade.
 
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use regex::Regex;
+use serde_json::Value;
 use tokio::sync::Mutex;
 
 use crate::http::ShedError;
+use crate::models::dart_trim;
 
 /// A minted control token plus its optional expiry (unix seconds). `None` expiry
 /// → only an explicit `invalidate*()` forces a refresh (mirrors `MintedToken`).
-/// Swift parses the host agent's ISO-8601 expiry to epoch before handing it over,
-/// keeping timestamp parsing off this crate.
+/// Swift parses the host agent's ISO-8601 expiry to epoch before handing it over;
+/// the SSH-bundle path parses RFC3339 in this module instead
+/// ([`parse_token_bundle`]), and always yields `Some` — a bundle without a
+/// parseable expiry is rejected, never treated as non-expiring (plan 001 §3.5).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MintedToken {
     pub token: String,
@@ -87,6 +92,339 @@ pub fn name_jitter(name: &str, max_ms: u64) -> u64 {
         h = h.wrapping_mul(31).wrapping_add(i32::from(cu));
     }
     u64::from(h.unsigned_abs()) % max_ms.max(1)
+}
+
+// ---------------------------------------------------------------------------
+// SSH token-bundle parsing (plan 001 §3.5) — fail-closed ports of mobile's
+// `token_bundle.dart` (itself a port of the orchestrator's controlToken.ts).
+//
+// Sibling, NOT a duplicate: `shed-broker/src/bootstrap.rs:decode_bundle` also
+// decodes a `_bootstrap` bundle, but with Go-parity semantics — expiry is
+// OPTIONAL there (absent/zero → non-expiring `None`). These parsers are the
+// MOBILE-parity view: expiry is REQUIRED and a bundle without one is rejected.
+// The two must not be merged (§3.5); shed-core also must never depend on
+// shed-broker (the dependency direction is broker → core).
+// ---------------------------------------------------------------------------
+
+/// Fail-closed rejection of an SSH `_bootstrap` token bundle. Mirrors the
+/// mobile error codes (`app_error.dart`): `SHED_AUTH_EXPIRED`,
+/// `SHED_TLS_PIN_MISMATCH`, `SHED_TLS_PIN_MISSING`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum TokenBundleError {
+    /// Bad JSON, non-`control` scope, empty token, or a missing / unparseable
+    /// / pre-epoch `expires_at` (mobile `SHED_AUTH_EXPIRED`).
+    #[error("control token bundle rejected: expired or malformed (SHED_AUTH_EXPIRED)")]
+    AuthExpired,
+    /// The bundle's TLS fingerprint differs from the already-configured pin —
+    /// a trust-model change we refuse to make silently
+    /// (mobile `SHED_TLS_PIN_MISMATCH`).
+    #[error("control token bundle TLS fingerprint does not match the configured pin (SHED_TLS_PIN_MISMATCH)")]
+    PinMismatch,
+    /// The bundle omits a well-formed TLS fingerprint where one is REQUIRED
+    /// (the add-server flow, [`parse_control_bundle`]; mobile
+    /// `SHED_TLS_PIN_MISSING`).
+    #[error("control token bundle omits a valid tls_cert_fingerprint (SHED_TLS_PIN_MISSING)")]
+    PinMissing,
+}
+
+/// The full `_bootstrap control` bundle (token + TLS pin + https port), used by
+/// the add-server flow, which bootstraps the TLS pin from this SSH-delivered
+/// value (the SSH channel is host-key-pinned). Stricter than
+/// [`parse_token_bundle`]: the fingerprint and a positive `https_port` are
+/// REQUIRED. Port of `token_bundle.dart:66-78`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControlBundle {
+    pub token: String,
+    pub expires_at_unix: u64,
+    /// Canonical `sha256:<lowercase hex>` leaf-cert pin (`fingerprint.dart:5-8`).
+    pub tls_cert_fingerprint: String,
+    pub https_port: u16,
+}
+
+/// Canonical TLS pin form: `sha256:` + lowercase hex of SHA-256(DER leaf) —
+/// mobile's `kTlsFingerprintRe` (`fingerprint.dart:8`). The SSH host-key pin
+/// uses a different format (`SHA256:<base64>`); never cross-compare the two.
+static RE_TLS_FINGERPRINT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^sha256:[0-9a-f]{64}$").unwrap());
+
+/// Validate an SSH bootstrap bundle (one JSON line) into a [`MintedToken`],
+/// failing closed. Rule-for-rule port of `token_bundle.dart:29-60`
+/// (`parseTokenBundle`):
+///   * bad JSON, a non-object, non-`control` scope, an empty/whitespace
+///     token, or a missing/unparseable `expires_at` →
+///     [`TokenBundleError::AuthExpired`]
+///   * a minted `tls_cert_fingerprint` that is malformed or differs from an
+///     already-configured `expected_pin` → [`TokenBundleError::PinMismatch`]
+///     (a trust-model change we refuse to make silently)
+///
+/// When `expected_pin` is `Some`, a present bundle fingerprint must match; an
+/// ABSENT one (or a non-string value) is tolerated — the bundle still arrived
+/// over a host-key-pinned SSH channel (`token_bundle.dart:25-28,45-52`). The
+/// add-server flow additionally requires the pin — that is
+/// [`parse_control_bundle`]. `expected_pin` must already be in canonical
+/// lowercase `sha256:<hex>` form (mobile stores it canonicalized).
+///
+/// The result's `expires_at_unix` is always `Some` — elsewhere in this module
+/// `None` means non-expiring, but the bundle parse REJECTS an absent expiry
+/// instead (plan 001 §3.5). One deliberate divergence from Dart: mobile keeps
+/// the parsed expiry as a signed `DateTime`, while `MintedToken` carries
+/// `u64` unix seconds — a PRE-EPOCH (negative) expiry therefore maps to
+/// [`TokenBundleError::AuthExpired`] here. Justified fail-closed: a control
+/// token that expired before 1970 is already expired / nonsensical, and no
+/// live mint emits one.
+pub fn parse_token_bundle(
+    stdout: &str,
+    expected_pin: Option<&str>,
+) -> Result<MintedToken, TokenBundleError> {
+    let raw: Value = serde_json::from_str(stdout).map_err(|_| TokenBundleError::AuthExpired)?;
+    let obj = raw.as_object().ok_or(TokenBundleError::AuthExpired)?;
+
+    if obj.get("scope").and_then(Value::as_str) != Some("control") {
+        return Err(TokenBundleError::AuthExpired);
+    }
+
+    // Dart-set trim ([`dart_trim`]): Dart's `String.trim()` strips U+FEFF
+    // (BOM) where Rust's `str::trim` does not — a BOM-only token must fail
+    // closed here exactly as it does on mobile (`token_bundle.dart:42-43`).
+    let token = dart_trim(
+        obj.get("token")
+            .and_then(Value::as_str)
+            .ok_or(TokenBundleError::AuthExpired)?,
+    );
+    if token.is_empty() {
+        return Err(TokenBundleError::AuthExpired);
+    }
+
+    // Conditional/tolerant pin check (`token_bundle.dart:45-52`): only when a
+    // pin is configured AND the bundle carries a string fingerprint.
+    if let Some(pin) = expected_pin {
+        if let Some(minted_fp) = obj.get("tls_cert_fingerprint").and_then(Value::as_str) {
+            let minted = dart_trim(minted_fp).to_lowercase();
+            if !RE_TLS_FINGERPRINT.is_match(&minted) || minted != pin {
+                return Err(TokenBundleError::PinMismatch);
+            }
+        }
+    }
+
+    let expires_at_unix = require_expiry_unix(obj)?;
+
+    Ok(MintedToken {
+        token: token.to_string(),
+        expires_at_unix: Some(expires_at_unix),
+    })
+}
+
+/// Parse the full `_bootstrap control` bundle for the add-server flow. Rule-
+/// for-rule port of `token_bundle.dart:80-118` (`parseControlBundle`) —
+/// STRICTER than [`parse_token_bundle`]:
+///   * JSON / object / `scope == "control"` / non-blank token / required
+///     parseable `expires_at` → [`TokenBundleError::AuthExpired`] on failure
+///   * `tls_cert_fingerprint` REQUIRED: not a string, or malformed after
+///     trim+lowercase → [`TokenBundleError::PinMissing`]; well-formed but
+///     different from a `Some` `expected_pin` →
+///     [`TokenBundleError::PinMismatch`]
+///   * `https_port` REQUIRED: not an integer or outside `1..=65535` →
+///     [`TokenBundleError::AuthExpired`]
+///
+/// Same pre-epoch-expiry divergence as [`parse_token_bundle`] (see its doc).
+pub fn parse_control_bundle(
+    stdout: &str,
+    expected_pin: Option<&str>,
+) -> Result<ControlBundle, TokenBundleError> {
+    let raw: Value = serde_json::from_str(stdout).map_err(|_| TokenBundleError::AuthExpired)?;
+    let obj = raw.as_object().ok_or(TokenBundleError::AuthExpired)?;
+
+    if obj.get("scope").and_then(Value::as_str) != Some("control") {
+        return Err(TokenBundleError::AuthExpired);
+    }
+
+    // Dart-set trim, as in [`parse_token_bundle`] (BOM parity,
+    // `token_bundle.dart:90-93`).
+    let token = dart_trim(
+        obj.get("token")
+            .and_then(Value::as_str)
+            .ok_or(TokenBundleError::AuthExpired)?,
+    );
+    if token.is_empty() {
+        return Err(TokenBundleError::AuthExpired);
+    }
+
+    let fp = dart_trim(
+        obj.get("tls_cert_fingerprint")
+            .and_then(Value::as_str)
+            .ok_or(TokenBundleError::PinMissing)?,
+    )
+    .to_lowercase();
+    if !RE_TLS_FINGERPRINT.is_match(&fp) {
+        return Err(TokenBundleError::PinMissing);
+    }
+    if let Some(pin) = expected_pin {
+        if fp != pin {
+            return Err(TokenBundleError::PinMismatch);
+        }
+    }
+
+    // Dart `portRaw is! int` (`token_bundle.dart:101-104`): a JSON float is
+    // rejected — `Value::as_i64` is `None` for non-integer numbers.
+    let port = obj
+        .get("https_port")
+        .and_then(Value::as_i64)
+        .ok_or(TokenBundleError::AuthExpired)?;
+    let https_port = u16::try_from(port).map_err(|_| TokenBundleError::AuthExpired)?;
+    if https_port == 0 {
+        return Err(TokenBundleError::AuthExpired);
+    }
+
+    let expires_at_unix = require_expiry_unix(obj)?;
+
+    Ok(ControlBundle {
+        token: token.to_string(),
+        expires_at_unix,
+        tls_cert_fingerprint: fp,
+        https_port,
+    })
+}
+
+/// The shared REQUIRED-expiry tail of both bundle parses
+/// (`token_bundle.dart:54-57,107-110`): `expires_at` must be a string that
+/// parses as RFC3339; anything else — including the pre-epoch u64 divergence
+/// documented on [`parse_token_bundle`] — is [`TokenBundleError::AuthExpired`].
+fn require_expiry_unix(obj: &serde_json::Map<String, Value>) -> Result<u64, TokenBundleError> {
+    let raw = obj
+        .get("expires_at")
+        .and_then(Value::as_str)
+        .ok_or(TokenBundleError::AuthExpired)?;
+    let secs = parse_rfc3339_to_unix(raw).map_err(|()| TokenBundleError::AuthExpired)?;
+    u64::try_from(secs).map_err(|_| TokenBundleError::AuthExpired)
+}
+
+/// Parse a strict UTC RFC3339 timestamp
+/// (`YYYY-MM-DDTHH:MM:SS[.frac](Z|±HH:MM)`) to unix seconds, sub-second
+/// digits validated then truncated.
+///
+/// Std-only (shed-core carries no time dependency): the same Howard Hinnant
+/// days-from-civil mechanism as `shed-broker/src/status.rs:
+/// parse_rfc3339_to_unix` — PORTED, not imported (the dependency direction is
+/// broker → core), and with one semantic difference: the broker collapses the
+/// Go zero time `0001-01-01T00:00:00Z` to `None` (Go `IsZero()` parity),
+/// while this parser has no such case — it returns the plain instant
+/// (-62135596800), matching Dart's `DateTime.tryParse`, which parses the Go
+/// zero time successfully (`token_bundle.dart:56`). The bundle parses above
+/// then reject any pre-epoch value at the u64 conversion.
+///
+/// Calendar validation is STRICTER than both siblings — deliberate for a
+/// fail-closed auth parser (a live mint never emits an impossible date):
+/// impossible dates (`2023-02-29`, day 32, month 13) are REJECTED rather
+/// than silently normalized through the civil-date math (the broker parser)
+/// or by `DateTime.tryParse` (Dart). The one permissive carve-out is
+/// `second == 60`, kept because real RFC3339 timestamps carry leap seconds.
+fn parse_rfc3339_to_unix(s: &str) -> Result<i64, ()> {
+    let (date, time_and_zone) = s.split_once('T').ok_or(())?;
+    let (y, mo, d) = {
+        let mut it = date.split('-');
+        let y: i64 = parse_fixed(it.next().ok_or(())?, 4)?;
+        let mo: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
+        let d: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
+        if it.next().is_some() {
+            return Err(());
+        }
+        (y, mo, d)
+    };
+    // Split the zone suffix off the time, then split off fractional seconds.
+    let (time_part, offset_secs) = split_zone(time_and_zone)?;
+    let (hms, frac) = match time_part.split_once('.') {
+        Some((h, f)) => (h, Some(f)),
+        None => (time_part, None),
+    };
+    if let Some(f) = frac {
+        // Sub-second digits are validated then dropped (truncation).
+        if f.is_empty() || !f.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(());
+        }
+    }
+    let (h, mi, se) = {
+        let mut it = hms.split(':');
+        let h: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
+        let mi: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
+        let se: u32 = parse_fixed(it.next().ok_or(())?, 2)?;
+        if it.next().is_some() {
+            return Err(());
+        }
+        (h, mi, se)
+    };
+    // Strict calendar validation (see the doc comment): real month/day only.
+    // se == 60 admits a leap second (RFC3339 allows it).
+    if !(1..=12).contains(&mo) || d < 1 || d > days_in_month(y, mo) || h > 23 || mi > 59 || se > 60
+    {
+        return Err(());
+    }
+    let days = days_from_civil(y, mo, d);
+    Ok(days * 86_400 + i64::from(h) * 3_600 + i64::from(mi) * 60 + i64::from(se) - offset_secs)
+}
+
+/// Days in `month` of Gregorian `year` (proleptic leap rules:
+/// `y%4==0 && (y%100!=0 || y%400==0)`). Callers guarantee `1 <= month <= 12`.
+fn days_in_month(year: i64, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        _ => {
+            if year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) {
+                29
+            } else {
+                28
+            }
+        }
+    }
+}
+
+/// Days from the civil date to the unix epoch (Howard Hinnant's
+/// `days_from_civil`; the same math as `shed-broker/src/status.rs:171-179`).
+fn days_from_civil(y: i64, m: u32, d: u32) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400; // [0, 399]
+    let mp = i64::from(if m > 2 { m - 3 } else { m + 9 }); // [0, 11]
+    let doy = (153 * mp + 2) / 5 + i64::from(d) - 1; // [0, 365]
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
+    era * 146_097 + doe - 719_468
+}
+
+/// Split an RFC3339 zone suffix (`Z` or `±HH:MM`) off the end, returning the
+/// remaining time text and the offset in seconds to SUBTRACT to reach UTC.
+fn split_zone(time_and_zone: &str) -> Result<(&str, i64), ()> {
+    if let Some(rest) = time_and_zone.strip_suffix('Z') {
+        return Ok((rest, 0));
+    }
+    // The last '+' or '-' after index 0 starts the offset.
+    let bytes = time_and_zone.as_bytes();
+    let mut idx = None;
+    for (i, &b) in bytes.iter().enumerate() {
+        if (b == b'+' || b == b'-') && i > 0 {
+            idx = Some(i);
+        }
+    }
+    let i = idx.ok_or(())?;
+    let (time_part, off) = time_and_zone.split_at(i);
+    // `+05:00` is 5h AHEAD of UTC → subtract 5h to reach UTC; `-05:00` adds.
+    let sign = if off.as_bytes()[0] == b'+' { 1 } else { -1 };
+    let off = &off[1..];
+    let (oh, om) = off.split_once(':').ok_or(())?;
+    let oh = i64::from(parse_fixed::<u32>(oh, 2)?);
+    let om = i64::from(parse_fixed::<u32>(om, 2)?);
+    if oh > 23 || om > 59 {
+        return Err(());
+    }
+    Ok((time_part, sign * (oh * 3_600 + om * 60)))
+}
+
+/// Parse an exactly-`width`-digit unsigned field (RFC3339 fields are
+/// fixed-width).
+fn parse_fixed<T: std::str::FromStr>(s: &str, width: usize) -> Result<T, ()> {
+    if s.len() != width || !s.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(());
+    }
+    s.parse().map_err(|_| ())
 }
 
 /// The provider's mutable state, all behind one lock so the mint stays
@@ -823,5 +1161,471 @@ mod tests {
         // Dart `maxMs < 1 ? 1 : maxMs`: max 0 → % 1 → always 0 (jitter off).
         assert_eq!(name_jitter("my-server", 0), 0);
         assert_eq!(name_jitter("", 300_000), 0); // h stays 0
+    }
+}
+
+#[cfg(test)]
+mod bundle_tests {
+    use super::*;
+    use serde_json::json;
+
+    // Port of mobile's `token_bundle_test.dart:29-152` (plan 001 §7 AC#5),
+    // plus the RFC3339 parser's own unit tests and the documented pre-epoch
+    // u64 divergence.
+
+    /// Dart's `bundle()` helper (`token_bundle_test.dart:17-27`).
+    fn bundle(scope: &str, token: &str, fp: Option<&str>, expires_at: Option<&str>) -> String {
+        let mut m = serde_json::Map::new();
+        m.insert("scope".into(), json!(scope));
+        m.insert("token".into(), json!(token));
+        if let Some(fp) = fp {
+            m.insert("tls_cert_fingerprint".into(), json!(fp));
+        }
+        if let Some(e) = expires_at {
+            m.insert("expires_at".into(), json!(e));
+        }
+        Value::Object(m).to_string()
+    }
+
+    fn default_bundle() -> String {
+        bundle(
+            "control",
+            "shed_control_abc",
+            None,
+            Some("2026-06-27T19:09:50.730171-05:00"),
+        )
+    }
+
+    /// Dart's `cbundle()` helper (`token_bundle_test.dart:98-111`): like its
+    /// `includeFp: true` default, the fingerprint is always present — `None`
+    /// means the default `sha256:aaa…` pin, not omission (the omission case
+    /// builds its map by hand).
+    fn cbundle(fp: Option<&str>, port: Value, exp: &str) -> String {
+        let mut m = serde_json::Map::new();
+        m.insert("scope".into(), json!("control"));
+        m.insert("token".into(), json!("tok"));
+        m.insert(
+            "tls_cert_fingerprint".into(),
+            json!(fp.map_or_else(|| pin('a'), str::to_string)),
+        );
+        m.insert("https_port".into(), port);
+        m.insert("expires_at".into(), json!(exp));
+        Value::Object(m).to_string()
+    }
+
+    fn pin(c: char) -> String {
+        format!("sha256:{}", c.to_string().repeat(64))
+    }
+
+    // ---- parseTokenBundle ports (`token_bundle_test.dart:30-95`) ----
+
+    // Dart `accepts a valid control bundle` (:31-35).
+    #[test]
+    fn token_accepts_a_valid_control_bundle() {
+        let t = parse_token_bundle(&default_bundle(), None).unwrap();
+        assert_eq!(t.token, "shed_control_abc");
+        assert!(t.expires_at_unix.is_some());
+    }
+
+    // Dart `accepts a matching minted fingerprint` (:37-41).
+    #[test]
+    fn token_accepts_a_matching_minted_fingerprint() {
+        let p = pin('a');
+        let src = bundle(
+            "control",
+            "shed_control_abc",
+            Some(&p),
+            Some("2026-06-27T19:09:50.730171-05:00"),
+        );
+        let t = parse_token_bundle(&src, Some(&p)).unwrap();
+        assert_eq!(t.token, "shed_control_abc");
+    }
+
+    // Dart `rejects a non-control scope` (:43-50).
+    #[test]
+    fn token_rejects_a_non_control_scope() {
+        let src = bundle(
+            "session",
+            "shed_control_abc",
+            None,
+            Some("2026-06-27T19:09:50.730171-05:00"),
+        );
+        assert_eq!(
+            parse_token_bundle(&src, None),
+            Err(TokenBundleError::AuthExpired)
+        );
+    }
+
+    // Dart `rejects a minted fingerprint that differs from the pin (no silent
+    // re-pin)` (:52-69).
+    #[test]
+    fn token_rejects_a_differing_minted_fingerprint() {
+        let src = bundle(
+            "control",
+            "shed_control_abc",
+            Some(&pin('b')),
+            Some("2026-06-27T19:09:50.730171-05:00"),
+        );
+        assert_eq!(
+            parse_token_bundle(&src, Some(&pin('a'))),
+            Err(TokenBundleError::PinMismatch)
+        );
+    }
+
+    // Dart `rejects unparseable JSON` (:71-76).
+    #[test]
+    fn token_rejects_unparseable_json() {
+        assert_eq!(
+            parse_token_bundle("not json", None),
+            Err(TokenBundleError::AuthExpired)
+        );
+        // A parseable non-object is equally rejected (`raw is! Map`, :36).
+        assert_eq!(
+            parse_token_bundle("\"a string\"", None),
+            Err(TokenBundleError::AuthExpired)
+        );
+    }
+
+    // Dart `rejects an empty or whitespace-only token` (:78-83).
+    #[test]
+    fn token_rejects_an_empty_or_whitespace_only_token() {
+        let src = bundle("control", "   ", None, Some("2026-06-27T19:09:50Z"));
+        assert_eq!(
+            parse_token_bundle(&src, None),
+            Err(TokenBundleError::AuthExpired)
+        );
+    }
+
+    // BOM parity (codex C7 review): Dart's `String.trim()` strips U+FEFF,
+    // Rust's `str::trim` does not — [`dart_trim`] closes the gap. A BOM-only
+    // token must fail closed in BOTH parsers, exactly as on mobile.
+    #[test]
+    fn bom_only_token_is_auth_expired_in_both_parsers() {
+        let t = bundle("control", "\u{FEFF}", None, Some("2026-06-27T19:09:50Z"));
+        assert_eq!(
+            parse_token_bundle(&t, None),
+            Err(TokenBundleError::AuthExpired)
+        );
+        let mut m = serde_json::Map::new();
+        m.insert("scope".into(), json!("control"));
+        m.insert("token".into(), json!("\u{FEFF}"));
+        m.insert("tls_cert_fingerprint".into(), json!(pin('a')));
+        m.insert("https_port".into(), json!(8443));
+        m.insert("expires_at".into(), json!("2026-06-27T19:09:50Z"));
+        assert_eq!(
+            parse_control_bundle(&Value::Object(m).to_string(), None),
+            Err(TokenBundleError::AuthExpired)
+        );
+    }
+
+    // The BOM half of the fingerprint normalization: a BOM-wrapped but
+    // otherwise valid fingerprint matches after [`dart_trim`] in both parsers.
+    #[test]
+    fn bom_wrapped_fingerprint_matches_after_dart_trim() {
+        let wrapped = format!("\u{FEFF}{}\u{FEFF}", pin('a'));
+        let t = bundle(
+            "control",
+            "shed_control_abc",
+            Some(&wrapped),
+            Some("2026-06-27T19:09:50Z"),
+        );
+        let minted = parse_token_bundle(&t, Some(&pin('a'))).unwrap();
+        assert_eq!(minted.token, "shed_control_abc");
+
+        let c = cbundle(Some(&wrapped), json!(8443), "2026-06-27T19:09:50Z");
+        let b = parse_control_bundle(&c, Some(&pin('a'))).unwrap();
+        assert_eq!(b.tls_cert_fingerprint, pin('a'));
+    }
+
+    // Strict calendar validation surfaces as AuthExpired at the bundle level:
+    // an impossible expiry date is a failed parse, never a usable token.
+    #[test]
+    fn impossible_expiry_date_is_auth_expired() {
+        let t = bundle(
+            "control",
+            "shed_control_abc",
+            None,
+            Some("2023-02-29T00:00:00Z"),
+        );
+        assert_eq!(
+            parse_token_bundle(&t, None),
+            Err(TokenBundleError::AuthExpired)
+        );
+        let c = cbundle(None, json!(8443), "2023-02-29T00:00:00Z");
+        assert_eq!(
+            parse_control_bundle(&c, None),
+            Err(TokenBundleError::AuthExpired)
+        );
+    }
+
+    // Dart `rejects a missing or unparseable expiry (never non-expiring)`
+    // (:85-94).
+    #[test]
+    fn token_rejects_a_missing_or_unparseable_expiry() {
+        let missing = bundle("control", "shed_control_abc", None, None);
+        assert_eq!(
+            parse_token_bundle(&missing, None),
+            Err(TokenBundleError::AuthExpired)
+        );
+        let junk = bundle("control", "shed_control_abc", None, Some("soon"));
+        assert_eq!(
+            parse_token_bundle(&junk, None),
+            Err(TokenBundleError::AuthExpired)
+        );
+    }
+
+    // Load-bearing tolerance (`token_bundle.dart:25-28,45-52`, not a Dart test
+    // case): a configured pin with an ABSENT bundle fingerprint is accepted —
+    // the bundle arrived over a host-key-pinned SSH channel.
+    #[test]
+    fn token_tolerates_an_absent_fingerprint_when_a_pin_is_configured() {
+        let t = parse_token_bundle(&default_bundle(), Some(&pin('a'))).unwrap();
+        assert_eq!(t.token, "shed_control_abc");
+    }
+
+    // The regex half of the pin gate (`token_bundle.dart:49`): a present but
+    // MALFORMED fingerprint under a configured pin is PinMismatch.
+    #[test]
+    fn token_rejects_a_malformed_fingerprint_when_a_pin_is_configured() {
+        let src = bundle(
+            "control",
+            "shed_control_abc",
+            Some("sha256:nothex"),
+            Some("2026-06-27T19:09:50Z"),
+        );
+        assert_eq!(
+            parse_token_bundle(&src, Some(&pin('a'))),
+            Err(TokenBundleError::PinMismatch)
+        );
+    }
+
+    // Exact expiry pin: trimmed token + a known epoch instant.
+    #[test]
+    fn token_yields_exact_unix_expiry() {
+        let src = bundle(
+            "control",
+            "  shed_control_abc  ",
+            None,
+            Some("2001-09-09T01:46:40Z"),
+        );
+        let t = parse_token_bundle(&src, None).unwrap();
+        assert_eq!(t.token, "shed_control_abc"); // trimmed (:42)
+        assert_eq!(t.expires_at_unix, Some(1_000_000_000));
+    }
+
+    // ---- parseControlBundle ports (`token_bundle_test.dart:97-152`) ----
+
+    // Dart `accepts a valid bundle` (:113-118).
+    #[test]
+    fn control_accepts_a_valid_bundle() {
+        let b = parse_control_bundle(&cbundle(None, json!(8443), "2026-06-27T19:09:50Z"), None)
+            .unwrap();
+        assert_eq!(b.https_port, 8443);
+        assert_eq!(b.tls_cert_fingerprint, pin('a'));
+        assert_eq!(b.token, "tok");
+    }
+
+    // Dart `requires the TLS fingerprint` (:120-127). `cbundle(None, ...)`
+    // defaults the fingerprint like Dart's `includeFp: true`; build without it
+    // here.
+    #[test]
+    fn control_requires_the_tls_fingerprint() {
+        let mut m = serde_json::Map::new();
+        m.insert("scope".into(), json!("control"));
+        m.insert("token".into(), json!("tok"));
+        m.insert("https_port".into(), json!(8443));
+        m.insert("expires_at".into(), json!("2026-06-27T19:09:50Z"));
+        let src = Value::Object(m).to_string();
+        assert_eq!(
+            parse_control_bundle(&src, None),
+            Err(TokenBundleError::PinMissing)
+        );
+    }
+
+    // A malformed fingerprint is PinMissing in the control variant
+    // (`token_bundle.dart:98`), unlike the token variant's PinMismatch.
+    #[test]
+    fn control_rejects_a_malformed_fingerprint_as_pin_missing() {
+        let src = cbundle(Some("sha256:nothex"), json!(8443), "2026-06-27T19:09:50Z");
+        assert_eq!(
+            parse_control_bundle(&src, None),
+            Err(TokenBundleError::PinMissing)
+        );
+    }
+
+    // Dart `rejects an out-of-range https_port` (:129-138).
+    #[test]
+    fn control_rejects_an_out_of_range_https_port() {
+        for port in [json!(70_000), json!(0)] {
+            let src = cbundle(None, port, "2026-06-27T19:09:50Z");
+            assert_eq!(
+                parse_control_bundle(&src, None),
+                Err(TokenBundleError::AuthExpired)
+            );
+        }
+        // Dart `portRaw is! int`: a JSON float / string port is equally out.
+        for port in [json!(8443.5), json!("8443")] {
+            let src = cbundle(None, port, "2026-06-27T19:09:50Z");
+            assert_eq!(
+                parse_control_bundle(&src, None),
+                Err(TokenBundleError::AuthExpired)
+            );
+        }
+    }
+
+    // Dart `enforces an expected pin` (:140-151).
+    #[test]
+    fn control_enforces_an_expected_pin() {
+        let src = cbundle(None, json!(8443), "2026-06-27T19:09:50Z");
+        assert_eq!(
+            parse_control_bundle(&src, Some(&pin('b'))),
+            Err(TokenBundleError::PinMismatch)
+        );
+    }
+
+    // Fingerprint normalization (`token_bundle.dart:97,113-115`): uppercase
+    // hex is lowercased before the match, and the RESULT carries the
+    // normalized form.
+    #[test]
+    fn control_normalizes_the_fingerprint_to_lowercase() {
+        let upper = format!("sha256:{}", "A".repeat(64));
+        let src = cbundle(Some(&upper), json!(8443), "2026-06-27T19:09:50Z");
+        let b = parse_control_bundle(&src, Some(&pin('a'))).unwrap();
+        assert_eq!(b.tls_cert_fingerprint, pin('a'));
+    }
+
+    // ---- the documented pre-epoch u64 divergence (plan 001 §3.5) ----
+
+    // Dart's `DateTime.tryParse` parses a pre-epoch expiry (incl. the Go zero
+    // time) into a negative instant; `MintedToken.expires_at_unix` is u64, so
+    // both parses map it to AuthExpired — a control token that expired before
+    // 1970 is already expired.
+    #[test]
+    fn pre_epoch_expiry_is_auth_expired() {
+        for exp in ["0001-01-01T00:00:00Z", "1969-12-31T23:59:59Z"] {
+            let t = bundle("control", "shed_control_abc", None, Some(exp));
+            assert_eq!(
+                parse_token_bundle(&t, None),
+                Err(TokenBundleError::AuthExpired),
+                "token bundle, expiry {exp}"
+            );
+            let c = cbundle(None, json!(8443), exp);
+            assert_eq!(
+                parse_control_bundle(&c, None),
+                Err(TokenBundleError::AuthExpired),
+                "control bundle, expiry {exp}"
+            );
+        }
+        // The epoch itself is representable and accepted.
+        let ok = bundle("control", "t", None, Some("1970-01-01T00:00:00Z"));
+        assert_eq!(
+            parse_token_bundle(&ok, None).unwrap().expires_at_unix,
+            Some(0)
+        );
+    }
+
+    // ---- the std-only RFC3339 parser ----
+
+    #[test]
+    fn rfc3339_known_epochs() {
+        assert_eq!(parse_rfc3339_to_unix("1970-01-01T00:00:00Z"), Ok(0));
+        // The Unix "billennium": 2001-09-09 01:46:40 UTC.
+        assert_eq!(
+            parse_rfc3339_to_unix("2001-09-09T01:46:40Z"),
+            Ok(1_000_000_000)
+        );
+        assert_eq!(
+            parse_rfc3339_to_unix("2023-11-14T22:13:20Z"),
+            Ok(1_700_000_000)
+        );
+    }
+
+    #[test]
+    fn rfc3339_leap_year() {
+        // 2024-02-29 exists (leap year) and lands on the known instant.
+        assert_eq!(
+            parse_rfc3339_to_unix("2024-02-29T00:00:00Z"),
+            Ok(1_709_164_800)
+        );
+        // 2000 is a leap year (divisible by 400); 1900 and 2023 are not —
+        // strict calendar validation rejects their Feb 29 (fail-closed;
+        // stricter than Dart's normalizing `DateTime.tryParse`).
+        assert!(parse_rfc3339_to_unix("2000-02-29T00:00:00Z").is_ok());
+        assert_eq!(parse_rfc3339_to_unix("1900-02-29T00:00:00Z"), Err(()));
+        assert_eq!(parse_rfc3339_to_unix("2023-02-29T00:00:00Z"), Err(()));
+        // 30-day months cap at 30.
+        assert_eq!(parse_rfc3339_to_unix("2023-04-31T00:00:00Z"), Err(()));
+        assert!(parse_rfc3339_to_unix("2023-04-30T00:00:00Z").is_ok());
+    }
+
+    #[test]
+    fn rfc3339_timezone_offsets() {
+        // +05:00 is 5h ahead of UTC → same instant as midnight UTC.
+        assert_eq!(
+            parse_rfc3339_to_unix("2030-01-01T05:00:00+05:00"),
+            Ok(1_893_456_000)
+        );
+        // -05:00 is behind → 5h AFTER the epoch.
+        assert_eq!(
+            parse_rfc3339_to_unix("1970-01-01T00:00:00-05:00"),
+            Ok(18_000)
+        );
+    }
+
+    #[test]
+    fn rfc3339_fractional_seconds_truncate() {
+        assert_eq!(
+            parse_rfc3339_to_unix("2030-01-01T00:00:00.500Z"),
+            Ok(1_893_456_000)
+        );
+        // The mobile fixture shape: fraction + offset together.
+        assert_eq!(
+            parse_rfc3339_to_unix("2026-06-27T19:09:50.730171-05:00"),
+            Ok(1_782_605_390)
+        );
+    }
+
+    #[test]
+    fn rfc3339_go_zero_time_parses_pre_epoch() {
+        // No zero-time→None collapse here (unlike the broker's parser): the
+        // Go zero value parses to its plain pre-epoch instant, Dart
+        // `DateTime.tryParse` parity.
+        assert_eq!(
+            parse_rfc3339_to_unix("0001-01-01T00:00:00Z"),
+            Ok(-62_135_596_800)
+        );
+    }
+
+    #[test]
+    fn rfc3339_rejects_malformed_input() {
+        for s in [
+            "",
+            "soon",
+            "garbage",
+            "2030-01-01",                // date only, no 'T'
+            "2030-01-01T00:00:00",       // missing zone
+            "2030-13-01T00:00:00Z",      // bad month
+            "2023-13-01T00:00:00Z",      // bad month
+            "2030-00-01T00:00:00Z",      // month 0
+            "2030-01-32T00:00:00Z",      // day 32
+            "2023-01-32T00:00:00Z",      // day 32
+            "2023-02-29T00:00:00Z",      // impossible date (non-leap Feb 29)
+            "2030-01-00T00:00:00Z",      // day 0
+            "2030-01-01T24:00:00Z",      // hour 24
+            "2030-01-01T25:00:00Z",      // hour 25
+            "2030-01-01T00:60:00Z",      // minute 60
+            "2030-01-01T00:61:00Z",      // minute 61
+            "2030-01-01T00:00:61Z",      // second 61 (60 = leap second is OK)
+            "2030-01-01T00:00:00.Z",     // empty fraction
+            "2030-01-01T00:00:00.5xZ",   // non-digit fraction
+            "2030-1-01T00:00:00Z",       // non-fixed-width month
+            "30-01-01T00:00:00Z",        // non-fixed-width year
+            "2030-01-01T00:00:00+5:00",  // non-fixed-width offset hour
+            "2030-01-01T00:00:00+25:00", // offset hour out of range
+        ] {
+            assert_eq!(parse_rfc3339_to_unix(s), Err(()), "should reject {s:?}");
+        }
+        // The leap second itself is admitted (broker-parser parity).
+        assert!(parse_rfc3339_to_unix("2030-01-01T00:00:60Z").is_ok());
     }
 }

--- a/crates/shed-core/src/token.rs
+++ b/crates/shed-core/src/token.rs
@@ -599,13 +599,25 @@ impl ControlTokenProvider {
         if let Some(current) = st.cached.clone() {
             if !expired(&current, now) {
                 if self.needs_refresh(&current, now) {
-                    if let Ok(minted) = self.mint_locked(&mut st, now).await {
-                        return Ok(minted.token);
+                    match self.mint_locked(&mut st, now).await {
+                        Ok(minted) => return Ok(minted.token),
+                        Err(e) => {
+                            // Keep-valid-on-proactive-failure (strict
+                            // improvement #1, `control_token_provider.dart:82-92`):
+                            // the refresh mint failed — normally fall through and
+                            // return the cached token rather than erroring. BUT
+                            // `now` was read before awaiting the minter: a slow
+                            // mint can finish AFTER the cached token expired, and
+                            // returning it then would hand back a dead credential.
+                            // Re-read the clock and only keep the token if it is
+                            // STILL valid against the fresh now; otherwise fail
+                            // closed with the real mint error.
+                            let fresh_now = (self.now_unix)();
+                            if expired(&current, fresh_now) {
+                                return Err(e);
+                            }
+                        }
                     }
-                    // Keep-valid-on-proactive-failure (strict improvement #1,
-                    // `control_token_provider.dart:82-92`): the refresh mint
-                    // failed but the cached token is not yet expired — fall
-                    // through and return it rather than erroring.
                 }
                 return Ok(current.token);
             }
@@ -916,6 +928,70 @@ mod tests {
             .with_seed(seed(10_000));
         assert_eq!(p.token().await.unwrap(), "seed"); // kept, not an error
         assert_eq!(minter.count(), 1); // the refresh mint WAS attempted
+    }
+
+    // Finding 4 (fail-closed correctness): `now` is captured BEFORE awaiting the
+    // minter, so a SLOW proactive mint can finish after the cached token has
+    // expired. Keep-valid must re-check the clock and NOT serve a now-expired
+    // token. A minter that advances the shared clock while it runs models the
+    // slow mint; the two sub-cases are (a) clock crosses expiry → Err, and (b)
+    // clock stays before expiry → the still-valid cached token.
+    #[tokio::test]
+    async fn proactive_mint_failure_fails_closed_when_the_clock_crossed_expiry() {
+        // A failing minter that, mid-mint, advances the shared clock to a target
+        // (simulating wall-clock elapsing during a slow doomed mint).
+        struct SlowFailMinter {
+            clock: Arc<AtomicU64>,
+            advance_to: u64,
+        }
+        #[async_trait::async_trait]
+        impl TokenMinter for SlowFailMinter {
+            async fn mint(&self, _server: &str) -> Result<MintedToken, ShedError> {
+                self.clock.store(self.advance_to, Ordering::SeqCst);
+                Err(ShedError::Transport("mint failed".into()))
+            }
+        }
+
+        // (a) clock advances 900 -> 1500, past the 1000 expiry → fail closed.
+        let clock = Arc::new(AtomicU64::new(900));
+        let p = ControlTokenProvider::new(
+            "mini3".into(),
+            Arc::new(SlowFailMinter {
+                clock: clock.clone(),
+                advance_to: 1500,
+            }),
+        )
+        .with_now({
+            let clock = clock.clone();
+            move || clock.load(Ordering::SeqCst)
+        })
+        .with_refresh_window(Duration::from_secs(5000)) // 900 >= 1000-5000 → in window
+        .with_seed(seed(1000));
+        // In the refresh window, mint attempted, fails, and by the time it
+        // returns the clock reads 1500 >= 1000 → the cached token is now expired.
+        assert!(
+            p.token().await.is_err(),
+            "must not return the now-expired cached token"
+        );
+        assert_eq!(clock.load(Ordering::SeqCst), 1500);
+
+        // (b) clock stays at 900 (mint fails without wall-clock crossing expiry)
+        // → the still-valid cached token is kept.
+        let clock = Arc::new(AtomicU64::new(900));
+        let p = ControlTokenProvider::new(
+            "mini3".into(),
+            Arc::new(SlowFailMinter {
+                clock: clock.clone(),
+                advance_to: 900, // no advance past expiry
+            }),
+        )
+        .with_now({
+            let clock = clock.clone();
+            move || clock.load(Ordering::SeqCst)
+        })
+        .with_refresh_window(Duration::from_secs(5000))
+        .with_seed(seed(1000));
+        assert_eq!(p.token().await.unwrap(), "seed"); // still valid → kept
     }
 
     // Dart `mints when the seed is expired, throwing if that mint fails`

--- a/crates/shed-core/src/token.rs
+++ b/crates/shed-core/src/token.rs
@@ -1,13 +1,34 @@
-//! Control-token FSM — ported from Swift's `ControlTokenProvider` actor.
+//! Control-token FSM — ported from Swift's `ControlTokenProvider` actor, with
+//! the mobile client's FSM extensions ported from
+//! `shed-mobile/lib/control/control_token_provider.dart` (itself a faithful
+//! port of the orchestrator's controlToken.ts).
 //!
 //! Caches a shed-server CONTROL token, refreshing it near expiry or on demand
-//! (`invalidate()`, called on a 401). The mint primitive is a foreign
+//! (`invalidate*`, called on a 401). The mint primitive is a foreign
 //! `TokenMinter` (the host agent, in Swift; a mock in tests) — this crate owns
 //! only the cache/refresh/single-flight logic, so it stays pure.
 //!
+//! FSM extensions (all builder-opted, defaults preserve the pre-existing
+//! desktop behavior — plan 001 §3.4):
+//!   * a tunable refresh window ([`ControlTokenProvider::with_refresh_window`])
+//!   * deterministic per-name refresh jitter ([`name_jitter`],
+//!     [`ControlTokenProvider::with_name_jitter`])
+//!   * a mint-failure cooldown ([`ControlTokenProvider::with_mint_cooldown`])
+//!   * a persisted seed token ([`ControlTokenProvider::with_seed`])
+//!   * an injectable clock ([`ControlTokenProvider::with_now`])
+//!
+//! Two unconditional semantics ported as strict improvements (§3.4):
+//!   * keep-valid-on-proactive-failure — a failed refresh mint inside the
+//!     refresh window returns the still-valid cached token instead of erroring
+//!     (`control_token_provider.dart:82-92`)
+//!   * the stale-401 guard — [`ControlTokenProvider::invalidate_if_current`]
+//!     ignores a 401 for a token already rotated past
+//!     (`control_token_provider.dart:99-105`)
+//!
 //! Fail-closed contract (mirrors the SDK/CLI, guarded by the tests here since
-//! test mode drops the token path so e2e can't reach it): a mint failure yields
-//! an error and the client then sends NO token — never a static downgrade.
+//! test mode drops the token path so e2e can't reach it): a mint failure with
+//! no still-valid cached token yields an error and the client then sends NO
+//! token — never a static downgrade.
 
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -17,7 +38,7 @@ use tokio::sync::Mutex;
 use crate::http::ShedError;
 
 /// A minted control token plus its optional expiry (unix seconds). `None` expiry
-/// → only an explicit `invalidate()` forces a refresh (mirrors `MintedToken`).
+/// → only an explicit `invalidate*()` forces a refresh (mirrors `MintedToken`).
 /// Swift parses the host agent's ISO-8601 expiry to epoch before handing it over,
 /// keeping timestamp parsing off this crate.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -34,19 +55,114 @@ pub trait TokenMinter: Send + Sync {
     async fn mint(&self, server: &str) -> Result<MintedToken, ShedError>;
 }
 
-/// The 2h refresh window mirrors the SDK/CLI: refresh this long before expiry so
-/// routine requests rarely race a 401.
+/// The default 2h refresh window mirrors the SDK/CLI: refresh this long before
+/// expiry so routine requests rarely race a 401. (Mobile passes its own 2h5m
+/// via [`ControlTokenProvider::with_refresh_window`] — per-client parity, not
+/// forced convergence.)
 const REFRESH_WINDOW: Duration = Duration::from_secs(2 * 60 * 60);
+
+/// The PERSISTED mint-failure message, served on later cooldown-blocked
+/// calls. Deliberately FIXED/redacted: a [`TokenMinter`] error's Display text
+/// can embed transport detail or even token material, which must never be
+/// stored and replayed to later callers. The immediate caller of the failing
+/// mint still receives the minter's real error (matching the pre-existing
+/// propagation and Dart's rethrow, `control_token_provider.dart:149`).
+const MINT_FAILED_REDACTED: &str = "control token mint failed";
+
+/// Deterministic per-name jitter in `[0, max_ms)` — stable across restarts, no
+/// RNG. Ported exactly from mobile's `nameJitter`
+/// (`control_token_provider.dart:175-181`), which mirrors controlToken.ts (a
+/// 32-bit signed hash like JS `|0`): iterate the name's UTF-16 CODE UNITS
+/// (Dart `codeUnitAt` parity — a non-BMP char such as an emoji contributes its
+/// surrogate PAIR, two units), fold `h = h*31 + cu` wrapped to 32-bit signed
+/// at every step, then take `unsigned_abs()` (`i32::MIN`-safe where Dart's
+/// 64-bit `abs()` is trivially safe and a Rust `abs()` would overflow) modulo
+/// `max(max_ms, 1)`. `max_ms == 0` therefore always yields 0 (jitter off).
+pub fn name_jitter(name: &str, max_ms: u64) -> u64 {
+    let mut h: i32 = 0;
+    for cu in name.encode_utf16() {
+        // Dart computes `h * 31 + cu` in 64-bit then `.toSigned(32)`; a
+        // stepwise 32-bit wrapping mul+add is identical (truncation mod 2^32
+        // distributes over * and +).
+        h = h.wrapping_mul(31).wrapping_add(i32::from(cu));
+    }
+    u64::from(h.unsigned_abs()) % max_ms.max(1)
+}
+
+/// The provider's mutable state, all behind one lock so the mint stays
+/// single-flight (mirrors the Dart fields, `control_token_provider.dart:48-54`;
+/// the Dart `_inflight` future dance is subsumed by holding the lock across
+/// the mint).
+#[derive(Default)]
+struct State {
+    cached: Option<MintedToken>,
+    /// A 401 was observed for the cached token (`invalidate*`) — the next
+    /// `token()` must mint and may never return the rejected token
+    /// (`control_token_provider.dart:72-79`).
+    must_mint: bool,
+    /// Unix second before which no mint attempt is made (set by a mint
+    /// failure; `control_token_provider.dart:52,147`).
+    cooldown_until: u64,
+    /// Presence of a recorded mint failure (`_lastError`,
+    /// `control_token_provider.dart:53,148`), surfaced when a later call must
+    /// error without attempting a mint (cooldown). Always the fixed
+    /// [`MINT_FAILED_REDACTED`] text, never the minter's Display output — see
+    /// that const's doc.
+    last_error: Option<String>,
+}
+
+impl State {
+    /// The cached token was rejected by a 401: drop it and force the next
+    /// `token()` to mint — it may never return the rejected token
+    /// (`control_token_provider.dart:72-79`). The shared tail of both
+    /// `invalidate*` variants.
+    fn reject_cached(&mut self) {
+        self.cached = None;
+        self.must_mint = true;
+    }
+}
 
 /// Caches a control token, refreshing when missing or within the refresh window
 /// of expiry. Concurrent `token()` callers serialize on the mint (single-flight:
 /// a late caller re-checks the cache under the lock and returns the fresh token
 /// rather than minting again).
+///
+/// Transport-identity binding is deliberately NOT ported from the Dart
+/// provider (plan 001 §3.4): a shed-core `Client` + provider pair is immutable
+/// per transport identity — the app layer constructs a NEW `Client` when the
+/// host/port/pin changes, which deletes the identity-race class instead of
+/// managing it. Recorded as a Phase B invariant.
+///
+/// Cancellation caveat (accepted limitation — C6 adversarial review #3, plan
+/// §9): because the lock is held ACROSS the mint, cancelling a `token()`
+/// future from outside (e.g. `Client::rc_events` bounds bearer resolution
+/// with its connect timeout) can drop the very future that holds the lock
+/// mid-mint. The lock frees on drop, but a remote mint side effect (host
+/// agent request, SSH mint) may still complete out-of-band, so the caller's
+/// immediate retry can start a SECOND concurrent mint. For this crate's
+/// minters a rare double-mint costs one extra round trip plus one abandoned
+/// short-TTL token — never a lockout (cooldown state mutates only when a mint
+/// COMPLETES as a failure) and never a wrong cached token (the cancelled
+/// mint's result is dropped, not cached). The upgrade, if it ever matters, is
+/// provider-owned in-flight mint state joined by waiters off the lock —
+/// shed-broker's watch-based single-flight (`shed-broker/src/minter.rs`,
+/// module docs) is the in-repo pattern.
 pub struct ControlTokenProvider {
     server: String,
     minter: Arc<dyn TokenMinter>,
-    now_unix: fn() -> u64,
-    cached: Mutex<Option<MintedToken>>,
+    /// The clock, unix SECONDS (an `Arc<dyn Fn>` so tests can drive advancing
+    /// time — a bare `fn` pointer can't capture per-test mutable state).
+    now_unix: Arc<dyn Fn() -> u64 + Send + Sync>,
+    refresh_window: Duration,
+    /// Deterministic per-name refresh jitter, derived ONCE from the server
+    /// name by [`Self::with_name_jitter`]. Subtracted from the refresh
+    /// threshold, so refresh happens EARLIER — a fleet of providers with the
+    /// same expiry de-synchronizes instead of thundering the minter together.
+    jitter: Duration,
+    /// Cooldown started by a mint failure; while it runs, `token()` makes no
+    /// mint attempt (returns the cached still-valid token, or the last error).
+    mint_cooldown: Duration,
+    state: Mutex<State>,
 }
 
 impl ControlTokenProvider {
@@ -54,46 +170,203 @@ impl ControlTokenProvider {
         Self {
             server,
             minter,
-            now_unix: default_now_unix,
-            cached: Mutex::new(None),
+            now_unix: Arc::new(default_now_unix),
+            refresh_window: REFRESH_WINDOW,
+            jitter: Duration::ZERO,
+            mint_cooldown: Duration::ZERO,
+            state: Mutex::new(State::default()),
         }
+    }
+
+    /// Replace the clock (unix seconds). Public, not `#[cfg(test)]`: the seam
+    /// must be reachable from shed-app tests and the Phase B bridge (the same
+    /// public-builder convention as `SseParser::with_max_event_bytes`).
+    pub fn with_now(mut self, now: impl Fn() -> u64 + Send + Sync + 'static) -> Self {
+        self.now_unix = Arc::new(now);
+        self
+    }
+
+    /// Refresh this long before expiry (default [`REFRESH_WINDOW`], 2h —
+    /// unchanged desktop behavior; mobile passes 2h5m).
+    pub fn with_refresh_window(mut self, window: Duration) -> Self {
+        self.refresh_window = window;
+        self
+    }
+
+    /// Enable deterministic refresh jitter in `[0, max)`: the value is derived
+    /// ONCE from the server name via [`name_jitter`] (Dart parity —
+    /// `control_token_provider.dart:39`, `nameJitter(name, jitterMs)`) and
+    /// SUBTRACTED from the refresh threshold, so this provider refreshes up to
+    /// `max` earlier than an un-jittered one. Default off (zero jitter).
+    ///
+    /// [`name_jitter`] works in the Dart algorithm's millisecond domain for
+    /// cross-language stability; the provider's clock is unix seconds, so the
+    /// derived jitter truncates to whole seconds here (sub-second precision is
+    /// noise against mobile's 5-minute max).
+    pub fn with_name_jitter(mut self, max: Duration) -> Self {
+        self.jitter = Duration::from_millis(name_jitter(&self.server, max.as_millis() as u64));
+        self
+    }
+
+    /// After a mint failure, make no further mint attempt until `cooldown` has
+    /// elapsed — a polling caller can't storm a host with doomed mints
+    /// (`control_token_provider.dart:107-123`). During the cooldown `token()`
+    /// returns the cached still-valid token if one exists, else the recorded
+    /// last error. Default `0` = off (every call may attempt a mint).
+    pub fn with_mint_cooldown(mut self, cooldown: Duration) -> Self {
+        self.mint_cooldown = cooldown;
+        self
+    }
+
+    /// Pre-populate the cache with a persisted token (mobile's config seed,
+    /// `control_token_provider.dart:153-157`) so the first `token()` can skip
+    /// the mint. An empty/whitespace token is IGNORED — an unusable credential
+    /// is never cached (plan 001 §3.4).
+    pub fn with_seed(mut self, seed: MintedToken) -> Self {
+        if !seed.token.trim().is_empty() {
+            self.state.get_mut().cached = Some(seed);
+        }
+        self
     }
 
     /// The current token, minting/refreshing when it is missing or near expiry.
-    /// Propagates a mint failure (the caller then sends no token — fail-closed).
+    /// FSM ported from Dart's `get()` (`control_token_provider.dart:57-97`),
+    /// minus the identity-binding and legacy-host branches (see the type-level
+    /// docs / the test-module note):
+    ///   * after an `invalidate*` the mint is FORCED — on failure this errors,
+    ///     never returning the rejected token (`:72-79`)
+    ///   * a still-valid cached token inside the refresh window mints
+    ///     proactively but KEEPS the cached token when that mint fails
+    ///     (`:81-92`)
+    ///   * missing/expired → mint; a failure here is fail-closed (the caller
+    ///     then sends no token) (`:94-96`)
     pub async fn token(&self) -> Result<String, ShedError> {
         // Hold the lock across the mint so concurrent callers serialize: the
         // first mints, the rest re-check here and return its result.
-        let mut cached = self.cached.lock().await;
-        if let Some(t) = cached.as_ref() {
-            if !self.needs_refresh(t) {
-                return Ok(t.token.clone());
+        let mut st = self.state.lock().await;
+        let now = (self.now_unix)();
+
+        // Reactive: a prior 401 means the current token is rejected — mint,
+        // and do not fall back to it.
+        if st.must_mint {
+            return match self.mint_locked(&mut st, now).await {
+                Ok(minted) => {
+                    st.must_mint = false;
+                    Ok(minted.token)
+                }
+                Err(e) => Err(e),
+            };
+        }
+
+        if let Some(current) = st.cached.clone() {
+            if !expired(&current, now) {
+                if self.needs_refresh(&current, now) {
+                    if let Ok(minted) = self.mint_locked(&mut st, now).await {
+                        return Ok(minted.token);
+                    }
+                    // Keep-valid-on-proactive-failure (strict improvement #1,
+                    // `control_token_provider.dart:82-92`): the refresh mint
+                    // failed but the cached token is not yet expired — fall
+                    // through and return it rather than erroring.
+                }
+                return Ok(current.token);
             }
         }
-        let minted = self.minter.mint(&self.server).await?;
-        if minted.token.is_empty() {
-            // An empty token is a mint failure, not a usable credential — don't
-            // cache it (fail-closed), even if the minter reported success.
-            return Err(ShedError::Transport(
-                "control-token mint returned an empty token".into(),
-            ));
-        }
-        let token = minted.token.clone();
-        *cached = Some(minted);
-        Ok(token)
+
+        self.mint_locked(&mut st, now).await.map(|m| m.token)
     }
 
-    /// Drop the cached token so the next `token()` re-mints. Called on a 401.
+    /// Drop the cached token UNCONDITIONALLY so the next `token()` force-mints.
+    /// Kept for back-compat; prefer [`Self::invalidate_if_current`] when the
+    /// rejected token is known — this variant can erase a NEWER token when a
+    /// stale 401 races a rotation.
     pub async fn invalidate(&self) {
-        *self.cached.lock().await = None;
+        self.state.lock().await.reject_cached();
     }
 
-    fn needs_refresh(&self, t: &MintedToken) -> bool {
-        match t.expires_at_unix {
-            None => false, // no expiry → only invalidate() refreshes
-            Some(exp) => (self.now_unix)() + REFRESH_WINDOW.as_secs() >= exp,
+    /// Stale-401 guard (strict improvement #2,
+    /// `control_token_provider.dart:99-105`): drop the cache ONLY if the
+    /// cached token is `observed` (the one the 401 rejected) — a 401 for a
+    /// token already rotated past is ignored. Sets the must-mint flag so the
+    /// next `token()` force-mints and never returns the rejected token.
+    pub async fn invalidate_if_current(&self, observed: &str) {
+        let mut st = self.state.lock().await;
+        if let Some(c) = &st.cached {
+            if c.token != observed {
+                return; // stale 401 — the rejected token is already gone
+            }
+        }
+        st.reject_cached();
+    }
+
+    /// One mint attempt under the held state lock (the single-flight point),
+    /// with the failure cooldown — Dart's `_mint` + `_doMint`
+    /// (`control_token_provider.dart:107-151`): inside the cooldown no attempt
+    /// is made (the recorded redacted error is returned, state untouched); a
+    /// success replaces the cache and clears the last error; a failure starts
+    /// the cooldown, records the fixed [`MINT_FAILED_REDACTED`] marker (never
+    /// the minter's Display text — it can embed secrets), returns the REAL
+    /// error to this immediate caller, and leaves the cache alone (an
+    /// expired-but-cached token stays for a later retry; a still-valid one
+    /// backs keep-valid). An empty minted token is a failure, not a usable
+    /// credential (fail-closed), even if the minter reported success.
+    async fn mint_locked(&self, st: &mut State, now: u64) -> Result<MintedToken, ShedError> {
+        if now < st.cooldown_until {
+            return Err(last_error(st));
+        }
+        let outcome = match self.minter.mint(&self.server).await {
+            Ok(minted) if minted.token.is_empty() => Err(ShedError::Transport(
+                "control-token mint returned an empty token".into(),
+            )),
+            other => other,
+        };
+        match outcome {
+            Ok(minted) => {
+                st.cached = Some(minted.clone());
+                st.last_error = None;
+                Ok(minted)
+            }
+            Err(e) => {
+                // Fresh clock read for the cooldown start (Dart `_doMint`
+                // re-reads `_now()`, `:147` — the mint itself took time).
+                st.cooldown_until = (self.now_unix)() + self.mint_cooldown.as_secs();
+                st.last_error = Some(MINT_FAILED_REDACTED.into());
+                Err(e)
+            }
         }
     }
+
+    /// Within the refresh window of expiry: `now >= exp - window - jitter`
+    /// (`control_token_provider.dart:162-166`; the jitter subtraction makes
+    /// refresh earlier). No expiry → never (only `invalidate*` refreshes).
+    /// `saturating_sub` matches Dart's signed math: a threshold below zero
+    /// means "always refresh".
+    fn needs_refresh(&self, t: &MintedToken, now: u64) -> bool {
+        match t.expires_at_unix {
+            None => false,
+            Some(exp) => {
+                now >= exp.saturating_sub(self.refresh_window.as_secs() + self.jitter.as_secs())
+            }
+        }
+    }
+}
+
+/// Past expiry (`control_token_provider.dart:159-160`). No expiry → never.
+fn expired(t: &MintedToken, now: u64) -> bool {
+    matches!(t.expires_at_unix, Some(exp) if now >= exp)
+}
+
+/// The error for a `token()` call blocked from minting (cooldown): the
+/// recorded redacted marker, or a generic fail-closed message (Dart's
+/// `_lastError ?? AppError.authExpired()`, `control_token_provider.dart:78,96`
+/// — except the persisted text is [`MINT_FAILED_REDACTED`], never the original
+/// minter error).
+fn last_error(st: &State) -> ShedError {
+    ShedError::Transport(
+        st.last_error
+            .clone()
+            .unwrap_or_else(|| "control token expired and mint unavailable".into()),
+    )
 }
 
 fn default_now_unix() -> u64 {
@@ -106,33 +379,55 @@ fn default_now_unix() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
-    /// A minter that counts calls and returns `tok-<n>` (or fails). Optional
-    /// expiry lets a test force the refresh-window path.
+    // Port coverage of mobile's `control_token_provider_test.dart:28-252`
+    // (plan 001 §7 AC#4). NOT ported (§3.4 decision, see the type docs): the
+    // two identity-binding cases (`drops the cached token when the host
+    // transport identity changes`, `does not hand an in-flight mint to a
+    // changed identity`) — a shed-core Client+provider pair is immutable per
+    // transport identity; the app layer constructs a NEW Client (and provider)
+    // on a host/port/pin change, deleting the identity-race class those cases
+    // guard. TRANSLATED rather than ported: `returns null for a legacy
+    // (non-secure) host` — Rust represents "legacy" at Client construction (a
+    // minter-less Client resolves its bearer from the static token or sends
+    // none; http.rs `static_token_used_without_provider` +
+    // `mint_failure_is_fail_closed_no_downgrade` pin that contract), not as a
+    // provider state.
+
+    /// A minter that counts calls and returns `tok-<n>` (or fails — the
+    /// switch is runtime-flippable, the Dart tests' `shouldFail` captures; a
+    /// FAILED attempt is counted in `n` too). Optional expiry lets a test
+    /// force the refresh-window path; a delay lets one force single-flight.
     struct MockMinter {
         calls: AtomicUsize,
-        fail: bool,
+        fail: AtomicBool,
         expires_at_unix: Option<u64>,
         delay_ms: u64,
     }
 
     impl MockMinter {
-        fn ok() -> Arc<Self> {
+        fn new(fail: bool, expires_at_unix: Option<u64>, delay_ms: u64) -> Arc<Self> {
             Arc::new(Self {
                 calls: AtomicUsize::new(0),
-                fail: false,
-                expires_at_unix: None,
-                delay_ms: 0,
+                fail: AtomicBool::new(fail),
+                expires_at_unix,
+                delay_ms,
             })
         }
+        fn ok() -> Arc<Self> {
+            Self::new(false, None, 0)
+        }
         fn failing() -> Arc<Self> {
-            Arc::new(Self {
-                calls: AtomicUsize::new(0),
-                fail: true,
-                expires_at_unix: None,
-                delay_ms: 0,
-            })
+            Self::new(true, None, 0)
+        }
+        /// The Dart FSM tests' minter shape: flippable failure, far-future
+        /// expiry.
+        fn flaky(fail: bool) -> Arc<Self> {
+            Self::new(fail, Some(FAR_FUTURE), 0)
+        }
+        fn set_fail(&self, v: bool) {
+            self.fail.store(v, Ordering::SeqCst);
         }
         fn count(&self) -> usize {
             self.calls.load(Ordering::SeqCst)
@@ -146,13 +441,24 @@ mod tests {
             if self.delay_ms > 0 {
                 tokio::time::sleep(Duration::from_millis(self.delay_ms)).await;
             }
-            if self.fail {
+            if self.fail.load(Ordering::SeqCst) {
                 return Err(ShedError::Transport("mint failed".into()));
             }
             Ok(MintedToken {
                 token: format!("tok-{n}"),
                 expires_at_unix: self.expires_at_unix,
             })
+        }
+    }
+
+    /// Dart's `farFuture` (99999999 ms there; unix seconds here — only "far
+    /// beyond every test clock" matters).
+    const FAR_FUTURE: u64 = 99_999_999;
+
+    fn seed(exp: u64) -> MintedToken {
+        MintedToken {
+            token: "seed".into(),
+            expires_at_unix: Some(exp),
         }
     }
 
@@ -177,14 +483,9 @@ mod tests {
 
     #[tokio::test]
     async fn refreshes_within_expiry_window() {
-        // Expiry = now → always within the 2h refresh window → re-mint each call.
+        // Expiry = now → expired → re-mint each call.
         let now = default_now_unix();
-        let minter = Arc::new(MockMinter {
-            calls: AtomicUsize::new(0),
-            fail: false,
-            expires_at_unix: Some(now),
-            delay_ms: 0,
-        });
+        let minter = MockMinter::new(false, Some(now), 0);
         let p = ControlTokenProvider::new("mini2".into(), minter.clone());
         assert_eq!(p.token().await.unwrap(), "tok-1");
         assert_eq!(p.token().await.unwrap(), "tok-2");
@@ -194,12 +495,7 @@ mod tests {
     #[tokio::test]
     async fn does_not_refresh_far_from_expiry() {
         let far = default_now_unix() + 10 * 60 * 60; // 10h out, beyond the 2h window
-        let minter = Arc::new(MockMinter {
-            calls: AtomicUsize::new(0),
-            fail: false,
-            expires_at_unix: Some(far),
-            delay_ms: 0,
-        });
+        let minter = MockMinter::new(false, Some(far), 0);
         let p = ControlTokenProvider::new("mini2".into(), minter.clone());
         assert_eq!(p.token().await.unwrap(), "tok-1");
         assert_eq!(p.token().await.unwrap(), "tok-1"); // still fresh
@@ -229,20 +525,303 @@ mod tests {
         assert!(p.token().await.is_err()); // empty token → mint failure, not cached
     }
 
+    // Also the port of Dart's `collapses concurrent mints into one
+    // (single-flight)` (`control_token_provider_test.dart:114-134`): no seed →
+    // every caller must mint, and the held lock collapses them to one.
     #[tokio::test]
     async fn concurrent_callers_mint_once() {
         // Single-flight: a slow mint + concurrent callers → exactly one mint.
-        let minter = Arc::new(MockMinter {
-            calls: AtomicUsize::new(0),
-            fail: false,
-            expires_at_unix: None,
-            delay_ms: 40,
-        });
+        let minter = MockMinter::new(false, None, 40);
         let p = Arc::new(ControlTokenProvider::new("mini2".into(), minter.clone()));
         let (a, b, c) = tokio::join!(p.token(), p.token(), p.token());
         assert_eq!(a.unwrap(), "tok-1");
         assert_eq!(b.unwrap(), "tok-1");
         assert_eq!(c.unwrap(), "tok-1");
         assert_eq!(minter.count(), 1);
+    }
+
+    // ---- mobile FSM ports (control_token_provider_test.dart:28-252) ----
+
+    // Dart `uses the config seed without minting when it is fresh` (:47-62).
+    #[tokio::test]
+    async fn uses_the_seed_without_minting_when_fresh() {
+        let minter = MockMinter::flaky(false);
+        let p = ControlTokenProvider::new("mini3".into(), minter.clone())
+            .with_now(|| 0)
+            .with_refresh_window(Duration::from_secs(1000))
+            .with_seed(seed(FAR_FUTURE));
+        assert_eq!(p.token().await.unwrap(), "seed");
+        assert_eq!(minter.count(), 0);
+    }
+
+    // Dart `proactively mints when within the refresh window` (:64-79).
+    #[tokio::test]
+    async fn proactively_mints_within_the_refresh_window() {
+        let minter = MockMinter::flaky(false);
+        let p = ControlTokenProvider::new("mini3".into(), minter.clone())
+            .with_now(|| 9000)
+            .with_refresh_window(Duration::from_secs(5000))
+            .with_seed(seed(10_000));
+        // 9000 >= 10000 - 5000 → inside the window (not yet expired) → mint.
+        assert_eq!(p.token().await.unwrap(), "tok-1");
+        assert_eq!(minter.count(), 1);
+    }
+
+    // Dart `keeps a still-valid token when a proactive mint fails` (:81-91) —
+    // strict improvement #1 over the pre-C6 Rust FSM, which errored here.
+    #[tokio::test]
+    async fn keeps_a_still_valid_token_when_a_proactive_mint_fails() {
+        let minter = MockMinter::flaky(true);
+        let p = ControlTokenProvider::new("mini3".into(), minter.clone())
+            .with_now(|| 9000)
+            .with_refresh_window(Duration::from_secs(5000))
+            .with_seed(seed(10_000));
+        assert_eq!(p.token().await.unwrap(), "seed"); // kept, not an error
+        assert_eq!(minter.count(), 1); // the refresh mint WAS attempted
+    }
+
+    // Dart `mints when the seed is expired, throwing if that mint fails`
+    // (:93-112). Cooldown 0 (the default) so the immediate retry may mint.
+    #[tokio::test]
+    async fn expired_seed_mints_and_errs_when_that_mint_fails() {
+        let minter = MockMinter::flaky(true);
+        let p = ControlTokenProvider::new("mini3".into(), minter.clone())
+            .with_now(|| 5000)
+            .with_seed(seed(1000)); // expired
+        assert!(p.token().await.is_err());
+        minter.set_fail(false);
+        assert_eq!(p.token().await.unwrap(), "tok-2"); // attempt 1 failed
+        assert_eq!(minter.count(), 2);
+    }
+
+    // Dart `forces a fresh mint on invalidate (401), never the rejected token`
+    // (:136-155).
+    #[tokio::test]
+    async fn invalidate_if_current_forces_a_fresh_mint_never_the_rejected_token() {
+        let minter = MockMinter::flaky(false);
+        let p = ControlTokenProvider::new("mini3".into(), minter.clone())
+            .with_now(|| 0)
+            .with_refresh_window(Duration::from_secs(1))
+            .with_seed(seed(FAR_FUTURE));
+        assert_eq!(p.token().await.unwrap(), "seed");
+        p.invalidate_if_current("seed").await;
+        assert_eq!(p.token().await.unwrap(), "tok-1");
+        assert_eq!(minter.count(), 1);
+    }
+
+    // The must-mint failure half of Dart's `get()` reactive branch (:72-79):
+    // after an invalidate, a failed mint is an ERROR — the still-valid (but
+    // rejected) seed is never handed back.
+    #[tokio::test]
+    async fn must_mint_failure_errs_even_with_an_unexpired_cached_token() {
+        let minter = MockMinter::flaky(true);
+        let p = ControlTokenProvider::new("mini3".into(), minter.clone())
+            .with_now(|| 0)
+            .with_refresh_window(Duration::from_secs(1))
+            .with_seed(seed(FAR_FUTURE));
+        assert_eq!(p.token().await.unwrap(), "seed"); // far from expiry: no mint
+        assert_eq!(minter.count(), 0);
+        p.invalidate_if_current("seed").await;
+        assert!(p.token().await.is_err()); // forced mint failed → Err, not "seed"
+        assert_eq!(minter.count(), 1);
+    }
+
+    // Dart `does not re-mint within the cooldown after a failed mint`
+    // (:157-179). Dart drives ms; the Rust clock is unix seconds — same
+    // numbers, seconds domain.
+    #[tokio::test]
+    async fn does_not_remint_within_the_cooldown_after_a_failed_mint() {
+        let now = Arc::new(AtomicU64::new(5000));
+        let minter = MockMinter::flaky(true);
+        let p = ControlTokenProvider::new("mini3".into(), minter.clone())
+            .with_now({
+                let now = now.clone();
+                move || now.load(Ordering::SeqCst)
+            })
+            .with_mint_cooldown(Duration::from_secs(1000))
+            .with_seed(seed(1000)); // expired
+        assert!(p.token().await.is_err()); // fails; cooldown until 6000
+        assert_eq!(minter.count(), 1);
+        now.store(5500, Ordering::SeqCst); // within cooldown → NO mint attempt
+        assert!(p.token().await.is_err());
+        assert_eq!(minter.count(), 1);
+        now.store(6000, Ordering::SeqCst); // cooldown elapsed → mints again
+        assert!(p.token().await.is_err());
+        assert_eq!(minter.count(), 2);
+    }
+
+    // The cooldown's still-valid half (plan §3.4): during a cooldown a cached
+    // still-valid token is returned WITHOUT a mint attempt.
+    #[tokio::test]
+    async fn cooldown_returns_the_cached_still_valid_token_without_minting() {
+        let now = Arc::new(AtomicU64::new(9000));
+        let minter = MockMinter::flaky(true);
+        let p = ControlTokenProvider::new("mini3".into(), minter.clone())
+            .with_now({
+                let now = now.clone();
+                move || now.load(Ordering::SeqCst)
+            })
+            .with_refresh_window(Duration::from_secs(5000))
+            .with_mint_cooldown(Duration::from_secs(1000))
+            .with_seed(seed(10_000));
+        // In the refresh window: the mint fails (keep-valid) + starts cooldown.
+        assert_eq!(p.token().await.unwrap(), "seed");
+        assert_eq!(minter.count(), 1);
+        now.store(9100, Ordering::SeqCst); // still in window, cooldown active
+        assert_eq!(p.token().await.unwrap(), "seed");
+        assert_eq!(minter.count(), 1); // no second attempt
+    }
+
+    // C6 adversarial review #2b: the PERSISTED last_error (served on later
+    // cooldown-blocked calls) is the fixed redacted marker — a minter error
+    // embedding secret material must never be stored and replayed. The
+    // immediate caller of the failing mint still receives the real error
+    // (pre-C6 propagation parity; Dart rethrows too, :149).
+    #[tokio::test]
+    async fn cooldown_blocked_error_is_redacted_never_the_minter_text() {
+        struct SecretErrMinter;
+        #[async_trait::async_trait]
+        impl TokenMinter for SecretErrMinter {
+            async fn mint(&self, _server: &str) -> Result<MintedToken, ShedError> {
+                Err(ShedError::Transport(
+                    "mint blew up: SECRET-TOKEN-MATERIAL".into(),
+                ))
+            }
+        }
+        let now = Arc::new(AtomicU64::new(5000));
+        let p = ControlTokenProvider::new("mini3".into(), Arc::new(SecretErrMinter))
+            .with_now({
+                let now = now.clone();
+                move || now.load(Ordering::SeqCst)
+            })
+            .with_mint_cooldown(Duration::from_secs(1000))
+            .with_seed(seed(1000)); // expired seed → the mint is forced
+        let immediate = p.token().await.unwrap_err().to_string();
+        // The immediate failure surfaces the minter's real error.
+        assert!(
+            immediate.contains("SECRET-TOKEN-MATERIAL"),
+            "got: {immediate}"
+        );
+        // A later cooldown-blocked call serves only the redacted marker.
+        now.store(5500, Ordering::SeqCst);
+        let blocked = p.token().await.unwrap_err().to_string();
+        assert!(
+            !blocked.contains("SECRET"),
+            "persisted error leaked: {blocked}"
+        );
+        assert!(
+            blocked.contains("control token mint failed"),
+            "got: {blocked}"
+        );
+    }
+
+    // Dart `ignores a stale 401 for a token it has already rotated past`
+    // (:181-203) — strict improvement #2.
+    #[tokio::test]
+    async fn ignores_a_stale_401_for_an_already_rotated_token() {
+        let minter = MockMinter::flaky(false);
+        let p = ControlTokenProvider::new("mini3".into(), minter.clone())
+            .with_now(|| 0)
+            .with_refresh_window(Duration::from_secs(1))
+            .with_seed(seed(FAR_FUTURE));
+        assert_eq!(p.token().await.unwrap(), "seed");
+        p.invalidate_if_current("seed").await; // real 401 on the seed
+        assert_eq!(p.token().await.unwrap(), "tok-1"); // rotated
+        p.invalidate_if_current("seed").await; // stale 401 → ignored
+        assert_eq!(p.token().await.unwrap(), "tok-1"); // still cached
+        assert_eq!(minter.count(), 1);
+    }
+
+    // Plan §3.4: `with_seed` ignores an empty/whitespace token — never caches
+    // an unusable credential; the first token() mints as if unseeded.
+    #[tokio::test]
+    async fn with_seed_ignores_empty_and_whitespace_tokens() {
+        for junk in ["", "   \t "] {
+            let minter = MockMinter::flaky(false);
+            let p = ControlTokenProvider::new("mini3".into(), minter.clone())
+                .with_now(|| 0)
+                .with_seed(MintedToken {
+                    token: junk.into(),
+                    expires_at_unix: Some(FAR_FUTURE),
+                });
+            assert_eq!(p.token().await.unwrap(), "tok-1", "seed {junk:?}");
+            assert_eq!(minter.count(), 1);
+        }
+    }
+
+    // Jitter is SUBTRACTED from the refresh threshold — refresh happens
+    // EARLIER. name_jitter("my-server", 300000 ms) = 145668 ms → 145 s in the
+    // provider's seconds-domain comparison. exp = 100000, window = 1000 s:
+    // threshold without jitter = 99000, with = 98855. At now = 98900 only the
+    // jittered provider refreshes.
+    #[tokio::test]
+    async fn name_jitter_is_subtracted_so_refresh_happens_earlier() {
+        let jittered_minter = MockMinter::flaky(false);
+        let jittered = ControlTokenProvider::new("my-server".into(), jittered_minter.clone())
+            .with_now(|| 98_900)
+            .with_refresh_window(Duration::from_secs(1000))
+            .with_name_jitter(Duration::from_secs(300))
+            .with_seed(seed(100_000));
+        assert_eq!(jittered.token().await.unwrap(), "tok-1");
+        assert_eq!(jittered_minter.count(), 1);
+
+        let plain_minter = MockMinter::flaky(false);
+        let plain = ControlTokenProvider::new("my-server".into(), plain_minter.clone())
+            .with_now(|| 98_900)
+            .with_refresh_window(Duration::from_secs(1000))
+            .with_seed(seed(100_000));
+        assert_eq!(plain.token().await.unwrap(), "seed");
+        assert_eq!(plain_minter.count(), 0);
+    }
+
+    // Cross-language vectors for [`name_jitter`] (plan §3.4/AC#5): expected
+    // values derived by running the Dart algorithm
+    // (`control_token_provider.dart:175-181`) by hand — per UTF-16 code unit,
+    // h = (h*31 + cu).toSigned(32), then h.abs() % max(maxMs, 1).
+    #[test]
+    fn name_jitter_matches_the_dart_algorithm() {
+        // "my-server" (ASCII), code units m=109 y=121 -=45 s=115 e=101 r=114
+        // v=118 e=101 r=114:
+        //   109 → 3500 → 108545 → 3365010 → 104315411
+        //   → 104315411*31+114 = 3233777855   → wraps to -1061189441
+        //   → -1061189441*31+118              → wraps to  1462865815
+        //   →  1462865815*31+101              → wraps to -1895799890
+        //   → -1895799890*31+114              → wraps to  1359745668
+        // abs(1359745668) % 300000 = 145668; % 1000 = 668.
+        assert_eq!(name_jitter("my-server", 300_000), 145_668);
+        assert_eq!(name_jitter("my-server", 1_000), 668);
+
+        // "grüß-server" (non-ASCII, still BMP — ONE code unit each: ü=252
+        // ß=223), units g=103 r=114 ü=252 ß=223 -=45 s=115 e=101 r=114 v=118
+        // e=101 r=114:
+        //   103 → 3307 → 102769 → 3186062 → 98767967
+        //   → 98767967*31+115 = 3061807092    → wraps to -1233160204
+        //   → -1233160204*31+101              → wraps to   426739441
+        //   →   426739441*31+114              → wraps to   344020897
+        //   →   344020897*31+118              → wraps to  2074713333
+        //   →  2074713333*31+101              → wraps to  -108396016
+        //   →  -108396016*31+114              → wraps to   934690914
+        // abs(934690914) % 300000 = 190914; % 1000 = 914.
+        assert_eq!(name_jitter("grüß-server", 300_000), 190_914);
+        assert_eq!(name_jitter("grüß-server", 1_000), 914);
+
+        // "shed-🚀" (emoji = a SURROGATE PAIR, TWO code units — Dart
+        // `codeUnitAt` sees the UTF-16 halves of U+1F680: high 0xD83D=55357,
+        // low 0xDE80=56960), units s=115 h=104 e=101 d=100 -=45 55357 56960:
+        //   115 → 3669 → 113840 → 3529140 → 109403385
+        //   → 109403385*31+55357 = 3391560292 → wraps to  -903407004
+        //   → -903407004*31+56960             → wraps to  2059210908
+        // abs(2059210908) % 300000 = 10908; % 1000 = 908.
+        assert_eq!(name_jitter("shed-🚀", 300_000), 10_908);
+        assert_eq!(name_jitter("shed-🚀", 1_000), 908);
+
+        // A name whose FINAL hash is negative, exercising unsigned_abs:
+        // "my-server-dev" folds to h = -267572916;
+        // abs(-267572916) % 300000 = 272916.
+        assert_eq!(name_jitter("my-server-dev", 300_000), 272_916);
+
+        // Dart `maxMs < 1 ? 1 : maxMs`: max 0 → % 1 → always 0 (jitter off).
+        assert_eq!(name_jitter("my-server", 0), 0);
+        assert_eq!(name_jitter("", 300_000), 0); // h stays 0
     }
 }

--- a/desktop/tauri/src-tauri/src/ipc.rs
+++ b/desktop/tauri/src-tauri/src/ipc.rs
@@ -773,7 +773,7 @@ impl Handler {
                     format!("{shed}/{slug}")
                 }
             }),
-            workdir: opt("workdir").unwrap_or_else(|| rc::DEFAULT_WORKDIR.to_string()),
+            workdir: Some(opt("workdir").unwrap_or_else(|| rc::DEFAULT_WORKDIR.to_string())),
             // kind + state both default (like the Swift `RcInjectTestParams`) — this
             // is the test-only fixture op; the harness always sends valid values.
             kind: params
@@ -789,6 +789,9 @@ impl Handler {
             created_by: opt("created_by"),
             created_at: opt("created_at"),
             target_label: opt("target_label"),
+            activity: None,
+            activity_at: None,
+            last_message: None,
             managed,
         })
     }


### PR DESCRIPTION
## What & why

Additive, **library-only** gap-fill of `shed-core` / `shed-app` — **Phase A** of porting the `shed-mobile` Flutter app onto the shared Rust client core (killing ~2,000 lines of hand-maintained Dart that already carry "Mirrors the Rust core" comments). This PR adds the client surface mobile actually uses so a later flutter_rust_bridge layer can consume it; every addition follows `crates/` conventions and is ported field-for-field from the Dart sources, so Swift (UniFFI) and Tauri can adopt the same code next.

**No release, no manifest bump, no `shed-core-ffi` API change, no new dependencies.** Desktop behavior is unchanged except three strictly-safer improvements (below). This is a **stacked-commit** PR — each commit is independently shippable and separately reviewable.

## Commits (per workstream)

| Commit | Adds |
|---|---|
| **C1** overview DTOs + RC groundwork | `Overview`/`OverviewServer`/`OverviewShed` with Dart-tolerant per-field decode (every substructure degrades independently); `RcActivity` (Unknown catch-all); activity fields on `RcSession`/`RcSessionDto` (`skip_serializing_if`); `RcKindFeatures.watch`/`input` (drift fix); `ServerInfo.features` + `has_feature()` (Go emits it; Rust was dropping it); `fixtures/overview.json` byte-copied from mobile's golden |
| **C2** sessions read-plane + rc proxy | `overview()`, `list_sessions()`, `delete_session()`, `rc_messages()`, `rc_input()`; `Session`/`SessionRC`/`RcMessagesPage` DTOs; status-code error dispatch |
| **C3** rc-events decode + fold | `rc_events` module: `RcEvent` tolerant never-error decode + `ActivityOverlay` fold (blocking-state suppression, per-shed drops), ported from `rc_events.dart` with its full test suite |
| **C4** rc-events SSE client | `Client::rc_events(sink)` — one connection, capped parser, **byte-level idle timer** (heartbeat comments reset it) |
| **C5** `RcEventsWatcher` (shed-app) | shared reconnect loop + fold + channel; `gotData` resync parity; backoff 500ms→30s; spawn-once/non-restartable |
| **C6** token FSM knobs + stale-401 guard | `with_now`/`with_refresh_window`/`with_name_jitter`/`with_mint_cooldown`/`with_seed` builders; keep-valid-on-proactive-failure; `invalidate_if_current()` |
| **C7** token-bundle fail-closed parse | `parse_token_bundle`/`parse_control_bundle` (mobile parity) + std-only RFC3339 parser (no chrono) |
| **C8** rc permission modes | permission-mode sets + `validate_permission_mode`; `--permission-mode` threaded through `create_argv`/`create_invocation` |

## Verification

**Automated (full workspace green):** shed-core **270** tests (+116 over branch base), shed-app 89 default / 102 `rc` / 121 `broker,rc`, plus shed-broker 339 / host-agent 43 / ffi 2 / shedctl 13 — 0 failures. Workspace + feature-matrix clippy `-D warnings` clean. Tauri `cargo check` green after C1's `RcSession` shape change. **Reverse-dep AC:** `cargo tree -i saphyr-parser|notify|aws-sdk-sts` show no path into shed-core / shed-core-ffi / default shed-app. No `Cargo.lock` change.

**Per-commit adversarial review:** every commit ran implement → gate → simplify → **Codex correctness review** → fix → commit. Real defects caught and fixed with regression tests each round — notably a **watcher receiver-drop leak** (C5: watcher + TCP connection lived forever on a heartbeat-only stream) and **5 auth findings** in C6 (unauthenticated retry on re-mint failure, `last_error` secret leak, same-token re-cache, unbounded invalidate await), plus a **path-segment injection** in C2 (`delete_session("proj","../../victim")` → `DELETE /api/sheds/victim`).

**Live wire-shape check** against the real localmac server (v0.7.6, *older* than the golden's v0.8.0 — a good backward-compat test): `/api/info` returned no `features` field (validates `ServerInfo.features` null_default); a live SSH `_bootstrap control` mint returned a bundle matching `parse_control_bundle`'s shape; `/api/overview` returned a `text/plain` `404 page not found` — the exact chi-mislabeled-404 `overview()` short-circuits to `BadStatus(404)` before decode. The rc-events/sessions **success** shapes don't exist on v0.7.6, so they're covered by the byte-copied golden + Go-handler citations + raw-TCP SSE streaming tests (honest coverage boundary noted below).

## Desktop-visible changes (all strictly safer)
1. Keep the cached control token on a proactive-mint failure while still valid (C6).
2. `invalidate_if_current(observed)` stale-401 guard — a 401 racing a rotation can't clear a newer token (C6).
3. All Client URL building one-segment-encodes identifiers + rejects bare `""`/`"."`/`".."` — closes a path-traversal class; byte-identical requests for all valid names (C2).

## Accepted risk (dispositioned)
Token-provider single-flight holds its mutex across the mint, so cancelling a `token()` waiter can start a rare second concurrent mint (one extra round-trip, one abandoned short-TTL token; never a lockout or wrong cached token). Documented on the type with shed-broker's watch-based single-flight as the future upgrade.

## Follow-ups (not this PR)
Tauri/Swift adopt `RcEventsWatcher`; FFI export of the new surface; shed-lifecycle push events; live re-verify against a v0.8.0+ server. Phase B (the shed-mobile FRB bridge) pins to this merge.

<details>
<summary>Plan (durable record — the plan lives outside the repo)</summary>

Full plan + §Verified: `~/.claude/plans/shed/001-shed-core-mobile-gaps.md` (panel-reviewed by Codex + GLM 5.2 + CodeRabbit before implementation; corrections recorded in its header). Parent program: `~/.claude/plans/shed-mobile-rust-core.md`.

Design decisions pinned in the plan: full-transport-swap adoption depth; rc-events split as pure-fold (shed-core) + reconnect-watcher (shed-app) so reconnect logic lives once; byte-level idle timer (heartbeat comments are SSE comments the parser swallows); Dart-tolerant overview decode across every substructure (forward-compat: a new server enum value must not vanish a session); identity-binding deliberately not ported (a new `Client` per transport identity deletes the race class); UTF-16 `name_jitter` for Dart parity; RFC3339 parser stricter-than-Dart (fail-closed) but leap-second-tolerant.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a richer server overview payload (server info, feature flags, storage totals, sheds, sessions, capabilities, warnings).
  * Added live RC event watching with typed updates, reconnection/backoff, and resynchronization behavior.
  * Added RC activity metadata, message/session feed decoding, and permission-mode support.

* **Bug Fixes**
  * Improved auth recovery with safer, bounded retries and hardened token handling.
  * Strengthened URL construction and SSE stream robustness (liveness, exact success handling, tolerant decoding).
  * Improved defensive parsing for overview/sessions and portability for peer ID detection.

* **Tests**
  * Expanded coverage for auth edge cases, SSE timing/frames, rc-events overlay/resync, and parsing tolerance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->