### PR TITLE
docs(desktop): rc message feed is codex AND opencode (follow-up to #279)

### DIFF
--- a/docs/desktop/rc-sessions.md
+++ b/docs/desktop/rc-sessions.md
@@ -98,12 +98,12 @@ mobile-style clients.
 ## Live activity (the rc hub)
 
 On VZ sheds a resident guest daemon — the **RC activity hub** (`shed-ext-rc serve`) —
-derives a live `activity` dimension for each session and, for codex, a message feed and
-gated input. Two server endpoints expose it to clients (advertised via the `rc-proxy`
+derives a live `activity` dimension for each session and, for codex and opencode, a
+message feed and gated input. Two server endpoints expose it to clients (advertised via the `rc-proxy`
 and `rc-events` feature tokens on `GET /api/info` / `GET /api/overview`):
 
 - **`GET/POST /api/sheds/{name}/rc/*`** reverse-proxies the hub's `/v1` API (session
-  list, SSE `/v1/events`, the codex `/messages` feed, and `POST /input`), ensure-starting
+  list, SSE `/v1/events`, the codex/opencode `/messages` feed, and `POST /input`), ensure-starting
   the hub on demand. The server is the authorization boundary; the hub is loopback-only
   inside the guest.
 - **`GET /api/rc/events`** is a single demand-driven aggregate SSE stream carrying


### PR DESCRIPTION
Small doc-accuracy fix. #279 added opencode to the RC message feed + gated input, and swept `docs/extensions/rc-helper.md`, but `docs/desktop/rc-sessions.md` still said the feed/`/messages`/gated-input was **codex-only**. Corrected both mentions to codex/opencode.

No code change. Relates to #279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Live Activity Hub documentation to cover activity details for both Codex and OpenCode sessions.
  * Clarified that message feeds and gated input are available for Codex and OpenCode.
  * Updated reverse-proxied endpoint documentation to include both session message feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->